### PR TITLE
fix(overlay): Monitor View discoverability + preserve timeout durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ https://allch.at/overlay/YOUR_OVERLAY_ID/view
 
 A Twitch-dashboard-inspired monitor with a **resizable live Chat panel + Activity feed**, per-platform connection indicators, a config summary, and its own **light/dark mode**. It ignores the overlay's themes and animations — purely for observability — and even keeps moderated messages visible (struck-through) with a moderation log. No login required; it reuses the same public overlay link.
 
+You can also open it from your overlay's settings page (or its preview page) via the **Monitor View** button.
+
 ### 3. Customize the look
 
 All-Chat ships with **12 ready-made themes** you can paste into your OBS Browser Source custom CSS:

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -2090,6 +2090,14 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               <Button
                 variant="outline"
                 size="sm"
+                onClick={() => window.open(`/overlay/${id}/view`, '_blank', 'noopener,noreferrer')}
+                title="Open the readable chat & activity monitor in a new tab"
+              >
+                Monitor View
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => router.push(`/overlays/${id}/events`)}
               >
                 Event Settings

--- a/services/message-processor/normalizer/deletion_test.go
+++ b/services/message-processor/normalizer/deletion_test.go
@@ -1,0 +1,108 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package normalizer
+
+import (
+	"testing"
+
+	"github.com/caesar/all-chat/services/message-processor/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeDeletion_BatchTimeout_BanDurationFloat64(t *testing.T) {
+	// After a JSON round-trip over Redis Streams, numeric EventData values are
+	// float64. This is the real production shape — a timeout must keep its duration.
+	raw := &models.RawChatMessage{
+		MessageID: "del-1",
+		Platform:  "twitch",
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type":   "batch",
+			"target_user_id":  "u123",
+			"target_username": "spammer",
+			"ban_duration":    float64(600),
+		},
+	}
+
+	unified := NormalizeDeletion(raw)
+
+	assert.Equal(t, "message_deletion", unified.Event.Type)
+	assert.Equal(t, "batch", unified.Event.Metadata["deletion_type"])
+	assert.Equal(t, "u123", unified.Event.Metadata["target_user_id"])
+	assert.Equal(t, "spammer", unified.Event.Metadata["target_username"])
+	// Forwarded as int and NOT dropped — distinguishes a timeout from a permanent ban.
+	assert.Equal(t, 600, unified.Event.Metadata["ban_duration"])
+}
+
+func TestNormalizeDeletion_BatchTimeout_BanDurationInt(t *testing.T) {
+	// Defensive: an in-process int (no JSON round-trip) must still work.
+	raw := &models.RawChatMessage{
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type":  "batch",
+			"target_user_id": "u123",
+			"ban_duration":   300,
+		},
+	}
+
+	unified := NormalizeDeletion(raw)
+
+	assert.Equal(t, 300, unified.Event.Metadata["ban_duration"])
+}
+
+func TestNormalizeDeletion_BatchBan_NoDuration(t *testing.T) {
+	// Permanent ban: no ban_duration present -> key omitted (frontend reads this as a ban).
+	raw := &models.RawChatMessage{
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type":  "batch",
+			"target_user_id": "u123",
+		},
+	}
+
+	unified := NormalizeDeletion(raw)
+
+	_, hasDuration := unified.Event.Metadata["ban_duration"]
+	assert.False(t, hasDuration, "permanent ban must not carry a ban_duration")
+	assert.Equal(t, "u123", unified.Event.Metadata["target_user_id"])
+}
+
+func TestNormalizeDeletion_Clear(t *testing.T) {
+	raw := &models.RawChatMessage{
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{"deletion_type": "clear"},
+	}
+
+	unified := NormalizeDeletion(raw)
+
+	assert.Equal(t, "clear", unified.Event.Metadata["deletion_type"])
+}
+
+func TestNormalizeDeletion_Single(t *testing.T) {
+	raw := &models.RawChatMessage{
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type": "single",
+			"target_uuid":   "msg-uuid-1",
+		},
+	}
+
+	unified := NormalizeDeletion(raw)
+
+	assert.Equal(t, "single", unified.Event.Metadata["deletion_type"])
+	assert.Equal(t, "msg-uuid-1", unified.Event.Metadata["target_uuid"])
+}

--- a/services/message-processor/normalizer/normalizer.go
+++ b/services/message-processor/normalizer/normalizer.go
@@ -55,8 +55,16 @@ func NormalizeDeletion(raw *models.RawChatMessage) *models.UnifiedChatMessage {
 		if username, ok := raw.EventData["target_username"].(string); ok {
 			eventMetadata["target_username"] = username
 		}
-		if duration, ok := raw.EventData["ban_duration"].(int); ok {
-			eventMetadata["ban_duration"] = duration
+		// ban_duration survives a JSON round-trip over Redis Streams as float64
+		// (gempir emits an int; the processor json.Unmarshals into a
+		// map[string]interface{}, widening numbers to float64). Accept both —
+		// otherwise the timeout duration is dropped and a timeout becomes
+		// indistinguishable from a permanent ban downstream.
+		switch d := raw.EventData["ban_duration"].(type) {
+		case float64:
+			eventMetadata["ban_duration"] = int(d)
+		case int:
+			eventMetadata["ban_duration"] = d
 		}
 
 	case "clear":


### PR DESCRIPTION
Two follow-ups to #368, both surfaced while answering "do we actually log bans?":

### 1. Discoverability — Monitor View button on the editor
The link only lived on the secondary **preview** page, but from the dashboard you land on the **editor** (`/overlays/[id]`). Adds a **Monitor View** button to the editor header action row (next to Event Settings / Credits / Clone), opening the monitor in a new tab. README updated.

### 2. Bug — timeouts were logged as permanent bans
Tracing the ban path end-to-end: Twitch `CLEARCHAT` → twitch-listener emits a `message_deletion` (`batch` for ban/timeout with `target_user_id`/`ban_duration`, `clear` for full clear) → normalizer → the monitor view's mod log. **Bans/timeouts/clears are logged.**

But `normalizer.go` read `ban_duration` with a Go `.(int)` assertion. The value round-trips through Redis Streams as JSON, arriving as **`float64`** (every other numeric `EventData` field is handled as float64), so the assertion failed and the duration was **silently dropped** — a timeout became indistinguishable from a permanent ban. Now accepts both float64 and int, with `NormalizeDeletion` tests covering the float64 (production), int, permanent-ban, clear, and single paths.

This was latent before the monitor view because the OBS overlay only uses batch deletions to *remove* messages and never read `ban_duration`.