### PR TITLE
chore(frontend): inline GitHub SVG, drop lucide-react Github icon (unblocks #355)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -34,7 +34,7 @@ import { InfinityLogo } from '@/components/InfinityLogo'
 import { PlatformBadge } from '@/components/ui/badge'
 import { PLATFORM_COLORS } from '@/lib/platform-colors'
 import { toastManager } from '@/lib/toast'
-import { LayoutGrid, Zap, Palette, Puzzle, Github, LogIn, Plus, MonitorPlay } from 'lucide-react'
+import { LayoutGrid, Zap, Palette, Puzzle, LogIn, Plus, MonitorPlay } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
@@ -526,7 +526,9 @@ export default function LandingPage() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-3 py-1 text-xs font-medium text-text-sub underline-offset-4 hover:text-text hover:underline"
               >
-                <Github className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <svg className="h-3.5 w-3.5 shrink-0" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                  <path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+                </svg>
                 GitHub Releases
               </a>
             </div>
@@ -547,7 +549,9 @@ export default function LandingPage() {
             rel="noopener noreferrer"
             className="flex items-center gap-1 underline-offset-4 hover:text-text hover:underline"
           >
-            <Github className="h-3.5 w-3.5" aria-hidden="true" />
+            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+            </svg>
             GitHub
           </a>
           <span aria-hidden="true">&bull;</span>


### PR DESCRIPTION
Prepares the codebase for lucide-react v1 (#355).

## Why

lucide v1 [removed all brand icons](https://github.com/lucide-icons/lucide/issues/2792) — Github, Twitter, Instagram, etc. — as out-of-scope for a UI icon library. With #355 wanting to bump `lucide-react` 0.563.0 → 1.16.0, this is the only import that would break in our 22 icons across 18 source files (the other 21 are non-brand, all still in v1).

## What

Replaced the `<Github />` component at both call sites in `frontend/src/app/page.tsx` (the GitHub Releases CTA at L529 and the footer link at L550) with an inline `<svg>`. Matches the existing pattern already used for Firefox and Chrome icons in the same file (L507, L518). No new dependency, no bundle bloat.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Visual check on the landing page footer + extension section after merge

After this lands, #355 will be CLEAN and the auto-merge enabled there will pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)