### PR TITLE
fix(twitch-listener): skip JOIN-rejection NOTICEs to break reconnect loop

### DIFF
--- a/services/twitch-listener/irc/connection.go
+++ b/services/twitch-listener/irc/connection.go
@@ -68,6 +68,22 @@ type ConnectionManager struct {
 	// format and the gempir lib's internal map.
 	pendingJoins   map[string]time.Time
 	pendingJoinsMu sync.Mutex
+
+	// bannedChannels marks channels Twitch has explicitly rejected our JOIN for
+	// (msg_banned, msg_channel_suspended, msg_room_not_found, or
+	// msg_concurrent_channel_limit_reached). Re-joining these on the next sync
+	// or after a reconnect is wasted effort: bans/suspensions never recover, and
+	// the cap is per-account so a fresh connection hits the same wall.
+	//
+	// Value semantics:
+	//   zero time     -> permanent (never re-attempt for this process lifetime)
+	//   non-zero time -> back off until this instant, then allow a re-attempt
+	//
+	// Without this guard the joinAckWatchdog enters a tight reconnect loop on a
+	// pod that holds a single banned/cap-rejected channel: ack never arrives,
+	// watchdog reconnects, fresh JOIN gets the same NOTICE, repeat.
+	bannedChannels   map[string]time.Time
+	bannedChannelsMu sync.Mutex
 }
 
 // Config holds the configuration for IRC connection
@@ -98,6 +114,7 @@ func NewConnectionManager(
 		stopChan:         make(chan struct{}),
 		firstMessageChan: make(map[string]chan struct{}),
 		pendingJoins:     make(map[string]time.Time),
+		bannedChannels:   make(map[string]time.Time),
 	}
 
 	cm.setupClientCallbacks(client)
@@ -156,6 +173,22 @@ const (
 	// pendingJoins for expired entries. Half of joinAckTimeout so a stuck
 	// JOIN is detected within ~1.5x the timeout in the worst case.
 	joinAckWatchdogInterval = 30 * time.Second
+
+	// concurrentChannelLimitBackoff is how long a channel is skipped after
+	// Twitch returns msg_concurrent_channel_limit_reached. The cap is per
+	// bot-account and shared across pods, so reconnecting doesn't free a
+	// slot — backing off and letting other PARTs/idle-aging make room is
+	// the only useful response.
+	concurrentChannelLimitBackoff = 10 * time.Minute
+)
+
+// JOIN-rejection NOTICE msg_id values that mean "do not re-attempt this JOIN".
+// See https://dev.twitch.tv/docs/irc/msg-id/ for the full list.
+const (
+	twitchMsgIDBanned                  = "msg_banned"
+	twitchMsgIDChannelSuspended        = "msg_channel_suspended"
+	twitchMsgIDRoomNotFound            = "msg_room_not_found"
+	twitchMsgIDConcurrentChannelLimit  = "msg_concurrent_channel_limit_reached"
 )
 
 // Connect establishes connection to Twitch IRC with automatic reconnection.
