### PR TITLE
chore(ci): gitignore cleanup + workflow PR path + nightly long-running tests

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,6 +18,7 @@ on:
       - 'services/**'
       - 'frontend/**'
       - 'shared/**'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,9 @@
 name: Dependabot auto-merge
 
-# Auto-approves and enables auto-merge for Dependabot PRs that are low-risk:
-# patch bumps and security updates of any severity. Minor and major bumps stay
-# for manual review. Auto-merge only completes once required status checks pass.
+# Enables auto-merge for Dependabot PRs that are low-risk: patch bumps and
+# security updates of any severity. Minor and major bumps stay for manual
+# review (labelled `needs-manual-review`). Auto-merge only completes once
+# required status checks pass.
 #
 # Uses pull_request_target intentionally so GITHUB_TOKEN has write scope to
 # enable auto-merge and label. We do NOT check out PR code here — only fetch

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,49 @@
+name: Nightly tests (long-running)
+
+# Runs the full Go test matrix without the `-short` flag so tests that are
+# excluded from PR CI (e.g. TestManager_JoinChannelsMultipleConnections_RespectsLeadership
+# which takes ~45s and flakes on GitHub-hosted runners under PR-time pressure)
+# are still covered. Failures here don't block PRs; they open an issue via
+# the standard Actions failure notification settings.
+
+on:
+  schedule:
+    # 04:00 UTC = 05:00 / 06:00 Berlin (winter / summer). Quiet hour, runners are free.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-full:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - auth-service
+          - overlay-manager
+          - emote-service
+          - api-gateway
+          - twitch-listener
+          - youtube-listener
+          - message-processor
+          - share-service
+          - source-manager
+          - token-refresh-service
+          - discord-listener
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Run full test suite for ${{ matrix.service }}
+        run: |
+          cd services/${{ matrix.service }}
+          go mod download
+          # No -short: include long-running concurrency/leadership tests.
+          go test -v -timeout 15m ./...

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,9 @@ docs/marketing/
 
 # Sub-repo symlinks (managed via .planning/config.json sub_repos)
 /caesar-deployment
+
+# Personal/local artifacts not part of the project
+.claude/projects/
+.claude/scheduled_tasks.lock
+package-lock.artillery.json
+post-save.yml


### PR DESCRIPTION
Three small follow-ups from the Dependabot auto-merge work in #358 / #359.

## 1. `.gitignore` — quiet local artifacts
Four files polluted every `git status` after the auto-merge work landed:
- `.claude/projects/` — Claude Code session state
- `.claude/scheduled_tasks.lock` — wakeup-scheduler lock
- `package-lock.artillery.json` — one-off artillery lockfile
- `post-save.yml` — Playwright a11y tree dump

All clearly personal-machine state.

## 2. `build-and-push.yml` — add `.github/workflows/**` to PR paths
With the new branch protection on `main` requiring the per-service `test (*)` jobs, workflow-only PRs were getting stuck in BLOCKED state forever: nothing in `services/`/`shared/` triggered build-and-push → required checks never reported → admin-merge was the only way out (#359 had to go that route).

Now workflow PRs go through the same CI as normal PRs.

## 3. `nightly-tests.yml` — run the full Go matrix without `-short`
Daily cron at 04:00 UTC. Specifically picks up `TestManager_JoinChannelsMultipleConnections_RespectsLeadership` which I had to gate behind `testing.Short()` in #358 — it consistently flaked at the 45s mark on GitHub-hosted PR runners but catches a real two-pod leadership coordination regression per its docstring.

## Test plan
- [ ] Merge — verify nightly workflow shows up in the Actions tab
- [ ] Wait for tomorrow's 04:00 UTC run to confirm the leadership test passes when not under PR time pressure
- [ ] Workflow PR test: any future workflow-only PR now triggers `test (*)` jobs (verified by this PR itself once it merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)