### PR TITLE
fix(twitch): make IRC↔EventSub chat partition resilient to delivery gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Architecture decisions are documented as ADRs in [`docs/adr/`](./docs/adr/README
 - **ADR-0008**: Feature gate infrastructure for premium capabilities
 - **ADR-0013**: Public overlay observability view + shared `useOverlayStream` hook
 - **ADR-0014**: Linger upstream capture demand symmetric with the downstream pub/sub linger
+- **ADR-0015**: Dynamic EventSub chat-ownership claim — IRC is the always-on fallback; EventSub owns a channel only while it is actively delivering chat (no silent loss across the partition)
 
 ### Documentation
 

--- a/docs/adr/0015-eventsub-chat-ownership-claim.md
+++ b/docs/adr/0015-eventsub-chat-ownership-claim.md
@@ -1,0 +1,140 @@
+# ADR-0015: Dynamic EventSub Chat-Ownership Claim for the IRC↔EventSub Partition
+
+**Date**: 2026-06-03
+**Status**: Accepted
+**Deciders**: All-Chat Platform Team
+
+---
+
+## Context and Problem Statement
+
+To relieve the shared Twitch IRC bot's ~100-channel cap, chat for channels whose owner granted the
+chat scopes is read via EventSub `channel.chat.message` instead of IRC (see the feature commit
+`feat(twitch): read chat via EventSub, demand-gated, to relieve IRC cap`). The two paths were
+**partitioned by a static SQL predicate**: `twitch-listener` (IRC) excluded any channel where
+`'user:read:chat' = ANY(users.granted_scopes) AND token_expires_at > NOW()`, expecting EventSub to
+own it.
+
+The defect: that predicate is **decoupled from whether EventSub is actually delivering chat**. A
+channel can satisfy the exclusion predicate yet receive no EventSub chat for many reasons, and in
+every one of them IRC has *also* dropped the channel — so chat is lost with **no fallback**:
+
+- **Revocation** (observed in production, broadcaster `196691714`): a `channel.chat.message`
+  subscription is revoked; the listener only logged it, never recreated the sub or cleared state —
+  permanent loss until pod restart.
+- **Partial consent**: the `channel.chat.message` subscription requires `user:read:chat` **+
+  `user:bot` + `channel:bot`**, but the IRC exclusion checked only `user:read:chat`. A channel with
+  the partial grant is excluded from IRC yet cannot get an EventSub sub — permanent loss.
+- **Verification pending/failed, token expiry skew, demand races, leader gaps, pod outage,
+  startup/reconnect latency** — each a window where the predicate says "EventSub owns it" but
+  EventSub is not delivering.
+
+## Decision Drivers
+
+- **No silent message loss is paramount.** A channel must always be read by *someone*.
+- **Preserve the cap-relief benefit** for the channels that actually matter (active chat).
+- **Self-healing:** recovery must not require a pod restart or manual action.
+- **Don't reintroduce divergent in-memory cross-pod state** (webhooks land on any pod; subscription
+  management is leader-gated) — coordinate through Redis, consistent with ADR-0002 / ADR-0014.
+- **Minimal blast radius and reversible.**
+
+## Considered Options
+
+1. **Dynamic traffic-driven ownership claim; IRC is the default, EventSub claims a channel only
+   while it is provably delivering chat (chosen).**
+   - The EventSub webhook handler writes a per-channel claim key `eventsub:chat:owner:{login}` (TTL
+     `EVENTSUB_CHAT_CLAIM_TTL`, default 5m) on each delivered `channel.chat.message`, throttled to one
+     write per channel per `ClaimRefreshInterval` (60s). It releases the claim on revocation. IRC
+     excludes only channels with a **live claim**, fetched via `SCAN eventsub:chat:owner:*`.
+   - ✅ Pros: IRC is the universal safety net — a channel leaves IRC *only while EventSub is actually
+     delivering chat*, and returns within the TTL the instant EventSub stops (revoke, verify-fail,
+     scope gap, pod outage, leader gap). Verify-fail/scope-fail produce **zero** loss (no message →
+     no claim → IRC never dropped it). No leader/cross-pod coordination on the hot path. Cap relief
+     tracks activity: busy channels stay on EventSub, idle ones cost a cheap IRC slot.
+   - ❌ Cons: A brief IRC↔EventSub overlap during handoff (≤ one IRC sync) and a possible ≤TTL fallback
+     delay in a total-EventSub-outage case; relies on message-processor native-id dedup to make the
+     overlap invisible.
+
+2. **Gate the IRC exclusion on all three required scopes (`user:read:chat`+`user:bot`+`channel:bot`).**
+   - ✅ Pros: Fixes the partial-consent case with a one-line predicate change.
+   - ❌ Cons: Leaves every other failure mode (revocation, verify-fail, demand/leader gaps, outage)
+     as permanent loss. Not self-healing.
+
+3. **Leader-driven "intent" claim (claim when the leader creates the sub).**
+   - ✅ Pros: Keeps idle-but-eligible channels off IRC (better steady-state cap relief).
+   - ❌ Cons: Claims a sub before it is confirmed delivering → reintroduces the startup gap and the
+     verify-fail loss; requires a revocation→leader signal to avoid resurrecting a revoked claim;
+     more cross-pod state. Higher complexity for marginal cap benefit.
+
+## Decision Outcome
+
+**Chosen: Option 1.** A chat-ownership claim means "EventSub is delivering this channel's chat right
+now." It is created/refreshed by the webhook handler on real delivered chat and released on
+revocation; it lapses on its own (TTL) whenever delivery stops for any reason. The IRC listener
+treats the presence of a claim as the sole exclusion signal, replacing the static scope predicate, so
+IRC automatically resumes any channel EventSub is not currently serving. The unavoidable brief
+handoff overlap is made idempotent by deduplicating in message-processor on the **native Twitch
+message id** (`tags["id"]`), which both the IRC parser and the EventSub handler set to the identical
+value.
+
+The claim key format and TTL live in a single shared package (`shared/twitchchat`) imported by both
+listeners, so the producer (EventSub) and consumer (IRC) of the claim cannot drift — the same
+discipline the previous byte-identical SQL predicate aimed for.
+
+## Consequences
+
+### Positive
+- Eliminates every identified permanent-loss mode; the worst case degrades to a bounded fallback
+  delay, never silent permanent loss.
+- Verify-fail / scope-fail / partial-consent channels are served by IRC with **zero** gap.
+- Self-healing with no restart: revoke/outage/leader-loss all resolve within the claim TTL.
+- Cap relief is preserved for active channels (the ones that pressure the cap).
+
+### Negative
+- A channel idle (no chat) for longer than the claim TTL falls back to an IRC slot until chat
+  resumes — cap relief is activity-scoped, not permanent.
+- **Deploy transient.** Immediately after a deploy, claims have not yet been (re)written, so IRC's
+  desired set briefly includes scope-eligible channels until each receives an EventSub message and
+  the claim forms (≤ the 60s refresh interval for active channels; quiet channels stay on IRC but
+  have no chat to lose). If the total exceeds the bot cap, JOINs are rate-limited, not dropped, and
+  the set converges within ~1–2 minutes. No chat is lost — EventSub continues delivering the
+  channels it owns, and message-processor dedupes any overlap.
+- Introduces a dependency on message-processor native-id dedup to hide the handoff overlap; without
+  it, viewers would briefly see duplicated Twitch chat during a handoff.
+- `SCAN eventsub:chat:owner:*` per IRC sync (cheap at current channel counts; bounded by channel
+  count, runs on the existing 30s-ish sync cadence).
+
+### Failure-mode behaviour (all → IRC serves, no loss)
+| Mode | Claim outcome | Result |
+|------|---------------|--------|
+| Verify-fail / scope-fail / partial consent | never created (no message) | IRC serves from the start |
+| Revocation | released by handler (or expires ≤TTL) | IRC resumes |
+| EventSub pod/total outage | expires ≤TTL | IRC resumes |
+| Leader gap | unaffected (claim is traffic-driven, not leader-driven) | continuous |
+| Startup / reconnect | absent until first EventSub message | IRC covers, then handoff (deduped) |
+
+## Implementation
+
+- **New**: `shared/twitchchat/claim.go` — `ClaimStore` (`Claim`, `Release`, `ClaimedLogins`),
+  `ClaimKey`, `ClaimTTL`, `ClaimRefreshInterval`. Tests in `claim_test.go` (miniredis).
+- **twitch-eventsub-listener**: `webhooks/handler.go` refreshes the claim on `channel.chat.message`
+  delivery (throttled) and releases it on revocation; `cmd/main.go` constructs the `ClaimStore` and
+  injects it into the handler.
+- **twitch-listener**: `channels/repository.go` drops the static `eventSubOwnedExclusion` SQL;
+  `channels/manager.go` filters the desired-channel set against live claims via `ClaimedLogins`
+  (fail-open on Redis error → IRC reads everything, deduped).
+- **message-processor**: `dedup/dedup.go` adds `IsDuplicateNativeID`; `consumer/stream_consumer.go`
+  drops duplicate Twitch chat by `platform|tags["id"]` before the handler.
+- **Configuration**: `EVENTSUB_CHAT_CLAIM_TTL` (Go duration, default `5m`; the IRC fallback delay in a
+  total-outage case is bounded by this).
+- **Timeline**: 2026-06-03.
+
+## Related Decisions
+
+- ADR-0014 (Demand linger) — the demand window during which a chat sub exists; this ADR makes the
+  IRC↔EventSub boundary resilient to *every* gap, not just demand.
+- ADR-0009 (Ring buffer publisher) — the "no silent drops" resilience philosophy, extended to the
+  partition boundary.
+- ADR-0007 (Leadership rebalancing) — leader gates subscription management; claims are deliberately
+  leader-independent so leader transitions never drop chat.
+- ADR-0002 (Redis Streams + Pub/Sub) — claims coordinate through Redis keys, like `overlay:connected:*`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -258,6 +258,17 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0015: Dynamic EventSub Chat-Ownership Claim for the IRC↔EventSub Partition
+
+**Status**: ✅ Accepted
+**Date**: 2026-06-03
+**Problem**: The IRC↔EventSub chat split used a static scope predicate, so a scope-eligible channel was dropped by IRC even when EventSub was not actually delivering (revocation, partial scope, verification failure, demand/leader gaps) — chat lost with no fallback
+**Decision**: Make the partition dynamic — EventSub writes a per-channel `eventsub:chat:owner:{login}` claim (TTL, refreshed on delivered chat); IRC excludes only channels with a live claim and serves everything else; message-processor dedupes the handoff overlap on the native Twitch message id
+**Impact**: IRC is the universal fallback — every gap where EventSub is not delivering is covered with no silent loss; cap relief preserved for active channels; self-healing within the claim TTL
+**→ Read**: [0015-eventsub-chat-ownership-claim.md](./0015-eventsub-chat-ownership-claim.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number
@@ -379,13 +390,13 @@ Create a new ADR if:
 
 ## Summary
 
-**Total ADRs**: 14
+**Total ADRs**: 15
 **Status**: All accepted (✅)
-**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view, demand linger)
+**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view, demand linger, EventSub chat-ownership partition)
 
 **Most Referenced**:
 1. ADR-0002 (Redis patterns) - Referenced by all listeners, message processor
 2. ADR-0001 (Go layout) - Referenced by all services
 3. ADR-0006 (Quota tracking) - Referenced by YouTube listener, overlay manager
 
