### PR TITLE
fix(twitch-eventsub): retry + re-acquire leadership instead of one-shot

### DIFF
--- a/services/twitch-eventsub-listener/README.md
+++ b/services/twitch-eventsub-listener/README.md
@@ -99,15 +99,21 @@ Without this, channels moved off IRC to EventSub would show no Twitch indicator.
 
 ## Leader Election
 
-Uses Redis-based distributed lock:
+A single leader manages all EventSub subscriptions (one webhook callback serves the cluster), so
+only one pod may create/delete subscriptions at a time. Leadership is a single `shard:0` lease
+acquired through the shared `LeadershipCoordinator` (source-manager), per ADR-0007.
 
-- **Leader:** Connects to EventSub, creates subscriptions, processes events
-- **Follower:** Standby, ready to take over if leader fails
-- **Lock TTL:** 10 seconds
-- **Renewal Interval:** 5 seconds
-- **Key:** `leader:twitch-eventsub`
+- **Leader:** Its subscription callback creates/deletes subscriptions and reads chat.
+- **Standby:** The channel manager still runs (started by `LeadershipListener.Start`) but its
+  callback is a no-op; it keeps trying to acquire leadership.
+- **Acquisition:** `EnsureLeadership` is called **repeatedly** (every ~10s) until acquired, and
+  re-acquired after loss. A one-shot attempt is wrong — after a rolling deploy the new pods race
+  the outgoing leader's still-held lease, and without retry no pod ever becomes leader.
+- **On acquire:** the manager's tracking map is reset (`ResetTracking`) and a sync is triggered,
+  so a freshly promoted pod (re)creates every subscription rather than skipping stale entries.
 
-Only the leader maintains the EventSub WebSocket connection to prevent duplicate event notifications.
+The webhook handler runs on every pod (any pod may receive Twitch's callback); only subscription
+*management* is leader-gated.
 
 ## Event Flow
 

--- a/services/twitch-eventsub-listener/channels/manager.go
+++ b/services/twitch-eventsub-listener/channels/manager.go
@@ -159,6 +159,29 @@ func (m *Manager) SetStatusPublisher(pub *status.Publisher) {
 	m.statusPublisher = pub
 }
 
+// ResetTracking drops the in-memory channel map so the next SyncChannels treats every active
+// channel as new and (re)creates its subscriptions. Called when this pod ACQUIRES leadership:
+// the manager runs on every pod (started by LeadershipListener.Start), so a standby may have
+// populated the map while its subscription callback was a no-op; clearing it ensures a freshly
+// promoted leader actually creates the subscriptions instead of seeing stale "already tracked"
+// entries and skipping them. Real Twitch subscriptions are not deleted here — re-creation is
+// idempotent (Twitch returns "already exists").
+func (m *Manager) ResetTracking() {
+	m.mu.Lock()
+	m.channels = make(map[string]*Channel)
+	m.mu.Unlock()
+}
+
+// TriggerSync requests an immediate (coalesced) SyncChannels via the periodic sync goroutine,
+// without blocking. Used right after acquiring leadership so subscriptions are rebuilt promptly
+// instead of waiting for the next periodic tick.
+func (m *Manager) TriggerSync() {
+	select {
+	case m.syncSignal <- struct{}{}:
+	default:
+	}
+}
+
 // publishChatOffline emits a platform:status "offline" for the channel's chat indicator,
 // keyed by the lowercased login (channel_id in overlay_chat_sources) so the api-gateway
 // status subscriber routes it to the right overlays — matching the IRC listener's convention.

--- a/services/twitch-eventsub-listener/channels/manager_test.go
+++ b/services/twitch-eventsub-listener/channels/manager_test.go
@@ -185,3 +185,43 @@ func TestResolveBroadcasterID_NegativeCache(t *testing.T) {
 		t.Fatalf("resolver called %d times, want 1 (negative cache)", got)
 	}
 }
+
+// TestResetTracking_ClearsChannels verifies ResetTracking drops tracked channels so a freshly
+// promoted leader rebuilds subscriptions instead of skipping "already tracked" entries.
+func TestResetTracking_ClearsChannels(t *testing.T) {
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.channels["111"] = &Channel{BroadcasterID: "111", ChatActive: true}
+	m.channels["222"] = &Channel{BroadcasterID: "222"}
+
+	m.ResetTracking()
+
+	if got := m.GetActiveChannelCount(); got != 0 {
+		t.Fatalf("after ResetTracking, active channels = %d, want 0", got)
+	}
+}
+
+// TestTriggerSync_NonBlocking verifies TriggerSync enqueues a coalesced sync signal without
+// blocking, and that a second call coalesces (does not block on the size-1 channel).
+func TestTriggerSync_NonBlocking(t *testing.T) {
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+
+	done := make(chan struct{})
+	go func() {
+		m.TriggerSync() // fills the buffer
+		m.TriggerSync() // must not block (coalesces)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("TriggerSync blocked")
+	}
+
+	// One signal should be queued and drainable.
+	select {
+	case <-m.syncSignal:
+	default:
+		t.Fatal("expected a queued sync signal")
+	}
+}

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -359,38 +359,73 @@ func main() {
 		return nil
 	})
 