@@ -336,13 +369,26 @@ func (cm *ConnectionManager) Disconnect() error {
 // Join joins a Twitch channel.
 // Records the channel as a pending JOIN so the joinAckWatchdog can detect
 // silent failures where Twitch never returns the SELFJOIN ack.
+//
+// Channels in the bannedChannels skip list (populated by handleNotice on
+// JOIN-rejection NOTICEs) are short-circuited: re-attempting them just churns
+// the connection without producing any messages, and historically caused the
+// joinAckWatchdog to enter a reconnect loop.
 func (cm *ConnectionManager) Join(channel string) {
+	lower := strings.ToLower(channel)
+
+	if cm.isJoinBanned(lower) {
+		cm.logger.Debug("Skipping JOIN for banned/cap-rejected channel",
+			zap.String("channel", lower),
+		)
+		return
+	}
+
 	cm.mu.RLock()
 	client := cm.client
 	connected := cm.connected
 	cm.mu.RUnlock()
 
-	lower := strings.ToLower(channel)
 	client.Join(channel)
 
 	// Only track pending acks while connected; if we're offline, the gempir
@@ -354,6 +400,28 @@ func (cm *ConnectionManager) Join(channel string) {
 	}
 
 	cm.logger.Debug("IRC JOIN", zap.String("channel", channel))
+}
+
+// isJoinBanned reports whether channel is currently in the JOIN-rejection
+// skip list. Permanent entries (zero time) always return true; transient
+// entries return true until their backoff expires, after which the entry is
+// evicted lazily so the next attempt proceeds normally.
+func (cm *ConnectionManager) isJoinBanned(channel string) bool {
+	cm.bannedChannelsMu.Lock()
+	defer cm.bannedChannelsMu.Unlock()
+
+	until, exists := cm.bannedChannels[channel]
+	if !exists {
+		return false
+	}
+	if until.IsZero() {
+		return true
+	}
+	if time.Now().Before(until) {
+		return true
+	}
+	delete(cm.bannedChannels, channel)
+	return false
 }
 
 // Depart leaves a Twitch channel.
@@ -419,6 +487,37 @@ func (cm *ConnectionManager) handleNotice(message twitch.NoticeMessage) {
 		zap.String("message", message.Message),
 	)
 	cm.metrics.RecordError("twitch", "twitch-listener", "irc_notice", "warning")
+
+	// JOIN-rejection NOTICEs: Twitch is telling us this JOIN will not produce
+	// a SELFJOIN. Drop the pendingJoins entry so the watchdog stops counting
+	// it as stuck, and remember the channel so future Join() calls short-
+	// circuit. Without this guard the watchdog enters a tight reconnect loop
+	// because the post-reconnect re-JOIN gets the same NOTICE.
+	var blockUntil time.Time
+	switch message.MsgID {
+	case twitchMsgIDBanned, twitchMsgIDChannelSuspended, twitchMsgIDRoomNotFound:
+		// Permanent within this process lifetime. zero time = forever.
+	case twitchMsgIDConcurrentChannelLimit:
+		// Per-account cap is shared across pods, so reconnecting to retry
+		// won't free a slot. Back off and let normal PARTs / idle-aging
+		// reduce demand before re-attempting.
+		blockUntil = time.Now().Add(concurrentChannelLimitBackoff)
+	default:
+		return
+	}
+
+	if channel == "" {
+		// Unparseable channel — nothing to skip.
+		return
+	}
+
+	cm.bannedChannelsMu.Lock()
+	cm.bannedChannels[channel] = blockUntil
+	cm.bannedChannelsMu.Unlock()
+
+	cm.pendingJoinsMu.Lock()
+	delete(cm.pendingJoins, channel)
+	cm.pendingJoinsMu.Unlock()
 }
 
 // joinAckWatchdog scans pendingJoins on a periodic ticker and forces a

