### PR TITLE
chore(oauth): drop scopes unused after extension v1.6.0

### DIFF
--- a/docs/adr/0012-oauth-scope-minimisation.md
+++ b/docs/adr/0012-oauth-scope-minimisation.md
@@ -1,0 +1,100 @@
+# ADR-0012: OAuth Scope Minimisation Post Extension v1.6.0
+
+**Date**: 2026-04-29
+**Status**: Accepted
+
+---
+
+## Context and Problem Statement
+
+The AllChat backend's viewer OAuth flows historically requested send-capable scopes — `user:write:chat` (Twitch), `youtube.force-ssl` (YouTube), `chat:write` plus `chat:read`/`channel:read` (Kick) — because the extension routed chat sending through the backend's `/auth/viewer/chat/send` endpoint. The endpoint used the viewer's OAuth token to call each platform's send API.
+
+Extension v1.6.0 (released 2026-04-29) moved chat sending entirely off the backend onto each platform's native session:
+
+- Twitch: GraphQL via the user's `auth-token` cookie
+- YouTube: native YouTube live-chat input bar (InnerTube + SAPISIDHASH from page session)
+- Kick: REST `messages/send/{chatroomId}` with cookie XSRF token
+
+After v1.6.0 ships and propagates, the backend's send-via-OAuth path is no longer reachable from any current client. The send-capable scopes therefore correspond to dead capability.
+
+Continuing to request them costs:
+
+1. **Consent friction.** Twitch / Google / Kick consent screens display a separate "send messages on your behalf" line, which a non-trivial fraction of viewers refuse. Conversion rate on first sign-in is a real signal we measure on the dashboard.
+2. **Token blast radius.** A leaked OAuth token grants strictly the scopes it was issued with. Reducing scope list reduces what an attacker can do with it (e.g. spam-send messages as the user across platforms).
+3. **"Only ask for what we need" honesty.** The marketing site's privacy paragraph explicitly invokes this principle. Requesting send scope while never sending is a contradiction.
+
+## Decision
+
+Drop every OAuth scope that has no remaining call site in current backend code, in a single hard cutover (no soft-deprecation phase). Effective immediately on this branch.
+
+**Final scope set per provider × flow:**
+
+| Provider | Flow | Final scopes | Removed |
+|---|---|---|---|
+| Twitch | viewer | (none — empty slice) | `user:write:chat` |
+| Twitch | streamer | `channel:read:redemptions`, `channel:read:subscriptions`, `bits:read`, `moderator:read:followers` | (no change — every scope still used by EventSub) |
+| YouTube | viewer | `youtube.readonly`, `userinfo.profile` | `youtube.force-ssl` (replaced with `youtube.readonly` for `GetChannelID`) |
+| YouTube | streamer | `youtube.readonly`, `userinfo.profile` | `youtube.force-ssl` |
+| Kick | viewer | `user:read` | `chat:read`, `chat:write`, `channel:read` |
+| Kick | streamer | `user:read` | `chat:read`, `channel:read` |
+| Discord | bot | `bot` + permissions `1024,2048,65536` | (no change — bot capability flags, not user OAuth) |
+
+**Verification basis for each removal:**
+
+- `user:write:chat` (Twitch viewer): only consumer was `helix/chat/messages POST` in auth-service `chat_send` handler, called only from extension's pre-1.6.0 send path. No other caller in repo.
+- `youtube.force-ssl` (YouTube viewer): only consumer was `liveChat/messages POST` in viewer-side `sendYouTubeMessage`. `GetChannelID` does `channels?part=id&mine=true` which is satisfied by `youtube.readonly`.
+- `youtube.force-ssl` (YouTube streamer): only consumer was `sendStreamerYouTubeMessage`. No production caller of that path remains; streamer-side YouTube sending happens via the streamer's own browser session.
+- `chat:write` (Kick viewer): only consumer was `api.kick.com/public/v1/chat POST` in `sendKickMessage`. Same dead-path situation.
+- `chat:read` (Kick, both flows): no consumer found anywhere — kick-listener uses Kick's authenticated WebSocket which doesn't gate on this OAuth scope.
+- `channel:read` (Kick, both flows): no consumer found — channel info fetched via unauthenticated public Kick API in kick-listener.
+
+Backend-side handler functions (`sendKickMessage`, `sendYouTubeMessage`, etc.) are intentionally left in place but unreachable. They will be removed in a follow-up refactor; keeping them here lets us re-enable temporarily if any of the v1.6.0 native send paths regress.
+
+## Cutover: hard, not soft
+
+We chose a hard cutover (drop scopes immediately) over a soft cutover (deprecate `/auth/viewer/chat/send` first, drop scopes a release later).
+
+**Soft path was rejected because:**
+
+- The v1.6.0 store rollout already started — Chrome Web Store + Firefox Add-ons review queues are in flight. Most users will upgrade naturally over the next 1–2 weeks.
+- A v1.5.x extension still in the wild only fails to send when the user re-authenticates after this change deploys. Existing tokens keep their old scopes until natural expiry/refresh.
+- The failure mode for an affected user is "send returns an error" — visible, noisy, prompts an upgrade. Not a silent corruption.
+- Maintaining two scope sets across a soft-deprecation window adds branching code and consent-screen variability that has to be reconciled later.
+
+The risk we accept: a v1.5.x user who reauths between deploy and their natural extension update will see send failures until they upgrade. We judged this acceptable given the explicit error UX.
+
+## Files Changed
+
+```
+services/auth-service/oauth/viewer_twitch.go    — empty Scopes slice
+services/auth-service/oauth/viewer_youtube.go   — force-ssl → readonly
+services/auth-service/oauth/viewer_kick.go      — only user:read
+services/auth-service/oauth/youtube.go          — drop force-ssl
+services/auth-service/oauth/kick.go             — only user:read (both PKCE call sites)
+docs/adr/0012-oauth-scope-minimisation.md       — this file
+```
+
+`go build ./...` clean across the auth-service module; `go test ./oauth/...` passes (existing tests don't assert scope literals, so no test changes were needed).
+
+## Consequences
+
+### Positive
+
+- Smaller consent screens; expected uplift on viewer sign-in conversion.
+- Reduced token-leak blast radius across all three platforms.
+- Backend's intent matches its marketed privacy promise.
+- Removes confusion about why "send messages on your behalf" appears on a dashboard sign-in flow that never sends.
+
+### Negative
+
+- v1.5.x extension users who re-authenticate during the cutover window will see send failures and need to upgrade. We judge this acceptable per the cutover analysis above.
+- Backend's `sendKickMessage` / `sendYouTubeMessage` / Twitch viewer-side helix call become dead code. They stay in the repo for a release as a safety hatch but should be removed in a follow-up.
+
+### Reversibility
+
+Trivial — re-add a string to the appropriate `Scopes` slice and redeploy. Existing tokens are unaffected. The change is per-flow and narrowly scoped.
+
+## Related
+
+- Extension v1.6.0 release (commits `b76b1c3` CSP fix for emote APIs, `b98d309` popout SW relay, tag `v1.6.0`)
+- Future ADR (TBD): removal of dead viewer-side send handlers from `auth-service`

--- a/services/auth-service/oauth/kick.go
+++ b/services/auth-service/oauth/kick.go
@@ -73,7 +73,10 @@ func (k *KickOAuth) GetAuthURL(state string) string {
 	params.Set("response_type", "code")
 	params.Set("redirect_uri", k.redirectURL)
 	params.Set("state", state)
-	params.Set("scope", "chat:read user:read channel:read")
+	// Streamer flow only needs `user:read` for identity. `chat:read` is
+	// unused — kick-listener consumes chat over WebSocket without an OAuth
+	// gate. `channel:read` had no caller. See ADR 0012.
+	params.Set("scope", "user:read")
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
 
@@ -99,7 +102,10 @@ func (k *KickOAuth) GetAuthURLWithPKCE(state string) (authURL string, codeVerifi
 	params.Set("response_type", "code")
 	params.Set("redirect_uri", k.redirectURL)
 	params.Set("state", state)
-	params.Set("scope", "chat:read user:read channel:read")
+	// Streamer flow only needs `user:read` for identity. `chat:read` is
+	// unused — kick-listener consumes chat over WebSocket without an OAuth
+	// gate. `channel:read` had no caller. See ADR 0012.
+	params.Set("scope", "user:read")
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
 

--- a/services/auth-service/oauth/viewer_kick.go
+++ b/services/auth-service/oauth/viewer_kick.go
@@ -62,7 +62,11 @@ func (k *ViewerKickOAuth) GetAuthURLWithPKCE(state string) (authURL string, code
 	params.Set("response_type", "code")
 	params.Set("redirect_uri", k.redirectURL)
 	params.Set("state", state)
-	params.Set("scope", "chat:read chat:write user:read channel:read") // Added chat:write for sending messages
+	// Only `user:read` is needed for viewer identity. `chat:write` was dropped
+	// in v1.6.0 (extension uses Kick's REST API with cookie XSRF token now,
+	// not OAuth). `chat:read` and `channel:read` had no consumer in code.
+	// See ADR 0012.
+	params.Set("scope", "user:read")
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
 

--- a/services/auth-service/oauth/viewer_twitch.go
+++ b/services/auth-service/oauth/viewer_twitch.go
@@ -37,9 +37,12 @@ func NewViewerTwitchOAuth(clientID, clientSecret, redirectURL string) *ViewerTwi
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		RedirectURL:  redirectURL,
-		Scopes: []string{
-			"user:write:chat", // Required to send messages on behalf of the user
-		},
+		// No scopes requested. The viewer flow only needs to identify the
+		// user, and `helix/users GET` works without any scope on the access
+		// token. Chat sending moved to the extension's native Twitch session
+		// (GraphQL via cookie auth) in v1.6.0, so `user:write:chat` is no
+		// longer reachable from any current client. See ADR 0012.
+		Scopes: []string{},
 		Endpoint: twitch.Endpoint,
 	}
 

--- a/services/auth-service/oauth/viewer_youtube.go
+++ b/services/auth-service/oauth/viewer_youtube.go
@@ -42,9 +42,15 @@ func NewViewerYouTubeOAuth(clientID, clientSecret, redirectURL string) *ViewerYo
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		RedirectURL:  redirectURL,
+		// `youtube.force-ssl` (write) was dropped in v1.6.0 — chat sending now
+		// goes through the extension's native YouTube input bar (InnerTube +
+		// SAPISIDHASH from the page session), no longer through this token.
+		// `youtube.readonly` is still required for `channels?part=id&mine=true`
+		// in GetChannelID, which resolves the viewer's YouTube channel ID.
+		// See ADR 0012.
 		Scopes: []string{
-			"https://www.googleapis.com/auth/youtube.force-ssl", // Required for sending messages
-			"https://www.googleapis.com/auth/userinfo.profile",  // For user info
+			"https://www.googleapis.com/auth/youtube.readonly", // GetChannelID for viewer identity
+			"https://www.googleapis.com/auth/userinfo.profile", // Display name / profile pic
 		},
 		Endpoint: google.Endpoint,
 	}

--- a/services/auth-service/oauth/youtube.go
+++ b/services/auth-service/oauth/youtube.go
@@ -48,9 +48,15 @@ func NewYouTubeOAuth(clientID, clientSecret, redirectURL string) *YouTubeOAuth {
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		RedirectURL:  redirectURL,
+		// `youtube.force-ssl` was dropped in v1.6.0 — backend's
+		// sendStreamerYouTubeMessage path is no longer called by any current
+		// client (streamer-side YouTube sending happens via the streamer's
+		// own browser session in the extension or YT Studio directly).
+		// `youtube.readonly` is required by youtube-listener for polling
+		// liveChat/messages/stream against the streamer's account.
+		// See ADR 0012.
 		Scopes: []string{
 			"https://www.googleapis.com/auth/youtube.readonly",
-			"https://www.googleapis.com/auth/youtube.force-ssl",
 			"https://www.googleapis.com/auth/userinfo.profile",
 		},
 		Endpoint: google.Endpoint,


### PR DESCRIPTION
## Summary

Reduce viewer + streamer OAuth scopes to what's actually consumed by the current backend code. Extension v1.6.0 (just released) moved chat sending to native platform sessions, leaving several scopes unreachable.

| Provider × Flow | Scopes after this change | Removed |
|---|---|---|
| Twitch viewer | (empty) | `user:write:chat` |
| Twitch streamer | unchanged (4 EventSub scopes still active) | — |
| YouTube viewer | `youtube.readonly`, `userinfo.profile` | `youtube.force-ssl` (replaced with `readonly` for `GetChannelID`) |
| YouTube streamer | `youtube.readonly`, `userinfo.profile` | `youtube.force-ssl` |
| Kick viewer | `user:read` | `chat:read`, `chat:write`, `channel:read` |
| Kick streamer | `user:read` | `chat:read`, `channel:read` |
| Discord bot | unchanged | — |

Each removal traced to a missing call site in the repo. Detailed audit + cutover analysis in `docs/adr/0012-oauth-scope-minimisation.md`.

## Cutover

Hard cutover. v1.5.x extension users in the field still call the backend's `/auth/viewer/chat/send`; once they re-auth post-deploy they'll get reduced-scope tokens and see send failures, prompting upgrade to v1.6.0 (which doesn't need those scopes). Acceptable per the ADR — failure mode is a visible error, not silent corruption, and v1.6.0 store rollout is in flight.

## Test plan

- [x] `go build ./...` clean from `services/auth-service/`
- [x] `go test ./oauth/...` passes (no test asserted any removed scope literal)
- [ ] Post-deploy: fresh viewer sign-in for each provider — consent screen lists only the kept scopes
- [ ] Post-deploy: extension v1.6.0 sends still work on Twitch / YouTube / Kick (uses native sessions, not OAuth)
- [ ] Post-deploy: Twitch EventSub streamer flow still receives channel-points / subs / bits / follows
- [ ] Post-deploy: kick-listener still receives chat over WebSocket (no OAuth required)