### PR TITLE
fix(twitch-eventsub): publish chat platform status + cut connect latency

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -249,6 +249,7 @@ jobs:
           - emote-service
           - api-gateway
           - twitch-listener
+          - twitch-eventsub-listener
           - youtube-listener
           - message-processor
           - share-service

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -27,6 +27,7 @@ jobs:
           - emote-service
           - api-gateway
           - twitch-listener
+          - twitch-eventsub-listener
           - youtube-listener
           - message-processor
           - share-service

--- a/services/twitch-eventsub-listener/README.md
+++ b/services/twitch-eventsub-listener/README.md
@@ -27,10 +27,37 @@ The Twitch EventSub Listener connects to Twitch's EventSub WebSocket API to rece
 
 ### Currently Implemented
 - ✅ `channel.channel_points_custom_reward_redemption.add` - Channel point redemptions
+- ✅ `channel.subscribe` / `channel.subscription.gift` / `channel.subscription.message` - Subscriptions, gifts, resubs
+- ✅ `channel.cheer`, `channel.raid`, `channel.follow` - Bits, raids, follows
+- ✅ `stream.online` / `stream.offline` - Stream lifecycle (cross-platform discovery + credits)
+- ✅ `channel.chat.message` - **Chat reading** (demand-gated; see below)
 
-### Optional (Already Handled via IRC)
-- ⏸️ `channel.subscribe` - Subscriptions (IRC USERNOTICE is sufficient)
-- ⏸️ `channel.subscription.gift` - Gift subs (IRC USERNOTICE is sufficient)
+> Transport note: subscriptions use **webhook** transport (HTTP callback at `EVENTSUB_CALLBACK_URL`), not the EventSub WebSocket. Twitch verifies each subscription via a `webhook_callback_verification` challenge before it becomes `enabled`.
+
+### Chat Reading (channel.chat.message)
+
+To relieve the IRC bot's ~100-channel cap, channels whose owner granted the chat scopes
+(`user:read:chat` + `user:bot`) are read via EventSub instead of IRC. The IRC listener and the
+EventSub listener use a byte-identical `granted_scopes` predicate so each channel lands on exactly
+one path (no double-read, no gap).
+
+The chat subscription is **demand-gated**: it exists only while an overlay using the channel has a
+live WebSocket. When demand arrives, the chat subscription is created *before* the always-on event
+subscriptions so chat starts flowing with minimal latency.
+
+### Platform Status Indicators
+
+The listener publishes the chat channel's connection state to the `platform:status` Redis Pub/Sub
+channel (consumed by api-gateway → overlay indicators), keyed by the lowercased login to match
+`overlay_chat_sources.channel_id`:
+
+- **`connected`** — published by the webhook handler when Twitch verifies the `channel.chat.message`
+  subscription (it is then `enabled` and will deliver). The login is resolved from `users.twitch_id`,
+  so any pod receiving the verification can publish it.
+- **`offline`** — published by the channel manager when the chat subscription is torn down (demand
+  lost or channel removed), and by the webhook handler on subscription revocation.
+
+Without this, channels moved off IRC to EventSub would show no Twitch indicator.
 
 ## Architecture
 

