### PR TITLE
fix(source-manager): reconcile demand from connection keys to stop listener flapping

### DIFF
--- a/services/source-manager/README.md
+++ b/services/source-manager/README.md
@@ -192,6 +192,23 @@ leader:stream:<video_id>  → "youtube-listener-pod-abc123"  (TTL: 60s)
 leader:stream:<video_id>  → "youtube-listener-pod-def456"  (another stream)
 ```
 
+### Demand Publishing (overlay → listeners)
+
+Demand-gated listeners (twitch-eventsub chat, youtube, …) only do work for sources whose overlay
+has a live WebSocket. source-manager computes that demand and publishes a full-replacement snapshot
+to the `source:demand` Pub/Sub channel.
+
+- **Source of truth:** the `overlay:connected:{overlay_id}` keys api-gateway sets (with a TTL) for
+  every live overlay WebSocket. The demanded set = sources of every overlay whose key exists.
+- **Triggers:** overlay connect/disconnect events (`overlay:connections`), source-config changes
+  (PostgreSQL `LISTEN`), and a **periodic reconcile every 15s**.
+- **Periodic reconcile is required for correctness.** source-manager runs on multiple replicas and
+  Redis Pub/Sub has no replay, so a replica that briefly drops its `overlay:connections`
+  subscription misses events and its in-memory demand diverges. Two replicas would then publish
+  conflicting snapshots and demand-gated listeners flap or get stuck on the wrong channel set. The
+  reconcile rebuilds demand from the `overlay:connected:*` keys (via SCAN) so every replica
+  converges to the same set; publishes are fingerprint-gated, so an unchanged set is not re-sent.
+
 ### Active Source Registry
 
 **Syncs from database every 30 seconds**:

--- a/services/source-manager/demand/subscriber.go
+++ b/services/source-manager/demand/subscriber.go
@@ -116,53 +116,106 @@ func (s *OverlayDemandSubscriber) Start(ctx context.Context) error {
 		go s.listenForSourceChanges(ctx)
 	}
 
-	// Step 4: subscribe to live events with retry loop.
+	// Step 4: periodically reconcile against the source-of-truth keys so a replica that missed
+	// a Pub/Sub event converges back instead of leaving listeners stuck on a stale snapshot.
+	go s.reconcileLoop(ctx)
+
+	// Step 5: subscribe to live events with retry loop.
 	return s.subscribeLoop(ctx)
 }
 
-// hydrate scans overlay:connected:* keys and populates the demand map.
-func (s *OverlayDemandSubscriber) hydrate(ctx context.Context) error {
-	keys, err := s.redisClient.Keys(ctx, "overlay:connected:*").Result()
-	if err != nil {
-		return err
-	}
+// reconcileInterval bounds how long a diverged demand view (e.g. after a missed Pub/Sub event)
+// can persist before being corrected from the source-of-truth keys.
+const reconcileInterval = 15 * time.Second
 
-	overlayIDs := make([]string, 0, len(keys))
-	for _, key := range keys {
+// buildDemandFromKeys derives the authoritative demand map from the `overlay:connected:*` keys
+// (set with a TTL by api-gateway for every live overlay WebSocket) plus the sources configured
+// for those overlays. This is the source of truth: source-manager runs on multiple replicas and
+// Redis Pub/Sub has no replay, so the event-driven in-memory map can diverge (a replica that
+// briefly drops its `overlay:connections` subscription misses connect/disconnect events). Two
+// replicas then publish conflicting full-replacement snapshots and demand-gated listeners flap or
+// get stuck on the wrong set of channels. Rebuilding from the keys lets every replica converge to
+// the same set. Uses SCAN (not KEYS) so it is safe to call on the periodic reconcile path.
+func (s *OverlayDemandSubscriber) buildDemandFromKeys(ctx context.Context) (map[string][]DemandSource, error) {
+	overlayIDs := make([]string, 0)
+	iter := s.redisClient.Scan(ctx, 0, "overlay:connected:*", 256).Iterator()
+	for iter.Next(ctx) {
 		// key format: overlay:connected:{overlay_id}
-		overlayID := strings.TrimPrefix(key, "overlay:connected:")
+		overlayID := strings.TrimPrefix(iter.Val(), "overlay:connected:")
 		if overlayID != "" {
 			overlayIDs = append(overlayIDs, overlayID)
 		}
 	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
 
+	demand := make(map[string][]DemandSource)
 	if len(overlayIDs) == 0 {
-		return nil
+		return demand, nil
 	}
 
 	sources, err := s.repo.GetSourcesForOverlays(ctx, overlayIDs)
+	if err != nil {
+		return nil, err
+	}
+	for _, src := range sources {
+		demand[src.OverlayID] = append(demand[src.OverlayID], DemandSource{
+			SourceID:  src.ID,
+			ChannelID: src.ChannelID,
+			Platform:  src.Platform,
+			OverlayID: src.OverlayID,
+		})
+	}
+	return demand, nil
+}
+
+// hydrate rebuilds the demand map from the source-of-truth keys (used at startup).
+func (s *OverlayDemandSubscriber) hydrate(ctx context.Context) error {
+	demand, err := s.buildDemandFromKeys(ctx)
 	if err != nil {
 		return err
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.demand = demand
+	s.mu.Unlock()
 
-	for _, src := range sources {
-		ds := DemandSource{
-			SourceID:  src.ID,
-			ChannelID: src.ChannelID,
-			Platform:  src.Platform,
-			OverlayID: src.OverlayID,
-		}
-		s.demand[src.OverlayID] = append(s.demand[src.OverlayID], ds)
+	s.logger.Info("Startup hydration complete", zap.Int("overlay_count", len(demand)))
+	return nil
+}
+
+// reconcile rebuilds the demand map from the source-of-truth keys and republishes if the demanded
+// set changed (publishDemandUpdate is fingerprint-gated). This both self-heals a diverged replica
+// and converges peers toward an identical snapshot, eliminating the flapping/stuck behaviour that
+// conflicting full-replacement snapshots cause for demand-gated listeners (twitch-eventsub chat,
+// youtube, …).
+func (s *OverlayDemandSubscriber) reconcile(ctx context.Context) {
+	demand, err := s.buildDemandFromKeys(ctx)
+	if err != nil {
+		s.logger.Warn("Demand reconcile failed; keeping current demand", zap.Error(err))
+		return
 	}
 
-	s.logger.Info("Startup hydration complete",
-		zap.Int("overlay_count", len(overlayIDs)),
-		zap.Int("source_count", len(sources)),
-	)
-	return nil
+	s.mu.Lock()
+	s.demand = demand
+	s.mu.Unlock()
+
+	s.publishDemandUpdate(ctx)
+}
+
+// reconcileLoop runs reconcile every reconcileInterval until the context is cancelled.
+func (s *OverlayDemandSubscriber) reconcileLoop(ctx context.Context) {
+	ticker := time.NewTicker(reconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcile(ctx)
+		}
+	}
 }
 
 // subscribeLoop runs the Redis Pub/Sub subscriber with exponential backoff retry.
@@ -507,4 +560,9 @@ func (s *OverlayDemandSubscriber) HandleSourceChangeForTest(ctx context.Context,
 // HydrateForTest exposes hydrate for unit testing.
 func (s *OverlayDemandSubscriber) HydrateForTest(ctx context.Context) error {
 	return s.hydrate(ctx)
+}
+
+// ReconcileForTest exposes reconcile for unit testing.
+func (s *OverlayDemandSubscriber) ReconcileForTest(ctx context.Context) {
+	s.reconcile(ctx)
 }

--- a/services/source-manager/demand/subscriber_test.go
+++ b/services/source-manager/demand/subscriber_test.go
@@ -416,3 +416,59 @@ func TestSourceDeleteRefreshesDemand(t *testing.T) {
 	require.Len(t, sources, 1)
 	assert.Equal(t, "source-yt", sources[0].SourceID)
 }
+
+// TestReconcile_RecoversFromMissedConnect verifies that if a replica's in-memory demand has
+// diverged (e.g. it missed a "connected" Pub/Sub event), the periodic reconcile rebuilds demand
+// from the overlay:connected:* keys (source of truth) and recovers the missing source.
+func TestReconcile_RecoversFromMissedConnect(t *testing.T) {
+	mr, client := newTestRedis(t)
+
+	repo := &mockRepository{
+		sources: map[string][]*models.ActiveSource{
+			"overlay-abc": {
+				{ID: "source-1", OverlayID: "overlay-abc", Platform: "twitch", ChannelID: "caesarlp"},
+			},
+		},
+	}
+
+	sub := demand.NewOverlayDemandSubscriber(client, repo, zap.NewNop())
+
+	// Overlay IS connected per the source-of-truth key, but the subscriber's in-memory map is
+	// empty (it missed the connect event) — the divergence that strands demand-gated listeners.
+	require.NoError(t, mr.Set("overlay:connected:overlay-abc", "1"))
+	require.Empty(t, sub.GetDemandedSources())
+
+	sub.ReconcileForTest(context.Background())
+
+	sources := sub.GetDemandedSources()
+	require.Len(t, sources, 1)
+	assert.Equal(t, "source-1", sources[0].SourceID)
+	assert.Equal(t, "caesarlp", sources[0].ChannelID)
+}
+
+// TestReconcile_DropsStaleDemand verifies reconcile removes demand for an overlay whose
+// connection key is gone (e.g. a missed "disconnected" event left stale demand).
+func TestReconcile_DropsStaleDemand(t *testing.T) {
+	mr, client := newTestRedis(t)
+
+	repo := &mockRepository{
+		sources: map[string][]*models.ActiveSource{
+			"overlay-abc": {
+				{ID: "source-1", OverlayID: "overlay-abc", Platform: "twitch", ChannelID: "caesarlp"},
+			},
+		},
+	}
+
+	sub := demand.NewOverlayDemandSubscriber(client, repo, zap.NewNop())
+
+	// Seed in-memory demand via a connect event, then remove the key (overlay actually gone).
+	connect, _ := json.Marshal(map[string]interface{}{"type": "connected", "overlay_id": "overlay-abc"})
+	require.NoError(t, sub.HandleConnectionEventForTest(context.Background(), string(connect)))
+	require.Len(t, sub.GetDemandedSources(), 1)
+
+	// No overlay:connected:* key set in miniredis → source of truth says nothing is connected.
+	_ = mr
+	sub.ReconcileForTest(context.Background())
+
+	assert.Empty(t, sub.GetDemandedSources(), "reconcile should drop demand with no connection key")
+}


### PR DESCRIPTION
## Problem

Twitch chat was **very flaky** — a channel's chat would go dead even while its overlay was connected (observed live: caesarlp's EventSub chat sub deleted at 18:58 and not recreated, despite both its overlays holding live `overlay:connected:*` keys).

## Root cause

`demandSubscriber.Start()` runs on **every** source-manager replica with no leader-gating. Each replica independently maintains an **event-driven** in-memory demand map and publishes **full-replacement** snapshots to `source:demand`. Redis Pub/Sub has no replay, so a replica that briefly drops its `overlay:connections` subscription misses connect/disconnect events and its map diverges permanently. The replicas then publish **conflicting** snapshots, and because `publishDemandUpdate` is fingerprint-gated, the wrong snapshot **sticks** — stranding demand-gated listeners.

This hits **twitch-eventsub chat** hardest: chat-scoped channels are excluded from IRC, so EventSub is their *only* reader. When demand wrongly drops them, their chat dies entirely.

## Fix

Derive demand from the **source of truth** — the `overlay:connected:{overlay_id}` keys api-gateway sets per live WebSocket — and **reconcile from them every 15s** (via `SCAN`, not `KEYS`):

- Every replica converges to the same key-derived set → no conflicting snapshots, no sustained flapping.
- A diverged replica self-heals within ≤15s instead of being stuck indefinitely.
- Publishes stay fingerprint-gated (unchanged sets aren't re-sent).
- `hydrate` now shares the same key-derived rebuild.

## Tests

- `reconcile` recovers a missed `connected` event and drops stale demand after a missed `disconnected`. Existing demand tests still pass.
- README documents the demand-publishing model.

## Follow-up (not in this PR)

A single-publisher (leader-gated) design would remove even the brief post-divergence window entirely; reconcile makes the system converge and self-heal, which resolves the observed flakiness with a small, low-risk change.

## Verification

After deploy: confirm caesarlp's EventSub chat sub is (re)created within ~15s and stays up while its overlay is connected; send test chat and confirm steady delivery with no flapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)