### PR TITLE
ci(dependabot): drop auto-approve step (Actions cannot approve PRs)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,8 +5,10 @@ name: Dependabot auto-merge
 # for manual review. Auto-merge only completes once required status checks pass.
 #
 # Uses pull_request_target intentionally so GITHUB_TOKEN has write scope to
-# approve and label. We do NOT check out PR code here — only fetch metadata
-# and call gh on the PR — so the elevated token cannot run untrusted code.
+# enable auto-merge and label. We do NOT check out PR code here — only fetch
+# metadata and call gh on the PR — so the elevated token cannot run untrusted
+# code. No approval step: branch protection on main has no required reviews,
+# and GitHub Actions cannot approve PRs anyway (org-level restriction).
 
 on:
   pull_request_target:
@@ -36,7 +38,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.meta.outputs.dependency-names }} (${{ steps.meta.outputs.update-type }})"
           gh pr merge "$PR_URL" --auto --squash
 
       - name: Comment on minor/major bumps


### PR DESCRIPTION
First validation of the auto-merge workflow on PR #340 surfaced two issues:

1. `gh pr review --approve` returns *GitHub Actions is not permitted to approve pull requests* — the repo-level toggle `can_approve_pull_request_reviews` is `false` (org default).
2. The approval wasn't needed anyway: main's branch protection has `required_pull_request_reviews: null`, so `gh pr merge --auto` proceeds without a review once status checks pass.

Dropping the approve step. Auto-merge still waits for the required status checks before completing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)