-**Last Updated**: 2026-06-02
+**Last Updated**: 2026-06-03

--- a/services/message-processor/cmd/main.go
+++ b/services/message-processor/cmd/main.go
@@ -437,7 +437,6 @@ func main() {
 					}
 				}
 
-
 				// Enrich with viewer identity (name_color from All-Chat account, all platforms)
 				startViewer := time.Now()
 				if err := viewerBadgeEnricher.Enrich(ctx, unified); err != nil {
@@ -651,6 +650,9 @@ func main() {
 
 	// Create and start stream consumer
 	streamConsumer := consumer.NewStreamConsumer(redisClient, log, processorMetrics, messageHandler, msgIDRegistry, deletionBuffer, hostname)
+	// Collapse the IRC↔EventSub Twitch handoff overlap (and Twitch webhook retries) by the native
+	// message id before enrichment, so viewers never see doubled chat (ADR-0015).
+	streamConsumer.SetNativeDeduplicator(deduplicator)
 	if err := streamConsumer.Start(ctx); err != nil {
 		log.Fatal("Failed to start stream consumer", zap.Error(err))
 	}

--- a/services/message-processor/consumer/native_dedup_test.go
+++ b/services/message-processor/consumer/native_dedup_test.go
@@ -1,0 +1,106 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/message-processor/dedup"
+	"github.com/caesar/all-chat/services/message-processor/models"
+	"github.com/caesar/all-chat/services/message-processor/registry"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func twitchStreamMsg(t *testing.T, internalID, nativeID, text string) redis.XMessage {
+	t.Helper()
+	raw := &models.RawChatMessage{
+		MessageID: internalID, // internal UUID — differs between the IRC and EventSub copies
+		Platform:  "twitch",
+		ChannelID: "somechannel",
+		UserID:    "42",
+		Username:  "viewer",
+		Text:      text,
+		Timestamp: time.Now().UTC(),
+		Tags:      map[string]string{"id": nativeID}, // native Twitch id — identical across both paths
+	}
+	data, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return redis.XMessage{ID: "0-1", Values: map[string]interface{}{"data": string(data)}}
+}
+
+// The same native Twitch id arriving twice (the IRC↔EventSub handoff overlap, or a Twitch webhook
+// retry) must reach the handler only once; a different native id passes through (ADR-0015).
+func TestProcessMessage_NativeIDDedup(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+	logger := zaptest.NewLogger(t)
+
+	var calls int
+	handler := func(ctx context.Context, msg *models.RawChatMessage) error { calls++; return nil }
+
+	c := NewStreamConsumer(client, logger, sharedTestMetrics, handler, nil,
+		registry.NewRedisDeletionBuffer(client, time.Hour), "host")
+	c.SetNativeDeduplicator(dedup.NewDeduplicator(client, logger))
+
+	ctx := context.Background()
+
+	// IRC copy of message "abc".
+	require.NoError(t, c.processMessage(ctx, twitchStreamMsg(t, "irc-uuid", "abc", "hello")))
+	// EventSub copy of the SAME native message (different internal UUID) — must be dropped.
+	require.NoError(t, c.processMessage(ctx, twitchStreamMsg(t, "eventsub-uuid", "abc", "hello")))
+	if calls != 1 {
+		t.Fatalf("handler called %d times for duplicate native id, want 1", calls)
+	}
+
+	// A genuinely different message passes through.
+	require.NoError(t, c.processMessage(ctx, twitchStreamMsg(t, "irc-uuid-2", "def", "world")))
+	if calls != 2 {
+		t.Fatalf("handler called %d times after distinct native id, want 2", calls)
+	}
+}
+
+// Without a native id (e.g. a malformed/legacy message), dedup must not drop the message.
+func TestProcessMessage_NativeIDDedup_EmptyIDPassesThrough(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	var calls int
+	c := NewStreamConsumer(client, zaptest.NewLogger(t), sharedTestMetrics,
+		func(ctx context.Context, msg *models.RawChatMessage) error { calls++; return nil },
+		nil, registry.NewRedisDeletionBuffer(client, time.Hour), "host")
+	c.SetNativeDeduplicator(dedup.NewDeduplicator(client, zaptest.NewLogger(t)))
+
+	ctx := context.Background()
+	require.NoError(t, c.processMessage(ctx, twitchStreamMsg(t, "u1", "", "no native id")))
+	require.NoError(t, c.processMessage(ctx, twitchStreamMsg(t, "u2", "", "no native id")))
+	if calls != 2 {
+		t.Fatalf("messages without a native id must not be deduped; handler called %d times, want 2", calls)
+	}
+}

--- a/services/message-processor/consumer/stream_consumer.go
+++ b/services/message-processor/consumer/stream_consumer.go
@@ -47,6 +47,13 @@ const (
 // MessageHandler is called for each consumed message
 type MessageHandler func(ctx context.Context, msg *models.RawChatMessage) error
 
+// NativeDeduplicator drops messages whose platform-native id has already been processed. Both the
+// IRC and EventSub Twitch chat paths stamp the same native id into Tags["id"], so this makes the
+// brief IRC↔EventSub handoff overlap (and Twitch webhook retries) idempotent (ADR-0015).
+type NativeDeduplicator interface {
+	IsDuplicateNativeID(ctx context.Context, platform, nativeID string) (bool, error)
+}
+
 // StreamConsumer consumes messages from Redis Streams
 type StreamConsumer struct {
 	client         *redis.Client
@@ -56,6 +63,7 @@ type StreamConsumer struct {
 	stopCh         chan struct{}
 	msgIDRegistry  registry.MessageIDRegistry
 	deletionBuffer registry.DeletionBuffer
+	nativeDedup    NativeDeduplicator // nil disables native-id dedup
 	consumerName   string
 }
 
@@ -72,6 +80,12 @@ func NewStreamConsumer(client *redis.Client, logger *zap.Logger, m *metrics.Proc
 		deletionBuffer: deletionBuffer,
 		consumerName:   consumerName,
 	}
+}
+
+// SetNativeDeduplicator injects the native-id deduplicator used to collapse the IRC↔EventSub
+// handoff overlap. Safe to leave unset (dedup disabled).
+func (c *StreamConsumer) SetNativeDeduplicator(d NativeDeduplicator) {
+	c.nativeDedup = d
 }
 
 // Start begins consuming messages from the stream
@@ -265,6 +279,27 @@ func (c *StreamConsumer) processMessage(ctx context.Context, msg redis.XMessage)
 				}
 
 				c.metrics.BufferedDeletionsApplied.Inc()
+			}
+		}
+	}
+
+	// Native-id dedup (ADR-0015): the IRC and EventSub Twitch paths both stamp the identical
+	// native Twitch message id into Tags["id"], so a channel handed off between them (or a Twitch
+	// webhook retry) can present the same message twice. Drop the second copy before enrichment so
+	// viewers never see doubled chat. Scoped to Twitch regular chat, where Tags["id"] is the native,
+	// globally-unique message id; deletion events and other platforms are unaffected.
+	if c.nativeDedup != nil && rawMsg.Platform == "twitch" &&
+		(rawMsg.EventType == "" || rawMsg.EventType == "chat_message") {
+		if nativeID := rawMsg.Tags["id"]; nativeID != "" {
+			if dup, derr := c.nativeDedup.IsDuplicateNativeID(ctx, rawMsg.Platform, nativeID); derr == nil && dup {
+				c.logger.Debug("Dropping duplicate Twitch message by native id",
+					zap.String("native_id", nativeID),
+					zap.String("channel", rawMsg.ChannelID),
+				)
+				if c.metrics != nil {
+					c.metrics.RecordMessageProcessed("message-processor", rawMsg.Platform, "native_dedup", "duplicate")
+				}
+				return nil // ACK + drop the duplicate
 			}
 		}
 	}