--- a/services/twitch-listener/irc/connection_notice_skip_test.go
+++ b/services/twitch-listener/irc/connection_notice_skip_test.go
@@ -1,0 +1,218 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package irc
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/shared/metrics"
+	"github.com/gempir/go-twitch-irc/v4"
+)
+
+// sharedTestMetrics is initialized once across the package: NewListenerMetrics
+// registers Prometheus collectors with the global registry, so a fresh instance
+// per test panics with "duplicate metrics collector registration attempted".
+var (
+	sharedTestMetricsOnce sync.Once
+	sharedTestMetrics     *metrics.ListenerMetrics
+)
+
+// newTestConnectionManagerWithMetrics returns a ConnectionManager primed for
+// handleNotice tests — handleNotice calls metrics.RecordError, which requires
+// a non-nil *metrics.ListenerMetrics.
+func newTestConnectionManagerWithMetrics() *ConnectionManager {
+	sharedTestMetricsOnce.Do(func() {
+		sharedTestMetrics = metrics.NewListenerMetrics("twitch", "twitch-listener-test")
+	})
+	cm := newTestConnectionManager()
+	cm.metrics = sharedTestMetrics
+	return cm
+}
+
+func TestIsJoinBanned_AbsentChannel_ReturnsFalse(t *testing.T) {
+	cm := newTestConnectionManager()
+	if cm.isJoinBanned("anychan") {
+		t.Error("an unseen channel must not be reported as banned")
+	}
+}
+
+func TestIsJoinBanned_PermanentEntry_ReturnsTrue(t *testing.T) {
+	cm := newTestConnectionManager()
+	cm.bannedChannels["kashashgaming"] = time.Time{} // zero = permanent
+
+	if !cm.isJoinBanned("kashashgaming") {
+		t.Error("permanent entry (zero time) must always be reported as banned")
+	}
+
+	// And the entry must NOT be evicted by a read — permanent stays permanent.
+	cm.bannedChannelsMu.Lock()
+	_, stillThere := cm.bannedChannels["kashashgaming"]
+	cm.bannedChannelsMu.Unlock()
+	if !stillThere {
+		t.Error("permanent entries must survive isJoinBanned reads")
+	}
+}
+
+func TestIsJoinBanned_NotYetExpired_ReturnsTrue(t *testing.T) {
+	cm := newTestConnectionManager()
+	cm.bannedChannels["caedrel"] = time.Now().Add(5 * time.Minute)
+
+	if !cm.isJoinBanned("caedrel") {
+		t.Error("entry within its backoff window must be reported as banned")
+	}
+}
+
+func TestIsJoinBanned_Expired_EvictsAndReturnsFalse(t *testing.T) {
+	cm := newTestConnectionManager()
+	cm.bannedChannels["caedrel"] = time.Now().Add(-1 * time.Second)
+
+	if cm.isJoinBanned("caedrel") {
+		t.Error("expired entry must allow re-attempt (return false)")
+	}
+
+	cm.bannedChannelsMu.Lock()
+	_, stillThere := cm.bannedChannels["caedrel"]
+	cm.bannedChannelsMu.Unlock()
+	if stillThere {
+		t.Error("expired entry must be evicted on read so the map doesn't grow forever")
+	}
+}
+
+func TestHandleNotice_MsgBanned_MarksPermanentAndClearsPending(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+	cm.pendingJoins["kashashgaming"] = time.Now()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "kashashgaming",
+		MsgID:   twitchMsgIDBanned,
+		Message: "You are permanently banned from talking in kashashgaming.",
+	})
+
+	cm.bannedChannelsMu.Lock()
+	until, ok := cm.bannedChannels["kashashgaming"]
+	cm.bannedChannelsMu.Unlock()
+	if !ok || !until.IsZero() {
+		t.Errorf("msg_banned must record a permanent (zero-time) skip entry; got ok=%v until=%s", ok, until)
+	}
+
+	cm.pendingJoinsMu.Lock()
+	_, stillPending := cm.pendingJoins["kashashgaming"]
+	cm.pendingJoinsMu.Unlock()
+	if stillPending {
+		t.Error("msg_banned must clear pendingJoins so the watchdog stops triggering reconnects")
+	}
+}
+
+func TestHandleNotice_MsgChannelSuspended_MarksPermanent(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "deadchan",
+		MsgID:   twitchMsgIDChannelSuspended,
+		Message: "Channel suspended.",
+	})
+
+	if !cm.isJoinBanned("deadchan") {
+		t.Error("msg_channel_suspended must short-circuit future Join() calls")
+	}
+}
+
+func TestHandleNotice_MsgRoomNotFound_MarksPermanent(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "typo_chan",
+		MsgID:   twitchMsgIDRoomNotFound,
+		Message: "No room found.",
+	})
+
+	if !cm.isJoinBanned("typo_chan") {
+		t.Error("msg_room_not_found must short-circuit future Join() calls")
+	}
+}
+
+func TestHandleNotice_ConcurrentChannelLimit_MarksTransient(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+	before := time.Now()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "byrakeru",
+		MsgID:   twitchMsgIDConcurrentChannelLimit,
+		Message: "You are connected to too many chat channels.",
+	})
+
+	cm.bannedChannelsMu.Lock()
+	until, ok := cm.bannedChannels["byrakeru"]
+	cm.bannedChannelsMu.Unlock()
+	if !ok {
+		t.Fatal("msg_concurrent_channel_limit_reached must populate bannedChannels")
+	}
+	if until.IsZero() {
+		t.Error("cap rejection must be transient (non-zero backoff time)")
+	}
+	expectedAtLeast := before.Add(concurrentChannelLimitBackoff - 5*time.Second)
+	expectedAtMost := before.Add(concurrentChannelLimitBackoff + 5*time.Second)
+	if until.Before(expectedAtLeast) || until.After(expectedAtMost) {
+		t.Errorf("backoff window outside expected ~%s; got until=%s (now was %s)",
+			concurrentChannelLimitBackoff, until, before)
+	}
+}
+
+func TestHandleNotice_UnrelatedMsgID_DoesNotPopulateSkipList(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+	cm.pendingJoins["chan_in_flight"] = time.Now()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "chan_in_flight",
+		MsgID:   "host_off", // unrelated NOTICE — has nothing to do with JOINs
+		Message: "Exited host mode.",
+	})
+
+	cm.bannedChannelsMu.Lock()
+	_, banned := cm.bannedChannels["chan_in_flight"]
+	cm.bannedChannelsMu.Unlock()
+	if banned {
+		t.Error("non-JOIN-rejection NOTICEs must not populate the skip list")
+	}
+
+	cm.pendingJoinsMu.Lock()
+	_, stillPending := cm.pendingJoins["chan_in_flight"]
+	cm.pendingJoinsMu.Unlock()
+	if !stillPending {
+		t.Error("non-JOIN-rejection NOTICEs must not clear pendingJoins")
+	}
+}
+
+func TestHandleNotice_EmptyChannel_DoesNotMutate(t *testing.T) {
+	cm := newTestConnectionManagerWithMetrics()
+
+	cm.handleNotice(twitch.NoticeMessage{
+		Channel: "",
+		MsgID:   twitchMsgIDBanned,
+		Message: "garbled",
+	})
+
+	cm.bannedChannelsMu.Lock()
+	_, hasEmpty := cm.bannedChannels[""]
+	count := len(cm.bannedChannels)
+	cm.bannedChannelsMu.Unlock()
+	if hasEmpty || count != 0 {
+		t.Errorf("a NOTICE with no parseable channel must be a no-op; got count=%d hasEmpty=%v", count, hasEmpty)
+	}
+}