--- a/services/twitch-eventsub-listener/channels/manager.go
+++ b/services/twitch-eventsub-listener/channels/manager.go
@@ -19,9 +19,11 @@ package channels
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
 	"github.com/caesar/all-chat/shared/encryption"
 	"github.com/caesar/all-chat/shared/listener"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -61,6 +63,12 @@ type Manager struct {
 	resolver UserIDResolver
 	callback SubscriptionCallback
 	cipher   *encryption.MultiKeyEncryptor
+
+	// statusPublisher emits platform:status "offline" when a channel's chat subscription is
+	// torn down (demand lost or channel removed). The matching "connected" is published by the
+	// webhook handler when Twitch verifies the chat subscription (it is actually enabled by
+	// then). nil disables status publishing.
+	statusPublisher *status.Publisher
 
 	mu       sync.RWMutex
 	channels map[string]*Channel // broadcaster_id -> Channel
@@ -143,6 +151,34 @@ func (m *Manager) resolveBroadcasterID(ctx context.Context, login string) (strin
 // SetSubscriptionCallback sets the callback for channel changes
 func (m *Manager) SetSubscriptionCallback(callback SubscriptionCallback) {
 	m.callback = callback
+}
+
+// SetStatusPublisher injects the platform-status publisher used to emit "offline" on chat
+// teardown. Safe to leave unset (publishing becomes a no-op).
+func (m *Manager) SetStatusPublisher(pub *status.Publisher) {
+	m.statusPublisher = pub
+}
+
+// publishChatOffline emits a platform:status "offline" for the channel's chat indicator,
+// keyed by the lowercased login (channel_id in overlay_chat_sources) so the api-gateway
+// status subscriber routes it to the right overlays — matching the IRC listener's convention.
+//
+// It publishes on a background goroutine with its own timeout: callers hold m.mu (it is invoked
+// from reconcileChatLocked / SyncChannels), and the publisher retries with backoff on Redis
+// failure, so a synchronous call would hold the manager lock across that retry window.
+func (m *Manager) publishChatOffline(login string) {
+	if m.statusPublisher == nil || login == "" {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		m.statusPublisher.Publish(ctx, status.Message{
+			Platform:  "twitch",
+			ChannelID: strings.ToLower(login),
+			Status:    "offline",
+		})
+	}()
 }
 
 // SetAssignedSourceIDs sets the assigned source IDs for filtering (coordinator integration)
@@ -246,6 +282,8 @@ func (m *Manager) reconcileChatLocked(demanded map[string]listener.DemandedSourc
 				continue
 			}
 			ch.ChatActive = false
+			// Chat reading stopped for this channel — clear its overlay indicator.
+			m.publishChatOffline(ch.BroadcasterName)
 		}
 	}
 }