--- a/services/message-processor/dedup/dedup.go
+++ b/services/message-processor/dedup/dedup.go
@@ -33,6 +33,14 @@ const (
 
 	// Key prefix for deduplication
 	dedupPrefix = "dedup:message"
+
+	// nativeDedupPrefix namespaces deduplication by platform-native message id.
+	nativeDedupPrefix = "dedup:native"
+
+	// nativeDedupTTL bounds how long a native message id is remembered. It only needs to cover
+	// the windows where the same native message can be ingested twice: the brief IRC↔EventSub
+	// handoff overlap (≤ one IRC sync) and Twitch webhook retries (seconds). 2 minutes is ample.
+	nativeDedupTTL = 2 * time.Minute
 )
 
 // Deduplicator provides message deduplication using Redis
@@ -77,6 +85,25 @@ func (d *Deduplicator) IsDuplicate(ctx context.Context, platform, channelID, use
 		)
 	}
 
+	return !wasSet, nil
+}
+
+// IsDuplicateNativeID reports whether a message with this platform-native message id has already
+// been seen within nativeDedupTTL, atomically recording it if not (SETNX). Both the IRC parser and
+// the EventSub webhook handler stamp the identical native Twitch message id into Tags["id"], so this
+// collapses the unavoidable IRC↔EventSub handoff overlap (and Twitch webhook retries) to a single
+// delivered message. An empty id is never a duplicate. Fails OPEN on a Redis error (treats the
+// message as new) so a Redis blip can never drop a real message — at worst a duplicate slips through.
+func (d *Deduplicator) IsDuplicateNativeID(ctx context.Context, platform, nativeID string) (bool, error) {
+	if nativeID == "" {
+		return false, nil
+	}
+	key := fmt.Sprintf("%s:%s:%s", nativeDedupPrefix, platform, nativeID)
+	wasSet, err := d.client.SetNX(ctx, key, "1", nativeDedupTTL).Result()
+	if err != nil {
+		d.logger.Error("native-id dedup SetNX failed, failing open", zap.Error(err))
+		return false, err
+	}
 	return !wasSet, nil
 }
 

--- a/services/message-processor/dedup/native_test.go
+++ b/services/message-processor/dedup/native_test.go
@@ -1,0 +1,84 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package dedup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+func newNativeTestDedup(t *testing.T) (*miniredis.Miniredis, *Deduplicator) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, NewDeduplicator(rc, zap.NewNop())
+}
+
+func TestIsDuplicateNativeID_FirstSeenThenDuplicate(t *testing.T) {
+	_, d := newNativeTestDedup(t)
+	ctx := context.Background()
+
+	dup, err := d.IsDuplicateNativeID(ctx, "twitch", "abc")
+	if err != nil || dup {
+		t.Fatalf("first sighting: dup=%v err=%v, want false/nil", dup, err)
+	}
+	dup, err = d.IsDuplicateNativeID(ctx, "twitch", "abc")
+	if err != nil || !dup {
+		t.Fatalf("second sighting: dup=%v err=%v, want true/nil", dup, err)
+	}
+}
+
+func TestIsDuplicateNativeID_NamespacedByPlatform(t *testing.T) {
+	_, d := newNativeTestDedup(t)
+	ctx := context.Background()
+	_, _ = d.IsDuplicateNativeID(ctx, "twitch", "shared-id")
+	// Same id under a different platform must be independent (key is platform-scoped).
+	if dup, _ := d.IsDuplicateNativeID(ctx, "kick", "shared-id"); dup {
+		t.Fatal("native id must be namespaced by platform")
+	}
+}
+
+func TestIsDuplicateNativeID_EmptyIDNeverDuplicate(t *testing.T) {
+	_, d := newNativeTestDedup(t)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if dup, err := d.IsDuplicateNativeID(ctx, "twitch", ""); dup || err != nil {
+			t.Fatalf("empty id must never be a duplicate; got dup=%v err=%v", dup, err)
+		}
+	}
+}
+
+func TestIsDuplicateNativeID_FailsOpenOnRedisError(t *testing.T) {
+	mr, d := newNativeTestDedup(t)
+	mr.Close() // force a connection error
+	dup, err := d.IsDuplicateNativeID(context.Background(), "twitch", "abc")
+	if dup {
+		t.Fatal("on Redis error the message must be treated as NOT a duplicate (fail open)")
+	}
+	if err == nil {
+		t.Fatal("expected the underlying Redis error to be returned for observability")
+	}
+}

--- a/services/twitch-eventsub-listener/README.md
+++ b/services/twitch-eventsub-listener/README.md
@@ -37,9 +37,18 @@ The Twitch EventSub Listener connects to Twitch's EventSub WebSocket API to rece
 ### Chat Reading (channel.chat.message)
 
 To relieve the IRC bot's ~100-channel cap, channels whose owner granted the chat scopes
-(`user:read:chat` + `user:bot`) are read via EventSub instead of IRC. The IRC listener and the
-EventSub listener use a byte-identical `granted_scopes` predicate so each channel lands on exactly
-one path (no double-read, no gap).
+(`user:read:chat` + `user:bot` + `channel:bot`) are read via EventSub instead of IRC.
+
+**Dynamic ownership claim (ADR-0015).** The IRC↔EventSub split is NOT a static scope predicate — it
+tracks *actual delivery*. On every delivered `channel.chat.message`, the webhook handler writes a
+per-channel claim key `eventsub:chat:owner:{login}` (TTL `EVENTSUB_CHAT_CLAIM_TTL`, default 5m,
+throttled to one write per channel per 60s) and releases it on revocation. The IRC listener excludes
+only channels that hold a **live claim** (`SCAN eventsub:chat:owner:*`). Any channel EventSub is not
+currently serving — never subscribed, verification failed, partial scope, revoked, or during an
+outage — has no claim and is read by IRC, the always-on fallback. The brief handoff overlap is made
+idempotent by message-processor deduplicating on the native Twitch message id (`tags["id"]`, set
+identically by both paths). This eliminated the previous permanent-loss modes where a scope-gated
+channel was dropped by IRC yet not delivered by EventSub.
 
 The chat subscription is **demand-gated**: it exists only while an overlay using the channel has a
 live WebSocket. When demand arrives, the chat subscription is created *before* the always-on event

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/caesar/all-chat/shared/logger"
 	"github.com/caesar/all-chat/shared/metrics"
 	"github.com/caesar/all-chat/shared/tracing"
+	"github.com/caesar/all-chat/shared/twitchchat"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -156,6 +157,22 @@ func main() {
 	// Initialize components
 	streamPublisher := publisher.NewStreamPublisher(redisClient, log)
 	statusPublisher := status.NewPublisher(redisClient, log)
+
+	// Chat-ownership claim store (ADR-0015): the webhook handler writes a per-channel claim on
+	// delivered chat so the IRC listener excludes only channels EventSub is actually serving. TTL
+	// bounds the IRC fallback delay in a total-outage case; overridable via EVENTSUB_CHAT_CLAIM_TTL.
+	claimTTL := twitchchat.DefaultClaimTTL
+	if v := listener.Env("EVENTSUB_CHAT_CLAIM_TTL", ""); v != "" {
+		if parsed, perr := time.ParseDuration(v); perr == nil && parsed > 0 {
+			claimTTL = parsed
+		} else {
+			log.Warn("Invalid EVENTSUB_CHAT_CLAIM_TTL, using default",
+				zap.String("value", v), zap.Duration("default", claimTTL))
+		}
+	}
+	chatClaims := twitchchat.NewClaimStoreWithTTL(redisClient, claimTTL)
+	log.Info("Chat-ownership claim store initialized", zap.Duration("claim_ttl", claimTTL))
+
 	subscriptionMgr := eventsub.NewSubscriptionManager(twitchClientID, twitchClientSecret, webhookSecret, callbackURL, log)
 	channelManager := channels.NewManager(db, log, subscriptionMgr, tokenCipher, ChannelSyncInterval)
 	channelManager.SetStatusPublisher(statusPublisher)
@@ -166,7 +183,7 @@ func main() {
 	}
 
 	// Create webhook handler
-	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, log)
+	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, chatClaims, log)
 
 	// isLeader tracks whether this pod currently holds EventSub leadership.
 	// Protected by mu; read by subscription callback and HTTP handlers.

--- a/services/twitch-eventsub-listener/webhooks/handler.go
+++ b/services/twitch-eventsub-listener/webhooks/handler.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
@@ -34,6 +35,7 @@ import (
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
 	"github.com/caesar/all-chat/shared/metrics"
+	"github.com/caesar/all-chat/shared/twitchchat"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -56,20 +58,29 @@ type Handler struct {
 	db              *pgxpool.Pool // for twitch_id -> user_id / login lookup
 	publisher       *publisher.StreamPublisher
 	listenerMetrics *metrics.ListenerMetrics
-	statusPublisher *status.Publisher // emits platform:status for the chat indicator (nil-safe)
+	statusPublisher *status.Publisher      // emits platform:status for the chat indicator (nil-safe)
+	claims          *twitchchat.ClaimStore // chat-ownership claims for the IRC↔EventSub partition (nil-safe, ADR-0015)
 	logger          *zap.Logger
+
+	// claimRefreshedAt throttles per-channel claim refreshes (one Redis write per channel per
+	// twitchchat.ClaimRefreshInterval) so high chat volume does not amplify into Redis writes.
+	claimMu          sync.Mutex
+	claimRefreshedAt map[string]time.Time
 }
 
-// NewHandler creates a new webhook handler
-func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, statusPublisher *status.Publisher, logger *zap.Logger) *Handler {
+// NewHandler creates a new webhook handler. claims may be nil to disable chat-ownership claims
+// (the IRC listener then never sees this listener's channels as claimed).
+func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, statusPublisher *status.Publisher, claims *twitchchat.ClaimStore, logger *zap.Logger) *Handler {
 	return &Handler{
-		secret:          []byte(secret),
-		redis:           redis,
-		db:              db,
-		publisher:       publisher,
-		listenerMetrics: listenerMetrics,
-		statusPublisher: statusPublisher,
-		logger:          logger,
+		secret:           []byte(secret),
+		redis:            redis,
+		db:               db,
+		publisher:        publisher,
+		listenerMetrics:  listenerMetrics,
+		statusPublisher:  statusPublisher,
+		claims:           claims,
+		logger:           logger,
+		claimRefreshedAt: make(map[string]time.Time),
 	}
 }
 
