### PR TITLE
fix(migrations): make 020_fix_twitch_display_names collision-safe

### DIFF
--- a/migrations/020_fix_twitch_display_names.sql
+++ b/migrations/020_fix_twitch_display_names.sql
@@ -8,7 +8,18 @@
 -- Twitch usernames are lowercase alphanumeric + underscore only
 -- Display names can have Unicode, mixed case, special characters
 
--- Update channel_id to use username instead of display_name
+-- Update channel_id to use username instead of display_name.
+--
+-- Collision-safe: skip a row when its corrected username already exists as a
+-- twitch source on the same overlay. Without this guard the UPDATE violates the
+-- unique constraint overlay_chat_sources_overlay_id_platform_channel_id_key when
+-- an overlay has the SAME channel added both correctly (channel_id = username)
+-- and via its display name (channel_id = LOWER(display_name)). The migration
+-- runner re-runs every migration on each pod start, so a non-idempotent failure
+-- here crash-loops the init container and blocks deploys/restarts for every
+-- service. Skipping leaves the redundant display-name row in place (a harmless
+-- dead source) rather than failing; cleaning up those duplicates is a separate
+-- data task.
 UPDATE overlay_chat_sources ocs
 SET channel_id = u.username,
     updated_at = NOW()
@@ -16,7 +27,14 @@ FROM users u
 WHERE ocs.platform = 'twitch'
   AND u.auth_provider = 'twitch'
   AND LOWER(u.display_name) = LOWER(ocs.channel_id)
-  AND ocs.channel_id != u.username;
+  AND ocs.channel_id != u.username
+  AND NOT EXISTS (
+      SELECT 1 FROM overlay_chat_sources dup
+      WHERE dup.overlay_id = ocs.overlay_id
+        AND dup.platform = 'twitch'
+        AND dup.channel_id = u.username
+        AND dup.id != ocs.id
+  );
 
 -- Log the changes (PostgreSQL doesn't return affected rows in migrations,
 -- but this comment shows what we expect):


### PR DESCRIPTION
## Problem

The migration runner re-runs **every** migration on each pod start. Migration `020_fix_twitch_display_names.sql` rewrites a twitch `channel_id` from `LOWER(display_name)` to the real `username`. When an overlay has the **same channel added twice** — once correctly (`channel_id = username`) and once via its display name (`channel_id = LOWER(display_name)`) — the UPDATE collides with `overlay_chat_sources_overlay_id_platform_channel_id_key` and aborts under `ON_ERROR_STOP`, crash-looping the `run-migrations` init container.

This blocks deploys and restarts for **every** migration-running service. It surfaced when a duplicate `(overlay 01c873fa, twitch, camvzns)` row was added 2026-06-02 00:52 on top of the existing `camvrns` row, stranding a source-manager rollout (and meaning no fresh migration pod could start).

## Fix

Add a `NOT EXISTS` guard so a row is skipped when its corrected username already exists as a twitch source on the same overlay. Idempotent and non-destructive — the redundant display-name row stays (a harmless dead source) instead of failing the whole migration set.

Verified against production in a rolled-back transaction: `UPDATE 0`, no error.

## Follow-ups (not in this PR)

- Clean up the redundant display-name duplicate rows (`camvzns` etc.).
- The migration runner re-running all migrations every start (untracked) is the underlying fragility — worth a tracked applied-migrations table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)