### PR TITLE
fix(migrations): widen seventv_emote_set_id to TEXT for ULID format

### DIFF
--- a/migrations/054_widen_seventv_emote_set_id.sql
+++ b/migrations/054_widen_seventv_emote_set_id.sql
@@ -1,0 +1,15 @@
+-- 054: widen seventv_emote_set_id from VARCHAR(24) to TEXT.
+--
+-- Migration 053 sized the column for legacy 24-char MongoDB ObjectIDs, but
+-- 7TV's current scheme uses 26-char Crockford-base32 ULIDs (e.g.
+-- 01K0BT1KXDYA24WQJD80CRZC75). Any user attaching a current 7TV emote set
+-- (every set created post-migration to the new backend) hits a Postgres
+-- "value too long for type character varying(24)" 500 on save. The resolver
+-- code already accepts both formats; the column just has to fit them.
+--
+-- TEXT is used instead of VARCHAR(26) so any future ID-scheme tweak by 7TV
+-- doesn't require another migration; the column stays small in practice
+-- because real values are 24 or 26 chars.
+
+ALTER TABLE overlay_configs
+    ALTER COLUMN seventv_emote_set_id TYPE TEXT;

--- a/migrations/054_widen_seventv_emote_set_id_down.sql
+++ b/migrations/054_widen_seventv_emote_set_id_down.sql
@@ -1,0 +1,8 @@
+-- Rollback for 054: narrow seventv_emote_set_id back to VARCHAR(24).
+--
+-- WARNING: this will fail if any row contains a value longer than 24 chars
+-- (e.g. a 26-char ULID). Manually clear or truncate such rows before
+-- applying this rollback.
+
+ALTER TABLE overlay_configs
+    ALTER COLUMN seventv_emote_set_id TYPE VARCHAR(24);


### PR DESCRIPTION
## Summary

Saving any current-format 7TV emote set onto an overlay returned **HTTP 500**. Reproduced live: `PUT /api/v1/overlays/<id>/config` with `seventv_emote_set_id: "https://7tv.app/users/01K0BSRG70F5HE3TYNDYCPFR70/emote-sets"` → `500 failed to update overlay config`.

Root cause: migration `053_overlay_seventv_override.sql` declared the column as `VARCHAR(24)` for legacy 24-char MongoDB ObjectIDs. 7TV's current scheme uses 26-char Crockford-base32 ULIDs (e.g. `01K0BT1KXDYA24WQJD80CRZC75`). The resolver code (#343) already accepts both formats and returns the canonical ID, but Postgres rejects the insert with `value too long for type character varying(24)`. Symptom: Verify works (it doesn't touch the DB), Save 500s.

Fix: widen the column to `TEXT`. Trivial metadata-only ALTER, safe on a populated table. Down migration is provided but flagged as risky if any ULID has already been stored.

## Test plan

- [ ] After migration runs (init container on overlay-manager restart): save a current 7TV emote-set URL onto an overlay → 200, set ID persists, GET config returns the 26-char ULID.
- [ ] Frontend pill shows the set name (auto-resolved on next page load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)