### PR TITLE
Harden channel ID enrichment

### DIFF
--- a/services/message-processor/enricher/emote_enricher.go
+++ b/services/message-processor/enricher/emote_enricher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -50,9 +51,13 @@ func NewHTTPEmoteClient(baseURL string, logger *zap.Logger) *HTTPEmoteClient {
 
 // GetEmotesForChannel fetches all emotes for a channel from the Emote Service
 func (c *HTTPEmoteClient) GetEmotesForChannel(ctx context.Context, channel string) ([]EmoteServiceEmote, error) {
-	url := fmt.Sprintf("%s/emotes/channel/%s", c.baseURL, channel)
+	escapedChannel := url.PathEscape(channel)
+	endpoint, err := url.JoinPath(c.baseURL, "emotes", "channel", escapedChannel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build emote service url: %w", err)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/services/message-processor/enricher/emote_enricher_test.go
+++ b/services/message-processor/enricher/emote_enricher_test.go
@@ -1,0 +1,34 @@
+package enricher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestHTTPEmoteClient_GetEmotesForChannel_EscapesChannelID(t *testing.T) {
+	maliciousChannel := "../evil channel"
+	var requestedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"channel":"test","emotes":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPEmoteClient(server.URL, zap.NewNop())
+
+	if _, err := client.GetEmotesForChannel(context.Background(), maliciousChannel); err != nil {
+		t.Fatalf("GetEmotesForChannel returned error: %v", err)
+	}
+
+	expectedPath := "/emotes/channel/" + url.PathEscape(maliciousChannel)
+	if requestedPath != expectedPath {
+		t.Fatalf("expected path %q, got %q", expectedPath, requestedPath)
+	}
+}

--- a/services/message-processor/normalizer/kick_normalizer.go
+++ b/services/message-processor/normalizer/kick_normalizer.go
@@ -21,6 +21,10 @@ func (n *KickNormalizer) Normalize(raw *models.RawChatMessage, overlayID string)
 		return nil, fmt.Errorf("unsupported platform: %s", raw.Platform)
 	}
 
+	if err := validateChannelID(raw.ChannelID); err != nil {
+		return nil, fmt.Errorf("invalid channel ID: %w", err)
+	}
+
 	// For Kick, the raw.Text might contain JSON data
 	// Try to parse it as a Kick message structure
 	// The Kick listener should have stored the message in the Text field as JSON

--- a/services/message-processor/normalizer/tiktok_normalizer.go
+++ b/services/message-processor/normalizer/tiktok_normalizer.go
@@ -22,6 +22,10 @@ func (n *TikTokNormalizer) Normalize(raw *models.RawChatMessage, overlayID strin
 		return nil, fmt.Errorf("unsupported platform: %s", raw.Platform)
 	}
 
+	if err := validateChannelID(raw.ChannelID); err != nil {
+		return nil, fmt.Errorf("invalid channel ID: %w", err)
+	}
+
 	// Extract user info from tags
 	userInfo := n.extractUserInfo(raw)
 
@@ -112,8 +116,8 @@ func (n *TikTokNormalizer) extractMetadata(raw *models.RawChatMessage) map[strin
 
 	metadata := make(map[string]interface{})
 	metadata["is_subscriber"] = tags["is_subscriber"] == "true"
-	metadata["is_moderator"] = false // TikTok doesn't have moderator concept in unofficial lib
-	metadata["bits"] = 0             // TikTok doesn't use bits
+	metadata["is_moderator"] = false  // TikTok doesn't have moderator concept in unofficial lib
+	metadata["bits"] = 0              // TikTok doesn't use bits
 	metadata["super_chat_amount"] = 0 // SuperChatAmount would be for TikTok gifts
 	metadata["raw_tags"] = tags
 

--- a/services/message-processor/normalizer/twitch_normalizer.go
+++ b/services/message-processor/normalizer/twitch_normalizer.go
@@ -22,6 +22,10 @@ func (n *TwitchNormalizer) Normalize(raw *models.RawChatMessage, overlayID strin
 		return nil, fmt.Errorf("unsupported platform: %s", raw.Platform)
 	}
 
+	if err := validateChannelID(raw.ChannelID); err != nil {
+		return nil, fmt.Errorf("invalid channel ID: %w", err)
+	}
+
 	// Extract user info from tags
 	userInfo := n.extractUserInfo(raw)
 

--- a/services/message-processor/normalizer/twitch_normalizer_test.go
+++ b/services/message-processor/normalizer/twitch_normalizer_test.go
@@ -20,6 +20,21 @@ func TestTwitchNormalizer_Normalize(t *testing.T) {
 		wantErr   bool
 	}{
 		{
+			name: "invalid channel id",
+			raw: &models.RawChatMessage{
+				MessageID: "msg-invalid",
+				Platform:  "twitch",
+				ChannelID: "../bad",
+				UserID:    "12345",
+				Username:  "viewer123",
+				Text:      "Hello World",
+				Timestamp: time.Now().UTC(),
+				Tags:      map[string]string{},
+			},
+			overlayID: "overlay-1",
+			wantErr:   true,
+		},
+		{
 			name: "basic message",
 			raw: &models.RawChatMessage{
 				MessageID: "msg-123",
@@ -47,7 +62,7 @@ func TestTwitchNormalizer_Normalize(t *testing.T) {
 				assert.Equal(t, "viewer123", msg.User.Username)
 				assert.Equal(t, "Viewer123", msg.User.DisplayName)
 				assert.Equal(t, "#FF0000", msg.User.Color)
-				assert.Contains(t, msg.User.Badges, "subscriber")
+				assertBadgePresent(t, msg.User.Badges, "subscriber")
 				assert.Equal(t, "Hello World", msg.Message.Text)
 				assert.True(t, msg.Metadata["is_subscriber"].(bool))
 			},
@@ -119,9 +134,9 @@ func TestTwitchNormalizer_Normalize(t *testing.T) {
 			},
 			overlayID: "overlay-4",
 			check: func(t *testing.T, msg *models.UnifiedChatMessage) {
-				assert.Contains(t, msg.User.Badges, "moderator")
-				assert.Contains(t, msg.User.Badges, "subscriber")
-				assert.Contains(t, msg.User.Badges, "turbo")
+				assertBadgePresent(t, msg.User.Badges, "moderator")
+				assertBadgePresent(t, msg.User.Badges, "subscriber")
+				assertBadgePresent(t, msg.User.Badges, "turbo")
 				assert.True(t, msg.Metadata["is_moderator"].(bool))
 			},
 		},
@@ -179,8 +194,18 @@ func TestTwitchNormalizer_ExtractUserInfo(t *testing.T) {
 	assert.Equal(t, "testuser", userInfo.Username)
 	assert.Equal(t, "TestUser", userInfo.DisplayName)
 	assert.Equal(t, "#00FF00", userInfo.Color)
-	assert.Contains(t, userInfo.Badges, "broadcaster")
-	assert.Contains(t, userInfo.Badges, "moderator")
+	assertBadgePresent(t, userInfo.Badges, "broadcaster")
+	assertBadgePresent(t, userInfo.Badges, "moderator")
+}
+
+func assertBadgePresent(t *testing.T, badges []models.Badge, name string) {
+	t.Helper()
+	for _, badge := range badges {
+		if badge.Name == name {
+			return
+		}
+	}
+	t.Fatalf("expected badge %q to be present", name)
 }
 
 func TestTwitchNormalizer_ExtractUserInfo_NoDisplayName(t *testing.T) {

--- a/services/message-processor/normalizer/validation.go
+++ b/services/message-processor/normalizer/validation.go
@@ -1,0 +1,19 @@
+package normalizer
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var channelIDPattern = regexp.MustCompile(`^[A-Za-z0-9_\-]+$`)
+
+func validateChannelID(channelID string) error {
+	if channelID == "" {
+		return errors.New("channel ID cannot be empty")
+	}
+	if !channelIDPattern.MatchString(channelID) {
+		return fmt.Errorf("channel ID contains unexpected characters: %q", channelID)
+	}
+	return nil
+}

--- a/services/message-processor/normalizer/validation_test.go
+++ b/services/message-processor/normalizer/validation_test.go
@@ -1,0 +1,20 @@
+package normalizer
+
+import "testing"
+
+func TestValidateChannelID(t *testing.T) {
+	valid := []string{"channel123", "UCxxxxxx", "my-channel", "user_name"}
+	invalid := []string{"", "../bad", "bad?param", "name with space"}
+
+	for _, id := range valid {
+		if err := validateChannelID(id); err != nil {
+			t.Fatalf("expected %q to be valid, got %v", id, err)
+		}
+	}
+
+	for _, id := range invalid {
+		if err := validateChannelID(id); err == nil {
+			t.Fatalf("expected %q to be invalid", id)
+		}
+	}
+}

--- a/services/message-processor/normalizer/youtube_normalizer.go
+++ b/services/message-processor/normalizer/youtube_normalizer.go
@@ -21,6 +21,10 @@ func (n *YouTubeNormalizer) Normalize(raw *models.RawChatMessage, overlayID stri
 		return nil, fmt.Errorf("unsupported platform: %s", raw.Platform)
 	}
 
+	if err := validateChannelID(raw.ChannelID); err != nil {
+		return nil, fmt.Errorf("invalid channel ID: %w", err)
+	}
+
 	// Extract user info from tags
 	userInfo := n.extractUserInfo(raw)
 

--- a/services/message-processor/normalizer/youtube_normalizer_test.go
+++ b/services/message-processor/normalizer/youtube_normalizer_test.go
@@ -54,6 +54,24 @@ func TestYouTubeNormalizer_Normalize_BasicMessage(t *testing.T) {
 	assert.Empty(t, unified.Message.Emotes) // No native YouTube emotes
 }
 
+func TestYouTubeNormalizer_Normalize_InvalidChannelID(t *testing.T) {
+	normalizer := NewYouTubeNormalizer()
+
+	raw := &models.RawChatMessage{
+		MessageID: "msg-123",
+		Platform:  "youtube",
+		ChannelID: "../evil",
+		UserID:    "UCyyyyyy",
+		Username:  "TestUser",
+		Text:      "Hello world!",
+		Timestamp: time.Now(),
+		Tags:      map[string]string{},
+	}
+
+	_, err := normalizer.Normalize(raw, "overlay-456")
+	assert.Error(t, err)
+}
+
 func TestYouTubeNormalizer_Normalize_WrongPlatform(t *testing.T) {
 	normalizer := NewYouTubeNormalizer()
 
@@ -98,7 +116,7 @@ func TestYouTubeNormalizer_ExtractBadges_Owner(t *testing.T) {
 	unified, err := normalizer.Normalize(raw, "overlay-456")
 
 	assert.NoError(t, err)
-	assert.Contains(t, unified.User.Badges, "owner")
+	assertBadgePresent(t, unified.User.Badges, "owner")
 	assert.True(t, unified.Metadata["is_owner"].(bool))
 }
 
@@ -125,7 +143,7 @@ func TestYouTubeNormalizer_ExtractBadges_Member(t *testing.T) {
 	unified, err := normalizer.Normalize(raw, "overlay-456")
 
 	assert.NoError(t, err)
-	assert.Contains(t, unified.User.Badges, "member")
+	assertBadgePresent(t, unified.User.Badges, "member")
 	assert.True(t, unified.Metadata["is_sponsor"].(bool))
 }
 
@@ -152,7 +170,7 @@ func TestYouTubeNormalizer_ExtractBadges_Moderator(t *testing.T) {
 	unified, err := normalizer.Normalize(raw, "overlay-456")
 
 	assert.NoError(t, err)
-	assert.Contains(t, unified.User.Badges, "moderator")
+	assertBadgePresent(t, unified.User.Badges, "moderator")
 	assert.True(t, unified.Metadata["is_moderator"].(bool))
 }
 
@@ -179,7 +197,7 @@ func TestYouTubeNormalizer_ExtractBadges_Verified(t *testing.T) {
 	unified, err := normalizer.Normalize(raw, "overlay-456")
 
 	assert.NoError(t, err)
-	assert.Contains(t, unified.User.Badges, "verified")
+	assertBadgePresent(t, unified.User.Badges, "verified")
 	assert.True(t, unified.Metadata["is_verified"].(bool))
 }
 
@@ -206,9 +224,9 @@ func TestYouTubeNormalizer_ExtractBadges_MultipleBadges(t *testing.T) {
 	unified, err := normalizer.Normalize(raw, "overlay-456")
 
 	assert.NoError(t, err)
-	assert.Contains(t, unified.User.Badges, "member")
-	assert.Contains(t, unified.User.Badges, "moderator")
-	assert.Contains(t, unified.User.Badges, "verified")
+	assertBadgePresent(t, unified.User.Badges, "member")
+	assertBadgePresent(t, unified.User.Badges, "moderator")
+	assertBadgePresent(t, unified.User.Badges, "verified")
 	assert.Len(t, unified.User.Badges, 3)
 }
 


### PR DESCRIPTION
## Summary
- escape emote service paths using url.JoinPath and add regression tests for malicious channel IDs
- validate channel IDs across all message normalizers with a shared helper and unit tests
- update existing normalizer tests to exercise the new validation rules

## Testing
- go test ./enricher ./normalizer

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918c73769e08323a43fe4728323bd02)