@@ -439,6 +477,21 @@ func (m *Manager) SyncChannels(ctx context.Context) error {
 				zap.Bool("has_chat_scope", fresh.HasChatScope),
 			)
 			if m.callback != nil {
+				// Create the chat subscription FIRST when the channel already has demand: it is
+				// the latency-sensitive, overlay-visible path, so we don't make it wait behind
+				// the (slower, sequential) always-on event-subscription setup. The chat callback
+				// is idempotent, so a later reconcileChatLocked pass is a no-op.
+				if fresh.HasChatScope && isChatDemanded(fresh.SourceIDs, demanded) {
+					if err := m.callback(broadcasterID, fresh.AccessToken, "subscribe_chat"); err != nil {
+						m.logger.Warn("Failed to subscribe chat for new channel",
+							zap.String("broadcaster_id", broadcasterID),
+							zap.Error(err),
+						)
+					} else {
+						fresh.ChatActive = true
+					}
+				}
+
 				if err := m.callback(broadcasterID, fresh.AccessToken, "subscribe"); err != nil {
 					m.logger.Error("Failed to subscribe to channel",
 						zap.String("broadcaster_id", broadcasterID),
@@ -457,7 +510,7 @@ func (m *Manager) SyncChannels(ctx context.Context) error {
 	}
 
 	// Find removed channels (delete ALL their subscriptions)
-	for broadcasterID := range m.channels {
+	for broadcasterID, ch := range m.channels {
 		if _, exists := activeChannels[broadcasterID]; !exists {
 			m.logger.Info("Channel removed",
 				zap.String("broadcaster_id", broadcasterID),
@@ -471,6 +524,11 @@ func (m *Manager) SyncChannels(ctx context.Context) error {
 					)
 					continue
 				}
+			}
+
+			// Removing the channel deletes its chat subscription too — clear the indicator.
+			if ch.ChatActive {
+				m.publishChatOffline(ch.BroadcasterName)
 			}
 
 			delete(m.channels, broadcasterID)

--- a/services/twitch-eventsub-listener/channels/manager_test.go
+++ b/services/twitch-eventsub-listener/channels/manager_test.go
@@ -18,13 +18,128 @@ package channels
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
+	"github.com/caesar/all-chat/shared/listener"
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 )
+
+// recordingCallback records the (broadcasterID, action) pairs the manager invokes, in order.
+type recordingCallback struct {
+	mu      sync.Mutex
+	actions []string // "action:broadcasterID"
+}
+
+func (r *recordingCallback) fn(broadcasterID, _ string, action string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.actions = append(r.actions, action+":"+broadcasterID)
+	return nil
+}
+
+func (r *recordingCallback) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.actions))
+	copy(out, r.actions)
+	return out
+}
+
+func demandFor(sourceIDs ...string) map[string]listener.DemandedSource {
+	d := make(map[string]listener.DemandedSource, len(sourceIDs))
+	for _, s := range sourceIDs {
+		d[s] = listener.DemandedSource{SourceID: s}
+	}
+	return d
+}
+
+// TestReconcileChat_SubscribesWhenScopedAndDemanded verifies a chat subscription is created
+// only when the channel has the chat scope AND live-overlay demand.
+func TestReconcileChat_SubscribesWhenScopedAndDemanded(t *testing.T) {
+	cb := &recordingCallback{}
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "scoped", SourceIDs: []string{"s1"}, HasChatScope: true}
+	m.channels["222"] = &Channel{BroadcasterID: "222", BroadcasterName: "noscope", SourceIDs: []string{"s2"}, HasChatScope: false}
+
+	m.mu.Lock()
+	m.reconcileChatLocked(demandFor("s1", "s2"))
+	m.mu.Unlock()
+
+	got := cb.snapshot()
+	if len(got) != 1 || got[0] != "subscribe_chat:111" {
+		t.Fatalf("want exactly [subscribe_chat:111], got %v", got)
+	}
+	if !m.channels["111"].ChatActive {
+		t.Fatal("scoped+demanded channel should be marked ChatActive")
+	}
+	if m.channels["222"].ChatActive {
+		t.Fatal("unscoped channel must not become ChatActive")
+	}
+}
+
+// TestReconcileChat_UnsubscribesAndPublishesOffline verifies that when demand drops, the chat
+// subscription is torn down AND an "offline" platform:status is published keyed by the
+// lowercased login, so the overlay indicator clears.
+func TestReconcileChat_UnsubscribesAndPublishesOffline(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mr.Close()
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rc.Close()
+
+	// Subscribe before triggering so we don't miss the message.
+	sub := rc.Subscribe(context.Background(), status.PlatformStatusChannel)
+	defer sub.Close()
+	if _, err := sub.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	msgs := sub.Channel()
+
+	cb := &recordingCallback{}
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetStatusPublisher(status.NewPublisher(rc, zap.NewNop()))
+
+	// Channel currently reading chat ("CaesarLP" mixed-case to prove lowercasing) but demand gone.
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "CaesarLP", SourceIDs: []string{"s1"}, HasChatScope: true, ChatActive: true}
+
+	// An explicit empty (non-nil) demand map means "no demand" (nil would fail open).
+	m.mu.Lock()
+	m.reconcileChatLocked(map[string]listener.DemandedSource{})
+	m.mu.Unlock()
+
+	if got := cb.snapshot(); len(got) != 1 || got[0] != "unsubscribe_chat:111" {
+		t.Fatalf("want exactly [unsubscribe_chat:111], got %v", got)
+	}
+	if m.channels["111"].ChatActive {
+		t.Fatal("channel should no longer be ChatActive after teardown")
+	}
+
+	select {
+	case msg := <-msgs:
+		var sm status.Message
+		if err := json.Unmarshal([]byte(msg.Payload), &sm); err != nil {
+			t.Fatalf("bad status payload: %v", err)
+		}
+		if sm.Platform != "twitch" || sm.ChannelID != "caesarlp" || sm.Status != "offline" {
+			t.Fatalf("unexpected status: %+v", sm)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an offline platform:status publish, got none")
+	}
+}
 
 // countingResolver counts GetUserIDByLogin calls to verify caching.
 type countingResolver struct {

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/channels"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/webhooks"
 	"github.com/caesar/all-chat/shared/database"
 	"github.com/caesar/all-chat/shared/encryption"
@@ -154,8 +155,10 @@ func main() {
 
 	// Initialize components
 	streamPublisher := publisher.NewStreamPublisher(redisClient, log)
+	statusPublisher := status.NewPublisher(redisClient, log)
 	subscriptionMgr := eventsub.NewSubscriptionManager(twitchClientID, twitchClientSecret, webhookSecret, callbackURL, log)
 	channelManager := channels.NewManager(db, log, subscriptionMgr, tokenCipher, ChannelSyncInterval)
+	channelManager.SetStatusPublisher(statusPublisher)
 
 	// Start LeadershipListener — runs demand subscriber; channel manager started after leadership
 	if err := ll.Start(ctx, channelManager); err != nil {
@@ -163,7 +166,7 @@ func main() {
 	}
 
 	// Create webhook handler
-	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, log)
+	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, log)
 
 	// isLeader tracks whether this pod currently holds EventSub leadership.
 	// Protected by mu; read by subscription callback and HTTP handlers.

--- a/services/twitch-eventsub-listener/go.mod
+++ b/services/twitch-eventsub-listener/go.mod
@@ -3,6 +3,7 @@ module github.com/caesar/all-chat/services/twitch-eventsub-listener
 go 1.25.6
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/caesar/all-chat/shared v0.0.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/uuid v1.6.0
@@ -55,6 +56,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect

--- a/services/twitch-eventsub-listener/status/publisher.go
+++ b/services/twitch-eventsub-listener/status/publisher.go
@@ -1,0 +1,97 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesar/all-chat/shared/listener"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+const (
+	PlatformStatusChannel = "platform:status"
+	// maxPublishAttempts is the number of attempts (1 initial + 2 retries = 3 total).
+	maxPublishAttempts = 3
+)
+
+// Message represents a platform connection status update
+type Message struct {
+	Platform     string     `json:"platform"`
+	ChannelID    string     `json:"channel_id"`
+	ChannelName  string     `json:"channel_name,omitempty"`
+	Status       string     `json:"status"` // "connected", "reconnecting", "offline"
+	NextRetryAt  *time.Time `json:"next_retry_at,omitempty"`
+	ErrorMessage string     `json:"error_message,omitempty"`
+}
+
+// marshalMessage serializes a Message to a JSON string for Redis Pub/Sub.
+func marshalMessage(msg Message) (string, error) {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// Publisher publishes platform status updates to Redis Pub/Sub
+type Publisher struct {
+	redisClient *redis.Client
+	logger      *zap.Logger
+}
+
+func NewPublisher(redisClient *redis.Client, logger *zap.Logger) *Publisher {
+	return &Publisher{redisClient: redisClient, logger: logger}
+}
+
+// Publish publishes a platform status message to Redis Pub/Sub.
+// On failure it retries up to maxPublishAttempts times with jittered exponential backoff.
+// If the context is cancelled between retries, it returns immediately.
+// After all attempts are exhausted, logs at Error level with sentinel "status_publish_exhausted".
+func (p *Publisher) Publish(ctx context.Context, msg Message) {
+	data, err := marshalMessage(msg)
+	if err != nil {
+		p.logger.Error("Failed to marshal status message", zap.Error(err))
+		return
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxPublishAttempts; attempt++ {
+		if attempt > 0 {
+			// Wait with jittered backoff, but honour context cancellation.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(listener.JitteredBackoff(attempt)):
+			}
+		}
+
+		if err := p.redisClient.Publish(ctx, PlatformStatusChannel, data).Err(); err != nil {
+			lastErr = err
+			continue
+		}
+		return // success
+	}
+
+	p.logger.Error("status_publish_exhausted",
+		zap.Int("attempts", maxPublishAttempts),
+		zap.Error(lastErr),
+	)
+}

--- a/services/twitch-eventsub-listener/status/publisher_test.go
+++ b/services/twitch-eventsub-listener/status/publisher_test.go
@@ -1,0 +1,185 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package status
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// publisherFunc is a function that simulates a Redis publish call.
+// The publisher uses this to allow test injection without a real Redis client.
+type publisherFunc func(ctx context.Context, channel string, data string) error
+
+// testPublisher wraps a publish function for testing.
+// This avoids needing a real Redis client or miniredis.
+type testPublisher struct {
+	publishFn publisherFunc
+	logger    *zap.Logger
+}
+
+func (p *testPublisher) publish(ctx context.Context, msg Message) {
+	data, err := marshalMessage(msg)
+	if err != nil {
+		p.logger.Error("Failed to marshal status message", zap.Error(err))
+		return
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxPublishAttempts; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(testBackoff(attempt)):
+			}
+		}
+		if err := p.publishFn(ctx, PlatformStatusChannel, data); err != nil {
+			lastErr = err
+			continue
+		}
+		return
+	}
+
+	p.logger.Error("status_publish_exhausted",
+		zap.Int("attempts", maxPublishAttempts),
+		zap.Error(lastErr),
+	)
+}
+
+// testBackoff is a deterministic zero-duration backoff for tests.
+func testBackoff(_ int) time.Duration {
+	return 0
+}
+
+// TestStatusPublisher_SuccessOnFirstTry verifies no retry occurs when Redis is healthy.
+func TestStatusPublisher_SuccessOnFirstTry(t *testing.T) {
+	var callCount atomic.Int32
+	publishFn := func(ctx context.Context, channel, data string) error {
+		callCount.Add(1)
+		return nil
+	}
+
+	logger := zap.NewNop()
+	p := &testPublisher{publishFn: publishFn, logger: logger}
+	p.publish(context.Background(), Message{Platform: "twitch", ChannelID: "xqc", Status: "connected"})
+
+	assert.Equal(t, int32(1), callCount.Load(), "should call publish exactly once on success")
+}
+
+// TestStatusPublisher_RetriesOnFailure verifies up to 3 retry attempts on Redis failure.
+func TestStatusPublisher_RetriesOnFailure(t *testing.T) {
+	var callCount atomic.Int32
+	publishFn := func(ctx context.Context, channel, data string) error {
+		callCount.Add(1)
+		return errors.New("redis: connection refused")
+	}
+
+	logger := zap.NewNop()
+	p := &testPublisher{publishFn: publishFn, logger: logger}
+	p.publish(context.Background(), Message{Platform: "twitch", ChannelID: "xqc", Status: "connected"})
+
+	assert.Equal(t, int32(maxPublishAttempts), callCount.Load(),
+		"should retry exactly %d times on persistent failure", maxPublishAttempts)
+}
+
+// TestStatusPublisher_SucceedsOnSecondAttempt verifies that when the first attempt fails
+// but the second succeeds, no further attempts are made.
+func TestStatusPublisher_SucceedsOnSecondAttempt(t *testing.T) {
+	var callCount atomic.Int32
+	publishFn := func(ctx context.Context, channel, data string) error {
+		n := callCount.Add(1)
+		if n == 1 {
+			return errors.New("transient error")
+		}
+		return nil
+	}
+
+	logger := zap.NewNop()
+	p := &testPublisher{publishFn: publishFn, logger: logger}
+	p.publish(context.Background(), Message{Platform: "twitch", ChannelID: "xqc", Status: "connected"})
+
+	assert.Equal(t, int32(2), callCount.Load(), "should stop retrying after first success")
+}
+
+// TestStatusPublisher_LogsErrorAfterExhaustion verifies that an error is logged after all
+// retry attempts are exhausted.
+func TestStatusPublisher_LogsErrorAfterExhaustion(t *testing.T) {
+	publishFn := func(ctx context.Context, channel, data string) error {
+		return errors.New("redis: connection refused")
+	}
+
+	core, logs := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+
+	p := &testPublisher{publishFn: publishFn, logger: logger}
+	p.publish(context.Background(), Message{Platform: "twitch", ChannelID: "xqc", Status: "connected"})
+
+	entries := logs.All()
+	require.Len(t, entries, 1, "should log exactly one error after exhausting retries")
+	assert.Equal(t, "status_publish_exhausted", entries[0].Message)
+}
+
+// TestStatusPublisher_RespectsContextCancellation verifies that in-progress retries
+// stop when the context is cancelled.
+func TestStatusPublisher_RespectsContextCancellation(t *testing.T) {
+	// Use a real backoff publisher with a slow backoff to allow cancellation.
+	var callCount atomic.Int32
+	publishFn := func(ctx context.Context, channel, data string) error {
+		callCount.Add(1)
+		return errors.New("redis: unavailable")
+	}
+
+	// Override backoff for this test with a real delay.
+	// We test via the real Publisher which uses JitteredBackoff — not the testPublisher.
+	// For this test, we just verify the real Publish method respects ctx cancellation
+	// by using a cancelled context from the start.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	// The real Publisher should not even attempt to retry after ctx is done.
+	// Since the context is already cancelled, retries after attempt 0 should be skipped.
+	// This is a best-effort check — the actual retry logic in Publisher.Publish
+	// should detect ctx.Done() before sleeping.
+	logger := zap.NewNop()
+	p := &testPublisher{publishFn: publishFn, logger: logger}
+
+	// With the real testPublisher, time.After(0) still allows a select to pick ctx.Done().
+	// Since testBackoff returns 0, this race isn't guaranteed, so we just verify
+	// the function returns promptly (no hanging).
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.publish(ctx, Message{Platform: "twitch", ChannelID: "xqc", Status: "connected"})
+	}()
+
+	select {
+	case <-done:
+		// Good — returned promptly
+	case <-time.After(2 * time.Second):
+		t.Error("Publish did not return promptly when context was cancelled")
+	}
+}

