### PR TITLE
fix(migrations): make 052 idempotent so service init doesn't crashloop

### DIFF
--- a/migrations/052_overlay_last_connected_at.sql
+++ b/migrations/052_overlay_last_connected_at.sql
@@ -16,10 +16,15 @@
 -- An index on the column lets the listener's WHERE-clause evaluate cheaply at
 -- 30s sync cadence even with thousands of overlays.
 
+-- IDEMPOTENCY: every service runs the full migration set on each pod restart
+-- (the runner does not track applied migrations), so this script must be
+-- safe to re-execute. The original version omitted IF NOT EXISTS on the
+-- ADD COLUMN, which crashloops every pod after the first successful run.
+
 BEGIN;
 
 ALTER TABLE overlays
-    ADD COLUMN last_connected_at TIMESTAMP NOT NULL DEFAULT NOW();
+    ADD COLUMN IF NOT EXISTS last_connected_at TIMESTAMP NOT NULL DEFAULT NOW();
 
 CREATE INDEX IF NOT EXISTS idx_overlays_last_connected_at
     ON overlays(last_connected_at);


### PR DESCRIPTION
## Summary

- Adds \`IF NOT EXISTS\` to \`ALTER TABLE overlays ADD COLUMN last_connected_at\` in migration 052 so re-running the migration on subsequent pod restarts is a no-op instead of aborting init.

## Live incident

Right now: \`source-manager\` is in \`Init:CrashLoopBackOff\` across all 3 replicas. \`Connection refused\` to \`source-manager:8088\` from the discord-listener pod, which loops \`Waiting for shard ownership...\` because \`EnsureLeadership\` can't reach the HTTP API. That fires the \`Listener Disconnected (shard:0)\` alert.

Init container log shows:
\`\`\`
Running migration: /migrations/052_overlay_last_connected_at.sql
BEGIN
psql:/migrations/052_overlay_last_connected_at.sql:22: ERROR:
  column "last_connected_at" of relation "overlays" already exists
ERROR: psql exited with code 3
\`\`\`

Pre-rollout init runs were fine because the column didn't exist yet. After PR #280's first successful run, every subsequent pod restart hits this.

## Why the contract matters

\`scripts/run-migrations.sh:22-26\` explicitly requires migrations to be idempotent — the runner replays the full set on every init, with \`ON_ERROR_STOP=1\`, and pre-deploy verification is "run the full set three times against a fresh postgres:16-alpine". I shipped 052 without \`IF NOT EXISTS\`, breaking the contract.

## Test plan

- [x] \`grep "ADD COLUMN"\` migrations/052 shows \`IF NOT EXISTS\`
- [ ] Post-merge: source-manager pods come back to \`Running\` once the new migrations image rolls; \`Discord Listener Disconnected\` alert auto-resolves; shard:0 ownership returns to 1
- [ ] Pod restart loop stops; \`kubectl get pods -l app=source-manager\` shows \`1/1 Running\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)