### PR TITLE
Handle Kick chatroom metadata parsing

### DIFF
--- a/services/kick-listener/channels/repository.go
+++ b/services/kick-listener/channels/repository.go
@@ -2,8 +2,12 @@ package channels
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"strconv"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 )
@@ -17,8 +21,13 @@ type ActiveChannel struct {
 }
 
 // Repository handles database operations for channels
+type queryExecutor interface {
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
 type Repository struct {
-	db     *pgxpool.Pool
+	db     queryExecutor
 	logger *zap.Logger
 }
 
@@ -52,7 +61,7 @@ func (r *Repository) GetActiveChannels(ctx context.Context) ([]*ActiveChannel, e
 	var channels []*ActiveChannel
 	for rows.Next() {
 		var ch ActiveChannel
-		var chatroomID *int
+		var chatroomID sql.NullString
 
 		err := rows.Scan(
 			&ch.OverlayID,
@@ -65,9 +74,19 @@ func (r *Repository) GetActiveChannels(ctx context.Context) ([]*ActiveChannel, e
 			continue
 		}
 
-		// If chatroom_id is set, use it
-		if chatroomID != nil {
-			ch.ChatroomID = *chatroomID
+		// If chatroom_id is set, parse the value
+		if chatroomID.Valid && chatroomID.String != "" {
+			parsedID, err := strconv.Atoi(chatroomID.String)
+			if err != nil {
+				r.logger.Warn("Invalid chatroom_id metadata",
+					zap.String("overlay_id", ch.OverlayID),
+					zap.String("channel_slug", ch.ChannelSlug),
+					zap.String("raw_chatroom_id", chatroomID.String),
+					zap.Error(err),
+				)
+			} else {
+				ch.ChatroomID = parsedID
+			}
 		}
 
 		channels = append(channels, &ch)

--- a/services/kick-listener/channels/repository_test.go
+++ b/services/kick-listener/channels/repository_test.go
@@ -1,0 +1,173 @@
+package channels
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"go.uber.org/zap"
+)
+
+func TestRepository_GetActiveChannelsHandlesStringChatroomIDs(t *testing.T) {
+	rows := newFakeRows([][]any{
+		{"overlay-1", "channel-one", "123", true},
+		{"overlay-2", "channel-two", "invalid", true},
+	})
+
+	mockDB := &mockQueryExecutor{rows: rows}
+	repo := &Repository{db: mockDB, logger: zap.NewNop()}
+
+	channels, err := repo.GetActiveChannels(context.Background())
+	if err != nil {
+		t.Fatalf("GetActiveChannels returned error: %v", err)
+	}
+
+	if len(channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(channels))
+	}
+
+	if channels[0].ChatroomID != 123 {
+		t.Fatalf("expected first chatroom ID to be 123, got %d", channels[0].ChatroomID)
+	}
+
+	if channels[1].ChatroomID != 0 {
+		t.Fatalf("expected invalid chatroom ID to fall back to 0, got %d", channels[1].ChatroomID)
+	}
+
+	if !rows.closed {
+		t.Fatalf("expected rows to be closed after iteration")
+	}
+
+	if mockDB.lastQuery == "" {
+		t.Fatalf("expected query to be executed")
+	}
+}
+
+type mockQueryExecutor struct {
+	rows      pgx.Rows
+	lastQuery string
+}
+
+func (m *mockQueryExecutor) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+	m.lastQuery = sql
+	return m.rows, nil
+}
+
+func (m *mockQueryExecutor) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, fmt.Errorf("not implemented")
+}
+
+type fakeRows struct {
+	data   [][]any
+	index  int
+	closed bool
+	err    error
+}
+
+func newFakeRows(data [][]any) *fakeRows {
+	return &fakeRows{data: data}
+}
+
+func (r *fakeRows) Close() {
+	r.closed = true
+}
+
+func (r *fakeRows) Err() error {
+	return r.err
+}
+
+func (r *fakeRows) CommandTag() pgconn.CommandTag {
+	return pgconn.CommandTag{}
+}
+
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription {
+	return nil
+}
+
+func (r *fakeRows) Next() bool {
+	if r.index >= len(r.data) {
+		r.Close()
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.index == 0 || r.index > len(r.data) {
+		return fmt.Errorf("no current row")
+	}
+
+	row := r.data[r.index-1]
+	if len(dest) != len(row) {
+		return fmt.Errorf("scan mismatch: dest=%d row=%d", len(dest), len(row))
+	}
+
+	for i := range dest {
+		if err := assignScanValue(dest[i], row[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *fakeRows) Values() ([]any, error) {
+	if r.index == 0 || r.index > len(r.data) {
+		return nil, fmt.Errorf("no current row")
+	}
+	row := r.data[r.index-1]
+	values := make([]any, len(row))
+	copy(values, row)
+	return values, nil
+}
+
+func (r *fakeRows) RawValues() [][]byte {
+	return nil
+}
+
+func (r *fakeRows) Conn() *pgx.Conn {
+	return nil
+}
+
+func assignScanValue(dest any, value any) error {
+	switch d := dest.(type) {
+	case *string:
+		if value == nil {
+			*d = ""
+			return nil
+		}
+		str, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+		*d = str
+		return nil
+	case *bool:
+		if value == nil {
+			*d = false
+			return nil
+		}
+		b, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("expected bool, got %T", value)
+		}
+		*d = b
+		return nil
+	case *sql.NullString:
+		if value == nil {
+			*d = sql.NullString{}
+			return nil
+		}
+		str, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+		*d = sql.NullString{String: str, Valid: true}
+		return nil
+	default:
+		return fmt.Errorf("unsupported destination type %T", dest)
+	}
+}


### PR DESCRIPTION
## Summary
- scan Kick chatroom metadata into a nullable string and add parsing + validation so invalid values only emit warnings instead of crashing
- add a lightweight database abstraction to the repository and backfill tests that exercise numeric and string chatroom IDs via fixtures

## Testing
- `cd services/kick-listener && go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918c75329088323b6409f067555cb65)