### PR TITLE
fix(twitch-listener): raise joinAckTimeout to 180s

### DIFF
--- a/services/twitch-listener/irc/connection.go
+++ b/services/twitch-listener/irc/connection.go
@@ -164,15 +164,21 @@ const (
 	staleLivenessThreshold = 10 * time.Minute
 
 	// joinAckTimeout is how long we wait for Twitch to send a SELFJOIN ack
-	// for a JOIN we issued. Twitch normally responds within seconds; if no
-	// ack arrives in this window the connection is silently dropping our
-	// JOINs and the joinAckWatchdog forces a reconnect to recover.
-	joinAckTimeout = 60 * time.Second
+	// for a JOIN we issued. Twitch normally responds within seconds, but
+	// the gempir lib's JOIN rate-limiter throttles us to 20 channels per
+	// 10s — a 94-channel sync burst takes ~47s on the wire before the last
+	// JOIN is even sent, and any cap pressure (msg_concurrent_channel_limit
+	// _reached) further delays NOTICE replies. The original 60s value
+	// blew through every burst and looped the watchdog into reconnect
+	// storms. 180s leaves comfortable headroom for the burst + ack while
+	// still catching genuinely silently-dropped JOINs (the original PR #279
+	// motivation) within ~3 minutes.
+	joinAckTimeout = 180 * time.Second
 
 	// joinAckWatchdogInterval is how often the joinAckWatchdog scans
-	// pendingJoins for expired entries. Half of joinAckTimeout so a stuck
-	// JOIN is detected within ~1.5x the timeout in the worst case.
-	joinAckWatchdogInterval = 30 * time.Second
+	// pendingJoins for expired entries. Tuned to ~1/3 of joinAckTimeout so
+	// a stuck JOIN is detected within ~1.3x the timeout in the worst case.
+	joinAckWatchdogInterval = 60 * time.Second
 
 	// concurrentChannelLimitBackoff is how long a channel is skipped after
 	// Twitch returns msg_concurrent_channel_limit_reached. The cap is per


### PR DESCRIPTION
## Summary

- Raises \`joinAckTimeout\` from 60s to 180s, and \`joinAckWatchdogInterval\` from 30s to 60s.
- Eliminates the watchdog reconnect loop that was firing the "Listener Disconnected" alert every ~90s on freshly-rolled pods.

## Why

PR #279's joinAckWatchdog is necessary (silent JOIN drops on long-lived sessions still need recovery), but its 60s timeout assumed Twitch acks within seconds. Reality: the gempir client's JOIN rate-limiter throttles us to 20 channels per 10s, so a 94-channel sync burst takes ~47s on the wire before the last JOIN is even sent. Add any NOTICE-reply latency under cap pressure and the 60s window blows on every cycle.

Live trace on \`twitch-listener-...-wnldx\`:

\`\`\`
15:54:11  forcing reconnect — 21 channels stuck, oldest_age=79.7s
15:55:41  forcing reconnect — 18 channels, oldest_age=79.9s
15:57:11  forcing reconnect — 21 channels, oldest_age=81.1s
15:58:41  forcing reconnect — 20 channels
16:00:11  forcing reconnect — 20 channels
\`\`\`

NOTICE arrivals across that 12-minute window: **3** total. The other ~150 channel-cycles were just waiting their turn in the JOIN queue.

The flapping zeros out \`listener_connection_status\` for ~30s every cycle, which fires the alert.

## Tradeoff

Slower recovery for the genuine "silent JOIN drop on long-lived session" case — was 60-90s, now 180-240s. Still finite. The watchdog's purpose (PR #279) is preserved.

## Test plan

- [x] go test + go vet green
- [ ] Post-merge: confirm \`listener_connection_status\` for all twitch-listener pods stays steady at 1; no \`forcing reconnect\` watchdog firings under normal load
- [ ] The "Listener Disconnected (shared metrics)" alert auto-resolves and stops re-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)