### PR TITLE
Add service authentication middleware

### DIFF
--- a/deployments/SERVICE_AUTH.md
+++ b/deployments/SERVICE_AUTH.md
@@ -1,0 +1,27 @@
+# Service-to-service authentication
+
+The Source Manager HTTP API now enforces authentication for every endpoint except the health checks. Internal callers must send a signed JWT in the `Authorization: Bearer <token>` header.
+
+## 1. Configure the shared signing secret
+
+Set `SERVICE_JWT_SECRET` for the Source Manager deployment. The Docker Compose file defaults this to `dev-service-secret`; override it in production via an `.env` file or your orchestration secrets store.
+
+## 2. Issue per-service credentials
+
+Use the helper located at `shared/cmd/service-token` to mint tokens for each service identity:
+
+```bash
+go run ./shared/cmd/service-token --service youtube-listener --secret "$SERVICE_JWT_SECRET" --expiry 24h
+```
+
+The output token can be stored as a secret (for example `YOUTUBE_LISTENER_SOURCE_MANAGER_TOKEN`) and injected into the calling service's environment. Each service should keep its token private and rotate it as needed.
+
+## 3. Distribute and use the tokens
+
+When calling the Source Manager API, include the token in the HTTP `Authorization` header:
+
+```
+Authorization: Bearer <service-token>
+```
+
+Health endpoints (`/health/live`, `/health/ready`, `/status`) remain unauthenticated so infrastructure probes can continue to check liveness and readiness without credentials.

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -244,6 +244,7 @@ services:
       DATABASE_PASSWORD: allchat_dev_password
       REDIS_HOST: redis
       REDIS_PORT: "6379"
+      SERVICE_JWT_SECRET: ${SERVICE_JWT_SECRET:-dev-service-secret}
     ports:
       - "8088:8088"
     depends_on:

--- a/services/source-manager/cmd/main.go
+++ b/services/source-manager/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caesar/all-chat/services/source-manager/registry"
 	"github.com/caesar/all-chat/shared/database"
 	"github.com/caesar/all-chat/shared/logger"
+	"github.com/caesar/all-chat/shared/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -89,13 +90,17 @@ func main() {
 	router.GET("/health/ready", healthHandler.ReadinessProbe)
 	router.GET("/status", healthHandler.Status)
 
+	serviceAuthSecret := getEnvOrDefault("SERVICE_JWT_SECRET", "dev-service-secret")
+	protected := router.Group("/")
+	protected.Use(middleware.ServiceJWTAuth(serviceAuthSecret))
+
 	// Source handlers
 	sourceHandler := handlers.NewSourceHandler(sourceRegistry, leaderManager)
-	router.GET("/sources", sourceHandler.GetSources)
-	router.POST("/leadership/claim", sourceHandler.ClaimLeadership)
-	router.POST("/leadership/renew", sourceHandler.RenewLeadership)
-	router.POST("/leadership/release", sourceHandler.ReleaseLeadership)
-	router.GET("/leadership", sourceHandler.GetLeadershipStatus)
+	protected.GET("/sources", sourceHandler.GetSources)
+	protected.POST("/leadership/claim", sourceHandler.ClaimLeadership)
+	protected.POST("/leadership/renew", sourceHandler.RenewLeadership)
+	protected.POST("/leadership/release", sourceHandler.ReleaseLeadership)
+	protected.GET("/leadership", sourceHandler.GetLeadershipStatus)
 
 	// Get port
 	port := getEnvOrDefault("PORT", "8088")

