### PR TITLE
Require JWT secret and lock down WebSocket origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ APP_VERSION=0.1.0
 
 # CORS (Frontend URL)
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
+
+# WebSocket Overlay Security
+# Comma-separated list; leave blank or use "*" to allow all origins
+WEBSOCKET_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080

--- a/docs/architecture/DEPLOYMENT_KUBERNETES.md
+++ b/docs/architecture/DEPLOYMENT_KUBERNETES.md
@@ -271,6 +271,11 @@ spec:
               value: "http://overlay-service:8082"
             - name: EMOTE_SERVICE_URL
               value: "http://emote-service:8083"
+            - name: WEBSOCKET_ALLOWED_ORIGINS
+              valueFrom:
+                configMapKeyRef:
+                  name: all-chat-config
+                  key: websocket_allowed_origins
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -807,7 +812,14 @@ data:
 
   # Logging
   log_level: "info"
+
+  # WebSocket Overlay Security
+  websocket_allowed_origins: "https://app.allchat.io,https://studio.allchat.io"
 ```
+
+> **API Gateway runtime knobs**
+> - `JWT_SECRET` (stored in `all-chat-secrets.jwt_secret`) is now mandatory. The gateway refuses to start if it is missing or empty, ensuring all proxied routes and WebSocket auth reuse the same verified signing key.
+> - `WEBSOCKET_ALLOWED_ORIGINS` (stored in `all-chat-config.websocket_allowed_origins`) defines the comma-separated allowlist for WebSocket upgrades. Use `*` or leave it blank only in trusted dev environments; production clusters should enumerate the exact frontend domains.
 
 ### Secret: `all-chat-secrets`
 

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -113,9 +114,9 @@ func main() {
 	subRepo := subscription.NewRepository(db)
 
 	// Get JWT secret from environment
-	jwtSecret := os.Getenv("JWT_SECRET")
+	jwtSecret := strings.TrimSpace(os.Getenv("JWT_SECRET"))
 	if jwtSecret == "" {
-		log.Warn("JWT_SECRET not set, auth middleware will fail")
+		log.Fatal("JWT_SECRET environment variable is required")
 	}
 
 	// Create handlers

--- a/services/api-gateway/handlers/websocket.go
+++ b/services/api-gateway/handlers/websocket.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/caesar/all-chat/services/api-gateway/models"
@@ -14,23 +16,16 @@ import (
 	"go.uber.org/zap"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		// Allow all origins in development
-		// TODO: Configure allowed origins for production
-		return true
-	},
-}
-
 // WebSocketHandler handles WebSocket connections for overlays
 type WebSocketHandler struct {
-	wsManager  *wsconn.Manager
-	subscriber *subscription.Subscriber
-	repo       *subscription.Repository
-	jwtSecret  string
-	logger     *zap.Logger
+	wsManager       *wsconn.Manager
+	subscriber      *subscription.Subscriber
+	repo            *subscription.Repository
+	jwtSecret       string
+	logger          *zap.Logger
+	upgrader        websocket.Upgrader
+	allowAllOrigins bool
+	allowedOrigins  map[string]struct{}
 }
 
 // NewWebSocketHandler creates a new WebSocket handler
@@ -41,13 +36,32 @@ func NewWebSocketHandler(
 	jwtSecret string,
 	logger *zap.Logger,
 ) *WebSocketHandler {
-	return &WebSocketHandler{
-		wsManager:  wsManager,
-		subscriber: subscriber,
-		repo:       repo,
-		jwtSecret:  jwtSecret,
-		logger:     logger,
+	allowedOrigins, allowAll := loadAllowedOrigins()
+	h := &WebSocketHandler{
+		wsManager:       wsManager,
+		subscriber:      subscriber,
+		repo:            repo,
+		jwtSecret:       jwtSecret,
+		logger:          logger,
+		allowedOrigins:  allowedOrigins,
+		allowAllOrigins: allowAll,
 	}
+
+	h.upgrader = websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     h.checkOrigin,
+	}
+
+	if h.allowAllOrigins {
+		logger.Info("WebSocket origin allowlist disabled; allowing all origins")
+	} else {
+		logger.Info("Configured WebSocket origin allowlist",
+			zap.Int("count", len(h.allowedOrigins)),
+		)
+	}
+
+	return h
 }
 
 // HandleOverlayConnection handles WebSocket connection requests for overlays
@@ -116,7 +130,7 @@ func (h *WebSocketHandler) HandleOverlayConnection(c *gin.Context) {
 	}
 
 	// Upgrade HTTP connection to WebSocket
-	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		h.logger.Error("Failed to upgrade WebSocket",
 			zap.String("overlay_id", overlayID),
@@ -180,4 +194,51 @@ func (h *WebSocketHandler) HandleOverlayConnection(c *gin.Context) {
 
 	// Return immediately - don't block the HTTP handler
 	// The WebSocket connection will continue in the background
+}
+
+func loadAllowedOrigins() (map[string]struct{}, bool) {
+	value := strings.TrimSpace(os.Getenv("WEBSOCKET_ALLOWED_ORIGINS"))
+	if value == "" {
+		return nil, true
+	}
+
+	allowed := make(map[string]struct{})
+	allowAll := false
+	for _, origin := range strings.Split(value, ",") {
+		origin = strings.TrimSpace(origin)
+		if origin == "" {
+			continue
+		}
+		if origin == "*" {
+			allowAll = true
+			continue
+		}
+		allowed[origin] = struct{}{}
+	}
+
+	if allowAll {
+		return nil, true
+	}
+
+	return allowed, false
+}
+
+func (h *WebSocketHandler) checkOrigin(r *http.Request) bool {
+	if h.allowAllOrigins {
+		return true
+	}
+
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	if _, ok := h.allowedOrigins[origin]; ok {
+		return true
+	}
+
+	h.logger.Warn("Blocked WebSocket connection from disallowed origin",
+		zap.String("origin", origin),
+	)
+	return false
 }

--- a/services/api-gateway/middleware/auth.go
+++ b/services/api-gateway/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"os"
 	"strings"
 
 	"github.com/caesar/all-chat/shared/auth"
@@ -9,12 +8,8 @@ import (
 )
 
 // JWTAuth returns a middleware that validates JWT tokens
-func JWTAuth(jwtSecret string) gin.HandlerFunc {
-	// If no secret is provided, try to get it from environment
-	if jwtSecret == "" {
-		jwtSecret = os.Getenv("JWT_SECRET")
-	}
 
+func JWTAuth(jwtSecret string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract token from Authorization header
 		authHeader := c.GetHeader("Authorization")


### PR DESCRIPTION
## Summary
- fail API Gateway startup if `JWT_SECRET` is missing and remove any implicit fallbacks so the validated key is consistently propagated to middleware and WebSocket handlers
- add a configurable WebSocket origin allowlist that is sourced from `WEBSOCKET_ALLOWED_ORIGINS`, enforce it via the upgrader’s `CheckOrigin`, and document the new knob alongside `.env.example`
- update the Kubernetes deployment guide/configmap so operators know how to provide both the JWT secret and the origin allowlist

## Testing
- `go test ./...` *(fails in this environment because module downloads through the corporate proxy are blocked)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918c70685a48323bb4e6e53bf46ea15)