### PR TITLE
fix: persist ElevenLabs TTS voice changes after key is saved (#276)

### DIFF
--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -1140,6 +1140,11 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   ttsSettingsRef.current = ttsSettings
   const [hasElevenLabsConfig, setHasElevenLabsConfig] = useState(false)
   const [obsUrl, setObsUrl] = useState<string | undefined>(undefined)
+  // Persisted ElevenLabs voice_id (Issue #276). Lives outside display_settings
+  // because the voice_id column is on overlay_tts_configs, not the overlay
+  // configs blob. Drives TTSGroup's picker initial value and the visibility of
+  // the "Save voice" button.
+  const [elevenLabsVoiceId, setElevenLabsVoiceId] = useState<string | undefined>(undefined)
 
   // --- OBS URL copy state ---
   const [copiedObs, setCopiedObs] = useState(false)
@@ -1277,12 +1282,22 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     const meta = await overlaysApi.getTTSConfig(id)
     setHasElevenLabsConfig(meta.has_elevenlabs_config)
     setObsUrl(meta.obs_url)
+    setElevenLabsVoiceId(meta.voice_id)
+  }, [id])
+
+  // Issue #276 — voice-only update path. Persists to PATCH /tts-config/voice
+  // and refreshes local state so the picker no longer shows the "Save voice"
+  // button (pickedVoiceId === savedVoiceId).
+  const handleSaveTTSVoice = useCallback(async (voiceId: string): Promise<void> => {
+    await overlaysApi.saveTTSVoice(id, voiceId)
+    setElevenLabsVoiceId(voiceId)
   }, [id])
 
   const handleRemoveTTSKey = useCallback(async (): Promise<void> => {
     await overlaysApi.removeTTSKey(id)
     setHasElevenLabsConfig(false)
     setObsUrl(undefined)
+    setElevenLabsVoiceId(undefined)
   }, [id])
 
   const handleRotateTTSToken = useCallback(async (): Promise<{ obsUrl: string }> => {
@@ -1552,6 +1567,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
             if (!cancelled) {
               setHasElevenLabsConfig(meta.has_elevenlabs_config)
               setObsUrl(meta.obs_url)
+              setElevenLabsVoiceId(meta.voice_id)
             }
           } catch (e) {
             console.warn('[OverlayEditor] getTTSConfig failed:', e)
@@ -2265,6 +2281,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                     }
                   }}
                   onSaveTTSKey={handleSaveTTSKey}
+                  onSaveTTSVoice={handleSaveTTSVoice}
+                  savedTTSVoiceId={elevenLabsVoiceId}
                   onTestTTSKey={handleTestTTSKey}
                   onRotateTTSToken={handleRotateTTSToken}
                   onRemoveTTSKey={handleRemoveTTSKey}