--- a/services/twitch-eventsub-listener/webhooks/handler.go
+++ b/services/twitch-eventsub-listener/webhooks/handler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/models"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
 	"github.com/caesar/all-chat/shared/metrics"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -52,20 +53,22 @@ type StreamEndEvent struct {
 type Handler struct {
 	secret          []byte
 	redis           *redis.Client
-	db              *pgxpool.Pool // for twitch_id -> user_id lookup
+	db              *pgxpool.Pool // for twitch_id -> user_id / login lookup
 	publisher       *publisher.StreamPublisher
 	listenerMetrics *metrics.ListenerMetrics
+	statusPublisher *status.Publisher // emits platform:status for the chat indicator (nil-safe)
 	logger          *zap.Logger
 }
 
 // NewHandler creates a new webhook handler
-func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, logger *zap.Logger) *Handler {
+func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, statusPublisher *status.Publisher, logger *zap.Logger) *Handler {
 	return &Handler{
 		secret:          []byte(secret),
 		redis:           redis,
 		db:              db,
 		publisher:       publisher,
 		listenerMetrics: listenerMetrics,
+		statusPublisher: statusPublisher,
 		logger:          logger,
 	}
 }
@@ -172,8 +175,17 @@ func (h *Handler) handleChallenge(c *gin.Context, body []byte) {
 		h.listenerMetrics.RecordConnection("twitch-eventsub", "twitch-eventsub-listener", "webhook", true)
 	}
 
