### PR TITLE
fix: linger upstream capture demand on overlay disconnect (caesarlp message loss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Architecture decisions are documented as ADRs in [`docs/adr/`](./docs/adr/README
 - **ADR-0007**: Leadership rebalancing for auto-scaling listeners
 - **ADR-0008**: Feature gate infrastructure for premium capabilities
 - **ADR-0013**: Public overlay observability view + shared `useOverlayStream` hook
+- **ADR-0014**: Linger upstream capture demand symmetric with the downstream pub/sub linger
 
 ### Documentation
 

--- a/docs/adr/0014-demand-linger-symmetric-with-pubsub-linger.md
+++ b/docs/adr/0014-demand-linger-symmetric-with-pubsub-linger.md
@@ -1,0 +1,100 @@
+# ADR-0014: Linger Upstream Capture Demand Symmetric with the Downstream Pub/Sub Linger
+
+**Date**: 2026-06-02
+**Status**: Accepted
+**Deciders**: All-Chat Platform Team
+
+---
+
+## Context and Problem Statement
+
+Demand-gated listeners (twitch-eventsub chat, youtube) only capture a channel's chat while an
+overlay that uses it has a live WebSocket. source-manager derives the demanded set from the
+`overlay:connected:{overlay_id}` keys api-gateway maintains (see ADR-0002 and the source-manager
+demand model). When the last WebSocket for an overlay disconnected, api-gateway **deleted** that key
+immediately (after a 60s disconnect grace period) and source-manager eagerly dropped the overlay
+from demand. The eventsub listener then tore down the `channel.chat.message` subscription.
+
+This created an asymmetry with the downstream delivery path, which is explicitly built to tolerate
+brief reconnects: the api-gateway pub/sub subscriber **lingers for `PUBSUB_LINGER_SECONDS` (default 5
+minutes)** after the last connection drops, buffering incoming messages and replaying them when the
+overlay reconnects. But because upstream capture stopped ~60s after disconnect, there was nothing to
+buffer or replay — any overlay reconnect gap between the grace period and the linger window lost chat
+**permanently**.
+
+Symptom (recurring, e.g. channel `caesarlp`, twitch_id `67241623`): an OBS browser-source reconnect
+(scene switch, source refresh, network blip) longer than the grace period silently dropped all chat
+that arrived during the gap, defeating the entire buffer/replay design.
+
+## Decision Drivers
+
+- **End-to-end resilience must be symmetric.** A reconnect the gateway can replay for is only useful
+  if the upstream listener actually captured the messages during the gap.
+- **OBS reconnects are normal and frequent**, not exceptional — the system is already designed to
+  absorb them downstream; upstream must match.
+- **Keep the source-of-truth model from the demand rework** (key-derived demand + 15s reconcile) —
+  do not reintroduce divergent in-memory state.
+- **Bounded cost.** A genuinely-gone overlay must still release demand so idle channels stop costing
+  Twitch/YouTube API work.
+- **Reversible.** Operators must be able to revert to immediate teardown.
+
+## Considered Options
+
+1. **Linger the `overlay:connected` key on disconnect, symmetric with the pub/sub linger (chosen)**
+   - On disconnect, api-gateway shortens the key's TTL to the linger window instead of deleting it;
+     source-manager stops eagerly dropping demand on the `disconnected` event and lets the 15s
+     reconcile release demand once the key expires.
+   - ✅ Pros: Upstream capture survives exactly the reconnect window the downstream can replay; reuses
+     the existing key-as-source-of-truth + reconcile model; one shared knob (`PUBSUB_LINGER_SECONDS`)
+     governs both windows; `=0` reverts to immediate teardown.
+   - ❌ Cons: A genuinely-gone overlay keeps its upstream subscription for up to the linger window
+     (bounded, identical to the cost the downstream linger already accepts).
+
+2. **Buffer upstream messages during the gap (ring buffer at the listener) instead of keeping the subscription**
+   - ✅ Pros: No idle subscription cost.
+   - ❌ Cons: EventSub/YouTube do not deliver missed messages after a subscription is torn down — the
+     data simply never arrives, so there is nothing to buffer. Does not solve the problem.
+
+3. **Shorten/remove the downstream linger to match the old 60s upstream teardown**
+   - ✅ Pros: Symmetric.
+   - ❌ Cons: Wrong direction — makes brief reconnects worse for every viewer; throws away working
+     buffer/replay resilience (ADR-0009 lineage).
+
+4. **Eager demand drop but re-add via reconcile**
+   - ❌ Cons: With a lingering key, the next reconcile re-adds demand, producing a flap that tears the
+     subscription down and back up within ~15s — still loses chat and churns subscriptions.
+
+## Decision Outcome
+
+Chosen: **Option 1.** On disconnect, api-gateway sets `overlay:connected:{id}` to a TTL equal to the
+disconnect linger window (read from `PUBSUB_LINGER_SECONDS`, default 5 minutes, `0` disables and
+reverts to immediate deletion) rather than deleting it. source-manager's `disconnected` handler no
+longer drops demand; demand is released only when the key expires, detected by the periodic
+reconcile. A reconnect within the window refreshes the key back to the full connection TTL, so
+capture is continuous and the downstream replay has messages to replay.
+
+## Consequences
+
+- Brief overlay reconnects (up to the linger window) no longer lose chat; buffer/replay works end to
+  end.
+- Demand for a truly-gone overlay falls away within `PUBSUB_LINGER_SECONDS` + one reconcile interval
+  (≤ ~5m15s by default) instead of ~grace period — an intentional, bounded trade.
+- `overlay:connected:*` key count (used by stats) now counts overlays in their linger window as
+  connected; treat it as "connected or recently-connected".
+- The two windows are governed by one env var, keeping them symmetric by construction.
+
+## Implementation
+
+- `services/api-gateway/websocket/manager.go`: `disconnectLingerTTL` field, initialised from
+  `PUBSUB_LINGER_SECONDS`; `publishConnectionEvent` lingers the key on `disconnected` (or deletes when
+  the TTL is 0).
+- `services/source-manager/demand/subscriber.go`: `handleConnectionEvent` `disconnected` branch is
+  now a no-op (reconcile-driven release).
+- Tests: `services/api-gateway/websocket/manager_linger_test.go`,
+  `services/source-manager/demand/subscriber_test.go` (`TestOverlayDemandSubscriber_Disconnected`).
+
+## Related Decisions
+
+- ADR-0002 (Redis Streams + Pub/Sub) — the `overlay:connected` keys and `source:demand` channel.
+- ADR-0009 (Ring Buffer Publisher) — the downstream resilience philosophy this extends upstream.
+- ADR-0007 (Leadership rebalancing) — demand gates which channels a listener acquires leadership for.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -247,6 +247,17 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0014: Linger Upstream Capture Demand Symmetric with the Downstream Pub/Sub Linger
+
+**Status**: ✅ Accepted
+**Date**: 2026-06-02
+**Problem**: On overlay disconnect the `overlay:connected` key was deleted after ~60s, tearing down upstream chat capture, while the downstream pub/sub subscriber lingers 5 min and replays — so reconnect gaps beyond the grace period lost chat permanently
+**Decision**: On disconnect, linger the `overlay:connected` key for `PUBSUB_LINGER_SECONDS` (default 5 min) instead of deleting it, and let source-manager release demand via the periodic reconcile when the key expires (no eager drop)
+**Impact**: Brief overlay reconnects no longer lose chat; capture and replay are symmetric end to end; bounded idle cost; `PUBSUB_LINGER_SECONDS=0` reverts to immediate teardown
+**→ Read**: [0014-demand-linger-symmetric-with-pubsub-linger.md](./0014-demand-linger-symmetric-with-pubsub-linger.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number
@@ -368,13 +379,13 @@ Create a new ADR if:
 
 ## Summary
 
-**Total ADRs**: 13
+**Total ADRs**: 14
 **Status**: All accepted (✅)
-**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view)
+**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view, demand linger)
 
 **Most Referenced**:
 1. ADR-0002 (Redis patterns) - Referenced by all listeners, message processor
 2. ADR-0001 (Go layout) - Referenced by all services
 3. ADR-0006 (Quota tracking) - Referenced by YouTube listener, overlay manager
 
-**Last Updated**: 2026-05-31
+**Last Updated**: 2026-06-02

--- a/services/api-gateway/websocket/manager.go
+++ b/services/api-gateway/websocket/manager.go
@@ -58,6 +58,17 @@ type Manager struct {
 	stopHeartbeat     chan struct{}
 	heartbeatWg       sync.WaitGroup
 
+	// disconnectLingerTTL is how long the overlay:connected key is kept (with a
+	// shortened TTL) after the last WebSocket disconnects, instead of being deleted
+	// immediately. The key is the source of truth for demand (source-manager rebuilds
+	// the demanded set from overlay:connected:* keys), so lingering it keeps the
+	// upstream capture (eventsub chat / youtube polling) alive across brief overlay
+	// reconnects. It is set symmetric with the downstream pubsub linger
+	// (PUBSUB_LINGER_SECONDS) so any reconnect the gateway can replay buffered messages
+	// for is also a reconnect the upstream listener actually captured. 0 disables the
+	// linger and reverts to immediate deletion on disconnect.
+	disconnectLingerTTL time.Duration
+
 	// Session management for credit roll
 	sessionManager *sessions.SessionManager
 }
@@ -89,10 +100,24 @@ func NewManager(logger *zap.Logger, m *metrics.GatewayMetrics, redisClient *redi
 		}
 	}
 