--- a/services/source-manager/election/leader.go
+++ b/services/source-manager/election/leader.go
@@ -3,6 +3,7 @@ package election
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caesar/all-chat/services/source-manager/models"
@@ -243,10 +244,9 @@ func (m *Manager) leaderKey(platform, streamID string) string {
 // parseLeaderKey parses a leader key into platform and stream ID
 func (m *Manager) parseLeaderKey(key string) (platform, streamID string, err error) {
 	// Key format: leader:{platform}:{stream_id}
-	var prefix string
-	n, err := fmt.Sscanf(key, "%s:%s:%s", &prefix, &platform, &streamID)
-	if err != nil || n != 3 || prefix != LeaderKeyPrefix {
+	parts := strings.Split(key, ":")
+	if len(parts) != 3 || parts[0] != LeaderKeyPrefix {
 		return "", "", fmt.Errorf("invalid leader key format: %s", key)
 	}
-	return platform, streamID, nil
+	return parts[1], parts[2], nil
 }

--- a/services/source-manager/go.sum
+++ b/services/source-manager/go.sum
@@ -126,3 +126,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=
+github.com/gin-contrib/cors v1.7.6/go.mod h1:Ulcl+xN4jel9t1Ry8vqph23a60FwH9xVLd+3ykmTjOk=

--- a/shared/auth/jwt.go
+++ b/shared/auth/jwt.go
@@ -23,6 +23,13 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
+// ServiceClaims represents JWT claims used for service-to-service auth
+type ServiceClaims struct {
+	ServiceName string   `json:"service_name"`
+	Permissions []string `json:"permissions,omitempty"`
+	jwt.RegisteredClaims
+}
+
 // GenerateJWT generates a new JWT token for the given user
 func GenerateJWT(userID, twitchID, username, email, secret string) (string, error) {
 	claims := Claims{
@@ -78,6 +85,46 @@ func ValidateJWT(tokenString, secret string) (*Claims, error) {
 	}
 
 	if claims, ok := token.Claims.(*Claims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, ErrInvalidToken
+}
+
+// GenerateServiceJWT creates a JWT representing a specific internal service
+func GenerateServiceJWT(serviceName, secret string, expiry time.Duration) (string, error) {
+	claims := ServiceClaims{
+		ServiceName: serviceName,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   serviceName,
+			Issuer:    "all-chat-services",
+			Audience:  []string{"internal"},
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+// ValidateServiceJWT validates service JWTs and returns the parsed claims
+func ValidateServiceJWT(tokenString, secret string) (*ServiceClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &ServiceClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(secret), nil
+	})
+
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return nil, ErrExpiredToken
+		}
+		return nil, ErrInvalidToken
+	}
+
+	if claims, ok := token.Claims.(*ServiceClaims); ok && token.Valid {
 		return claims, nil
 	}
 

--- a/shared/cmd/service-token/main.go
+++ b/shared/cmd/service-token/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/caesar/all-chat/shared/auth"
+)
+
+func main() {
+	service := flag.String("service", "", "Service name the token should represent")
+	secret := flag.String("secret", "", "Signing secret used by SERVICE_JWT_SECRET")
+	expiry := flag.Duration("expiry", 24*time.Hour, "How long the token should remain valid")
+	flag.Parse()
+
+	if *service == "" {
+		log.Fatal("service flag is required")
+	}
+
+	if *secret == "" {
+		log.Fatal("secret flag is required")
+	}
+
+	token, err := auth.GenerateServiceJWT(*service, *secret, *expiry)
+	if err != nil {
+		log.Fatalf("failed to generate token: %v", err)
+	}
+
+	fmt.Println(token)
+}

--- a/shared/middleware/service_auth.go
+++ b/shared/middleware/service_auth.go
@@ -1,0 +1,64 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/caesar/all-chat/shared/auth"
+	"github.com/gin-gonic/gin"
+)
+
+// ServiceJWTAuth enforces service-to-service authentication using signed JWTs.
+// Optionally accepts a list of allowed service names. If provided, requests from
+// other services will receive a 403 response.
+func ServiceJWTAuth(secret string, allowedServices ...string) gin.HandlerFunc {
+	allowed := map[string]struct{}{}
+	for _, svc := range allowedServices {
+		if svc == "" {
+			continue
+		}
+		allowed[svc] = struct{}{}
+	}
+
+	return func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Authorization header required",
+			})
+			c.Abort()
+			return
+		}
+
+		tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+		if tokenString == authHeader {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Invalid authorization header format",
+			})
+			c.Abort()
+			return
+		}
+
+		claims, err := auth.ValidateServiceJWT(tokenString, secret)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error": "Invalid or expired service token",
+			})
+			c.Abort()
+			return
+		}
+
+		if len(allowed) > 0 {
+			if _, ok := allowed[claims.ServiceName]; !ok {
+				c.JSON(http.StatusForbidden, gin.H{
+					"error": "service not permitted",
+				})
+				c.Abort()
+				return
+			}
+		}
+
+		c.Set("service_name", claims.ServiceName)
+		c.Next()
+	}
+}

--- a/shared/middleware/service_auth_test.go
+++ b/shared/middleware/service_auth_test.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/shared/auth"
+	"github.com/gin-gonic/gin"
+)
+
+func TestServiceJWTAuthMissingToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(ServiceJWTAuth("test-secret"))
+	router.GET("/protected", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", resp.Code)
+	}
+}
+
+func TestServiceJWTAuthDisallowedService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	secret := "test-secret"
+	token, err := auth.GenerateServiceJWT("youtube-listener", secret, time.Minute)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	router := gin.New()
+	router.Use(ServiceJWTAuth(secret, "source-manager"))
+	router.GET("/protected", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", resp.Code)
+	}
+}
+
+func TestServiceJWTAuthAllowedService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	secret := "test-secret"
+	token, err := auth.GenerateServiceJWT("source-manager", secret, time.Minute)
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+
+	router := gin.New()
+	router.Use(ServiceJWTAuth(secret, "source-manager"))
+	router.GET("/protected", func(c *gin.Context) {
+		svc, _ := c.Get("service_name")
+		c.JSON(http.StatusOK, gin.H{"service": svc})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- add reusable service JWT claims, middleware, and a helper CLI for minting tokens
- require the middleware on all Source Manager routes except health checks and document/distribute the new secret in the deployments docs
- extend automated coverage to assert 401/403 responses from the middleware and fix leader key parsing tests

## Testing
- `go test ./shared/...`
- `go test ./services/source-manager/election`
- `go test ./services/source-manager/...` *(fails: go command insists on running `go mod tidy`, which requires access to the Go checksum database in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918c7484b148323a962c8a18ded76fc)