--- a/frontend/src/components/appearance/AppearancePanel.tsx
+++ b/frontend/src/components/appearance/AppearancePanel.tsx
@@ -53,6 +53,11 @@ export interface AppearancePanelProps {
   onTTSPreview?: () => void
   onTTSPreviewStop?: () => void
   onSaveTTSKey?: (key: string, voiceId: string) => Promise<void>
+  // Issue #276 — voice-only PATCH after a key is already saved.
+  onSaveTTSVoice?: (voiceId: string) => Promise<void>
+  // Issue #276 — persisted voice_id from GET /tts-config; drives picker initial
+  // value and "Save voice" button visibility.
+  savedTTSVoiceId?: string
   onTestTTSKey?: () => Promise<TestKeyResult>
   onRotateTTSToken?: () => Promise<{ obsUrl: string }>
   onRemoveTTSKey?: () => Promise<void>
@@ -76,6 +81,8 @@ export function AppearancePanel({
   onTTSPreview,
   onTTSPreviewStop,
   onSaveTTSKey,
+  onSaveTTSVoice,
+  savedTTSVoiceId,
   onTestTTSKey,
   onRotateTTSToken,
   onRemoveTTSKey,
@@ -135,6 +142,8 @@ export function AppearancePanel({
             onPreview={onTTSPreview}
             onPreviewStop={onTTSPreviewStop}
             onSaveKey={onSaveTTSKey}
+            onSaveVoice={onSaveTTSVoice}
+            savedVoiceId={savedTTSVoiceId}
             onTestKey={onTestTTSKey}
             onRotateToken={onRotateTTSToken}
             onRemoveKey={onRemoveTTSKey}

--- a/frontend/src/components/appearance/TTSGroup.tsx
+++ b/frontend/src/components/appearance/TTSGroup.tsx
@@ -60,10 +60,17 @@ export interface TTSGroupProps {
   overlayId: string
   hasElevenLabsConfig: boolean
   obsUrl?: string
+  // Persisted voice_id for the overlay, read from the GET /tts-config response
+  // (Issue #276). Used to initialise the picker so the saved selection is
+  // shown on load, and to drive the "Save voice" button visibility.
+  savedVoiceId?: string
   onPreview?: () => void
   onPreviewStop?: () => void
   // ElevenLabs async callbacks — Plan 03 wires these in the editor page.
   onSaveKey?: (key: string, voiceId: string) => Promise<void>
+  // Voice-only PATCH used after a key is saved (Issue #276) — switches voice
+  // without re-submitting the api_key (which the UI doesn't have anymore).
+  onSaveVoice?: (voiceId: string) => Promise<void>
   onTestKey?: () => Promise<TestKeyResult>
   onRotateToken?: () => Promise<{ obsUrl: string }>
   onRemoveKey?: () => Promise<void>
@@ -638,10 +645,27 @@ export function TTSGroup(props: TTSGroupProps): React.ReactElement {
   // Advanced block — ElevenLabs voice selection state. Held locally because
   // the chosen voice is sent with the Save-key call, NOT persisted to
   // display_settings (ElevenLabs voice_id lives in overlay_tts_configs).
-  const [pickedVoiceId, setPickedVoiceId] = useState('')
+  // Initialised from savedVoiceId (Issue #276) so the persisted selection is
+  // shown on load instead of the auto-pick-first-voice fallback.
+  const [pickedVoiceId, setPickedVoiceId] = useState<string>(() => props.savedVoiceId ?? '')
   // Lifted out of ApiKeyInput so the voice picker can react to the typed
   // (unsaved) key in real time and call the preview endpoint.
   const [advancedApiKey, setAdvancedApiKey] = useState('')
+  // Saving state for the voice-only PATCH (Issue #276).
+  const [savingVoice, setSavingVoice] = useState(false)
+
+  // Sync the picker when the parent provides a fresh savedVoiceId — for
+  // example, after the very first key save resolves and the page reads back
+  // meta.voice_id from getTTSConfig.
+  useEffect(() => {
+    if (props.savedVoiceId && pickedVoiceId === '') {
+      setPickedVoiceId(props.savedVoiceId)
+    }
+    // Intentionally only react to savedVoiceId changes; pickedVoiceId is the
+    // user's live selection and must not be clobbered after they pick a new
+    // voice but before they save it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.savedVoiceId])
 
   function handlePlatformToggle(platform: string): void {
     const current = d.tts_enabled_platforms ?? [...ALL_PLATFORMS]
@@ -693,6 +717,37 @@ export function TTSGroup(props: TTSGroupProps): React.ReactElement {
           typedApiKey={advancedApiKey}
           disabled={!isPremium}
         />
+        {/* Save voice (Issue #276) — visible only when the user has changed
+            the picker after a key is already saved. The pre-save flow uses the
+            "Save key" button inside ApiKeyInput, which carries voice_id. */}
+        {props.hasElevenLabsConfig &&
+          props.onSaveVoice &&
+          pickedVoiceId !== '' &&
+          pickedVoiceId !== (props.savedVoiceId ?? '') && (
+            <button
+              type="button"
+              disabled={!isPremium || savingVoice}
+              onClick={() => {
+                if (!props.onSaveVoice) return
+                setSavingVoice(true)
+                void (async (): Promise<void> => {
+                  try {
+                    await props.onSaveVoice!(pickedVoiceId)
+                    toast.success('Voice updated.')
+                  } catch (e) {
+                    toast.error(
+                      `Could not save voice: ${e instanceof Error ? e.message : 'network error'}`,
+                    )
+                  } finally {
+                    setSavingVoice(false)
+                  }
+                })()
+              }}
+              className="rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text hover:bg-surface-alt disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {savingVoice ? 'Saving voice…' : 'Save voice'}
+            </button>
+          )}
         {props.hasElevenLabsConfig && props.obsUrl && (
           <ObsUrlPanel
             obsUrl={props.obsUrl}

--- a/frontend/src/components/appearance/__tests__/TTSGroup.test.tsx
+++ b/frontend/src/components/appearance/__tests__/TTSGroup.test.tsx
@@ -861,6 +861,102 @@ describe('TTSGroup', () => {
     expect(onSaveKey).toHaveBeenCalledWith('sk-typed-key', 'v-first')
   })
 
+  // ---- Issue #276: Save-voice flow when key is already saved ----------------
+
+  // The bug: once a key is saved, ApiKeyInput hides "Save key", and changing
+  // the voice picker silently does nothing. These tests pin the new
+  // `onSaveVoice` prop and the picker initial value driven by `savedVoiceId`.
+
+  it('276-1: pickedVoiceId initialises from savedVoiceId so the saved selection is shown on load', async () => {
+    const voices: ElevenLabsVoice[] = [
+      { voice_id: 'v-saved', name: 'Saved Voice' },
+      { voice_id: 'v-other', name: 'Other Voice' },
+    ]
+    const onFetchVoices = vi.fn().mockResolvedValue(voices)
+    renderTTSGroup({
+      displaySettings: baseSettings({ tts_provider: 'elevenlabs' }),
+      isPremium: true,
+      hasElevenLabsConfig: true,
+      savedVoiceId: 'v-saved',
+      onFetchVoices,
+    })
+    const select = await waitForVoiceOption('Saved Voice')
+    expect(select.value).toBe('v-saved')
+  })
+
+  it('276-2: Save voice button is HIDDEN when the picker matches savedVoiceId', async () => {
+    const voices: ElevenLabsVoice[] = [
+      { voice_id: 'v-saved', name: 'Saved Voice' },
+      { voice_id: 'v-other', name: 'Other Voice' },
+    ]
+    const onFetchVoices = vi.fn().mockResolvedValue(voices)
+    renderTTSGroup({
+      displaySettings: baseSettings({ tts_provider: 'elevenlabs' }),
+      isPremium: true,
+      hasElevenLabsConfig: true,
+      savedVoiceId: 'v-saved',
+      onFetchVoices,
+      onSaveVoice: vi.fn(),
+    })
+    await waitForVoiceOption('Saved Voice')
+    expect(screen.queryByRole('button', { name: /^Save voice/ })).toBeNull()
+  })
+
+  it('276-3: Save voice button appears after the picker changes and fires onSaveVoice with the new id', async () => {
+    const voices: ElevenLabsVoice[] = [
+      { voice_id: 'v-saved', name: 'Saved Voice' },
+      { voice_id: 'v-other', name: 'Other Voice' },
+    ]
+    const onFetchVoices = vi.fn().mockResolvedValue(voices)
+    const onSaveVoice = vi.fn().mockResolvedValue(undefined)
+    renderTTSGroup({
+      displaySettings: baseSettings({ tts_provider: 'elevenlabs' }),
+      isPremium: true,
+      hasElevenLabsConfig: true,
+      savedVoiceId: 'v-saved',
+      onFetchVoices,
+      onSaveVoice,
+    })
+    const select = await waitForVoiceOption('Other Voice')
+
+    // Switch to the other voice — Save voice should appear.
+    fireEvent.change(select, { target: { value: 'v-other' } })
+    const saveBtn = await screen.findByRole('button', { name: /^Save voice$/ })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+    expect(onSaveVoice).toHaveBeenCalledWith('v-other')
+    await waitFor(() => {
+      expect(toastMocks.success).toHaveBeenCalledWith('Voice updated.')
+    })
+  })
+
+  it('276-4: Save voice toasts the error when onSaveVoice rejects', async () => {
+    const voices: ElevenLabsVoice[] = [
+      { voice_id: 'v-saved', name: 'Saved Voice' },
+      { voice_id: 'v-other', name: 'Other Voice' },
+    ]
+    const onFetchVoices = vi.fn().mockResolvedValue(voices)
+    const onSaveVoice = vi.fn().mockRejectedValue(new Error('boom'))
+    renderTTSGroup({
+      displaySettings: baseSettings({ tts_provider: 'elevenlabs' }),
+      isPremium: true,
+      hasElevenLabsConfig: true,
+      savedVoiceId: 'v-saved',
+      onFetchVoices,
+      onSaveVoice,
+    })
+    const select = await waitForVoiceOption('Other Voice')
+    fireEvent.change(select, { target: { value: 'v-other' } })
+    const saveBtn = await screen.findByRole('button', { name: /^Save voice$/ })
+    await act(async () => {
+      fireEvent.click(saveBtn)
+    })
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith(expect.stringContaining('boom'))
+    })
+  })
+
   // Test A20: Non-premium user sees disabled inputs + PremiumBadge overlay + upgrade copy
   it('A20: non-premium user sees upgrade copy and disabled API-key input under the Advanced block', () => {
     renderTTSGroup({

--- a/frontend/src/lib/api/overlays.ts
+++ b/frontend/src/lib/api/overlays.ts
@@ -214,6 +214,19 @@ export const overlaysApi = {
   },
 
   /**
+   * Update only the saved ElevenLabs voice for the overlay (Issue #276).
+   * Backend: PATCH /api/v1/overlays/:id/tts-config/voice (RequirePremium("tts")).
+   * The encrypted_api_key and tts_signing_secret are left untouched — used by
+   * the picker once a key is already saved (no "Save key" button is shown then).
+   */
+  async saveTTSVoice(overlayId: string, voiceId: string): Promise<void> {
+    await apiClient.patch<{ status: string; voice_id: string }>(
+      `/api/v1/overlays/${overlayId}/tts-config/voice`,
+      { voice_id: voiceId },
+    )
+  },
+
+  /**
    * Remove the saved ElevenLabs key/voice + signing secret for the overlay.
    * Backend: DELETE /api/v1/overlays/:id/tts-config.
    */

--- a/services/overlay-manager/cmd/main.go
+++ b/services/overlay-manager/cmd/main.go
@@ -296,6 +296,7 @@ func main() {
 		ttsPremium.Use(middleware.RequirePremium(dbPool, gateCache, "tts", log))
 		{
 			ttsPremium.POST("/:id/tts-config", ttsHandler.HandleSaveTTSConfig)
+			ttsPremium.PATCH("/:id/tts-config/voice", ttsHandler.HandleSaveVoice)
 			ttsPremium.DELETE("/:id/tts-config", ttsHandler.HandleDeleteTTSConfig)
 			ttsPremium.POST("/:id/tts-config/rotate-token", ttsHandler.HandleRotateToken)
 			ttsPremium.GET("/:id/tts-voices", ttsHandler.HandleGetVoices)

--- a/services/overlay-manager/handlers/tts.go
+++ b/services/overlay-manager/handlers/tts.go
@@ -72,6 +72,7 @@ const (
 type ttsConfigStore interface {
 	GetByOverlayID(ctx context.Context, overlayID string) (*models.TTSConfig, error)
 	CreateOrUpdate(ctx context.Context, overlayID string, encryptedKey []byte, voiceID string) (*models.TTSConfig, error)
+	UpdateVoiceID(ctx context.Context, overlayID string, voiceID string) error
 	Delete(ctx context.Context, overlayID string) error
 	RotateSigningSecret(ctx context.Context, overlayID string) ([]byte, error)
 }
@@ -287,6 +288,48 @@ func (h *TTSHandler) HandleSaveTTSConfig(c *gin.Context) {
 
 	h.logger.Info("tts config saved", zap.String("overlay_id", overlayID))
 	c.JSON(http.StatusOK, gin.H{"status": "saved"})
+}
+
+// ---- HandleSaveVoice (Issue #276) ------------------------------------------
+
+// HandleSaveVoice handles PATCH /:id/tts-config/voice. Body {voice_id}.
+// Updates only the voice_id column without touching the encrypted_api_key or
+// tts_signing_secret. Lets users switch voices after the key is already
+// saved (where POST /:id/tts-config requires the api_key in the body and
+// the UI hides the "Save key" button once a key exists).
+func (h *TTSHandler) HandleSaveVoice(c *gin.Context) {
+	_, overlayID, ok := h.checkOwnership(c)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		VoiceID string `json:"voice_id"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	voiceID := strings.TrimSpace(req.VoiceID)
+	if voiceID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "voice_id is required"})
+		return
+	}
+
+	if err := h.repo.UpdateVoiceID(c.Request.Context(), overlayID, voiceID); err != nil {
+		if errors.Is(err, repository.ErrTTSConfigNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "tts config not found"})
+			return
+		}
+		h.logger.Error("tts voice update: persist failed",
+			zap.String("overlay_id", overlayID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save voice"})
+		return
+	}
+
+	h.logger.Info("tts voice updated",
+		zap.String("overlay_id", overlayID), zap.String("voice_id", voiceID))
+	c.JSON(http.StatusOK, gin.H{"status": "saved", "voice_id": voiceID})
 }
 
 // ---- HandleDeleteTTSConfig (D-12) ------------------------------------------

--- a/services/overlay-manager/handlers/tts_test.go
+++ b/services/overlay-manager/handlers/tts_test.go
@@ -88,6 +88,17 @@ func (m *mockTTSRepo) CreateOrUpdate(_ context.Context, overlayID string, encryp
 	return &copied, nil
 }
 
+func (m *mockTTSRepo) UpdateVoiceID(_ context.Context, _ string, voiceID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.row == nil {
+		return repository.ErrTTSConfigNotFound
+	}
+	m.row.VoiceID = voiceID
+	m.row.UpdatedAt = time.Now()
+	return nil
+}
+
 func (m *mockTTSRepo) Delete(_ context.Context, _ string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -197,6 +208,7 @@ func newRouter(t *testing.T, h *TTSHandler, gates sharedMiddleware.GateChecker, 
 	gated.Use(authShim, premium)
 	{
 		gated.POST("/:id/tts-config", h.HandleSaveTTSConfig)
+		gated.PATCH("/:id/tts-config/voice", h.HandleSaveVoice)
 		gated.DELETE("/:id/tts-config", h.HandleDeleteTTSConfig)
 		gated.POST("/:id/tts-config/rotate-token", h.HandleRotateToken)
 		gated.GET("/:id/tts-voices", h.HandleGetVoices)
@@ -265,6 +277,83 @@ func TestSaveTTSConfigRejectsNonOwner(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSaveVoiceUpdatesRowWithoutTouchingKey — the new PATCH endpoint
+// (Issue #276) rewrites only voice_id; the encrypted_api_key stays as-is.
+func TestSaveVoiceUpdatesRowWithoutTouchingKey(t *testing.T) {
+	f := newTestHandler(t, nil)
+	gates := &mockGateChecker{isPremiumResult: true}
+	r := newRouter(t, f.handler, gates, true, "user-1")
+
+	// Seed a saved config with key "sk_secret_key" + voice "v-original".
+	save := httptest.NewRequest(http.MethodPost, "/overlay-voice/tts-config",
+		strings.NewReader(`{"api_key":"sk_secret_key","voice_id":"v-original"}`))
+	save.Header.Set("Content-Type", "application/json")
+	saveW := httptest.NewRecorder()
+	r.ServeHTTP(saveW, save)
+	require.Equal(t, http.StatusOK, saveW.Code)
+	originalKey := append([]byte(nil), f.repo.row.EncryptedAPIKey...)
+
+	// PATCH the voice only.
+	patch := httptest.NewRequest(http.MethodPatch, "/overlay-voice/tts-config/voice",
+		strings.NewReader(`{"voice_id":"v-new"}`))
+	patch.Header.Set("Content-Type", "application/json")
+	patchW := httptest.NewRecorder()
+	r.ServeHTTP(patchW, patch)
+
+	require.Equal(t, http.StatusOK, patchW.Code, "body=%s", patchW.Body.String())
+	assert.Contains(t, patchW.Body.String(), `"voice_id":"v-new"`)
+	assert.Equal(t, "v-new", f.repo.row.VoiceID)
+	assert.Equal(t, originalKey, f.repo.row.EncryptedAPIKey,
+		"encrypted_api_key must be untouched by voice-only patch")
+}
+
+// TestSaveVoiceReturns404WhenNoConfig — patching before the user has saved a
+// key returns 404 so the UI can prompt for the key first.
+func TestSaveVoiceReturns404WhenNoConfig(t *testing.T) {
+	f := newTestHandler(t, nil)
+	gates := &mockGateChecker{isPremiumResult: true}
+	r := newRouter(t, f.handler, gates, true, "user-1")
+
+	patch := httptest.NewRequest(http.MethodPatch, "/overlay-empty/tts-config/voice",
+		strings.NewReader(`{"voice_id":"v-new"}`))
+	patch.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, patch)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSaveVoiceRejectsEmptyVoiceID — voice_id is required, blank gets 400.
+func TestSaveVoiceRejectsEmptyVoiceID(t *testing.T) {
+	f := newTestHandler(t, nil)
+	gates := &mockGateChecker{isPremiumResult: true}
+	r := newRouter(t, f.handler, gates, true, "user-1")
+
+	patch := httptest.NewRequest(http.MethodPatch, "/overlay-x/tts-config/voice",
+		strings.NewReader(`{"voice_id":"   "}`))
+	patch.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, patch)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestSaveVoiceRejectsNonOwner — ownership check fires before any DB work.
+func TestSaveVoiceRejectsNonOwner(t *testing.T) {
+	f := newTestHandler(t, nil)
+	f.overlays.owned = false
+	gates := &mockGateChecker{isPremiumResult: true}
+	r := newRouter(t, f.handler, gates, true, "user-1")
+
+	patch := httptest.NewRequest(http.MethodPatch, "/overlay-stranger/tts-config/voice",
+		strings.NewReader(`{"voice_id":"v"}`))
+	patch.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, patch)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/services/overlay-manager/repository/tts_config_repo.go
+++ b/services/overlay-manager/repository/tts_config_repo.go
@@ -98,6 +98,27 @@ func (r *TTSConfigRepository) CreateOrUpdate(ctx context.Context, overlayID stri
 	return cfg, nil
 }
 
+// UpdateVoiceID updates only the voice_id column for overlayID, leaving the
+// encrypted_api_key and tts_signing_secret untouched. Returns
+// ErrTTSConfigNotFound if no row matched. Used by PATCH /:id/tts-config/voice
+// so users can change voices after the key is already saved without having
+// to re-submit the key.
+func (r *TTSConfigRepository) UpdateVoiceID(ctx context.Context, overlayID string, voiceID string) error {
+	const q = `
+		UPDATE overlay_tts_configs
+		   SET voice_id = $1, updated_at = NOW()
+		 WHERE overlay_id = $2
+	`
+	tag, err := r.pool.Exec(ctx, q, voiceID, overlayID)
+	if err != nil {
+		return fmt.Errorf("tts_config_repo: update voice: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrTTSConfigNotFound
+	}
+	return nil
+}
+
 // Delete removes the config row for overlayID. Returns ErrTTSConfigNotFound
 // if no row matched.
 func (r *TTSConfigRepository) Delete(ctx context.Context, overlayID string) error {


### PR DESCRIPTION
## Summary

Fixes #276 — once an ElevenLabs key was saved, switching the voice in the picker silently did nothing. Two root causes:

1. **No save path for voice-only changes** — `ApiKeyInput` hides the "Save key" button when `hasSavedKey === true`, and that was the only thing wired to send the picker value to the backend.
2. **Picker did not initialise from the persisted voice** — `pickedVoiceId` was always `''` on load, so auto-select picked the first voice from ElevenLabs instead of the one the user actually saved.

### Changes

**Backend** (`services/overlay-manager`)
- `repository.UpdateVoiceID(ctx, overlayID, voiceID)` — `UPDATE voice_id` only; leaves `encrypted_api_key` and `tts_signing_secret` untouched
- `handlers.HandleSaveVoice` — `PATCH /api/v1/overlays/:id/tts-config/voice` body `{voice_id}`, gated by `RequirePremium("tts")`, returns 404 when no config row exists, 400 on blank `voice_id`
- 4 new handler tests pin: success path leaves key bytes untouched, 404 when no config, 400 on blank input, 404 on non-owner

**Frontend** (`frontend/`)
- `overlaysApi.saveTTSVoice(overlayId, voiceId)` — calls the new PATCH
- `TTSGroup`: new `savedVoiceId` + `onSaveVoice` props; picker initialises from `savedVoiceId`; "Save voice" button appears only when the picker has changed and a key is already saved
- `AppearancePanel` threads the new props through
- `overlays/[id]/page.tsx`: tracks `elevenLabsVoiceId`, populates from `getTTSConfig` on initial load + after `handleSaveTTSKey`, wires `handleSaveTTSVoice`
- 4 new vitest cases pin: picker initial value, button hidden when picker matches saved, button fires `onSaveVoice` + success toast, button toasts the error message on rejection

## Test plan

- [x] Backend: `go test ./services/overlay-manager/handlers/... -run SaveVoice` — 4/4 passing
- [x] Backend: `go test ./services/overlay-manager/repository/... -run TTS` — passing (existing tests still green)
- [x] Frontend: `vitest run TTSGroup.test.tsx` — 45/45 passing (was 41 + 4 new)
- [x] `go vet ./...` clean for `services/overlay-manager`
- [x] `tsc --noEmit` clean (no new errors)
- [x] `eslint` shows no new violations (3 pre-existing className-concat errors in `TTSGroup.tsx` unchanged)
- [ ] Manual: in the editor, save an ElevenLabs key + Voice A, refresh, change picker to Voice B, click "Save voice", refresh, confirm Voice B is preselected

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)