### PR TITLE
fix(seventv-import): unbreak import for current 7TV URL/ID formats

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -474,6 +474,7 @@ func main() {
 		protectedAPI.POST("/overlays/:id/clone", proxyHandler.ForwardRequest)
 		protectedAPI.GET("/overlays/:id/config", proxyHandler.ForwardRequest)
 		protectedAPI.PUT("/overlays/:id/config", proxyHandler.ForwardRequest)
+		protectedAPI.POST("/overlays/:id/config/seventv/resolve", proxyHandler.ForwardRequest)
 		protectedAPI.GET("/overlays/:id/sources", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/overlays/:id/sources", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/overlays/:id/mock-messages", proxyHandler.ForwardRequest)

--- a/services/emote-service/clients/seventv.go
+++ b/services/emote-service/clients/seventv.go
@@ -435,8 +435,9 @@ func (c *SevenTVClient) FetchCombinedEmotes(ctx context.Context, channel, platfo
 	return allEmotes, nil
 }
 
-// fetchEmoteSetByID fetches a specific 7TV emote set by its 24-char hex ID.
-// channel is only used to populate the Channel field on the parsed emotes.
+// fetchEmoteSetByID fetches a specific 7TV emote set by its ID (24-char hex
+// legacy ObjectID or 26-char ULID). channel is only used to populate the
+// Channel field on the parsed emotes.
 func (c *SevenTVClient) fetchEmoteSetByID(ctx context.Context, setID, channel string) ([]models.Emote, error) {
 	urlPath := fmt.Sprintf("%s/v3/emote-sets/%s", c.baseURL, setID)
 

--- a/services/overlay-manager/clients/seventv_resolver.go
+++ b/services/overlay-manager/clients/seventv_resolver.go
@@ -30,12 +30,37 @@ import (
 )
 
 const (
-	sevenTVAPIBase           = "https://7tv.io"
-	sevenTVResolverTimeout   = 5 * time.Second
-	sevenTVEmoteSetIDPattern = `^[0-9a-fA-F]{24}$`
+	sevenTVAPIBase         = "https://7tv.io"
+	sevenTVResolverTimeout = 5 * time.Second
+	// 7TV uses two ID formats in the wild:
+	//   - 24-char lowercase-hex (legacy MongoDB ObjectIDs)
+	//   - 26-char Crockford-base32 ULIDs (current scheme, e.g. 01K0BT1KXDYA24WQJD80CRZC75)
+	// Both must be accepted so we can resolve user-pasted links and IDs.
+	sevenTVHexIDPattern  = `^[0-9a-fA-F]{24}$`
+	sevenTVULIDPattern   = `^[0-9A-HJKMNP-TV-Z]{26}$`
+	sevenTVUserIDPattern = sevenTVULIDPattern // user IDs are ULIDs
 )
 
-var sevenTVIDRegex = regexp.MustCompile(sevenTVEmoteSetIDPattern)
+var (
+	sevenTVHexIDRegex  = regexp.MustCompile(sevenTVHexIDPattern)
+	sevenTVULIDRegex   = regexp.MustCompile(sevenTVULIDPattern)
+	sevenTVUserIDRegex = regexp.MustCompile(sevenTVUserIDPattern)
+)
+
+// sevenTVKnownPlatforms is the set of platform connection slugs that 7TV
+// exposes under /v3/users/{platform}/{platform_id}. Anything outside this set
+// is treated as a 7TV user ID instead (so /users/{ulid}/emote-sets and
+// /users/{ulid}/... paths don't get mis-routed as platform lookups).
+var sevenTVKnownPlatforms = map[string]struct{}{
+	"twitch":  {},
+	"youtube": {},
+	"kick":    {},
+	"discord": {},
+}
+
+func isSevenTVID(s string) bool {
+	return sevenTVHexIDRegex.MatchString(s) || sevenTVULIDRegex.MatchString(s)
+}
 
 // SevenTVResolver validates and resolves user-supplied 7TV identifiers (raw
 // emote-set IDs, 7tv.app emote-set URLs, or 7tv.app user profile URLs) to a
@@ -80,13 +105,14 @@ func (r *SevenTVResolver) Resolve(ctx context.Context, input string) (ResolvedSe
 }
 
 // extractEmoteSetID parses the user input. Supported forms:
-//   - bare 24-char hex emote-set ID
-//   - URL pointing at /emote-sets/{id}     (e.g. https://7tv.app/emote-sets/abc...)
-//   - URL pointing at /users/{user_id}     (resolved to the user's active set)
-//   - URL pointing at /users/{platform}/{platform_id} (resolved via connection)
+//   - bare 24-char hex or 26-char ULID emote-set ID
+//   - URL pointing at /emote-sets/{id}                  (e.g. https://7tv.app/emote-sets/01K0...)
+//   - URL pointing at /users/{user_id}                  (resolved to the user's active set)
+//   - URL pointing at /users/{user_id}/emote-sets[/...] (same, the page the 7TV UI links to)
+//   - URL pointing at /users/{platform}/{platform_id}   (resolved via connection)
 func (r *SevenTVResolver) extractEmoteSetID(ctx context.Context, input string) (string, error) {
-	if sevenTVIDRegex.MatchString(input) {
-		return strings.ToLower(input), nil
+	if isSevenTVID(input) {
+		return normalizeSevenTVID(input), nil
 	}
 
 	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
@@ -101,26 +127,44 @@ func (r *SevenTVResolver) extractEmoteSetID(ctx context.Context, input string) (
 
 		segments := splitPath(parsed.Path)
 		if len(segments) >= 2 && segments[0] == "emote-sets" {
-			if !sevenTVIDRegex.MatchString(segments[1]) {
-				return "", fmt.Errorf("emote-set id in URL must be a 24-char hex string")
+			if !isSevenTVID(segments[1]) {
+				return "", fmt.Errorf("emote-set id in URL must be a 24-char hex or 26-char ULID")
 			}
-			return strings.ToLower(segments[1]), nil
+			return normalizeSevenTVID(segments[1]), nil
 		}
 
 		if len(segments) >= 2 && segments[0] == "users" {
-			// /users/{platform}/{id} or /users/{user_id}
-			if len(segments) >= 3 {
-				platform := segments[1]
-				platformID := segments[2]
-				return r.resolveUserConnectionToSetID(ctx, platform, platformID)
+			second := segments[1]
+			// Disambiguate /users/{user_id}[/...] from /users/{platform}/{id}.
+			// 7TV user IDs are 26-char ULIDs; platform slugs are short
+			// lowercase keywords (twitch, youtube, kick, discord). The
+			// 7TV UI links streamers' emote-set pages as
+			// /users/{user_id}/emote-sets — the trailing segment is part
+			// of the SPA route, not a platform id.
+			if sevenTVUserIDRegex.MatchString(second) {
+				return r.resolveUserToSetID(ctx, second)
 			}
-			return r.resolveUserToSetID(ctx, segments[1])
+			if _, ok := sevenTVKnownPlatforms[strings.ToLower(second)]; ok && len(segments) >= 3 {
+				return r.resolveUserConnectionToSetID(ctx, strings.ToLower(second), segments[2])
+			}
+			// Fallback: try as a user ID anyway (some legacy IDs may not match the ULID pattern).
+			return r.resolveUserToSetID(ctx, second)
 		}
 
 		return "", fmt.Errorf("URL path %q does not point to a 7TV emote set or user", parsed.Path)
 	}
 
-	return "", fmt.Errorf("input %q is not a 24-char emote-set id or a 7tv.app URL", input)
+	return "", fmt.Errorf("input %q is not a 7TV emote-set id or a 7tv.app URL", input)
+}
+
+// normalizeSevenTVID canonicalizes an ID for caching/storage: hex IDs are
+// lowercased (they're case-insensitive); ULIDs are uppercased per the
+// Crockford-base32 spec, which is how 7TV emits them.
+func normalizeSevenTVID(id string) string {
+	if sevenTVHexIDRegex.MatchString(id) {
+		return strings.ToLower(id)
+	}
+	return strings.ToUpper(id)
 }
 
 func (r *SevenTVResolver) fetchEmoteSet(ctx context.Context, setID string) (ResolvedSet, error) {
@@ -153,32 +197,100 @@ func (r *SevenTVResolver) fetchEmoteSet(ctx context.Context, setID string) (Reso
 
 func (r *SevenTVResolver) resolveUserToSetID(ctx context.Context, userID string) (string, error) {
 	endpoint := fmt.Sprintf("%s/v3/users/%s", r.baseURL, userID)
-	return r.extractActiveSetIDFromUser(ctx, endpoint)
-}
-
-func (r *SevenTVResolver) resolveUserConnectionToSetID(ctx context.Context, platform, platformID string) (string, error) {
-	endpoint := fmt.Sprintf("%s/v3/users/%s/%s", r.baseURL, platform, platformID)
-	return r.extractActiveSetIDFromUser(ctx, endpoint)
-}
-
-func (r *SevenTVResolver) extractActiveSetIDFromUser(ctx context.Context, endpoint string) (string, error) {
 	body, err := r.getJSON(ctx, endpoint)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch 7TV user: %w", err)
 	}
+	return extractActiveSetIDFromUserBody(body)
+}
 
+func (r *SevenTVResolver) resolveUserConnectionToSetID(ctx context.Context, platform, platformID string) (string, error) {
+	endpoint := fmt.Sprintf("%s/v3/users/%s/%s", r.baseURL, platform, platformID)
+	body, err := r.getJSON(ctx, endpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch 7TV user connection: %w", err)
+	}
+	return extractActiveSetIDFromConnectionBody(body)
+}
+
+// extractActiveSetIDFromUserBody parses a /v3/users/{user_id} response, which
+// looks roughly like:
+//
+//	{
+//	  "id": "...",
+//	  "emote_sets": [{"id": "...", "name": "...", ...}],
+//	  "connections": [{"platform":"TWITCH", "emote_set_id":"...", "emote_set":{"id":"..."}}]
+//	}
+//
+// We prefer the active emote_set_id on the first Twitch connection (that's the
+// set actually being used in chat), fall back to any connection, then to the
+// first owned emote_set. 7TV does not currently include a top-level
+// `emote_set` field on this endpoint despite what the older code assumed.
+func extractActiveSetIDFromUserBody(body []byte) (string, error) {
 	var resp struct {
-		EmoteSet struct {
+		EmoteSets []struct {
 			ID string `json:"id"`
-		} `json:"emote_set"`
+		} `json:"emote_sets"`
+		Connections []struct {
+			Platform    string `json:"platform"`
+			EmoteSetID  string `json:"emote_set_id"`
+			EmoteSetObj struct {
+				ID string `json:"id"`
+			} `json:"emote_set"`
+		} `json:"connections"`
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return "", fmt.Errorf("failed to decode 7TV user response: %w", err)
 	}
-	if resp.EmoteSet.ID == "" {
-		return "", fmt.Errorf("7TV user has no active emote set")
+
+	// Prefer Twitch connection (most users link Twitch first / use it as canonical).
+	for _, c := range resp.Connections {
+		if strings.EqualFold(c.Platform, "TWITCH") {
+			if id := firstNonEmpty(c.EmoteSetID, c.EmoteSetObj.ID); id != "" {
+				return id, nil
+			}
+		}
 	}
-	return resp.EmoteSet.ID, nil
+	// Any other connection with an active set.
+	for _, c := range resp.Connections {
+		if id := firstNonEmpty(c.EmoteSetID, c.EmoteSetObj.ID); id != "" {
+			return id, nil
+		}
+	}
+	// User has no platform connection but owns sets directly.
+	for _, s := range resp.EmoteSets {
+		if s.ID != "" {
+			return s.ID, nil
+		}
+	}
+	return "", fmt.Errorf("7TV user has no active emote set")
+}
+
+// extractActiveSetIDFromConnectionBody parses /v3/users/{platform}/{id}, which
+// returns a single connection object (not wrapped in a user).
+func extractActiveSetIDFromConnectionBody(body []byte) (string, error) {
+	var resp struct {
+		EmoteSetID  string `json:"emote_set_id"`
+		EmoteSetObj struct {
+			ID string `json:"id"`
+		} `json:"emote_set"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("failed to decode 7TV connection response: %w", err)
+	}
+	if id := firstNonEmpty(resp.EmoteSetID, resp.EmoteSetObj.ID); id != "" {
+		return id, nil
+	}
+	return "", fmt.Errorf("7TV user has no active emote set on this platform connection")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func (r *SevenTVResolver) getJSON(ctx context.Context, endpoint string) ([]byte, error) {

--- a/services/overlay-manager/clients/seventv_resolver_test.go
+++ b/services/overlay-manager/clients/seventv_resolver_test.go
@@ -28,12 +28,12 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-func TestSevenTVResolver_Resolve_BareID(t *testing.T) {
+func TestSevenTVResolver_Resolve_BareHexID(t *testing.T) {
 	const setID = "0123456789abcdef01234567"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Contains(t, r.URL.Path, "/v3/emote-sets/"+setID)
-		w.Write([]byte(`{"id": "` + setID + `", "name": "MySet", "emotes": [{"id": "a"}, {"id": "b"}]}`))
+		_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "MySet", "emotes": [{"id": "a"}, {"id": "b"}]}`))
 	}))
 	defer server.Close()
 
@@ -47,6 +47,24 @@ func TestSevenTVResolver_Resolve_BareID(t *testing.T) {
 	assert.Equal(t, 2, resolved.EmoteCount)
 }
 
+func TestSevenTVResolver_Resolve_BareULID(t *testing.T) {
+	const setID = "01K0BT1KXDYA24WQJD80CRZC75" // real 7TV ULID format
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, r.URL.Path, "/v3/emote-sets/"+setID)
+		_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "coom", "emotes": []}`))
+	}))
+	defer server.Close()
+
+	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
+	resolver.baseURL = server.URL
+
+	resolved, err := resolver.Resolve(context.Background(), setID)
+	require.NoError(t, err)
+	assert.Equal(t, setID, resolved.EmoteSetID)
+	assert.Equal(t, "coom", resolved.Name)
+}
+
 func TestSevenTVResolver_Resolve_EmptyInput(t *testing.T) {
 	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
 	// Empty input should be a clean no-op without hitting the network.
@@ -57,12 +75,12 @@ func TestSevenTVResolver_Resolve_EmptyInput(t *testing.T) {
 	assert.Equal(t, "", resolved.EmoteSetID)
 }
 
-func TestSevenTVResolver_Resolve_EmoteSetURL(t *testing.T) {
+func TestSevenTVResolver_Resolve_EmoteSetURL_Hex(t *testing.T) {
 	const setID = "abcdef0123456789abcdef01"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Contains(t, r.URL.Path, "/v3/emote-sets/"+setID)
-		w.Write([]byte(`{"id": "` + setID + `", "name": "URLSet", "emotes": []}`))
+		_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "URLSet", "emotes": []}`))
 	}))
 	defer server.Close()
 