@@ -155,7 +166,7 @@ func (h *Handler) verifySignature(c *gin.Context, body []byte) bool {
 // handleChallenge responds to subscription verification challenge
 func (h *Handler) handleChallenge(c *gin.Context, body []byte) {
 	var challenge struct {
-		Challenge    string                   `json:"challenge"`
+		Challenge    string                    `json:"challenge"`
 		Subscription eventsub.SubscriptionInfo `json:"subscription"`
 	}
 
@@ -231,14 +242,22 @@ func (h *Handler) handleNotification(c *gin.Context, body []byte, messageID stri
 			h.listenerMetrics.RecordPublish("twitch-eventsub", "twitch-eventsub-listener", "error")
 			h.listenerMetrics.RecordError("twitch-eventsub", "twitch-eventsub-listener", "publish", "error")
 		}
-		// Still return 204 to acknowledge receipt
-	} else if h.listenerMetrics != nil {
-		h.listenerMetrics.RecordPublish("twitch-eventsub", "twitch-eventsub-listener", "success")
-	}
-
-	// Mark as processed (TTL: 24 hours)
-	if err := h.redis.SetEx(ctx, cacheKey, "1", 24*time.Hour).Err(); err != nil {
-		h.logger.Warn("Failed to cache message ID", zap.Error(err))
+		// Deliberately do NOT mark this message processed. The previous code marked it as
+		// processed even on failure, so a Twitch redelivery (same Twitch-Eventsub-Message-Id)
+		// would be silently deduped away and the message lost forever. Leaving the dedup key
+		// unset lets a redelivery reprocess. Chat publishes are ring-buffered (ADR-0009), so a
+		// transient Redis blip never surfaces here as an error; the errors that do reach here are
+		// deterministic parse failures where a retry would not help — hence we still ack 204
+		// rather than 5xx (a 5xx storm risks notification_failures_exceeded revocation).
+	} else {
+		if h.listenerMetrics != nil {
+			h.listenerMetrics.RecordPublish("twitch-eventsub", "twitch-eventsub-listener", "success")
+		}
+		// Mark as processed (TTL: 24 hours) only after a successful handoff so a failed message
+		// is never recorded as done.
+		if err := h.redis.SetEx(ctx, cacheKey, "1", 24*time.Hour).Err(); err != nil {
+			h.logger.Warn("Failed to cache message ID", zap.Error(err))
+		}
 	}
 
 	c.Status(http.StatusNoContent)
@@ -262,10 +281,12 @@ func (h *Handler) handleRevocation(c *gin.Context, body []byte) {
 		zap.String("status", revocation.Subscription.Status),
 	)
 
-	// A revoked chat subscription stops delivering chat — clear the channel's indicator.
+	// A revoked chat subscription stops delivering chat. Release the ownership claim so the IRC
+	// listener resumes this channel immediately (ADR-0015) instead of waiting for the claim TTL,
+	// and clear the channel's indicator.
 	if revocation.Subscription.Type == "channel.chat.message" {
 		if bid := conditionBroadcasterID(revocation.Subscription.Condition); bid != "" {
-			go h.publishChatStatus(bid, "offline")
+			go h.handleChatSubRevoked(bid)
 		}
 	}
 
@@ -284,34 +305,95 @@ func conditionBroadcasterID(condition map[string]interface{}) string {
 	return ""
 }
 
-// publishChatStatus emits a platform:status update for a Twitch channel's chat indicator.
-// It resolves the broadcaster's login (the key api-gateway matches against
-// overlay_chat_sources.channel_id) from the users table, since the webhook may land on any
-// pod — including a non-leader whose channel manager has no in-memory mapping. Best-effort:
-// a missing user or publish failure is logged and dropped.
-func (h *Handler) publishChatStatus(broadcasterID, state string) {
-	if h.statusPublisher == nil || broadcasterID == "" {
-		return
+// resolveLogin maps a Twitch broadcaster id to its login (the key api-gateway matches against
+// overlay_chat_sources.channel_id, and the key chat-ownership claims use). Returns "" when the
+// broadcaster is not a registered all-chat Twitch user. The webhook may land on any pod, so this
+// always reads the DB rather than an in-memory channel map.
+func (h *Handler) resolveLogin(broadcasterID string) string {
+	if broadcasterID == "" {
+		return ""
 	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	var login string
-	err := h.db.QueryRow(ctx,
-		"SELECT username FROM users WHERE twitch_id = $1 AND auth_provider = 'twitch'", broadcasterID).Scan(&login)
-	if err != nil || login == "" {
-		h.logger.Debug("Could not resolve login for chat status",
-			zap.String("broadcaster_id", broadcasterID),
-			zap.Error(err))
+	if err := h.db.QueryRow(ctx,
+		"SELECT username FROM users WHERE twitch_id = $1 AND auth_provider = 'twitch'", broadcasterID).Scan(&login); err != nil {
+		h.logger.Debug("Could not resolve login for broadcaster",
+			zap.String("broadcaster_id", broadcasterID), zap.Error(err))
+		return ""
+	}
+	return login
+}
+
+// publishChatStatus resolves the broadcaster login and emits a platform:status update for the
+// channel's chat indicator. Best-effort: a missing user or publish failure is logged and dropped.
+func (h *Handler) publishChatStatus(broadcasterID, state string) {
+	h.publishChatStatusForLogin(h.resolveLogin(broadcasterID), state)
+}
+
+// publishChatStatusForLogin emits the platform:status update for an already-resolved login.
+func (h *Handler) publishChatStatusForLogin(login, state string) {
+	if h.statusPublisher == nil || login == "" {
 		return
 	}
-
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	h.statusPublisher.Publish(ctx, status.Message{
 		Platform:  "twitch",
 		ChannelID: strings.ToLower(login),
 		Status:    state,
 	})
+}
+
+// handleChatSubRevoked reacts to a revoked channel.chat.message subscription: it releases the
+// chat-ownership claim so the IRC listener resumes the channel immediately (rather than after the
+// claim TTL), then clears the chat indicator. Runs on a background goroutine (resolves the login
+// from the DB; the webhook may land on any pod).
+func (h *Handler) handleChatSubRevoked(broadcasterID string) {
+	login := h.resolveLogin(broadcasterID)
+	if h.claims != nil && login != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := h.claims.Release(ctx, login); err != nil {
+			h.logger.Warn("Failed to release chat-ownership claim on revocation",
+				zap.String("login", login), zap.Error(err))
+		}
+		cancel()
+	}
+	h.publishChatStatusForLogin(login, "offline")
+}
+
+// refreshChatClaim renews the EventSub chat-ownership claim for a channel that just delivered a
+// chat message, throttled to one Redis write per channel per twitchchat.ClaimRefreshInterval. The
+// live claim is what keeps this channel on the EventSub path and excluded from IRC (ADR-0015);
+// letting it lapse hands the channel back to the always-on IRC listener. The login comes straight
+// from the event, so no DB lookup is needed on the hot path.
+func (h *Handler) refreshChatClaim(login, broadcasterID string) {
+	if h.claims == nil || login == "" {
+		return
+	}
+	login = strings.ToLower(login)
+
+	now := time.Now()
+	h.claimMu.Lock()
+	if last, ok := h.claimRefreshedAt[login]; ok && now.Sub(last) < twitchchat.ClaimRefreshInterval {
+		h.claimMu.Unlock()
+		return
+	}
+	h.claimRefreshedAt[login] = now
+	h.claimMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.claims.Claim(ctx, login, broadcasterID); err != nil {
+		h.logger.Warn("Failed to refresh chat-ownership claim",
+			zap.String("login", login), zap.Error(err))
+		// Roll back the throttle stamp so the next message retries promptly rather than waiting a
+		// full interval after a transient Redis error.
+		h.claimMu.Lock()
+		delete(h.claimRefreshedAt, login)
+		h.claimMu.Unlock()
+	}
 }
 
 // routeEvent routes events to appropriate handlers based on subscription type
@@ -470,14 +552,14 @@ func (h *Handler) handleChannelPointsRedemption(ctx context.Context, eventData j
 
 	// Create raw message for Message Processor
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        text, // User input if available, otherwise system message
-		Timestamp:   event.RedeemedAt,
-		EventType:   "channel_points",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      text, // User input if available, otherwise system message
+		Timestamp: event.RedeemedAt,
+		EventType: "channel_points",
 		EventData: map[string]interface{}{
 			"reward_id":     event.Reward.ID,
 			"reward_title":  event.Reward.Title,
@@ -500,14 +582,14 @@ func (h *Handler) handleSubscribe(ctx context.Context, eventData json.RawMessage
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        fmt.Sprintf("Subscribed at %s", event.Tier),
-		Timestamp:   time.Now(),
-		EventType:   "subscription",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      fmt.Sprintf("Subscribed at %s", event.Tier),
+		Timestamp: time.Now(),
+		EventType: "subscription",
 		EventData: map[string]interface{}{
 			"tier":      event.Tier,
 			"is_gift":   event.IsGift,
@@ -526,19 +608,19 @@ func (h *Handler) handleSubscriptionGift(ctx context.Context, eventData json.Raw
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        fmt.Sprintf("Gifted %d subs", event.Total),
-		Timestamp:   time.Now(),
-		EventType:   "mystery_gift",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      fmt.Sprintf("Gifted %d subs", event.Total),
+		Timestamp: time.Now(),
+		EventType: "mystery_gift",
 		EventData: map[string]interface{}{
-			"tier":              event.Tier,
-			"total":             event.Total,
-			"cumulative_total":  event.CumulativeTotal,
-			"is_anonymous":      event.IsAnonymous,
+			"tier":             event.Tier,
+			"total":            event.Total,
+			"cumulative_total": event.CumulativeTotal,
+			"is_anonymous":     event.IsAnonymous,
 		},
 	}
 
@@ -553,19 +635,19 @@ func (h *Handler) handleResubscription(ctx context.Context, eventData json.RawMe
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        event.Message.Text,
-		Timestamp:   time.Now(),
-		EventType:   "resubscription",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      event.Message.Text,
+		Timestamp: time.Now(),
+		EventType: "resubscription",
 		EventData: map[string]interface{}{
-			"tier":              event.Tier,
-			"months":            event.CumulativeMonths,
-			"streak":            event.StreakMonths,
-			"duration_months":   event.DurationMonths,
+			"tier":            event.Tier,
+			"months":          event.CumulativeMonths,
+			"streak":          event.StreakMonths,
+			"duration_months": event.DurationMonths,
 		},
 	}
 
@@ -580,14 +662,14 @@ func (h *Handler) handleRaid(ctx context.Context, eventData json.RawMessage) err
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.ToBroadcasterUserLogin,
-		UserID:      event.FromBroadcasterUserID,
-		Username:    event.FromBroadcasterUserLogin,
-		Text:        fmt.Sprintf("Raiding with %d viewers", event.Viewers),
-		Timestamp:   time.Now(),
-		EventType:   "raid",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.ToBroadcasterUserLogin,
+		UserID:    event.FromBroadcasterUserID,
+		Username:  event.FromBroadcasterUserLogin,
+		Text:      fmt.Sprintf("Raiding with %d viewers", event.Viewers),
+		Timestamp: time.Now(),
+		EventType: "raid",
 		EventData: map[string]interface{}{
 			"viewer_count": event.Viewers,
 			"from_id":      event.FromBroadcasterUserID,
@@ -606,14 +688,14 @@ func (h *Handler) handleCheer(ctx context.Context, eventData json.RawMessage) er
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        event.Message,
-		Timestamp:   time.Now(),
-		EventType:   "bits",
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      event.Message,
+		Timestamp: time.Now(),
+		EventType: "bits",
 		EventData: map[string]interface{}{
 			"bits":         event.Bits,
 			"is_anonymous": event.IsAnonymous,
@@ -631,15 +713,15 @@ func (h *Handler) handleFollow(ctx context.Context, eventData json.RawMessage) e
 	}
 
 	rawMsg := &models.RawChatMessage{
-		MessageID:   uuid.New().String(),
-		Platform:    "twitch",
-		ChannelID:   event.BroadcasterUserLogin,
-		UserID:      event.UserID,
-		Username:    event.UserLogin,
-		Text:        "Followed",
-		Timestamp:   event.FollowedAt,
-		EventType:   "follow",
-		EventData:   map[string]interface{}{},
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: event.BroadcasterUserLogin,
+		UserID:    event.UserID,
+		Username:  event.UserLogin,
+		Text:      "Followed",
+		Timestamp: event.FollowedAt,
+		EventType: "follow",
+		EventData: map[string]interface{}{},
 	}
 
 	return h.publisher.Publish(ctx, rawMsg)
@@ -671,6 +753,10 @@ func (h *Handler) handleChatMessage(ctx context.Context, eventData json.RawMessa
 		Tags:      buildChatTags(&event),
 		EventType: "", // regular chat → message-processor uses Normalize()
 	}
+
+	// A delivered chat message proves EventSub currently owns this channel's chat — refresh the
+	// ownership claim (throttled) so it stays excluded from IRC (ADR-0015).
+	h.refreshChatClaim(event.BroadcasterUserLogin, event.BroadcasterUserID)
 
 	return h.publisher.Publish(ctx, rawMsg)
 }

--- a/services/twitch-eventsub-listener/webhooks/handler_claim_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_claim_test.go
@@ -1,0 +1,136 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
+	"github.com/caesar/all-chat/shared/twitchchat"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// newClaimTestHandler builds a Handler wired to an in-memory Redis with a chat-ownership claim
+// store. db/metrics/status are nil — the chat-message path does not touch them.
+func newClaimTestHandler(t *testing.T) (*miniredis.Miniredis, *Handler) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	pub := publisher.NewStreamPublisher(rc, zap.NewNop())
+	t.Cleanup(pub.Stop)
+
+	h := NewHandler("secret", rc, nil, pub, nil, nil, twitchchat.NewClaimStore(rc), zap.NewNop())
+	return mr, h
+}
+
+func chatEventJSON(t *testing.T, login, broadcasterID, msgID string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(eventsub.ChatMessageEvent{
+		BroadcasterUserID:    broadcasterID,
+		BroadcasterUserLogin: login,
+		ChatterUserID:        "999",
+		ChatterUserLogin:     "viewer",
+		MessageID:            msgID,
+		Message:              eventsub.ChatMessageBody{Text: "hello"},
+	})
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return b
+}
+
+// A delivered chat message must create the chat-ownership claim so the IRC listener excludes the
+// channel (ADR-0015). The claim key is the lower-cased login.
+func TestHandleChatMessage_CreatesOwnershipClaim(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+
+	if err := h.handleChatMessage(context.Background(), chatEventJSON(t, "CaesarLP", "67241623", "m1")); err != nil {
+		t.Fatalf("handleChatMessage: %v", err)
+	}
+
+	val, err := mr.Get("eventsub:chat:owner:caesarlp")
+	if err != nil {
+		t.Fatalf("expected ownership claim to exist after delivered chat: %v", err)
+	}
+	if val != "67241623" {
+		t.Fatalf("claim value = %q, want broadcaster id 67241623", val)
+	}
+	if ttl := mr.TTL("eventsub:chat:owner:caesarlp"); ttl <= 0 {
+		t.Fatalf("claim must have a TTL so it lapses when EventSub stops delivering; got %v", ttl)
+	}
+}
+
+// The per-channel refresh is throttled, but a second message for the SAME channel must keep the
+// claim alive (idempotent), and a message for a DIFFERENT channel must create its own claim.
+func TestHandleChatMessage_ClaimPerChannel(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	ctx := context.Background()
+
+	_ = h.handleChatMessage(ctx, chatEventJSON(t, "chanA", "1", "a1"))
+	_ = h.handleChatMessage(ctx, chatEventJSON(t, "chanA", "1", "a2")) // throttled refresh, still claimed
+	_ = h.handleChatMessage(ctx, chatEventJSON(t, "chanB", "2", "b1"))
+
+	if !mr.Exists("eventsub:chat:owner:chana") {
+		t.Error("chanA should remain claimed after a second (throttled) message")
+	}
+	if !mr.Exists("eventsub:chat:owner:chanb") {
+		t.Error("chanB should be claimed independently")
+	}
+}
+
+// A nil claim store must not panic and must not block message handling (claims are an optimisation
+// layered on top of delivery).
+func TestHandleChatMessage_NilClaimStoreIsSafe(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	pub := publisher.NewStreamPublisher(rc, zap.NewNop())
+	t.Cleanup(pub.Stop)
+
+	h := NewHandler("secret", rc, nil, pub, nil, nil, nil /* no claim store */, zap.NewNop())
+	if err := h.handleChatMessage(context.Background(), chatEventJSON(t, "chan", "1", "m1")); err != nil {
+		t.Fatalf("handleChatMessage with nil claim store: %v", err)
+	}
+}
+
+// A message missing required fields must be dropped without creating a claim.
+func TestHandleChatMessage_MissingFieldsNoClaim(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	// Missing MessageID and ChatterUserLogin → handler returns nil and drops it.
+	bad := chatEventJSON(t, "lonelychan", "1", "")
+	if err := h.handleChatMessage(context.Background(), bad); err != nil {
+		t.Fatalf("handleChatMessage: %v", err)
+	}
+	if mr.Exists("eventsub:chat:owner:lonelychan") {
+		t.Fatal("a dropped (invalid) message must not create an ownership claim")
+	}
+}

--- a/services/twitch-listener/README.md
+++ b/services/twitch-listener/README.md
@@ -6,6 +6,12 @@ The Twitch Listener service connects to Twitch IRC, monitors configured channels
 
 - **Twitch IRC Connection**: Connects to Twitch IRC using go-twitch-irc library
 - **Dynamic Channel Management**: Automatically syncs with database to JOIN/PART channels
+- **EventSub fallback partition (ADR-0015)**: excludes channels the EventSub listener is *currently*
+  delivering chat for, identified by a live `eventsub:chat:owner:{login}` claim in Redis. Any
+  scope-eligible channel EventSub is not actively serving (never subscribed, revoked, verification
+  failed, partial scope, outage) has no claim and is read here — IRC is the always-on safety net.
+  Fails open: a Redis error reading claims excludes nothing (message-processor dedupes the overlap on
+  native id), so the partition can never silently drop chat.
 - **Rate Limiting**: Respects Twitch rate limits (20 JOIN/10s)
 - **Message Parsing**: Extracts user info, badges, emotes, colors from IRC tags
 - **Redis Streams**: Publishes raw messages to `chat:raw` stream

--- a/services/twitch-listener/channels/manager.go
+++ b/services/twitch-listener/channels/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/caesar/all-chat/shared/listener"
 	"github.com/caesar/all-chat/shared/metrics"
 	"github.com/caesar/all-chat/shared/sourcemanager"
+	"github.com/caesar/all-chat/shared/twitchchat"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -65,34 +66,35 @@ type JoinParterInterface interface {
 
 // Manager manages which Twitch channels to monitor
 type Manager struct {
-	repo             RepositoryInterface
-	joinParter       JoinParterInterface
-	logger           *zap.Logger
-	metrics          *metrics.ListenerMetrics
-	rateLimiter      *rate.Limiter
-	activeChans      map[string]bool              // Currently joined channels
-	mu               sync.RWMutex
-	syncTicker       *time.Ticker
-	stopChan         chan struct{}
-	wg               sync.WaitGroup
-	dbConn           DBConnInterface              // For PostgreSQL LISTEN
-	leader                *sourcemanager.LeadershipCoordinator
-	assignedSourceIDs     map[string]bool             // From coordinator
-	filteredAssignmentCount int                         // Number of assigned sources that have database channels
-	ircClients            []JoinParterInterface        // Multiple IRC connections for >100 channels
-	migrationMu      sync.RWMutex                 // Protects migration state
-	firstMessageChan map[string]chan struct{}     // Per-channel first message signal
-	redisClient      *redis.Client                // Redis client for migration confirmations
-	podID            string                       // Pod ID for migration confirmations
-	statusPublisher  *status.Publisher            // Publishes platform status to Redis Pub/Sub
-	initialSyncDone  bool                         // Set to true after the first SyncChannels completes (legacy, kept for vet)
+	repo                    RepositoryInterface
+	joinParter              JoinParterInterface
+	logger                  *zap.Logger
+	metrics                 *metrics.ListenerMetrics
+	rateLimiter             *rate.Limiter
+	activeChans             map[string]bool // Currently joined channels
+	mu                      sync.RWMutex
+	syncTicker              *time.Ticker
+	stopChan                chan struct{}
+	wg                      sync.WaitGroup
+	dbConn                  DBConnInterface // For PostgreSQL LISTEN
+	leader                  *sourcemanager.LeadershipCoordinator
+	assignedSourceIDs       map[string]bool          // From coordinator
+	filteredAssignmentCount int                      // Number of assigned sources that have database channels
+	ircClients              []JoinParterInterface    // Multiple IRC connections for >100 channels
+	migrationMu             sync.RWMutex             // Protects migration state
+	firstMessageChan        map[string]chan struct{} // Per-channel first message signal
+	redisClient             *redis.Client            // Redis client for migration confirmations
+	chatClaims              *twitchchat.ClaimStore   // EventSub chat-ownership claims; excludes EventSub-served channels from IRC (ADR-0015, nil disables)
+	podID                   string                   // Pod ID for migration confirmations
+	statusPublisher         *status.Publisher        // Publishes platform status to Redis Pub/Sub
+	initialSyncDone         bool                     // Set to true after the first SyncChannels completes (legacy, kept for vet)
 
 	// Atomic fields for lock-free health probe reads (F-01).
 	// These shadow the mutex-protected values so that liveness/readiness probe
 	// HTTP handlers can read them without competing for m.mu.
-	initialSyncDoneAtomic          atomic.Bool
-	activeChannelCountAtomic       atomic.Int64
-	filteredAssignmentCountAtomic  atomic.Int64
+	initialSyncDoneAtomic         atomic.Bool
+	activeChannelCountAtomic      atomic.Int64
+	filteredAssignmentCountAtomic atomic.Int64
 }
 
 // DBConnInterface allows getting a raw pgxpool.Pool for LISTEN
@@ -109,6 +111,7 @@ func NewManager(repo RepositoryInterface, joinParter JoinParterInterface, dbConn
 		leader:            leader,
 		assignedSourceIDs: assignedSourceIDs,
 		redisClient:       redisClient,
+		chatClaims:        newChatClaimStore(redisClient),
 		podID:             podID,
 		logger:            logger,
 		metrics:           m,
@@ -119,6 +122,59 @@ func NewManager(repo RepositoryInterface, joinParter JoinParterInterface, dbConn
 		syncTicker:        time.NewTicker(SyncInterval),
 		stopChan:          make(chan struct{}),
 	}
+}
+
+// newChatClaimStore builds the EventSub chat-ownership claim store, or returns nil when no Redis
+// client is available (e.g. in tests) so the claim filter is simply skipped — IRC then reads every
+// channel, which is the safe (no-loss) default.
+func newChatClaimStore(rc *redis.Client) *twitchchat.ClaimStore {
+	if rc == nil {
+		return nil
+	}
+	return twitchchat.NewClaimStore(rc)
+}
+
+// SetChatClaimStore overrides the chat-ownership claim store (used by tests to inject an in-memory
+// Redis-backed store).
+func (m *Manager) SetChatClaimStore(s *twitchchat.ClaimStore) {
+	m.chatClaims = s
+}
+
+// excludeEventSubOwnedChannels removes channels the EventSub listener is currently delivering chat
+// for (ADR-0015). A channel is excluded only while it holds a live ownership claim, so any channel
+// EventSub is NOT actively serving — revoked, verification-failed, partially-scoped, outage, or
+// never claimed — is read here by IRC, the always-on fallback. Fails OPEN on a Redis error (reads
+// every channel) so a Redis blip can never cause silent chat loss; message-processor dedupes the
+// brief handoff overlap on the native Twitch message id.
+func (m *Manager) excludeEventSubOwnedChannels(ctx context.Context, desired []string) []string {
+	if m.chatClaims == nil || len(desired) == 0 {
+		return desired
+	}
+	claimed, err := m.chatClaims.ClaimedLogins(ctx)
+	if err != nil {
+		m.logger.Warn("Failed to read EventSub chat-ownership claims; reading all channels (fail-open)",
+			zap.Error(err))
+		return desired
+	}
+	if len(claimed) == 0 {
+		return desired
+	}
+	kept := desired[:0]
+	excluded := 0
+	for _, ch := range desired {
+		if _, owned := claimed[strings.ToLower(ch)]; owned {
+			excluded++
+			continue
+		}
+		kept = append(kept, ch)
+	}
+	if excluded > 0 {
+		m.logger.Debug("Excluded EventSub-owned channels from IRC desired set",
+			zap.Int("excluded", excluded),
+			zap.Int("remaining", len(kept)),
+		)
+	}
+	return kept
 }
 
 // SetStatusPublisher injects the status publisher after construction
@@ -420,6 +476,12 @@ func (m *Manager) SyncChannels(ctx context.Context) error {
 			}
 		}
 	}
+
+	// EventSub chat-ownership partition (ADR-0015): drop channels EventSub is currently serving
+	// before any cap/rebalance math, so they neither occupy an IRC slot nor count toward the
+	// per-pod share. Channels EventSub is not actively serving fall through to IRC. Done here (not
+	// in SQL) so the partition tracks live delivery, not a static scope predicate.
+	desiredChannels = m.excludeEventSubOwnedChannels(ctx, desiredChannels)
 
 	// Rebalance leadership leases before acquiring new ones.
 	// This ensures that when pods scale up/down, excess leases are shed so
@@ -1025,4 +1087,3 @@ func (m *Manager) joinChannelsMultipleConnectionsUnlocked(ctx context.Context, c
 
 	return joined
 }
-

--- a/services/twitch-listener/channels/manager_claim_test.go
+++ b/services/twitch-listener/channels/manager_claim_test.go
@@ -1,0 +1,107 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package channels
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/shared/twitchchat"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+func managerWithClaims(t *testing.T) (*miniredis.Miniredis, *twitchchat.ClaimStore, *Manager) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	store := twitchchat.NewClaimStore(rc)
+	m := &Manager{logger: zap.NewNop()}
+	m.SetChatClaimStore(store)
+	return mr, store, m
+}
+
+// Channels EventSub is actively serving (have a live claim) must be excluded from the IRC desired
+// set; everything else falls through to IRC (ADR-0015). Matching is case-insensitive.
+func TestExcludeEventSubOwnedChannels_ExcludesClaimedOnly(t *testing.T) {
+	_, store, m := managerWithClaims(t)
+	ctx := context.Background()
+
+	if err := store.Claim(ctx, "ownedchan", "1"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := store.Claim(ctx, "OwnedTwo", "2"); err != nil { // mixed case
+		t.Fatalf("Claim: %v", err)
+	}
+
+	desired := []string{"OwnedChan", "freechan", "ownedtwo", "another"}
+	got := m.excludeEventSubOwnedChannels(ctx, desired)
+
+	sort.Strings(got)
+	want := []string{"another", "freechan"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// With no live claims, IRC must read every desired channel.
+func TestExcludeEventSubOwnedChannels_NoClaimsKeepsAll(t *testing.T) {
+	_, _, m := managerWithClaims(t)
+	desired := []string{"a", "b", "c"}
+	got := m.excludeEventSubOwnedChannels(context.Background(), append([]string(nil), desired...))
+	if len(got) != 3 {
+		t.Fatalf("want all 3 channels kept, got %v", got)
+	}
+}
+
+// Fail-open: a Redis error while reading claims must NOT exclude anything (IRC reads everything),
+// so a Redis blip can never silently lose chat. message-processor dedupes the resulting overlap.
+func TestExcludeEventSubOwnedChannels_FailsOpenOnRedisError(t *testing.T) {
+	mr, store, m := managerWithClaims(t)
+	ctx := context.Background()
+	_ = store.Claim(ctx, "ownedchan", "1")
+	mr.Close() // subsequent SCAN errors
+
+	desired := []string{"ownedchan", "freechan"}
+	got := m.excludeEventSubOwnedChannels(ctx, append([]string(nil), desired...))
+	if len(got) != 2 {
+		t.Fatalf("fail-open must keep all channels on Redis error; got %v", got)
+	}
+}
+
+// A nil claim store (e.g. no Redis in tests) disables the filter — IRC reads everything.
+func TestExcludeEventSubOwnedChannels_NilStoreKeepsAll(t *testing.T) {
+	m := &Manager{logger: zap.NewNop()} // chatClaims left nil
+	desired := []string{"a", "b"}
+	got := m.excludeEventSubOwnedChannels(context.Background(), desired)
+	if len(got) != 2 {
+		t.Fatalf("nil store must keep all channels; got %v", got)
+	}
+}

--- a/services/twitch-listener/channels/repository.go
+++ b/services/twitch-listener/channels/repository.go
@@ -31,22 +31,15 @@ import (
 // IRC-PARTed on the next sync. Configurable via IDLE_OVERLAY_THRESHOLD env var.
 const DefaultIdleOverlayThreshold = 7 * 24 * time.Hour
 
-// eventSubOwnedExclusion excludes Twitch sources that the EventSub chat listener owns —
-// channels whose owner granted the chat scope (user:read:chat) and still has a valid
-// token. It is the exact complement of the scope/token predicate in
-// services/twitch-eventsub-listener/channels/manager.go SyncChannels; the two MUST stay
-// byte-identical so every Twitch source is read by exactly one listener — no double-read,
-// no gap. Keyed on ocs.channel_id (the Twitch login, matching the EventSub join), NOT
-// ocs.channel_name (the display name, which may differ in case/Unicode and would silently
-// fail to match). Used by both GetUniqueChannels and GetActiveChannels so they cannot drift.
-const eventSubOwnedExclusion = `
-		  AND NOT EXISTS (
-		      SELECT 1 FROM users u
-		      WHERE LOWER(u.username) = LOWER(ocs.channel_id)
-		        AND u.auth_provider = 'twitch'
-		        AND 'user:read:chat' = ANY(u.granted_scopes)
-		        AND u.token_expires_at > NOW()
-		  )`
+// EventSub chat-ownership partition (ADR-0015): the IRC↔EventSub split is NO LONGER a static SQL
+// scope predicate. The previous `NOT EXISTS (... 'user:read:chat' = ANY(granted_scopes) ...)`
+// excluded a channel from IRC whenever its owner *could* be read via EventSub — even when EventSub
+// was not actually delivering (revoked sub, partial scopes, verification failure, demand/leader
+// gap), leaving the channel read by neither listener and silently losing chat. The exclusion now
+// lives in channels.Manager.excludeEventSubOwnedChannels, which drops only channels that hold a
+// LIVE chat-ownership claim (refreshed by the EventSub handler on delivered chat). Any channel
+// EventSub is not currently serving falls through to IRC here. These queries therefore return ALL
+// active Twitch channels; the claim filter is applied in the manager.
 
 // RepositoryInterface defines the interface for channel repository
 type RepositoryInterface interface {
@@ -97,7 +90,7 @@ func (r *Repository) GetActiveChannels(ctx context.Context) ([]models.ChannelSou
 		FROM overlays o
 		JOIN overlay_chat_sources ocs ON o.id = ocs.overlay_id
 		WHERE o.is_active = true
-		  AND ocs.platform = 'twitch'` + eventSubOwnedExclusion + r.freshnessClause() + `
+		  AND ocs.platform = 'twitch'` + r.freshnessClause() + `
 		ORDER BY ocs.channel_name
 	`
 
@@ -136,7 +129,7 @@ func (r *Repository) GetUniqueChannels(ctx context.Context) ([]string, error) {
 		FROM overlays o
 		JOIN overlay_chat_sources ocs ON o.id = ocs.overlay_id
 		WHERE o.is_active = true
-		  AND ocs.platform = 'twitch'` + eventSubOwnedExclusion + r.freshnessClause() + `
+		  AND ocs.platform = 'twitch'` + r.freshnessClause() + `
 		ORDER BY ocs.channel_name
 	`
 

--- a/services/twitch-listener/go.mod
+++ b/services/twitch-listener/go.mod
@@ -3,6 +3,7 @@ module github.com/caesar/all-chat/services/twitch-listener
 go 1.25.6
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/caesar/all-chat/services/message-processor v0.0.0-00010101000000-000000000000
 	github.com/caesar/all-chat/shared v0.0.0-00010101000000-000000000000
 	github.com/gempir/go-twitch-irc/v4 v4.4.1
@@ -60,6 +61,7 @@ require (
 	github.com/redis/go-redis/extra/redisotel/v9 v9.19.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect

--- a/shared/twitchchat/claim.go
+++ b/shared/twitchchat/claim.go
@@ -1,0 +1,114 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package twitchchat holds the shared contract for the dynamic IRC↔EventSub chat-ownership
+// partition (ADR-0015). A chat-ownership claim means "the EventSub listener is delivering this
+// channel's chat right now"; the EventSub webhook handler writes/refreshes it on delivered chat
+// and the IRC listener excludes claimed channels from its desired set. Both listeners import this
+// package so the key format and TTL cannot drift between producer and consumer.
+package twitchchat
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// ClaimKeyPrefix namespaces per-channel chat-ownership claim keys in Redis.
+	// A live key at ClaimKey(login) means EventSub currently owns that channel's chat.
+	ClaimKeyPrefix = "eventsub:chat:owner:"
+
+	// DefaultClaimTTL is how long a claim survives without a refresh. The EventSub handler
+	// refreshes on delivered chat (throttled to ClaimRefreshInterval), so a channel with at
+	// least one chat message per TTL stays claimed (and off IRC). When EventSub stops
+	// delivering — revocation, verification failure, scope gap, pod/total outage — the claim
+	// lapses within this window and the IRC listener resumes the channel. It therefore also
+	// bounds the worst-case fallback delay in a total-EventSub-outage scenario. Overridable per
+	// deployment via NewClaimStoreWithTTL (EVENTSUB_CHAT_CLAIM_TTL).
+	DefaultClaimTTL = 5 * time.Minute
+
+	// ClaimRefreshInterval throttles how often delivered chat refreshes a claim, bounding Redis
+	// writes to one per channel per interval regardless of chat volume. Must be comfortably less
+	// than the claim TTL so a steadily-active channel never lets its claim lapse.
+	ClaimRefreshInterval = 60 * time.Second
+
+	// claimScanCount is the COUNT hint for SCAN; channel counts are small, so one batch suffices.
+	claimScanCount = 256
+)
+
+// ClaimKey returns the Redis key for a channel's chat-ownership claim. The login is lower-cased so
+// the EventSub producer (which sees the broadcaster login from the event) and the IRC consumer
+// (which keys on overlay_chat_sources.channel_id) agree regardless of stored casing.
+func ClaimKey(login string) string {
+	return ClaimKeyPrefix + strings.ToLower(login)
+}
+
+// ClaimStore reads and writes chat-ownership claims in Redis. It is safe for concurrent use.
+type ClaimStore struct {
+	rc  *redis.Client
+	ttl time.Duration
+}
+
+// NewClaimStore creates a ClaimStore with the default TTL.
+func NewClaimStore(rc *redis.Client) *ClaimStore {
+	return NewClaimStoreWithTTL(rc, DefaultClaimTTL)
+}
+
+// NewClaimStoreWithTTL creates a ClaimStore with a custom claim TTL. A non-positive ttl falls back
+// to DefaultClaimTTL so a misconfiguration can never set an immediately-expiring claim.
+func NewClaimStoreWithTTL(rc *redis.Client, ttl time.Duration) *ClaimStore {
+	if ttl <= 0 {
+		ttl = DefaultClaimTTL
+	}
+	return &ClaimStore{rc: rc, ttl: ttl}
+}
+
+// TTL returns the configured claim TTL.
+func (s *ClaimStore) TTL() time.Duration { return s.ttl }
+
+// Claim creates or refreshes the chat-ownership claim for login, resetting its TTL. value is stored
+// for operator visibility (e.g. the broadcaster id) and is not interpreted. Call this on every
+// delivered chat message (throttled by ClaimRefreshInterval at the caller).
+func (s *ClaimStore) Claim(ctx context.Context, login, value string) error {
+	return s.rc.Set(ctx, ClaimKey(login), value, s.ttl).Err()
+}
+
+// Release deletes the chat-ownership claim for login. Best-effort early teardown (e.g. on
+// revocation) so IRC resumes the channel promptly; the TTL would expire the claim regardless.
+func (s *ClaimStore) Release(ctx context.Context, login string) error {
+	return s.rc.Del(ctx, ClaimKey(login)).Err()
+}
+
+// ClaimedLogins returns the set of lower-cased logins that currently hold a live chat-ownership
+// claim. The IRC listener excludes these from its desired channel set. Uses SCAN (not KEYS) so it
+// is safe to call on the periodic sync path.
+func (s *ClaimStore) ClaimedLogins(ctx context.Context) (map[string]struct{}, error) {
+	claimed := make(map[string]struct{})
+	iter := s.rc.Scan(ctx, 0, ClaimKeyPrefix+"*", claimScanCount).Iterator()
+	for iter.Next(ctx) {
+		login := strings.TrimPrefix(iter.Val(), ClaimKeyPrefix)
+		if login != "" {
+			claimed[login] = struct{}{}
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return nil, err
+	}
+	return claimed, nil
+}

--- a/shared/twitchchat/claim_test.go
+++ b/shared/twitchchat/claim_test.go
@@ -1,0 +1,168 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package twitchchat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestStore(t *testing.T, ttl time.Duration) (*miniredis.Miniredis, *ClaimStore) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, NewClaimStoreWithTTL(rc, ttl)
+}
+
+func TestClaimKey_LowercasesAndPrefixes(t *testing.T) {
+	if got, want := ClaimKey("CaesarLP"), "eventsub:chat:owner:caesarlp"; got != want {
+		t.Fatalf("ClaimKey = %q, want %q", got, want)
+	}
+}
+
+func TestClaim_SetsKeyWithTTL(t *testing.T) {
+	mr, store := newTestStore(t, 90*time.Second)
+	ctx := context.Background()
+
+	if err := store.Claim(ctx, "CaesarLP", "67241623"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	// Stored under the lower-cased key with the broadcaster id as value.
+	got, err := mr.Get("eventsub:chat:owner:caesarlp")
+	if err != nil {
+		t.Fatalf("expected key to exist: %v", err)
+	}
+	if got != "67241623" {
+		t.Fatalf("value = %q, want %q", got, "67241623")
+	}
+
+	// TTL is set (not persistent).
+	if ttl := mr.TTL("eventsub:chat:owner:caesarlp"); ttl <= 0 || ttl > 90*time.Second {
+		t.Fatalf("TTL = %v, want (0, 90s]", ttl)
+	}
+}
+
+func TestClaim_ExpiresAfterTTL(t *testing.T) {
+	mr, store := newTestStore(t, 90*time.Second)
+	ctx := context.Background()
+
+	if err := store.Claim(ctx, "quietchannel", "1"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if !mr.Exists("eventsub:chat:owner:quietchannel") {
+		t.Fatal("claim should exist immediately after Claim")
+	}
+
+	// No refresh within the TTL → claim lapses → IRC resumes the channel.
+	mr.FastForward(91 * time.Second)
+	if mr.Exists("eventsub:chat:owner:quietchannel") {
+		t.Fatal("claim should have expired after TTL with no refresh")
+	}
+}
+
+func TestClaim_RefreshExtendsTTL(t *testing.T) {
+	mr, store := newTestStore(t, 90*time.Second)
+	ctx := context.Background()
+
+	_ = store.Claim(ctx, "active", "1")
+	mr.FastForward(60 * time.Second) // 30s of TTL left
+	_ = store.Claim(ctx, "active", "1")
+	mr.FastForward(60 * time.Second) // would have expired without the refresh
+
+	if !mr.Exists("eventsub:chat:owner:active") {
+		t.Fatal("refresh should have extended the TTL; claim must still exist")
+	}
+}
+
+func TestRelease_DeletesClaim(t *testing.T) {
+	mr, store := newTestStore(t, 90*time.Second)
+	ctx := context.Background()
+
+	_ = store.Claim(ctx, "Revoked", "1")
+	if err := store.Release(ctx, "revoked"); err != nil { // case-insensitive
+		t.Fatalf("Release: %v", err)
+	}
+	if mr.Exists("eventsub:chat:owner:revoked") {
+		t.Fatal("Release should have deleted the claim")
+	}
+}
+
+func TestRelease_MissingClaimIsNoError(t *testing.T) {
+	_, store := newTestStore(t, 90*time.Second)
+	if err := store.Release(context.Background(), "never-claimed"); err != nil {
+		t.Fatalf("Release of missing claim should be a no-op, got %v", err)
+	}
+}
+
+func TestClaimedLogins_ReturnsLowercasedSet(t *testing.T) {
+	_, store := newTestStore(t, 90*time.Second)
+	ctx := context.Background()
+
+	_ = store.Claim(ctx, "CaesarLP", "1")
+	_ = store.Claim(ctx, "another", "2")
+	_ = store.Claim(ctx, "Third", "3")
+	_ = store.Release(ctx, "another")
+
+	claimed, err := store.ClaimedLogins(ctx)
+	if err != nil {
+		t.Fatalf("ClaimedLogins: %v", err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("len(claimed) = %d, want 2 (%v)", len(claimed), claimed)
+	}
+	if _, ok := claimed["caesarlp"]; !ok {
+		t.Errorf("expected lower-cased 'caesarlp' in claimed set: %v", claimed)
+	}
+	if _, ok := claimed["third"]; !ok {
+		t.Errorf("expected lower-cased 'third' in claimed set: %v", claimed)
+	}
+	if _, ok := claimed["another"]; ok {
+		t.Errorf("released login 'another' should not be claimed: %v", claimed)
+	}
+}
+
+func TestClaimedLogins_EmptyWhenNoClaims(t *testing.T) {
+	_, store := newTestStore(t, 90*time.Second)
+	claimed, err := store.ClaimedLogins(context.Background())
+	if err != nil {
+		t.Fatalf("ClaimedLogins: %v", err)
+	}
+	if len(claimed) != 0 {
+		t.Fatalf("want empty set, got %v", claimed)
+	}
+}
+
+func TestNewClaimStoreWithTTL_NonPositiveFallsBackToDefault(t *testing.T) {
+	// No Redis I/O needed — only the TTL guard is under test.
+	store := NewClaimStoreWithTTL(redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"}), 0)
+	if store.TTL() != DefaultClaimTTL {
+		t.Fatalf("TTL = %v, want default %v", store.TTL(), DefaultClaimTTL)
+	}
+	if neg := NewClaimStoreWithTTL(nil, -5*time.Second); neg.TTL() != DefaultClaimTTL {
+		t.Fatalf("negative TTL = %v, want default %v", neg.TTL(), DefaultClaimTTL)
+	}
+}


### PR DESCRIPTION
## Problem

"Still losing messages on the new twitch listener." The IRC↔EventSub chat partition keyed IRC exclusion off a **static scope predicate** (`'user:read:chat' = ANY(granted_scopes) AND token_expires_at > NOW()`), **decoupled from whether EventSub was actually delivering**. IRC dropped a channel the moment the scope was granted, but EventSub had many ways to *not* deliver — and in each, IRC had also dropped the channel, so chat was lost with **no fallback**:

| Failure mode | Was | 
|---|---|
| `channel.chat.message` revocation | never recreated, IRC still excluded → permanent loss (observed today, broadcaster `196691714`) |
| Partial consent (has `user:read:chat`, missing `user:bot`/`channel:bot`) | sub never created, IRC still excluded → permanent loss |
| Verification pending/failed | sub cached as active, IRC excluded → loss |
| Startup / reconnect / demand flap / leader gap / pod outage | gap with no IRC coverage |

The webhook handler also marked a message **processed even when `routeEvent` failed** (acked-and-dropped, no Twitch retry).

## Fix — dynamic ownership claim (ADR-0015)

A channel leaves IRC **only while EventSub is provably delivering its chat**, and returns the instant EventSub stops.

- **`shared/twitchchat/`** (new): `ClaimStore` — per-channel `eventsub:chat:owner:{login}` key (TTL 5m, `EVENTSUB_CHAT_CLAIM_TTL`). Single shared contract so the producer (EventSub) and consumer (IRC) can't drift.
- **twitch-eventsub-listener**: handler **creates/refreshes** the claim on each delivered `channel.chat.message` (throttled 1/60s/channel), **releases** it on revocation; marks a message processed **only on success**.
- **twitch-listener**: dropped the static scope SQL; excludes only channels with a **live claim** (`SCAN`), **fail-open** on Redis error → reads everything rather than risk loss.
- **message-processor**: dedups Twitch chat on the **native message id** (`tags["id"]`, set identically by both paths) → the brief handoff overlap is invisible.

The key safety property: the claim is refreshed **only by real delivered chat**, so it can never wrongly persist while EventSub is dead. Every failure mode now resolves to *"IRC serves, no loss"* (verify/scope-fail → never claimed → zero gap; revocation → released instantly; outage → lapses ≤ TTL).

## Tests (TDD)
- `shared/twitchchat`: claim/release/scan, TTL expiry, refresh
- eventsub handler: claim created on delivered chat, per-channel, nil-safe, none for dropped messages
- IRC manager: excludes claimed only, **fail-open on Redis error**, nil-safe
- message-processor: IRC+EventSub copies of one native id → handler runs once; distinct/empty ids pass through; fail-open

All four modules: `go build` / `go vet` / `go test` green, `gofmt` clean.

## Deploy notes
- **No DB migration** (removed SQL from a Go query string, not a schema change).
- Keel rolls images independently; the native-id dedup makes **any** ordering safe.
- Documented ~1–2 min post-deploy transient (IRC briefly wants scope-eligible channels until claims rebuild) — no loss; EventSub keeps delivering, JOINs just rate-limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)