### PR TITLE
fix(api-gateway): proxy PATCH /tts-config/voice (#276 follow-up)

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -491,6 +491,7 @@ func main() {
 		// (not user JWT) and must be forwarded as a public endpoint (added above).
 		protectedAPI.GET("/overlays/:id/tts-config", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/overlays/:id/tts-config", proxyHandler.ForwardRequest)
+		protectedAPI.PATCH("/overlays/:id/tts-config/voice", proxyHandler.ForwardRequest)
 		protectedAPI.DELETE("/overlays/:id/tts-config", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/overlays/:id/tts-config/rotate-token", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/overlays/:id/tts-config/test", proxyHandler.ForwardRequest)


### PR DESCRIPTION
## Summary

Follow-up to #277. The voice-only PATCH endpoint added on overlay-manager was returning 404 in prod:

\`\`\`
PATCH https://allch.at/api/v1/overlays/{id}/tts-config/voice → 404
\`\`\`

Root cause: the api-gateway proxies TTS routes via explicit per-method/per-path entries (`services/api-gateway/cmd/main.go:492-498`). Without an entry for the new PATCH, gin's router rejects the method before the request ever reaches overlay-manager. I added the new endpoint to overlay-manager and the gateway proxy list to the frontend, but missed the gateway's own route table — so the frontend hit the gateway, the gateway 404'd, and overlay-manager never saw the request.

## Change

- `protectedAPI.PATCH("/overlays/:id/tts-config/voice", proxyHandler.ForwardRequest)` — added alongside the existing `tts-config` proxy routes

## Test plan

- [x] `go build ./...` and `go vet ./...` clean for `services/api-gateway`
- [x] Verified ingress (`caesar-deployment/ingress/allchat-ingress.yaml`) is path-prefix `/api → api-gateway` with no method filter
- [x] Verified NetworkPolicies are L3/L4 so PATCH is automatically allowed once api-gateway → overlay-manager already is
- [ ] Once deployed via Keel: `PATCH /api/v1/overlays/{id}/tts-config/voice` returns 200 instead of 404

Refs #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)