### PR TITLE
Update TikTok platform status to beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Configure in the dashboard:
 | **Twitch** | ✅ Working | Chat, emotes (Twitch/7TV/BTTV/FFZ), badges, colors |
 | **YouTube** | 🧪 Beta | Chat, Super Chat, member badges (closed beta) |
 | **Kick** | ✅ Working | Chat, emotes, badges via Pusher WebSocket |
-| **TikTok** | 🚧 Development | OAuth complete, listener in development (closed beta) |
+| **TikTok** | 🧪 Beta | Unofficial listener via TikTok-Live-Connector; username-based with limited metadata (see [service README](services/tiktok-listener/README.md)) |
 
 ## 🏗️ Architecture
 


### PR DESCRIPTION
## Summary
- mark TikTok platform support as beta with caveated listener details
- link to the TikTok listener service README for capabilities and limitations

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69490229366c8323acfe387def12abe2)