--- a/services/twitch-listener/irc/connection_stale_test.go
+++ b/services/twitch-listener/irc/connection_stale_test.go
@@ -28,6 +28,7 @@ func newTestConnectionManager() *ConnectionManager {
 		stopChan:         make(chan struct{}),
 		firstMessageChan: make(map[string]chan struct{}),
 		pendingJoins:     make(map[string]time.Time),
+		bannedChannels:   make(map[string]time.Time),
 		logger:           zap.NewNop(),
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a NOTICE-driven skip list so the joinAckWatchdog from PR #279 stops looping on channels Twitch has explicitly rejected (\`msg_banned\`, \`msg_channel_suspended\`, \`msg_room_not_found\`, \`msg_concurrent_channel_limit_reached\`).
- Permanent rejections stay until the process restarts; cap-rejection rejections back off for 10 minutes (cap is per bot-account and shared across pods, so reconnecting doesn't free a slot).
- \`Join()\` short-circuits for channels in the skip list, so reconnect cycles no longer re-cycle banned channels.

## Why

Live alert \`Listener Disconnected (shared metrics)\` fired at 15:59 today — pod \`svsxt\` was flapping \`listener_connection_status\` 1→0→0→1 every ~90 s. Cause: joinAckWatchdog forces a reconnect when JOIN ack is missing past 60 s, but the same channels (\`kashashgaming\` permanently banned, \`caedrel\`/\`byrakeru\`/etc cap-rejected) just get the same NOTICE on every reconnect. PR #279's watchdog was necessary for silent-JOIN recovery but blind to NOTICE-explicit failures.

## Behaviour

| NOTICE msg_id | Skip list TTL | Reasoning |
|---|---|---|
| \`msg_banned\` | permanent (process lifetime) | Channel mods banned the bot; only un-ban or process restart recovers |
| \`msg_channel_suspended\` | permanent | Channel suspended by Twitch — never recovers automatically |
| \`msg_room_not_found\` | permanent | Channel renamed/deleted — re-trying same name won't help |
| \`msg_concurrent_channel_limit_reached\` | 10 min | Per-account cap; backoff lets idle-aging (PR #280) make room |

In all cases the channel is dropped from \`pendingJoins\` immediately so the watchdog stops counting it as stuck.

## Tests

- \`isJoinBanned\` semantics: absent / permanent / not-yet-expired / expired-evicts
- \`handleNotice\` for each of the 4 msg_ids + unrelated NOTICEs (\`host_off\`) being a no-op + empty-channel guard
- Shared Prometheus metrics fixture via \`sync.Once\` (avoids global-registry duplicate-collector panic)
- All existing tests still pass; \`go vet\` clean

## Test plan

- [x] \`go test ./...\` green
- [ ] Post-merge: confirm svsxt's \`listener_connection_status\` stops flapping (steady 1) and the alert auto-resolves
- [ ] Post-merge: confirm \`msg_banned\` for kashashgaming logs once per pod restart instead of every 90 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)