-	// Respond with challenge string
+	// Respond with challenge string FIRST — Twitch enforces a short verification timeout, so we
+	// must not block the response on the status publish below.
 	c.String(http.StatusOK, challenge.Challenge)
+
+	// A verified channel.chat.message subscription is now enabled and will deliver chat, so the
+	// channel's chat is "connected". Publish in the background to keep the challenge response fast.
+	if challenge.Subscription.Type == "channel.chat.message" {
+		if bid := conditionBroadcasterID(challenge.Subscription.Condition); bid != "" {
+			go h.publishChatStatus(bid, "connected")
+		}
+	}
 }
 
 // handleNotification processes an event notification
@@ -250,7 +262,56 @@ func (h *Handler) handleRevocation(c *gin.Context, body []byte) {
 		zap.String("status", revocation.Subscription.Status),
 	)
 
+	// A revoked chat subscription stops delivering chat — clear the channel's indicator.
+	if revocation.Subscription.Type == "channel.chat.message" {
+		if bid := conditionBroadcasterID(revocation.Subscription.Condition); bid != "" {
+			go h.publishChatStatus(bid, "offline")
+		}
+	}
+
 	c.Status(http.StatusNoContent)
+}
+
+// conditionBroadcasterID extracts broadcaster_user_id from an EventSub subscription condition
+// (typed as map[string]interface{}). Returns "" when absent or not a string.
+func conditionBroadcasterID(condition map[string]interface{}) string {
+	if condition == nil {
+		return ""
+	}
+	if v, ok := condition["broadcaster_user_id"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// publishChatStatus emits a platform:status update for a Twitch channel's chat indicator.
+// It resolves the broadcaster's login (the key api-gateway matches against
+// overlay_chat_sources.channel_id) from the users table, since the webhook may land on any
+// pod — including a non-leader whose channel manager has no in-memory mapping. Best-effort:
+// a missing user or publish failure is logged and dropped.
+func (h *Handler) publishChatStatus(broadcasterID, state string) {
+	if h.statusPublisher == nil || broadcasterID == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var login string
+	err := h.db.QueryRow(ctx,
+		"SELECT username FROM users WHERE twitch_id = $1 AND auth_provider = 'twitch'", broadcasterID).Scan(&login)
+	if err != nil || login == "" {
+		h.logger.Debug("Could not resolve login for chat status",
+			zap.String("broadcaster_id", broadcasterID),
+			zap.Error(err))
+		return
+	}
+
+	h.statusPublisher.Publish(ctx, status.Message{
+		Platform:  "twitch",
+		ChannelID: strings.ToLower(login),
+		Status:    state,
+	})
 }
 
 // routeEvent routes events to appropriate handlers based on subscription type

--- a/services/twitch-eventsub-listener/webhooks/handler_chat_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_chat_test.go
@@ -184,3 +184,23 @@ func TestBuildChatTags_SharedChat(t *testing.T) {
 		}
 	}
 }
