### PR TITLE
feat(security): OAuth auth code exchange for viewers

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -386,6 +386,9 @@ func main() {
 		publicAPI.GET("/auth/viewer/kick/callback", proxyHandler.ForwardRequest)
 		publicAPI.POST("/auth/viewer/kick/exchange", proxyHandler.ForwardRequest)
 
+		// Auth code exchange (viewer trades code for JWT)
+		publicAPI.POST("/auth/viewer/token/exchange", proxyHandler.ForwardRequest)
+
 		// Streamer info (public)
 		publicAPI.GET("/auth/streamers/:username", proxyHandler.ForwardRequest)
 

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -319,6 +319,9 @@ func main() {
 	router.GET("/viewer/kick/callback", viewerAuthHandler.HandleKickCallback)
 	router.POST("/viewer/kick/exchange", viewerAuthHandler.HandleKickExchange)
 
+	// Auth code exchange (viewer trades short-lived code for JWT)
+	router.POST("/viewer/token/exchange", viewerAuthHandler.HandleTokenExchange)
+
 	// Public streamer info routes
 	router.GET("/streamers/:username", streamerInfoHandler.HandleGetStreamerInfo)
 

--- a/services/auth-service/handlers/viewer_auth.go
+++ b/services/auth-service/handlers/viewer_auth.go
@@ -91,6 +91,44 @@ func (h *ViewerAuthHandler) WithMetrics(m *metrics.BusinessMetrics) *ViewerAuthH
 	return h
 }
 
+const authCodeTTL = 60 * time.Second
+
+// storeAuthCode saves a JWT under a random code in Redis and returns the code.
+func (h *ViewerAuthHandler) storeAuthCode(ctx context.Context, jwtToken string) (string, error) {
+	code := uuid.New().String()
+	key := "auth_code:" + code
+	if err := h.redis.Set(ctx, key, jwtToken, authCodeTTL).Err(); err != nil {
+		return "", err
+	}
+	return code, nil
+}
+
+// HandleTokenExchange swaps a short-lived auth code for the JWT token.
+// POST /viewer/token/exchange { "code": "..." }
+func (h *ViewerAuthHandler) HandleTokenExchange(c *gin.Context) {
+	var req struct {
+		Code string `json:"code" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "code is required"})
+		return
+	}
+
+	key := "auth_code:" + req.Code
+	token, err := h.redis.GetDel(c.Request.Context(), key).Result()
+	if err == redis.Nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired code"})
+		return
+	}
+	if err != nil {
+		h.logger.Error("Failed to retrieve auth code", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"token": token})
+}
+
 // findLinkedStreamer returns the streamer (dashboard user) that shares the given platform identity,
 // or nil if no such account exists or the lookup fails.
 func (h *ViewerAuthHandler) findLinkedStreamer(ctx context.Context, platform, platformUserID string) *models.User {
@@ -280,8 +318,16 @@ func (h *ViewerAuthHandler) HandleTwitchCallback(c *gin.Context) {
 		return
 	}
 
-	// Redirect to frontend with JWT token and optional context
-	redirectURL := fmt.Sprintf("%s/chat/auth-success?token=%s", h.frontendURL, jwtToken)
+	// Store JWT under a short-lived auth code and redirect with the code
+	
+	authCode, err := h.storeAuthCode(c.Request.Context(), jwtToken)
+	if err != nil {
+		h.logger.Error("Failed to store auth code", zap.Error(err))
+		h.redirectToFrontendWithError(c, "Failed to generate auth code")
+		return
+	}
+
+	redirectURL := fmt.Sprintf("%s/chat/auth-success?code=%s", h.frontendURL, authCode)
 	if streamer, ok := stateData["streamer"]; ok && streamer != "" {
 		redirectURL += fmt.Sprintf("&streamer=%s", streamer)
 	}
@@ -676,7 +722,15 @@ func (h *ViewerAuthHandler) HandleYouTubeCallback(c *gin.Context) {
 		return
 	}
 
-	redirectURL := fmt.Sprintf("%s/chat/auth-success?token=%s", h.frontendURL, jwtToken)
+	
+	authCode, err := h.storeAuthCode(c.Request.Context(), jwtToken)
+	if err != nil {
+		h.logger.Error("Failed to store auth code", zap.Error(err))
+		h.redirectToFrontendWithError(c, "Failed to generate auth code")
+		return
+	}
+
+	redirectURL := fmt.Sprintf("%s/chat/auth-success?code=%s", h.frontendURL, authCode)
 	if streamer, ok := storedState["streamer"]; ok {
 		redirectURL += fmt.Sprintf("&streamer=%s", streamer)
 	}
@@ -879,8 +933,16 @@ func (h *ViewerAuthHandler) HandleKickCallback(c *gin.Context) {
 		return
 	}
 
-	// Redirect to frontend
-	redirectURL := fmt.Sprintf("%s/chat/auth-success?token=%s", h.frontendURL, jwtToken)
+	// Store JWT under short-lived code and redirect
+	
+	authCode, err := h.storeAuthCode(c.Request.Context(), jwtToken)
+	if err != nil {
+		h.logger.Error("Failed to store auth code", zap.Error(err))
+		h.redirectToFrontendWithError(c, "Failed to generate auth code")
+		return
+	}
+
+	redirectURL := fmt.Sprintf("%s/chat/auth-success?code=%s", h.frontendURL, authCode)
 	if streamer, ok := storedState["streamer"]; ok {
 		redirectURL += fmt.Sprintf("&streamer=%s", streamer)
 	}


### PR DESCRIPTION
## Summary

Replace JWT tokens in OAuth redirect URLs with short-lived auth codes. The extension exchanges the code for a token via POST, preventing token exposure in browser history and logs.

- Codes stored in Redis with 60s TTL, consumed on first use (GetDel)
- All three viewer OAuth flows updated (Twitch, YouTube, Kick)

Companion: caesarakalaeii/all-chat-extension (exchanges code for token)

## Test plan

- [ ] Twitch viewer login returns code in URL, extension exchanges it
- [ ] YouTube viewer login works
- [ ] Kick viewer login works
- [ ] Code expires after 60s
- [ ] Code can only be used once