+	// Disconnect linger TTL: keep the overlay:connected key alive this long after the
+	// last WebSocket disconnects (instead of deleting it immediately) so upstream
+	// capture survives brief overlay reconnects. Kept symmetric with the downstream
+	// pubsub linger (same PUBSUB_LINGER_SECONDS env var, same 5-minute default, same
+	// "0 disables" semantics) so the windows the gateway buffers/replays for are the
+	// windows the upstream listener actually captured.
+	disconnectLingerTTL := 5 * time.Minute
+	if envLinger := os.Getenv("PUBSUB_LINGER_SECONDS"); envLinger != "" {
+		if seconds, err := strconv.Atoi(envLinger); err == nil && seconds >= 0 {
+			disconnectLingerTTL = time.Duration(seconds) * time.Second
+		}
+	}
+
 	logger.Info("WebSocket manager initialized",
 		zap.Duration("disconnect_grace_period", gracePeriod),
 		zap.Duration("connection_ttl", connectionTTL),
 		zap.Duration("heartbeat_interval", heartbeatInterval),
+		zap.Duration("disconnect_linger_ttl", disconnectLingerTTL),
 	)
 
 	mgr := &Manager{
@@ -105,6 +130,7 @@ func NewManager(logger *zap.Logger, m *metrics.GatewayMetrics, redisClient *redi
 		disconnectGracePeriod: gracePeriod,
 		heartbeatInterval:     heartbeatInterval,
 		connectionTTL:         connectionTTL,
+		disconnectLingerTTL:   disconnectLingerTTL,
 		stopHeartbeat:         make(chan struct{}),
 		sessionManager:        sessions.NewSessionManager(redisClient, db, logger, gracePeriod),
 	}
@@ -236,8 +262,23 @@ func (m *Manager) publishConnectionEvent(ctx context.Context, overlayID, eventTy
 			)
 		}
 	} else if eventType == "disconnected" {
-		// Immediately delete connection key
-		if err := m.redisClient.Del(ctx, key).Err(); err != nil {
+		// Do NOT delete the key immediately. It is the source of truth for demand, and
+		// deleting it tears down the upstream capture (eventsub chat / youtube polling)
+		// after only the disconnect grace period — even though the downstream pubsub
+		// subscriber lingers for PUBSUB_LINGER_SECONDS and replays buffered messages on
+		// reconnect. That asymmetry permanently loses chat on any reconnect gap longer
+		// than the grace period. Instead, shorten the key's TTL to the linger window so a
+		// brief reconnect keeps capture alive (and replay works end to end), while a
+		// genuinely-gone overlay still releases demand once the linger expires.
+		if m.disconnectLingerTTL > 0 {
+			if err := m.redisClient.SetEx(ctx, key, "1", m.disconnectLingerTTL).Err(); err != nil {
+				m.logger.Error("Failed to set overlay connection linger TTL",
+					zap.String("overlay_id", overlayID),
+					zap.Error(err),
+				)
+			}
+		} else if err := m.redisClient.Del(ctx, key).Err(); err != nil {
+			// Linger disabled (PUBSUB_LINGER_SECONDS=0): revert to immediate deletion.
 			m.logger.Error("Failed to delete overlay connection key",
 				zap.String("overlay_id", overlayID),
 				zap.Error(err),

--- a/services/api-gateway/websocket/manager_linger_test.go
+++ b/services/api-gateway/websocket/manager_linger_test.go
@@ -1,0 +1,81 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package websocket
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newLingerTestManager builds a minimal Manager wired only with the fields
+// publishConnectionEvent touches (redis client, logger, linger TTL). It deliberately
+// avoids NewManager so the test does not start the heartbeat goroutine or need a DB.
+func newLingerTestManager(t *testing.T, lingerTTL time.Duration) (*miniredis.Miniredis, *Manager) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	t.Cleanup(mr.Close)
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	return mr, &Manager{
+		logger:              zap.NewNop(),
+		redisClient:         client,
+		disconnectLingerTTL: lingerTTL,
+	}
+}
+
+// TestPublishDisconnect_LingersConnectionKey verifies that on disconnect the
+// overlay:connected key is retained (with a shortened TTL) rather than deleted, so the
+// demand source-of-truth — and thus upstream chat capture — survives a brief reconnect.
+func TestPublishDisconnect_LingersConnectionKey(t *testing.T) {
+	mr, m := newLingerTestManager(t, 5*time.Minute)
+
+	const overlayID = "overlay-caesarlp"
+	key := "overlay:connected:" + overlayID
+	require.NoError(t, mr.Set(key, "1"))
+
+	m.publishConnectionEvent(context.Background(), overlayID, "disconnected")
+
+	assert.True(t, mr.Exists(key), "connection key must survive disconnect so upstream capture lingers")
+
+	ttl := mr.TTL(key)
+	assert.Greater(t, ttl, time.Duration(0), "lingering key must carry a TTL so it expires for genuinely-gone overlays")
+	assert.LessOrEqual(t, ttl, 5*time.Minute, "linger TTL must not exceed the configured window")
+}
+
+// TestPublishDisconnect_ImmediateDeleteWhenLingerDisabled verifies the opt-out:
+// PUBSUB_LINGER_SECONDS=0 (linger TTL 0) reverts to the previous immediate-delete behavior.
+func TestPublishDisconnect_ImmediateDeleteWhenLingerDisabled(t *testing.T) {
+	mr, m := newLingerTestManager(t, 0)
+
+	const overlayID = "overlay-caesarlp"
+	key := "overlay:connected:" + overlayID
+	require.NoError(t, mr.Set(key, "1"))
+
+	m.publishConnectionEvent(context.Background(), overlayID, "disconnected")
+
+	assert.False(t, mr.Exists(key), "with linger disabled the key must be deleted immediately on disconnect")
+}

--- a/services/source-manager/README.md
+++ b/services/source-manager/README.md
@@ -200,8 +200,16 @@ to the `source:demand` Pub/Sub channel.
 
 - **Source of truth:** the `overlay:connected:{overlay_id}` keys api-gateway sets (with a TTL) for
   every live overlay WebSocket. The demanded set = sources of every overlay whose key exists.
-- **Triggers:** overlay connect/disconnect events (`overlay:connections`), source-config changes
+- **Triggers:** overlay connect events (`overlay:connections`), source-config changes
   (PostgreSQL `LISTEN`), and a **periodic reconcile every 15s**.
+- **Disconnect is reconcile-driven, not eager (ADR-0014).** A `disconnected` event does *not* drop
+  demand. api-gateway keeps the `overlay:connected` key alive for a linger window after the last
+  WebSocket drops (it shortens the TTL to `PUBSUB_LINGER_SECONDS`, default 5 min, instead of deleting
+  it), symmetric with the downstream pub/sub buffer/replay window. Demand is released only when the
+  key actually expires, detected by the reconcile. This keeps upstream capture (eventsub chat /
+  youtube polling) alive across brief overlay reconnects so messages during the gap are captured and
+  replayed end to end, instead of being lost. Eagerly dropping on disconnect would just be re-added
+  by the next reconcile (the key still lingers) — a flap that tears the subscription down and back up.
 - **Periodic reconcile is required for correctness.** source-manager runs on multiple replicas and
   Redis Pub/Sub has no replay, so a replica that briefly drops its `overlay:connections`
   subscription misses events and its in-memory demand diverges. Two replicas would then publish

--- a/services/source-manager/demand/subscriber.go
+++ b/services/source-manager/demand/subscriber.go
@@ -310,13 +310,17 @@ func (s *OverlayDemandSubscriber) handleConnectionEvent(ctx context.Context, pay
 		)
 
 	case "disconnected":
-		s.mu.Lock()
-		delete(s.demand, event.OverlayID)
-		s.mu.Unlock()
-
-		s.logger.Info("Overlay disconnected, demand updated",
+		// Do NOT eagerly drop demand here. api-gateway keeps the overlay:connected key
+		// alive for a linger window after disconnect (it shortens the TTL instead of
+		// deleting), so the upstream capture survives brief overlay reconnects. The key
+		// is the source of truth; removing demand now would only be re-added by the next
+		// reconcile (the key is still present during the linger) — a flap that tears the
+		// upstream subscription down and back up, losing chat. Let demand fall away when
+		// the key actually expires, detected by reconcileLoop.
+		s.logger.Debug("Overlay disconnected; demand retained until connection key expires (reconcile-driven)",
 			zap.String("overlay_id", event.OverlayID),
 		)
+		return nil
 
 	default:
 		s.logger.Warn("Unknown connection event type",

--- a/services/source-manager/demand/subscriber_test.go
+++ b/services/source-manager/demand/subscriber_test.go
@@ -99,10 +99,12 @@ func TestOverlayDemandSubscriber_Connected(t *testing.T) {
 	assert.Equal(t, "creator123", sources[0].ChannelID)
 }
 
-// TestOverlayDemandSubscriber_Disconnected tests that disconnecting removes overlay sources from demand
+// TestOverlayDemandSubscriber_Disconnected verifies that a "disconnected" event alone does
+// NOT drop demand. api-gateway lingers the overlay:connected key after disconnect so upstream
+// capture survives brief overlay reconnects; demand is only released when the key actually
+// expires (detected by reconcile). Eagerly dropping here would flap the upstream subscription.
 func TestOverlayDemandSubscriber_Disconnected(t *testing.T) {
 	mr, client := newTestRedis(t)
-	_ = mr
 
 	repo := &mockRepository{
 		sources: map[string][]*models.ActiveSource{
@@ -119,7 +121,8 @@ func TestOverlayDemandSubscriber_Disconnected(t *testing.T) {
 
 	sub := demand.NewOverlayDemandSubscriber(client, repo, zap.NewNop())
 
-	// First connect
+	// Connect: api-gateway sets the source-of-truth key and the event seeds demand.
+	require.NoError(t, mr.Set("overlay:connected:overlay-abc", "1"))
 	connectEvent := map[string]interface{}{
 		"type":       "connected",
 		"overlay_id": "overlay-abc",
@@ -129,12 +132,10 @@ func TestOverlayDemandSubscriber_Disconnected(t *testing.T) {
 	require.NoError(t, err)
 	err = sub.HandleConnectionEventForTest(context.Background(), string(connectPayload))
 	require.NoError(t, err)
+	require.Len(t, sub.GetDemandedSources(), 1)
 
-	// Verify connected
-	sources := sub.GetDemandedSources()
-	require.Len(t, sources, 1)
-
-	// Now disconnect
+	// Disconnect event arrives. The key is still present (lingering); demand must be retained
+	// so the upstream listener keeps capturing across the brief gap.
 	disconnectEvent := map[string]interface{}{
 		"type":       "disconnected",
 		"overlay_id": "overlay-abc",
@@ -145,9 +146,16 @@ func TestOverlayDemandSubscriber_Disconnected(t *testing.T) {
 	err = sub.HandleConnectionEventForTest(context.Background(), string(disconnectPayload))
 	require.NoError(t, err)
 
-	// Verify removed
-	sources = sub.GetDemandedSources()
-	assert.Empty(t, sources)
+	assert.Len(t, sub.GetDemandedSources(), 1, "disconnect event must not drop demand while the connection key lingers")
+
+	// A reconcile while the key still lingers keeps demand alive (the brief-reconnect window).
+	sub.ReconcileForTest(context.Background())
+	assert.Len(t, sub.GetDemandedSources(), 1, "demand must survive reconcile while the lingering key is present")
+
+	// Once the linger key expires, the next reconcile releases demand.
+	mr.Del("overlay:connected:overlay-abc")
+	sub.ReconcileForTest(context.Background())
+	assert.Empty(t, sub.GetDemandedSources(), "demand must be released after the connection key expires")
 }
 
 // TestStartupHydration tests that Start() hydrates demand from existing overlay:connected:* keys


### PR DESCRIPTION
## Problem

Recurring message loss on demand-gated channels (e.g. `caesarlp`, twitch_id `67241623`).

`caesarlp` is a **chat-scoped** channel: the owner granted `user:read:chat`, so the IRC `twitch-listener` correctly excludes it and `twitch-eventsub-listener` is the sole reader of its chat (`channel.chat.message`). That partition works.

The loss came from an **asymmetry** in reconnect handling:

- **Downstream** (gateway → client) lingers `PUBSUB_LINGER_SECONDS` (5 min), buffers messages, and replays them on reconnect.
- **Upstream** (listener capture) was torn down ~60s after the last overlay WebSocket disconnected: api-gateway deleted the `overlay:connected` key and source-manager eagerly dropped demand → eventsub deleted the chat subscription.

So any overlay reconnect gap between the 60s grace period and the 5-min replay window lost chat **permanently** — nothing was captured to replay. Confirmed in prod: caesarlp's chat sub was deleted `18:39:34` and recreated `18:44:33` when both its overlays briefly disconnected. OBS browser-sources reconnect constantly (scene switches, refreshes, blips), so it recurs.

## Fix

Make upstream capture survive the same reconnect window the downstream replays:

- **api-gateway** (`websocket/manager.go`): on disconnect, shorten the `overlay:connected` key TTL to the linger window (`PUBSUB_LINGER_SECONDS`, default 5m; `0` disables → immediate delete) instead of deleting it. Reconnect refreshes it to the full connection TTL.
- **source-manager** (`demand/subscriber.go`): the `disconnected` event no longer drops demand. The key is the source of truth; demand is released only when the key expires, detected by the 15s reconcile. (Eager removal would be re-added by the next reconcile while the key lingers — a flap that churns the subscription.)

Both windows are now governed by one env var, symmetric by construction.

## Tests

- `services/api-gateway/websocket/manager_linger_test.go` — key lingers with a bounded TTL on disconnect; `=0` reverts to immediate delete.
- `services/source-manager/demand/subscriber_test.go` — `TestOverlayDemandSubscriber_Disconnected` updated: disconnect event retains demand; reconcile keeps it while the key lingers and releases it once the key expires.

## Docs

ADR-0014, source-manager README demand model, root README + ADR index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)