### PR TITLE
feat(twitch-listener): deactivate idle overlays' twitch IRC after 7d

### DIFF
--- a/migrations/052_overlay_last_connected_at.sql
+++ b/migrations/052_overlay_last_connected_at.sql
@@ -1,0 +1,30 @@
+-- All-Chat Migration 052: Track per-overlay last-connected timestamp
+-- Migration: 052
+--
+-- Adds overlays.last_connected_at, bumped by api-gateway whenever a frontend
+-- WebSocket attaches to an overlay (and on each heartbeat tick while attached).
+-- twitch-listener filters its desired-channel query on this timestamp so
+-- overlays nobody has watched in N days fall out of the listener's view and
+-- get IRC-PARTed automatically. Without this, the bot account stays connected
+-- to every twitch channel of every overlay we've ever created and runs into
+-- Twitch's per-account concurrent-channel cap (msg_concurrent_channel_limit_reached).
+--
+-- The column is NOT NULL with default NOW() so existing rows back-fill to the
+-- deploy moment — every overlay gets a fresh N-day grace period from rollout
+-- and nothing disconnects the instant this migration applies.
+--
+-- An index on the column lets the listener's WHERE-clause evaluate cheaply at
+-- 30s sync cadence even with thousands of overlays.
+
+BEGIN;
+
+ALTER TABLE overlays
+    ADD COLUMN last_connected_at TIMESTAMP NOT NULL DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS idx_overlays_last_connected_at
+    ON overlays(last_connected_at);
+
+COMMENT ON COLUMN overlays.last_connected_at IS
+    'Timestamp of the most recent WebSocket attach for this overlay (bumped by api-gateway on AddConnection and during the connection heartbeat tick). twitch-listener filters its source-discovery query on this column to skip channels nobody is watching, avoiding Twitchs per-account concurrent-channel cap.';
+
+COMMIT;

--- a/migrations/052_overlay_last_connected_at_down.sql
+++ b/migrations/052_overlay_last_connected_at_down.sql
@@ -1,0 +1,16 @@
+-- Down migration for 052_overlay_last_connected_at.sql
+--
+-- Drops the index and the last_connected_at column from overlays.
+--
+-- Safe to run: dropping the column does not lose any user-configured state.
+-- The column is purely an api-gateway-bumped activity marker; recreating it
+-- and rolling forward simply restarts the grace period from the next deploy.
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_overlays_last_connected_at;
+
+ALTER TABLE overlays
+    DROP COLUMN IF EXISTS last_connected_at;
+
+COMMIT;