@@ -74,15 +92,33 @@ func TestSevenTVResolver_Resolve_EmoteSetURL(t *testing.T) {
 	assert.Equal(t, setID, resolved.EmoteSetID)
 }
 
+func TestSevenTVResolver_Resolve_EmoteSetURL_ULID(t *testing.T) {
+	const setID = "01K0BT1KXDYA24WQJD80CRZC75"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Contains(t, r.URL.Path, "/v3/emote-sets/"+setID)
+		_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "ULIDSet", "emotes": [{"id":"x"}]}`))
+	}))
+	defer server.Close()
+
+	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
+	resolver.baseURL = server.URL
+
+	resolved, err := resolver.Resolve(context.Background(), "https://7tv.app/emote-sets/"+setID)
+	require.NoError(t, err)
+	assert.Equal(t, setID, resolved.EmoteSetID)
+	assert.Equal(t, 1, resolved.EmoteCount)
+}
+
 func TestSevenTVResolver_Resolve_UserConnectionURL(t *testing.T) {
 	const setID = "999999999999999999999999"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case strings.Contains(r.URL.Path, "/v3/users/twitch/71092938"):
-			w.Write([]byte(`{"emote_set": {"id": "` + setID + `"}}`))
+			_, _ = w.Write([]byte(`{"emote_set_id": "` + setID + `", "emote_set": {"id": "` + setID + `"}}`))
 		case strings.Contains(r.URL.Path, "/v3/emote-sets/"+setID):
-			w.Write([]byte(`{"id": "` + setID + `", "name": "ResolvedFromUser", "emotes": []}`))
+			_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "ResolvedFromUser", "emotes": []}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -98,6 +134,110 @@ func TestSevenTVResolver_Resolve_UserConnectionURL(t *testing.T) {
 	assert.Equal(t, "ResolvedFromUser", resolved.Name)
 }
 
+// TestSevenTVResolver_Resolve_UserULID_EmoteSetsURL is the regression test for
+// the broken-import bug — the 7TV web UI links streamers' emote-set pages as
+// /users/{user_id}/emote-sets and the old resolver mis-routed that to
+// /v3/users/{user_id}/emote-sets (which 7TV returns 400 "invalid platform" for).
+// It must now be treated as the user form and resolve via the user's Twitch
+// connection's active emote set.
+func TestSevenTVResolver_Resolve_UserULID_EmoteSetsURL(t *testing.T) {
+	const (
+		userID = "01K0BSRG70F5HE3TYNDYCPFR70"
+		setID  = "01K0BT1KXDYA24WQJD80CRZC75"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3/users/"+userID:
+			// Mirror the real 7TV response shape: emote_sets[] and connections[].
+			_, _ = w.Write([]byte(`{
+				"id": "` + userID + `",
+				"username": "tuffaholicc",
+				"emote_sets": [{"id": "` + setID + `", "name": "coom"}],
+				"connections": [{
+					"platform": "TWITCH",
+					"emote_set_id": "` + setID + `",
+					"emote_set": {"id": "` + setID + `"}
+				}]
+			}`))
+		case r.URL.Path == "/v3/emote-sets/"+setID:
+			_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "coom", "emotes": [{"id":"a"},{"id":"b"},{"id":"c"}]}`))
+		default:
+			t.Logf("unexpected request: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
+	resolver.baseURL = server.URL
+
+	// Both the bare /users/{id} form and the /users/{id}/emote-sets SPA form
+	// should resolve identically — that's the whole point of the fix.
+	for _, input := range []string{
+		"https://7tv.app/users/" + userID,
+		"https://7tv.app/users/" + userID + "/emote-sets",
+	} {
+		t.Run(input, func(t *testing.T) {
+			resolved, err := resolver.Resolve(context.Background(), input)
+			require.NoError(t, err)
+			assert.Equal(t, setID, resolved.EmoteSetID)
+			assert.Equal(t, "coom", resolved.Name)
+			assert.Equal(t, 3, resolved.EmoteCount)
+		})
+	}
+}
+
+// TestSevenTVResolver_Resolve_UserNoTwitchConnection covers a user whose
+// active set is reachable only via emote_sets[] or a non-Twitch connection.
+// We should still resolve to an active set, not error out.
+func TestSevenTVResolver_Resolve_UserNoTwitchConnection(t *testing.T) {
+	const (
+		userID = "01K0BSRG70F5HE3TYNDYCPFR70"
+		setID  = "01K0BT1KXDYA24WQJD80CRZC76"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3/users/"+userID:
+			_, _ = w.Write([]byte(`{
+				"id": "` + userID + `",
+				"emote_sets": [{"id": "` + setID + `", "name": "fallback"}],
+				"connections": [{"platform": "KICK", "emote_set_id": "` + setID + `"}]
+			}`))
+		case r.URL.Path == "/v3/emote-sets/"+setID:
+			_, _ = w.Write([]byte(`{"id": "` + setID + `", "name": "fallback", "emotes": []}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
+	resolver.baseURL = server.URL
+
+	resolved, err := resolver.Resolve(context.Background(), "https://7tv.app/users/"+userID)
+	require.NoError(t, err)
+	assert.Equal(t, setID, resolved.EmoteSetID)
+}
+
+func TestSevenTVResolver_Resolve_UserWithoutSets(t *testing.T) {
+	const userID = "01K0BSRG70F5HE3TYNDYCPFR70"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v3/users/"+userID, r.URL.Path)
+		_, _ = w.Write([]byte(`{"id": "` + userID + `", "emote_sets": [], "connections": []}`))
+	}))
+	defer server.Close()
+
+	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
+	resolver.baseURL = server.URL
+
+	_, err := resolver.Resolve(context.Background(), "https://7tv.app/users/"+userID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active emote set")
+}
+
 func TestSevenTVResolver_Resolve_InvalidInput(t *testing.T) {
 	resolver := NewSevenTVResolver(zaptest.NewLogger(t))
 	resolver.baseURL = "http://invalid.invalid"
@@ -107,11 +247,11 @@ func TestSevenTVResolver_Resolve_InvalidInput(t *testing.T) {
 		input   string
 		errPart string
 	}{
-		{"random gibberish", "not-an-id", "not a 24-char"},
-		{"too short hex", "deadbeef", "not a 24-char"},
+		{"random gibberish", "not-an-id", "not a 7TV emote-set id"},
+		{"too short hex", "deadbeef", "not a 7TV emote-set id"},
 		{"foreign host", "https://example.com/emote-sets/0123456789abcdef01234567", "unsupported host"},
 		{"7tv URL with bad path", "https://7tv.app/store", "does not point to"},
-		{"7tv emote-sets URL with bad id", "https://7tv.app/emote-sets/short", "24-char hex"},
+		{"7tv emote-sets URL with bad id", "https://7tv.app/emote-sets/short", "24-char hex or 26-char ULID"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The per-overlay 7TV emote-set override (#?, commit 980eb46a) shipped broken for every URL/ID the 7TV web UI actually hands users. Reproduced by pasting `https://7tv.app/users/01K0BSRG70F5HE3TYNDYCPFR70/emote-sets` (the URL of the **Emote Sets** tab on a user's profile) into the overlay editor's 7TV field on production — the Verify button returns 404 before the request even reaches overlay-manager. Same with the bare set URL `https://7tv.app/emote-sets/01K0BT1KXDYA24WQJD80CRZC75`.

Four independent bugs, all fixed here:

1. **api-gateway allowlist gap** — `POST /overlays/:id/config/seventv/resolve` was never registered in `protectedAPI`, so the gateway 404s before forwarding. (The PUT `/config` path that the *save* flow uses was already registered, which is why the bug only surfaced on Verify.)

2. **Resolver URL parsing** — `/users/{user_id}/emote-sets` was misparsed as `/users/{platform}/{platform_id}` and called `https://7tv.io/v3/users/{user_id}/emote-sets`, which 7TV returns `400 invalid platform` for. Now disambiguated: ULID-shaped second segment → user lookup, known platform slug (`twitch` / `youtube` / `kick` / `discord`) → connection lookup.

3. **ID regex stuck on MongoDB ObjectIDs** — the bare-ID and `/emote-sets/{id}` path required a 24-char hex string. Current 7TV IDs are 26-char Crockford-base32 ULIDs. Both formats now accepted.

4. **Wrong response shape** — `/v3/users/{user_id}` returns the active set under `connections[].emote_set_id` (preferred: Twitch connection) or `emote_sets[]`, **not** a top-level `emote_set` field. Old code returned "no active emote set" even on success.

## Verification

- Unit tests added for ULID IDs, the `/users/{id}/emote-sets` URL form, and the real connection-based response shape — all passing.
- E2E sanity check against the live 7TV API: the three forms in the bug report all resolve to the same set with the correct name and emote count.
- `go build ./...` and `go test ./...` green for `overlay-manager`, `api-gateway`, and `emote-service`.

## Test plan

- [ ] Once deployed: paste `https://7tv.app/users/01K0BSRG70F5HE3TYNDYCPFR70/emote-sets` into an overlay's 7TV field and click Verify → should resolve to "coom" (43 emotes).
- [ ] Same with `https://7tv.app/emote-sets/01K0BT1KXDYA24WQJD80CRZC75` (bare set URL).
- [ ] Same with `01K0BT1KXDYA24WQJD80CRZC75` (bare ULID).
- [ ] Save and confirm the set appears in messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)