### PR TITLE
feat(security): WebSocket message-based auth for viewers

### DIFF
--- a/services/api-gateway/handlers/websocket_viewer.go
+++ b/services/api-gateway/handlers/websocket_viewer.go
@@ -135,6 +135,20 @@ func (h *ViewerWebSocketHandler) HandleViewerChatConnection(c *gin.Context) {
 	// Viewer connections will have overlay_id stripped from all messages
 	wsConn := wsconn.NewViewerConnection(conn, overlayID, viewerID, h.replayBuffer, h.logger)
 
+	// Allow viewers to authenticate via WebSocket message (preferred over URL token)
+	wsConn.SetOnAuth(func(token string) (string, string, bool) {
+		claims, err := auth.ValidateViewerJWT(token, h.jwtSecret)
+		if err != nil || !claims.IsViewer {
+			return "", "", false
+		}
+		return claims.SessionID, claims.Username, true
+	})
+
+	// If already authenticated via URL param, mark connection as authenticated
+	if isAuthenticated {
+		// Backwards compatibility: URL token still works
+	}
+
 	// Subscribe to overlay's Redis Pub/Sub channel WITHOUT publishing connection event
 	// This is critical: viewers should NOT trigger YouTube polling
 	if err := h.subscriber.SubscribeViewerOnly(context.Background(), overlayID); err != nil {

--- a/services/api-gateway/websocket/connection.go
+++ b/services/api-gateway/websocket/connection.go
@@ -26,17 +26,23 @@ const (
 	MaxMessageSize = 512 * 1024 // 512 KB
 )
 
+// AuthCallback is called when a viewer authenticates via WebSocket message.
+// Returns true if the token is valid.
+type AuthCallback func(token string) (viewerID, username string, ok bool)
+
 // Connection wraps a WebSocket connection for an overlay
 type Connection struct {
-	conn         *websocket.Conn
-	overlayID    string
-	userID       string
-	send         chan []byte
-	replayBuffer replay.DeletionReplayBuffer
-	logger       *zap.Logger
-	mu           sync.Mutex
-	closed       bool
-	isViewer     bool // True for viewer connections (extension, public viewers)
+	conn            *websocket.Conn
+	overlayID       string
+	userID          string
+	send            chan []byte
+	replayBuffer    replay.DeletionReplayBuffer
+	logger          *zap.Logger
+	mu              sync.Mutex
+	closed          bool
+	isViewer        bool // True for viewer connections (extension, public viewers)
+	authenticated   bool
+	onAuth          AuthCallback
 }
 
 // NewConnection creates a new WebSocket connection for overlay owners
@@ -224,6 +230,9 @@ func (c *Connection) handleMessage(data []byte) {
 	case "replay_request":
 		c.handleReplayRequest(msg.Data)
 
+	case "auth":
+		c.handleAuth(msg.Data)
+
 	default:
 		c.logger.Debug("Unhandled message type",
 			zap.String("overlay_id", c.overlayID),
@@ -289,6 +298,64 @@ func (c *Connection) handleReplayRequest(data interface{}) {
 		zap.Int("count", len(deletions)),
 		zap.Int64("since", request.Since),
 	)
+}
+
+// SetOnAuth sets the callback invoked when a viewer sends an auth message.
+func (c *Connection) SetOnAuth(cb AuthCallback) {
+	c.onAuth = cb
+}
+
+// handleAuth processes an incoming auth message from the client.
+func (c *Connection) handleAuth(data interface{}) {
+	if c.authenticated {
+		c.logger.Debug("Already authenticated, ignoring auth message",
+			zap.String("overlay_id", c.overlayID))
+		return
+	}
+
+	if c.onAuth == nil {
+		c.logger.Warn("Auth message received but no auth callback configured")
+		return
+	}
+
+	var req struct {
+		Token string `json:"token"`
+	}
+	raw, _ := json.Marshal(data)
+	if err := json.Unmarshal(raw, &req); err != nil || req.Token == "" {
+		resp := models.WSMessage{Type: "auth_error", Data: map[string]string{"error": "invalid auth payload"}, Timestamp: time.Now().UTC()}
+		b, _ := json.Marshal(resp)
+		c.Send(b)
+		return
+	}
+
+	viewerID, username, ok := c.onAuth(req.Token)
+	if !ok {
+		resp := models.WSMessage{Type: "auth_error", Data: map[string]string{"error": "invalid or expired token"}, Timestamp: time.Now().UTC()}
+		b, _ := json.Marshal(resp)
+		c.Send(b)
+		return
+	}
+
+	c.mu.Lock()
+	c.authenticated = true
+	c.userID = viewerID
+	c.mu.Unlock()
+
+	resp := models.WSMessage{Type: "auth_success", Data: map[string]string{"viewer_id": viewerID, "username": username}, Timestamp: time.Now().UTC()}
+	b, _ := json.Marshal(resp)
+	c.Send(b)
+
+	c.logger.Info("Viewer authenticated via WebSocket message",
+		zap.String("overlay_id", c.overlayID),
+		zap.String("viewer", username))
+}
+
+// IsAuthenticated returns whether this connection has been authenticated.
+func (c *Connection) IsAuthenticated() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.authenticated
 }
 
 // OverlayID returns the overlay ID for this connection


### PR DESCRIPTION
## Summary

Move viewer WebSocket authentication from URL query parameter to first WebSocket message. Tokens in URLs are visible in browser history, proxy logs, and DevTools.

- Server accepts `{"type": "auth", "data": {"token": "..."}}` as first message
- Responds with `auth_success` or `auth_error`
- URL `?token=` still works for backwards compatibility with older extension versions

Companion: caesarakalaeii/all-chat-extension (sends auth as first message)

## Test plan

- [ ] Extension connects and authenticates via message
- [ ] Anonymous viewers can still connect without auth
- [ ] Old extension versions with URL token still work