--- a/services/api-gateway/websocket/manager.go
+++ b/services/api-gateway/websocket/manager.go
@@ -45,6 +45,7 @@ type Manager struct {
 	logger      *zap.Logger
 	metrics     *metrics.GatewayMetrics
 	redisClient *redis.Client
+	db          *pgxpool.Pool // For bumping overlays.last_connected_at on attach + heartbeat
 
 	// Grace period tracking for disconnection events
 	gracePeriodTimers map[string]*time.Timer
@@ -99,6 +100,7 @@ func NewManager(logger *zap.Logger, m *metrics.GatewayMetrics, redisClient *redi
 		logger:                logger,
 		metrics:               m,
 		redisClient:           redisClient,
+		db:                    db,
 		gracePeriodTimers:     make(map[string]*time.Timer),
 		disconnectGracePeriod: gracePeriod,
 		heartbeatInterval:     heartbeatInterval,
@@ -177,6 +179,31 @@ func (m *Manager) AddConnection(ctx context.Context, conn *Connection) {
 	// Publish overlay connection event if this is the first connection
 	if isFirstConnection {
 		m.publishConnectionEvent(ctx, overlayID, "connected")
+	}
+
+	// Bump overlays.last_connected_at so twitch-listener keeps this overlay's
+	// channels in its desired set. Fire-and-forget on a goroutine — DB latency
+	// must not delay the WebSocket handshake completion.
+	go m.bumpLastConnectedAt(context.Background(), overlayID)
+}
+
+// bumpLastConnectedAt updates overlays.last_connected_at = NOW() for the given
+// overlay IDs. Used both on first WebSocket attach (single ID) and on each
+// heartbeat tick (all currently-connected IDs in one batched UPDATE).
+//
+// Failures are logged but never returned — this is a best-effort idle-tracking
+// signal and must not break user-visible operations.
+func (m *Manager) bumpLastConnectedAt(ctx context.Context, overlayIDs ...string) {
+	if len(overlayIDs) == 0 || m.db == nil {
+		return
+	}
+	const query = `UPDATE overlays SET last_connected_at = NOW() WHERE id = ANY($1)`
+	if _, err := m.db.Exec(ctx, query, overlayIDs); err != nil {
+		m.logger.Warn("Failed to bump overlays.last_connected_at",
+			zap.Int("count", len(overlayIDs)),
+			zap.Error(err),
+		)
+		m.metrics.RecordSubscriptionEvent("api-gateway", "last_connected_bump_failed")
 	}
 }
 
@@ -504,6 +531,10 @@ func (m *Manager) refreshConnectionTTLs() {
 		zap.Int("count", refreshed),
 		zap.Int("total_overlays", len(overlayIDs)),
 	)
+
+	// Single batched UPDATE so twitch-listener's idle-overlay filter stays
+	// fresh for streamers who keep OBS open all week without ever closing it.
+	m.bumpLastConnectedAt(ctx, overlayIDs...)
 }
 
 // Shutdown gracefully stops the WebSocket manager

--- a/services/twitch-listener/channels/repository.go
+++ b/services/twitch-listener/channels/repository.go
@@ -19,10 +19,17 @@ package channels
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/caesar/all-chat/services/twitch-listener/models"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// DefaultIdleOverlayThreshold is the default value for the freshness window
+// applied to overlays.last_connected_at. Overlays whose last WebSocket attach
+// is older than this fall out of the listener's desired-channel set and get
+// IRC-PARTed on the next sync. Configurable via IDLE_OVERLAY_THRESHOLD env var.
+const DefaultIdleOverlayThreshold = 7 * 24 * time.Hour
 
 // RepositoryInterface defines the interface for channel repository
 type RepositoryInterface interface {
@@ -35,12 +42,31 @@ type RepositoryInterface interface {
 
 // Repository handles database queries for channel management
 type Repository struct {
-	db *pgxpool.Pool
+	db              *pgxpool.Pool
+	idleThreshold   time.Duration
 }
 
-// NewRepository creates a new channel repository
-func NewRepository(db *pgxpool.Pool) *Repository {
-	return &Repository{db: db}
+// NewRepository creates a new channel repository.
+// idleThreshold gates which overlays are considered "in use" — overlays with
+// last_connected_at older than now()-idleThreshold are excluded so the listener
+// PARTs their twitch channels. A non-positive value disables the filter (every
+// is_active overlay is included).
+func NewRepository(db *pgxpool.Pool, idleThreshold time.Duration) *Repository {
+	return &Repository{db: db, idleThreshold: idleThreshold}
+}
+
+// freshnessClause renders the SQL predicate that gates overlays on
+// last_connected_at. Returns an empty string when idleThreshold is non-positive
+// so callers can append it unconditionally.
+func (r *Repository) freshnessClause() string {
+	if r.idleThreshold <= 0 {
+		return ""
+	}
+	// Use a parameter-free interval literal because pgx's $N substitution does
+	// not interpolate intervals nicely; the threshold is a server-trusted value
+	// derived once from configuration, so direct embedding is safe.
+	return fmt.Sprintf(" AND o.last_connected_at > NOW() - INTERVAL '%d seconds'",
+		int64(r.idleThreshold.Seconds()))
 }
 
 // GetActiveChannels returns all active Twitch channels that should be monitored
@@ -54,7 +80,7 @@ func (r *Repository) GetActiveChannels(ctx context.Context) ([]models.ChannelSou
 		FROM overlays o
 		JOIN overlay_chat_sources ocs ON o.id = ocs.overlay_id
 		WHERE o.is_active = true
-		  AND ocs.platform = 'twitch'
+		  AND ocs.platform = 'twitch'` + r.freshnessClause() + `
 		ORDER BY ocs.channel_name
 	`
 
@@ -82,16 +108,18 @@ func (r *Repository) GetActiveChannels(ctx context.Context) ([]models.ChannelSou
 
 // GetUniqueChannels returns a deduplicated list of channel names (usernames)
 // For Twitch IRC, we need the channel_name (username) not the channel_id (numeric ID)
-// NOTE: This query intentionally does NOT check ocs.is_active because that field
-// is used as a runtime status indicator (is the listener currently connected),
-// not a configuration flag. We determine what to listen to based on active overlays.
+//
+// NOTE: ocs.is_active is intentionally NOT in this filter — it's a runtime
+// status flag set by the listener itself ("is currently connected"), not a
+// config flag. Idle gating is done via overlays.last_connected_at instead
+// (bumped by api-gateway on every WebSocket attach + heartbeat).
 func (r *Repository) GetUniqueChannels(ctx context.Context) ([]string, error) {
 	query := `
 		SELECT DISTINCT ocs.channel_name
 		FROM overlays o
 		JOIN overlay_chat_sources ocs ON o.id = ocs.overlay_id
 		WHERE o.is_active = true
-		  AND ocs.platform = 'twitch'
+		  AND ocs.platform = 'twitch'` + r.freshnessClause() + `
 		ORDER BY ocs.channel_name
 	`
 

--- a/services/twitch-listener/channels/repository_freshness_test.go
+++ b/services/twitch-listener/channels/repository_freshness_test.go
@@ -1,0 +1,67 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package channels
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFreshnessClause_PositiveThreshold_RendersInterval(t *testing.T) {
+	r := &Repository{idleThreshold: 7 * 24 * time.Hour}
+
+	clause := r.freshnessClause()
+
+	if !strings.Contains(clause, "AND o.last_connected_at > NOW() - INTERVAL") {
+		t.Errorf("expected freshness clause to include the SQL predicate, got %q", clause)
+	}
+	if !strings.Contains(clause, "604800 seconds") {
+		t.Errorf("expected 7d to render as 604800 seconds, got %q", clause)
+	}
+}
+
+func TestFreshnessClause_ZeroThreshold_ReturnsEmpty(t *testing.T) {
+	r := &Repository{idleThreshold: 0}
+
+	if got := r.freshnessClause(); got != "" {
+		t.Errorf("zero threshold must disable filter; got %q", got)
+	}
+}
+
+func TestFreshnessClause_NegativeThreshold_ReturnsEmpty(t *testing.T) {
+	r := &Repository{idleThreshold: -time.Second}
+
+	if got := r.freshnessClause(); got != "" {
+		t.Errorf("negative threshold must disable filter; got %q", got)
+	}
+}
+
+func TestDefaultIdleOverlayThreshold_IsSevenDays(t *testing.T) {
+	if DefaultIdleOverlayThreshold != 7*24*time.Hour {
+		t.Errorf("expected default threshold to be 7d, got %s", DefaultIdleOverlayThreshold)
+	}
+}
+
+func TestNewRepository_StoresThreshold(t *testing.T) {
+	threshold := 36 * time.Hour
+	r := NewRepository(nil, threshold)
+
+	if r.idleThreshold != threshold {
+		t.Errorf("expected idleThreshold=%s, got %s", threshold, r.idleThreshold)
+	}
+}

--- a/services/twitch-listener/cmd/main.go
+++ b/services/twitch-listener/cmd/main.go
@@ -162,8 +162,28 @@ func main() {
 	zombieDetector := zombie.NewDetector(time.Duration(zombieStallMinutes) * time.Minute)
 	log.Info("Initialized zombie detector", zap.Int("stall_window_minutes", zombieStallMinutes))
 
+	// Idle-overlay threshold — overlays whose last_connected_at is older than
+	// this drop out of the listener's desired-channel set on the next sync,
+	// so dormant twitch sources stop occupying slots in the bot's per-account
+	// concurrent-channel cap. Env: IDLE_OVERLAY_THRESHOLD (Go duration syntax,
+	// e.g. "168h", "72h"). Default: 7 days.
+	idleThreshold := channels.DefaultIdleOverlayThreshold
+	if v := listener.Env("IDLE_OVERLAY_THRESHOLD", ""); v != "" {
+		parsed, err := time.ParseDuration(v)
+		if err != nil {
+			log.Fatal("Invalid IDLE_OVERLAY_THRESHOLD",
+				zap.String("value", v),
+				zap.Error(err),
+			)
+		}
+		idleThreshold = parsed
+	}
+	log.Info("Idle overlay threshold configured",
+		zap.Duration("threshold", idleThreshold),
+	)
+
 	// Initialize channel manager — pass nil for assignedSourceIDs; SDK calls UpdateAssignedSourceIDs inside ll.Start
-	channelRepo := channels.NewRepository(db)
+	channelRepo := channels.NewRepository(db, idleThreshold)
 	dbConnWrapper := &dbConnWrapper{pool: db}
 	channelMgr := channels.NewManager(channelRepo, ircConn, dbConnWrapper, ll.LeadershipCoordinator(), nil, redisClient, podName, log, listenerMetrics)
 


### PR DESCRIPTION
## Summary

- Adds `overlays.last_connected_at`, bumped by api-gateway on every WebSocket attach + every 2-min heartbeat tick.
- twitch-listener's `GetUniqueChannels` / `GetActiveChannels` queries gain a freshness predicate so overlays nobody has watched in 7 days fall out of the listener's desired-channel set on the next 30 s sync; the existing `partChannel` path PARTs IRC and releases leadership for free, and the existing 24 h source-cleanup later flips `ocs.is_active=false` for clean UI state.
- Threshold is `IDLE_OVERLAY_THRESHOLD` (Go duration syntax, default `168h` = 7 d).

## Why now

PR #279's new `OnNoticeMessage` handler surfaced that the bot account is hitting Twitch's per-account concurrent-channel cap (`msg_concurrent_channel_limit_reached`). Twitch IRC is push, not poll — unlike kick/youtube/tiktok it doesn't pause when nobody is subscribed, so we accumulate IRC subscriptions for every overlay we've ever created. This deletes the ones nobody is using.

## Reactivation

Automatic. WebSocket attach → api-gateway bumps `last_connected_at` → next 30 s twitch-listener sync re-adds the channel → `EnsureLeadership` + `Join`. No explicit reactivation code anywhere.

## Scope

Twitch only. Non-twitch listeners are already demand-driven through the existing `source:demand` Pub/Sub flow (`shared/listener/demand.go`); they pause naturally when no api-gateway WebSocket is subscribed to the overlay. Adding a freshness gate there would be redundant.

## Files changed

| Purpose | File |
|---|---|
| Schema | `migrations/052_overlay_last_connected_at.sql` (+ `_down`) |
| Listener query | `services/twitch-listener/channels/repository.go` |
| Listener wiring | `services/twitch-listener/cmd/main.go` |
| WS bump | `services/api-gateway/websocket/manager.go` |

## Test plan

- [x] Unit tests: freshness clause behavior (positive / zero / negative threshold, default = 7 d, `NewRepository` plumbing)
- [x] `go test ./...` green for both services
- [x] `go vet ./...` clean
- [ ] Post-merge in prod: backdate one overlay (`UPDATE overlays SET last_connected_at = NOW() - INTERVAL '8 days' WHERE id = ...`), watch twitch-listener log a `Parted channel` for its twitch channels within ~30 s, then open the overlay in a browser and watch it re-join.
- [ ] Metric watch: `listener_active_sources_total{platform=\"twitch\"}` should drop noticeably as the dormant tail ages out, eliminating the `msg_concurrent_channel_limit_reached` notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)