+
+func TestConditionBroadcasterID(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition map[string]interface{}
+		want      string
+	}{
+		{"nil condition", nil, ""},
+		{"missing key", map[string]interface{}{"user_id": "5"}, ""},
+		{"non-string value", map[string]interface{}{"broadcaster_user_id": 67241623}, ""},
+		{"present", map[string]interface{}{"broadcaster_user_id": "67241623", "user_id": "67241623"}, "67241623"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := conditionBroadcasterID(tt.condition); got != tt.want {
+				t.Errorf("conditionBroadcasterID(%v) = %q, want %q", tt.condition, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

We recently switched chat-scoped Twitch channels from IRC to EventSub (`channel.chat.message`, demand-gated). Two issues surfaced:

1. **Platform indicator broken for EventSub channels.** Every listener publishes connect/offline to the `platform:status` Redis channel (relayed by api-gateway to overlays) — except the EventSub listener, which had **no status publisher at all**. Since `twitch-listener` now *excludes* chat-scoped channels from IRC, those channels published nothing, so their Twitch indicator showed offline/stale.

2. **Connect latency** ("messages flow, but later than I'd appreciate"). Since `aafccfdb` demand-gated the whole sync, a newly-demanded channel runs the full 8-subscription event setup sequentially (~1.5s) and only *then* creates the chat subscription, after which Twitch's webhook verification adds more delay — so early messages are lost during setup.

## Changes

- New `status` publisher (mirrors `twitch-listener/status`).
- **`connected`** published by the webhook handler when Twitch verifies a `channel.chat.message` subscription (it is `enabled` by then). Login resolved from `users.twitch_id` so any pod receiving the verification can publish it.
- **`offline`** published by the channel manager on demand-loss / channel removal, and by the webhook handler on revocation. Keyed by lowercased login to match `overlay_chat_sources.channel_id`, like IRC.
- **Latency:** create the chat subscription *before* the always-on event subscriptions for a newly-demanded channel.

## Tests

- `reconcileChatLocked` gating + offline publish (miniredis), `conditionBroadcasterID` parsing. Existing suite green.
- README updated (chat path, webhook transport, status-indicator behaviour).

## Verification

After merge + Keel deploy: open an overlay with a chat-scoped Twitch source (e.g. caesarlp), confirm the Twitch indicator goes connected and `test_twitch_chat.py` messages render; close the overlay and confirm it returns to offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)