-	// Leadership acquisition goroutine — replaces old Redis SETNX loop
+	setLeader := func(v bool) {
+		isLeaderMu.Lock()
+		isLeader = v
+		isLeaderMu.Unlock()
+	}
+
+	// Leadership acquisition goroutine. The channel manager itself is already running on every
+	// pod (LeadershipListener.Start started it); leadership only gates whether this pod's
+	// subscription callback does real work. We therefore RETRY acquisition forever and
+	// re-acquire after loss — a one-shot attempt (the previous behaviour) left no pod as leader
+	// after a rolling deploy, because the new pods raced the outgoing leader's still-held lease,
+	// got a "claim skipped", and never tried again. See ADR-0007: EnsureLeadership is meant to
+	// be called repeatedly, not once.
 	go func() {
 		lc := ll.LeadershipCoordinator()
 		if lc == nil {
 			log.Info("Leadership coordination disabled — acting as standalone leader")
-			isLeaderMu.Lock()
-			isLeader = true
-			isLeaderMu.Unlock()
-			if err := channelManager.Start(ctx); err != nil {
-				log.Error("Channel manager start failed", zap.Error(err))
-			}
+			channelManager.ResetTracking()
+			setLeader(true)
+			channelManager.TriggerSync()
 			return
 		}
 
-		acquired, err := lc.EnsureLeadership(ctx, "shard:0", func() {
-			log.Warn("Lost EventSub leadership — stopping subscription management")
-			isLeaderMu.Lock()
-			isLeader = false
-			isLeaderMu.Unlock()
-			channelManager.Stop()
-		})
-		if err != nil {
-			log.Error("Leadership acquisition failed", zap.Error(err))
-			return
+		const reacquireInterval = 10 * time.Second
+		lostCh := make(chan struct{}, 1)
+		onLost := func() {
+			log.Warn("Lost EventSub leadership — will re-acquire")
+			setLeader(false)
+			select {
+			case lostCh <- struct{}{}:
+			default:
+			}
 		}
-		if acquired {
-			log.Info("Acquired EventSub leadership")
-			isLeaderMu.Lock()
-			isLeader = true
-			isLeaderMu.Unlock()
-			if err := channelManager.Start(ctx); err != nil {
-				log.Error("Channel manager start failed", zap.Error(err))
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			acquired, err := lc.EnsureLeadership(ctx, "shard:0", onLost)
+			if err != nil {
+				log.Error("Leadership acquisition failed — retrying", zap.Error(err))
+			} else if acquired {
+				log.Info("Acquired EventSub leadership")
+				// Rebuild from a clean slate: as a standby this pod may have tracked channels
+				// with a no-op callback, so clear that state before (re)creating subscriptions.
+				channelManager.ResetTracking()
+				setLeader(true)
+				channelManager.TriggerSync()
+
+				// Hold leadership until it is lost or the service shuts down.
+				select {
+				case <-ctx.Done():
+					return
+				case <-lostCh:
+					continue // re-acquire immediately
+				}
+			}
+
+			// Not acquired (another pod holds it) or transient error — wait and retry so this
+			// standby takes over promptly once the lease frees.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(reacquireInterval):
 			}
 		}
 	}()


### PR DESCRIPTION
## Problem (production outage)

Discovered while verifying #371: after a rolling deploy, **EventSub chat went down platform-wide**. The leadership acquisition goroutine made a *single* `EnsureLeadership(ctx, "shard:0", …)` call. During the rollout the new pods raced the outgoing leader's still-held lease → `claim_skipped` (`acquired=false, err=nil`) → the goroutine returned and never retried. When the old leader terminated, **no pod held leadership** and no subscriptions were managed. Recovery needed a manual `kubectl rollout restart`.

Confirmed live: both new pods showed `source_manager_leadership_events_total{event="claim_skipped"} 1` and `leadership_active 0`.

## Fix

Per **ADR-0007**, `EnsureLeadership` is meant to be called repeatedly. 

- Replace the one-shot goroutine with a **retry/re-acquire loop** (~10s) that also re-acquires after leadership loss.
- The channel manager runs on every pod (`LeadershipListener.Start`), so a standby can populate its tracking map while its callback is a no-op. Add `Manager.ResetTracking()` + `TriggerSync()` and call them **on acquire**, so a freshly promoted pod rebuilds every subscription from a clean slate (re-creation is idempotent — Twitch returns "already exists").
- Stop calling `channelManager.Start/Stop` from the leadership goroutine; leadership now only flips the `isLeader` gate (lifecycle is owned by `LeadershipListener.Start` + graceful shutdown).

## Tests

`ResetTracking` clears tracking; `TriggerSync` is non-blocking/coalesces. README leader-election section corrected (shard:0 lease, webhook transport, retry/re-acquire).

## Verification

After merge + deploy, then a second `rollout restart`: confirm a leader is always present (`/status` `is_leader:true` on exactly one pod; `leadership_active 1`) with no manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)