### PR TITLE
fix(twitch-eventsub): honor chat deletion events on EventSub-owned channels

### DIFF
--- a/docs/adr/0015-eventsub-chat-ownership-claim.md
+++ b/docs/adr/0015-eventsub-chat-ownership-claim.md
@@ -101,6 +101,11 @@ discipline the previous byte-identical SQL predicate aimed for.
   channels it owns, and message-processor dedupes any overlap.
 - Introduces a dependency on message-processor native-id dedup to hide the handoff overlap; without
   it, viewers would briefly see duplicated Twitch chat during a handoff.
+- **Timeout vs. ban is not distinguishable on EventSub-owned channels.** `channel.chat.clear_user_messages`
+  carries no duration (unlike IRC's `CLEARCHAT` `@ban-duration`), so a timeout is reported downstream
+  as a permanent ban. The messages are removed identically either way; only the moderation-log label
+  differs. Restoring the distinction would require an additional `channel.moderate`/`channel.ban`
+  subscription (broader scope) and is deliberately out of scope here.
 - `SCAN eventsub:chat:owner:*` per IRC sync (cheap at current channel counts; bounded by channel
   count, runs on the existing 30s-ish sync cadence).
 
@@ -120,6 +125,17 @@ discipline the previous byte-identical SQL predicate aimed for.
 - **twitch-eventsub-listener**: `webhooks/handler.go` refreshes the claim on `channel.chat.message`
   delivery (throttled) and releases it on revocation; `cmd/main.go` constructs the `ClaimStore` and
   injects it into the handler.
+- **twitch-eventsub-listener (deletion parity)**: because a claimed channel is read *only* by
+  EventSub, IRC's `CLEARMSG`/`CLEARCHAT` handling and its message-ID registry population no longer
+  run for it — so EventSub must reproduce both, or moderation silently fails to reach the overlay.
+  The listener therefore also subscribes to `channel.chat.message_delete`,
+  `channel.chat.clear_user_messages`, and `channel.chat.clear` (created/torn down together with the
+  `channel.chat.message` subscription — same scope + condition), maps them to the existing
+  `message_deletion` raw-event shape (`single` / `batch` / `clear`, identical to
+  `twitch-listener`'s parser), and populates the shared `message-processor/registry`
+  (native id → internal UUID) on each delivered chat message so single-message deletes resolve to
+  the displayed message. See `webhooks/handler.go` (`handleChatMessageDelete` /
+  `handleChatClearUserMessages` / `handleChatClear`) and `eventsub/subscription_manager.go`.
 - **twitch-listener**: `channels/repository.go` drops the static `eventSubOwnedExclusion` SQL;
   `channels/manager.go` filters the desired-channel set against live claims via `ClaimedLogins`
   (fail-open on Redis error → IRC reads everything, deduped).

--- a/services/twitch-eventsub-listener/Dockerfile
+++ b/services/twitch-eventsub-listener/Dockerfile
@@ -9,6 +9,11 @@ WORKDIR /build
 # Copy shared module first
 COPY shared /build/shared
 
+# Copy the message-processor module — the listener imports its message-ID registry
+# (deletion handling, ADR-0015) via a local replace directive, so its source must be in
+# the build context for `go mod download`/build to resolve it.
+COPY services/message-processor /build/services/message-processor
+
 # Copy service files
 COPY services/twitch-eventsub-listener /build/services/twitch-eventsub-listener
 

--- a/services/twitch-eventsub-listener/README.md
+++ b/services/twitch-eventsub-listener/README.md
@@ -31,6 +31,7 @@ The Twitch EventSub Listener connects to Twitch's EventSub WebSocket API to rece
 - ✅ `channel.cheer`, `channel.raid`, `channel.follow` - Bits, raids, follows
 - ✅ `stream.online` / `stream.offline` - Stream lifecycle (cross-platform discovery + credits)
 - ✅ `channel.chat.message` - **Chat reading** (demand-gated; see below)
+- ✅ `channel.chat.message_delete` / `channel.chat.clear_user_messages` / `channel.chat.clear` - **Chat moderation** (single delete, user timeout/ban, full clear; see below)
 
 > Transport note: subscriptions use **webhook** transport (HTTP callback at `EVENTSUB_CALLBACK_URL`), not the EventSub WebSocket. Twitch verifies each subscription via a `webhook_callback_verification` challenge before it becomes `enabled`.
 
@@ -53,6 +54,31 @@ channel was dropped by IRC yet not delivered by EventSub.
 The chat subscription is **demand-gated**: it exists only while an overlay using the channel has a
 live WebSocket. When demand arrives, the chat subscription is created *before* the always-on event
 subscriptions so chat starts flowing with minimal latency.
+
+### Chat Moderation (deletions)
+
+A claimed channel is read *only* by EventSub, so IRC's `CLEARMSG`/`CLEARCHAT` handling no longer
+runs for it. To keep moderation working, the listener subscribes to the three chat-deletion events
+**alongside** `channel.chat.message` (same `user:read:chat` scope, same condition, same demand-gated
+lifecycle — created on `subscribe_chat`, removed on `unsubscribe_chat`):
+
+| EventSub event | `deletion_type` | Overlay effect |
+|----------------|-----------------|----------------|
+| `channel.chat.message_delete` | `single` | removes one message (resolved via the message-ID registry) |
+| `channel.chat.clear_user_messages` | `batch` | removes all messages from a user (timeout/ban) |
+| `channel.chat.clear` | `clear` | removes all messages for the channel |
+
+These are normalized into the same `message_deletion` raw-event shape `twitch-listener` emits, so the
+message-processor and overlay handle EventSub- and IRC-sourced deletions identically.
+
+**Message-ID registry.** Single-message deletes carry only the *native* Twitch message id, so the
+listener registers `native id → internal UUID` for every delivered chat message (shared
+`message-processor/registry`, 1h TTL — identical to IRC's capture-point registration). For
+chat-scoped channels EventSub is the sole writer; without this the message-processor can't resolve
+which displayed message to remove and buffers the deletion until it expires.
+
+> **Limitation:** `channel.chat.clear_user_messages` carries no duration, so a timeout is reported as
+> a ban (the messages are removed either way; only the moderation-log label differs). See ADR-0015.
 
 ### Platform Status Indicators
 

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/caesar/all-chat/services/message-processor/registry"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/channels"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
@@ -173,6 +174,12 @@ func main() {
 	chatClaims := twitchchat.NewClaimStoreWithTTL(redisClient, claimTTL)
 	log.Info("Chat-ownership claim store initialized", zap.Duration("claim_ttl", claimTTL))
 
+	// Message-ID registry (native Twitch id → internal UUID), shared format with twitch-listener
+	// and read by message-processor to resolve single-message deletions. Same 1h TTL as IRC so the
+	// two writers behave identically. The webhook handler populates it on each delivered chat
+	// message; chat-scoped channels are EventSub-only (ADR-0015), so EventSub is their sole writer.
+	msgRegistry := registry.NewRedisRegistry(redisClient, 1*time.Hour)
+
 	subscriptionMgr := eventsub.NewSubscriptionManager(twitchClientID, twitchClientSecret, webhookSecret, callbackURL, log)
 	channelManager := channels.NewManager(db, log, subscriptionMgr, tokenCipher, ChannelSyncInterval)
 	channelManager.SetStatusPublisher(statusPublisher)
@@ -183,7 +190,7 @@ func main() {
 	}
 
 	// Create webhook handler
-	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, chatClaims, log)
+	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, chatClaims, msgRegistry, log)
 
 	// isLeader tracks whether this pod currently holds EventSub leadership.
 	// Protected by mu; read by subscription callback and HTTP handlers.
@@ -354,20 +361,61 @@ func main() {
 			// EventSub chat (it stays on IRC unless/until the owner grants the missing scope).
 			if _, err := subscriptionMgr.SubscribeToChatMessages(ctx, broadcasterID); err != nil {
 				if strings.Contains(err.Error(), "subscription already exists") {
-					return nil
-				}
-				if isScopeError(err) {
+					// Already subscribed — fall through to ensure deletion subs also exist.
+				} else if isScopeError(err) {
 					log.Info("Chat message subscription requires user:read:chat + user:bot scopes",
 						zap.String("broadcaster_id", broadcasterID))
+					// No chat sub → the deletion subs (same scope) would fail too. The channel
+					// stays on IRC, which still handles its deletions.
 					return nil
+				} else {
+					return err
 				}
-				return err
+			} else {
+				log.Info("Subscribed to chat messages", zap.String("broadcaster_id", broadcasterID))
 			}
-			log.Info("Subscribed to chat messages", zap.String("broadcaster_id", broadcasterID))
+
+			// Chat-moderation subscriptions: deletions of a single message, of a user's messages
+			// (timeout/ban), and full chat clears. They share user:read:chat and the chat
+			// condition, so they live with the chat subscription. Best-effort — a failure here
+			// doesn't undo the chat subscription (the channel still reads chat, just may miss a
+			// deletion type until the next sync re-attempts).
+			for _, sub := range []struct {
+				name string
+				fn   func(context.Context, string) (string, error)
+			}{
+				{"channel.chat.message_delete", subscriptionMgr.SubscribeToChatMessageDelete},
+				{"channel.chat.clear_user_messages", subscriptionMgr.SubscribeToChatClearUserMessages},
+				{"channel.chat.clear", subscriptionMgr.SubscribeToChatClear},
+			} {
+				if _, err := sub.fn(ctx, broadcasterID); err != nil {
+					if strings.Contains(err.Error(), "subscription already exists") || isScopeError(err) {
+						continue
+					}
+					log.Warn("Failed to subscribe to chat moderation event",
+						zap.String("broadcaster_id", broadcasterID),
+						zap.String("type", sub.name),
+						zap.Error(err))
+				}
+			}
 			return nil
 
 		} else if action == "unsubscribe_chat" {
-			return subscriptionMgr.UnsubscribeType(ctx, broadcasterID, "channel.chat.message")
+			// Tear down the chat subscription and its moderation subscriptions together — they
+			// share the same lifecycle (chat scope + live-overlay demand). Returns the first error
+			// but attempts every deletion.
+			var firstErr error
+			for _, subType := range []string{
+				"channel.chat.message",
+				"channel.chat.message_delete",
+				"channel.chat.clear_user_messages",
+				"channel.chat.clear",
+			} {
+				if err := subscriptionMgr.UnsubscribeType(ctx, broadcasterID, subType); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+			return firstErr
 
 		} else if action == "unsubscribe" {
 			return subscriptionMgr.Unsubscribe(ctx, broadcasterID)

--- a/services/twitch-eventsub-listener/eventsub/subscription_manager.go
+++ b/services/twitch-eventsub-listener/eventsub/subscription_manager.go
@@ -225,7 +225,41 @@ func (sm *SubscriptionManager) SubscribeToStreamOnline(ctx context.Context, broa
 // subscription-creation time; a 4xx scope error means the streamer must re-auth with the
 // chat scopes (handled non-fatally by the caller).
 func (sm *SubscriptionManager) SubscribeToChatMessages(ctx context.Context, broadcasterID string) (string, error) {
-	cacheKey := broadcasterID + ":channel.chat.message"
+	return sm.subscribeChatScoped(ctx, "channel.chat.message", broadcasterID)
+}
+
+// SubscribeToChatMessageDelete creates a channel.chat.message_delete subscription — fired when a
+// moderator removes a single message. It honors the same own-channel authorization as
+// channel.chat.message (user:read:chat + user:bot, broadcaster == chatter), so it is created and
+// torn down together with the chat subscription. Without it, single-message deletions on
+// EventSub-owned channels never reach the overlay, because IRC (which handled CLEARMSG) no longer
+// sees these channels (ADR-0015).
+func (sm *SubscriptionManager) SubscribeToChatMessageDelete(ctx context.Context, broadcasterID string) (string, error) {
+	return sm.subscribeChatScoped(ctx, "channel.chat.message_delete", broadcasterID)
+}
+
+// SubscribeToChatClearUserMessages creates a channel.chat.clear_user_messages subscription — fired
+// when all of a user's messages are removed (timeout or ban). Same authorization/lifecycle as
+// channel.chat.message. Replaces, for EventSub-owned channels, the user-targeted CLEARCHAT that IRC
+// no longer receives.
+func (sm *SubscriptionManager) SubscribeToChatClearUserMessages(ctx context.Context, broadcasterID string) (string, error) {
+	return sm.subscribeChatScoped(ctx, "channel.chat.clear_user_messages", broadcasterID)
+}
+
+// SubscribeToChatClear creates a channel.chat.clear subscription — fired when the entire chat is
+// cleared. Same authorization/lifecycle as channel.chat.message. Replaces, for EventSub-owned
+// channels, the full CLEARCHAT that IRC no longer receives.
+func (sm *SubscriptionManager) SubscribeToChatClear(ctx context.Context, broadcasterID string) (string, error) {
+	return sm.subscribeChatScoped(ctx, "channel.chat.clear", broadcasterID)
+}
+
+// subscribeChatScoped creates a channel.chat.* EventSub subscription whose condition is the
+// own-channel reading pair broadcaster_user_id == user_id == broadcasterID. Every channel.chat.*
+// type (message, message_delete, clear_user_messages, clear) shares this exact condition, version,
+// scope (user:read:chat) and webhook transport, so they are created and cached identically and gated
+// together on chat scope + live-overlay demand. Cached under "broadcasterID:subType".
+func (sm *SubscriptionManager) subscribeChatScoped(ctx context.Context, subType, broadcasterID string) (string, error) {
+	cacheKey := broadcasterID + ":" + subType
 	sm.mu.RLock()
 	if subID, exists := sm.subscriptions[cacheKey]; exists {
 		sm.mu.RUnlock()
@@ -244,7 +278,7 @@ func (sm *SubscriptionManager) SubscribeToChatMessages(ctx context.Context, broa
 		"user_id":             broadcasterID,
 	}
 
-	return sm.subscribeWithCondition(ctx, "channel.chat.message", broadcasterID, token, "1", condition, cacheKey)
+	return sm.subscribeWithCondition(ctx, subType, broadcasterID, token, "1", condition, cacheKey)
 }
 
 // Unsubscribe deletes ALL EventSub subscriptions for a broadcaster.

--- a/services/twitch-eventsub-listener/eventsub/subscription_manager_test.go
+++ b/services/twitch-eventsub-listener/eventsub/subscription_manager_test.go
@@ -38,3 +38,25 @@ func TestSubscribeToStreamOffline(t *testing.T) {
 	// We expect an error (no real Twitch API in test), but the call must exist.
 	_ = err
 }
+
+// TestSubscribeToChatDeletionEvents verifies the chat-moderation subscription methods exist and are
+// callable. Each shares channel.chat.message's own-channel condition + user:read:chat scope, so the
+// listener can honor deletions (single message, user timeout/ban, full clear) on EventSub-owned
+// channels. No real Twitch API in tests, so getAccessToken errors out before the POST — we only
+// assert the methods exist and surface that error rather than panicking.
+func TestSubscribeToChatDeletionEvents(t *testing.T) {
+	log, _ := zap.NewDevelopment()
+	sm := NewSubscriptionManager("client-id", "client-secret", "webhook-secret", "https://example.com/callback", log)
+	require.NotNil(t, sm)
+
+	ctx := context.Background()
+	if _, err := sm.SubscribeToChatMessageDelete(ctx, "broadcaster-123"); err == nil {
+		t.Error("expected an error without a real Twitch token endpoint")
+	}
+	if _, err := sm.SubscribeToChatClearUserMessages(ctx, "broadcaster-123"); err == nil {
+		t.Error("expected an error without a real Twitch token endpoint")
+	}
+	if _, err := sm.SubscribeToChatClear(ctx, "broadcaster-123"); err == nil {
+		t.Error("expected an error without a real Twitch token endpoint")
+	}
+}

--- a/services/twitch-eventsub-listener/eventsub/types.go
+++ b/services/twitch-eventsub-listener/eventsub/types.go
@@ -276,6 +276,45 @@ type ChatReply struct {
 	ThreadUserName    string `json:"thread_user_name"`
 }
 
+// ChatMessageDeleteEvent represents a single-message deletion (a moderator removed one message).
+// subscription type: channel.chat.message_delete (v1)
+// Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatmessage_delete
+// MessageID is the native Twitch id of the removed message — the same value the chat path stamps
+// into Tags["id"], so it resolves to the displayed message via the message-ID registry.
+type ChatMessageDeleteEvent struct {
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	TargetUserID         string `json:"target_user_id"`
+	TargetUserLogin      string `json:"target_user_login"`
+	TargetUserName       string `json:"target_user_name"`
+	MessageID            string `json:"message_id"`
+}
+
+// ChatClearUserMessagesEvent represents removing all of one user's messages (a timeout or ban).
+// subscription type: channel.chat.clear_user_messages (v1)
+// Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatclear_user_messages
+// NOTE: Twitch does not include a duration here, so a timeout cannot be distinguished from a
+// permanent ban from this event (unlike IRC's CLEARCHAT @ban-duration tag). Downstream treats the
+// absence of a duration as a ban; either way every message from the user is removed.
+type ChatClearUserMessagesEvent struct {
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+	TargetUserID         string `json:"target_user_id"`
+	TargetUserLogin      string `json:"target_user_login"`
+	TargetUserName       string `json:"target_user_name"`
+}
+
+// ChatClearEvent represents clearing the entire chat.
+// subscription type: channel.chat.clear (v1)
+// Reference: https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatclear
+type ChatClearEvent struct {
+	BroadcasterUserID    string `json:"broadcaster_user_id"`
+	BroadcasterUserLogin string `json:"broadcaster_user_login"`
+	BroadcasterUserName  string `json:"broadcaster_user_name"`
+}
+
 // SubscriptionInfo contains subscription metadata (used in webhook callbacks)
 type SubscriptionInfo struct {
 	ID        string                 `json:"id"`

--- a/services/twitch-eventsub-listener/go.mod
+++ b/services/twitch-eventsub-listener/go.mod
@@ -4,6 +4,7 @@ go 1.25.6
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0
+	github.com/caesar/all-chat/services/message-processor v0.0.0-00010101000000-000000000000
 	github.com/caesar/all-chat/shared v0.0.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/uuid v1.6.0
@@ -84,3 +85,5 @@ require (
 )
 
 replace github.com/caesar/all-chat/shared => ../../shared
+
+replace github.com/caesar/all-chat/services/message-processor => ../message-processor

--- a/services/twitch-eventsub-listener/webhooks/handler.go
+++ b/services/twitch-eventsub-listener/webhooks/handler.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caesar/all-chat/services/message-processor/registry"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/models"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
@@ -58,8 +59,9 @@ type Handler struct {
 	db              *pgxpool.Pool // for twitch_id -> user_id / login lookup
 	publisher       *publisher.StreamPublisher
 	listenerMetrics *metrics.ListenerMetrics
-	statusPublisher *status.Publisher      // emits platform:status for the chat indicator (nil-safe)
-	claims          *twitchchat.ClaimStore // chat-ownership claims for the IRC↔EventSub partition (nil-safe, ADR-0015)
+	statusPublisher *status.Publisher          // emits platform:status for the chat indicator (nil-safe)
+	claims          *twitchchat.ClaimStore     // chat-ownership claims for the IRC↔EventSub partition (nil-safe, ADR-0015)
+	registry        registry.MessageIDRegistry // native→internal-UUID map for single-message deletions (nil-safe)
 	logger          *zap.Logger
 
 	// claimRefreshedAt throttles per-channel claim refreshes (one Redis write per channel per
@@ -69,8 +71,10 @@ type Handler struct {
 }
 
 // NewHandler creates a new webhook handler. claims may be nil to disable chat-ownership claims
-// (the IRC listener then never sees this listener's channels as claimed).
-func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, statusPublisher *status.Publisher, claims *twitchchat.ClaimStore, logger *zap.Logger) *Handler {
+// (the IRC listener then never sees this listener's channels as claimed). reg may be nil to disable
+// native→UUID registration (single-message deletions then can't resolve their target and are
+// buffered until they expire).
+func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher *publisher.StreamPublisher, listenerMetrics *metrics.ListenerMetrics, statusPublisher *status.Publisher, claims *twitchchat.ClaimStore, reg registry.MessageIDRegistry, logger *zap.Logger) *Handler {
 	return &Handler{
 		secret:           []byte(secret),
 		redis:            redis,
@@ -79,6 +83,7 @@ func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher 
 		listenerMetrics:  listenerMetrics,
 		statusPublisher:  statusPublisher,
 		claims:           claims,
+		registry:         reg,
 		logger:           logger,
 		claimRefreshedAt: make(map[string]time.Time),
 	}
@@ -401,6 +406,12 @@ func (h *Handler) routeEvent(ctx context.Context, subscriptionType string, event
 	switch subscriptionType {
 	case "channel.chat.message":
 		return h.handleChatMessage(ctx, eventData)
+	case "channel.chat.message_delete":
+		return h.handleChatMessageDelete(ctx, eventData)
+	case "channel.chat.clear_user_messages":
+		return h.handleChatClearUserMessages(ctx, eventData)
+	case "channel.chat.clear":
+		return h.handleChatClear(ctx, eventData)
 	case "channel.channel_points_custom_reward_redemption.add":
 		return h.handleChannelPointsRedemption(ctx, eventData)
 	case "channel.subscribe":
@@ -754,11 +765,146 @@ func (h *Handler) handleChatMessage(ctx context.Context, eventData json.RawMessa
 		EventType: "", // regular chat → message-processor uses Normalize()
 	}
 
+	// Register the native→internal-UUID mapping BEFORE publishing (best-effort), mirroring the IRC
+	// listener's capture-point registration. This is what lets a later channel.chat.message_delete
+	// resolve its native message id to the internal UUID the overlay tracks (message-processor's
+	// registry lookup). For chat-scoped channels IRC no longer runs, so EventSub is the only writer
+	// of this mapping (ADR-0015); without it single-message deletes would buffer until they expire.
+	if h.registry != nil {
+		if nativeID := rawMsg.Tags["id"]; nativeID != "" {
+			if err := h.registry.Add(ctx, rawMsg.Platform, rawMsg.ChannelID, nativeID, rawMsg.MessageID); err != nil {
+				h.logger.Error("Failed to add message to registry",
+					zap.String("native_id", nativeID),
+					zap.String("internal_uuid", rawMsg.MessageID),
+					zap.Error(err))
+				// Continue — registration is best-effort; the chat message must still be delivered.
+			}
+		}
+	}
+
 	// A delivered chat message proves EventSub currently owns this channel's chat — refresh the
 	// ownership claim (throttled) so it stays excluded from IRC (ADR-0015).
 	h.refreshChatClaim(event.BroadcasterUserLogin, event.BroadcasterUserID)
 
 	return h.publisher.Publish(ctx, rawMsg)
+}
+
+// handleChatMessageDelete processes a channel.chat.message_delete event (a moderator removed a
+// single message) into a "single" message_deletion RawChatMessage, shaped identically to
+// twitch-listener's ParseClearMessage so the message-processor resolves and applies it the same way.
+func (h *Handler) handleChatMessageDelete(ctx context.Context, eventData json.RawMessage) error {
+	var event eventsub.ChatMessageDeleteEvent
+	if err := json.Unmarshal(eventData, &event); err != nil {
+		return fmt.Errorf("failed to unmarshal channel.chat.message_delete: %w", err)
+	}
+	rawMsg := buildSingleDeletion(&event)
+	if rawMsg == nil {
+		h.logger.Warn("channel.chat.message_delete missing required fields",
+			zap.String("broadcaster", event.BroadcasterUserLogin),
+			zap.String("message_id", event.MessageID))
+		return nil
+	}
+	return h.publisher.Publish(ctx, rawMsg)
+}
+
+// handleChatClearUserMessages processes a channel.chat.clear_user_messages event (a user's messages
+// were removed via timeout or ban) into a "batch" message_deletion. Twitch omits the duration, so
+// no ban_duration is set; the frontend filters by target_user_id either way.
+func (h *Handler) handleChatClearUserMessages(ctx context.Context, eventData json.RawMessage) error {
+	var event eventsub.ChatClearUserMessagesEvent
+	if err := json.Unmarshal(eventData, &event); err != nil {
+		return fmt.Errorf("failed to unmarshal channel.chat.clear_user_messages: %w", err)
+	}
+	rawMsg := buildBatchDeletion(&event)
+	if rawMsg == nil {
+		h.logger.Warn("channel.chat.clear_user_messages missing required fields",
+			zap.String("broadcaster", event.BroadcasterUserLogin),
+			zap.String("target_user_id", event.TargetUserID))
+		return nil
+	}
+	return h.publisher.Publish(ctx, rawMsg)
+}
+
+// handleChatClear processes a channel.chat.clear event (the entire chat was cleared) into a "clear"
+// message_deletion; the frontend drops all messages for the channel.
+func (h *Handler) handleChatClear(ctx context.Context, eventData json.RawMessage) error {
+	var event eventsub.ChatClearEvent
+	if err := json.Unmarshal(eventData, &event); err != nil {
+		return fmt.Errorf("failed to unmarshal channel.chat.clear: %w", err)
+	}
+	rawMsg := buildClearDeletion(&event)
+	if rawMsg == nil {
+		h.logger.Warn("channel.chat.clear missing broadcaster_user_login")
+		return nil
+	}
+	return h.publisher.Publish(ctx, rawMsg)
+}
+
+// buildSingleDeletion converts a channel.chat.message_delete event into the message_deletion
+// RawChatMessage the pipeline expects: EventType "message_deletion", deletion_type "single",
+// target_msg_id = the native message id (looked up against the registry to find the internal UUID).
+// ChannelID is the lower-cased broadcaster login, matching the chat path and the registry key.
+// Returns nil when the event lacks the fields needed to act on it.
+func buildSingleDeletion(e *eventsub.ChatMessageDeleteEvent) *models.RawChatMessage {
+	if e.MessageID == "" || e.BroadcasterUserLogin == "" {
+		return nil
+	}
+	return &models.RawChatMessage{
+		MessageID: uuid.New().String(), // UUID for the deletion event itself
+		Platform:  "twitch",
+		ChannelID: strings.ToLower(e.BroadcasterUserLogin),
+		Username:  strings.ToLower(e.TargetUserLogin), // author of the removed message, if provided
+		Timestamp: time.Now().UTC(),
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type": "single",
+			"target_msg_id": e.MessageID,
+		},
+	}
+}
+
+// buildBatchDeletion converts a channel.chat.clear_user_messages event into a "batch"
+// message_deletion (all of a user's messages removed). target_user_id is what the frontend filters
+// on. No ban_duration is set — Twitch does not provide it on this event, so a timeout is
+// indistinguishable from a ban here and is treated as a ban downstream. Returns nil when the event
+// lacks the fields needed to act on it.
+func buildBatchDeletion(e *eventsub.ChatClearUserMessagesEvent) *models.RawChatMessage {
+	if e.TargetUserID == "" || e.BroadcasterUserLogin == "" {
+		return nil
+	}
+	return &models.RawChatMessage{
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: strings.ToLower(e.BroadcasterUserLogin),
+		UserID:    e.TargetUserID,
+		Username:  strings.ToLower(e.TargetUserLogin),
+		Timestamp: time.Now().UTC(),
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type":   "batch",
+			"target_user_id":  e.TargetUserID,
+			"target_username": strings.ToLower(e.TargetUserLogin),
+		},
+	}
+}
+
+// buildClearDeletion converts a channel.chat.clear event into a "clear" message_deletion (the whole
+// chat was cleared). No target fields — the frontend drops every message for the channel. Returns
+// nil when the broadcaster login is absent (without it the deletion can't be routed to overlays).
+func buildClearDeletion(e *eventsub.ChatClearEvent) *models.RawChatMessage {
+	if e.BroadcasterUserLogin == "" {
+		return nil
+	}
+	return &models.RawChatMessage{
+		MessageID: uuid.New().String(),
+		Platform:  "twitch",
+		ChannelID: strings.ToLower(e.BroadcasterUserLogin),
+		Timestamp: time.Now().UTC(),
+		EventType: "message_deletion",
+		EventData: map[string]interface{}{
+			"deletion_type": "clear",
+		},
+	}
 }
 
 // buildChatTags reconstructs the IRC-style tag map (see twitch-listener/irc/parser.go and

--- a/services/twitch-eventsub-listener/webhooks/handler_claim_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_claim_test.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/message-processor/registry"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/publisher"
 	"github.com/caesar/all-chat/shared/twitchchat"
@@ -44,7 +46,8 @@ func newClaimTestHandler(t *testing.T) (*miniredis.Miniredis, *Handler) {
 	pub := publisher.NewStreamPublisher(rc, zap.NewNop())
 	t.Cleanup(pub.Stop)
 
-	h := NewHandler("secret", rc, nil, pub, nil, nil, twitchchat.NewClaimStore(rc), zap.NewNop())
+	reg := registry.NewRedisRegistry(rc, time.Hour)
+	h := NewHandler("secret", rc, nil, pub, nil, nil, twitchchat.NewClaimStore(rc), reg, zap.NewNop())
 	return mr, h
 }
 
@@ -116,7 +119,7 @@ func TestHandleChatMessage_NilClaimStoreIsSafe(t *testing.T) {
 	pub := publisher.NewStreamPublisher(rc, zap.NewNop())
 	t.Cleanup(pub.Stop)
 
-	h := NewHandler("secret", rc, nil, pub, nil, nil, nil /* no claim store */, zap.NewNop())
+	h := NewHandler("secret", rc, nil, pub, nil, nil, nil /* no claim store */, nil /* no registry */, zap.NewNop())
 	if err := h.handleChatMessage(context.Background(), chatEventJSON(t, "chan", "1", "m1")); err != nil {
 		t.Fatalf("handleChatMessage with nil claim store: %v", err)
 	}

--- a/services/twitch-eventsub-listener/webhooks/handler_deletion_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_deletion_test.go
@@ -1,0 +1,237 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/eventsub"
+	"github.com/caesar/all-chat/services/twitch-eventsub-listener/models"
+	"github.com/redis/go-redis/v9"
+)
+
+// firstStreamRawMessage decodes the first entry the publisher wrote to chat:raw. The ring-buffer
+// publisher writes synchronously on success, so the entry is present once the handler returns.
+func firstStreamRawMessage(t *testing.T, rc *redis.Client) models.RawChatMessage {
+	t.Helper()
+	res, err := rc.XRange(context.Background(), "chat:raw", "-", "+").Result()
+	if err != nil {
+		t.Fatalf("XRange chat:raw: %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("no message published to chat:raw")
+	}
+	data, _ := res[0].Values["data"].(string)
+	var rm models.RawChatMessage
+	if err := json.Unmarshal([]byte(data), &rm); err != nil {
+		t.Fatalf("unmarshal RawChatMessage: %v", err)
+	}
+	return rm
+}
+
+// --- pure builders: exact shape matches twitch-listener's CLEARMSG/CLEARCHAT parsing ---
+
+func TestBuildSingleDeletion(t *testing.T) {
+	got := buildSingleDeletion(&eventsub.ChatMessageDeleteEvent{
+		BroadcasterUserLogin: "CaesarLP",
+		TargetUserLogin:      "Spammer",
+		MessageID:            "native-123",
+	})
+	if got == nil {
+		t.Fatal("buildSingleDeletion returned nil for a valid event")
+	}
+	if got.EventType != "message_deletion" {
+		t.Errorf("EventType = %q, want message_deletion", got.EventType)
+	}
+	if got.Platform != "twitch" {
+		t.Errorf("Platform = %q, want twitch", got.Platform)
+	}
+	if got.ChannelID != "caesarlp" {
+		t.Errorf("ChannelID = %q, want lowercased login caesarlp", got.ChannelID)
+	}
+	if got.Username != "spammer" {
+		t.Errorf("Username = %q, want lowercased target spammer", got.Username)
+	}
+	if got.EventData["deletion_type"] != "single" {
+		t.Errorf("deletion_type = %v, want single", got.EventData["deletion_type"])
+	}
+	if got.EventData["target_msg_id"] != "native-123" {
+		t.Errorf("target_msg_id = %v, want native-123", got.EventData["target_msg_id"])
+	}
+	if got.MessageID == "" {
+		t.Error("deletion event must carry its own MessageID (UUID)")
+	}
+}
+
+func TestBuildSingleDeletion_MissingFieldsReturnsNil(t *testing.T) {
+	if buildSingleDeletion(&eventsub.ChatMessageDeleteEvent{BroadcasterUserLogin: "c"}) != nil {
+		t.Error("missing message_id must return nil")
+	}
+	if buildSingleDeletion(&eventsub.ChatMessageDeleteEvent{MessageID: "m"}) != nil {
+		t.Error("missing broadcaster login must return nil")
+	}
+}
+
+func TestBuildBatchDeletion(t *testing.T) {
+	got := buildBatchDeletion(&eventsub.ChatClearUserMessagesEvent{
+		BroadcasterUserLogin: "CaesarLP",
+		TargetUserID:         "u123",
+		TargetUserLogin:      "Spammer",
+	})
+	if got == nil {
+		t.Fatal("buildBatchDeletion returned nil for a valid event")
+	}
+	if got.ChannelID != "caesarlp" {
+		t.Errorf("ChannelID = %q, want caesarlp", got.ChannelID)
+	}
+	if got.UserID != "u123" {
+		t.Errorf("UserID = %q, want u123", got.UserID)
+	}
+	if got.EventData["deletion_type"] != "batch" {
+		t.Errorf("deletion_type = %v, want batch", got.EventData["deletion_type"])
+	}
+	if got.EventData["target_user_id"] != "u123" {
+		t.Errorf("target_user_id = %v, want u123", got.EventData["target_user_id"])
+	}
+	if got.EventData["target_username"] != "spammer" {
+		t.Errorf("target_username = %v, want spammer", got.EventData["target_username"])
+	}
+	// Twitch omits the duration on clear_user_messages; the key must be ABSENT so downstream reads
+	// it as a ban (a present ban_duration would falsely signal a timeout).
+	if _, ok := got.EventData["ban_duration"]; ok {
+		t.Error("ban_duration must be absent — EventSub does not provide it for clear_user_messages")
+	}
+}
+
+func TestBuildBatchDeletion_MissingFieldsReturnsNil(t *testing.T) {
+	if buildBatchDeletion(&eventsub.ChatClearUserMessagesEvent{BroadcasterUserLogin: "c"}) != nil {
+		t.Error("missing target_user_id must return nil")
+	}
+	if buildBatchDeletion(&eventsub.ChatClearUserMessagesEvent{TargetUserID: "u"}) != nil {
+		t.Error("missing broadcaster login must return nil")
+	}
+}
+
+func TestBuildClearDeletion(t *testing.T) {
+	got := buildClearDeletion(&eventsub.ChatClearEvent{BroadcasterUserLogin: "CaesarLP"})
+	if got == nil {
+		t.Fatal("buildClearDeletion returned nil for a valid event")
+	}
+	if got.ChannelID != "caesarlp" {
+		t.Errorf("ChannelID = %q, want caesarlp", got.ChannelID)
+	}
+	if got.EventData["deletion_type"] != "clear" {
+		t.Errorf("deletion_type = %v, want clear", got.EventData["deletion_type"])
+	}
+	if buildClearDeletion(&eventsub.ChatClearEvent{}) != nil {
+		t.Error("missing broadcaster login must return nil")
+	}
+}
+
+// --- routing + publish: routeEvent dispatches each deletion type onto chat:raw ---
+
+func TestRouteEvent_SingleDeletionPublished(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	ev, _ := json.Marshal(eventsub.ChatMessageDeleteEvent{
+		BroadcasterUserLogin: "CaesarLP",
+		TargetUserLogin:      "spammer",
+		MessageID:            "native-123",
+	})
+	if err := h.routeEvent(context.Background(), "channel.chat.message_delete", ev); err != nil {
+		t.Fatalf("routeEvent: %v", err)
+	}
+
+	rm := firstStreamRawMessage(t, rc)
+	if rm.EventType != "message_deletion" || rm.EventData["deletion_type"] != "single" {
+		t.Fatalf("published event = %q/%v, want message_deletion/single", rm.EventType, rm.EventData["deletion_type"])
+	}
+	if rm.EventData["target_msg_id"] != "native-123" {
+		t.Errorf("target_msg_id = %v, want native-123", rm.EventData["target_msg_id"])
+	}
+}
+
+func TestRouteEvent_BatchDeletionPublished(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	ev, _ := json.Marshal(eventsub.ChatClearUserMessagesEvent{
+		BroadcasterUserLogin: "CaesarLP",
+		TargetUserID:         "u123",
+		TargetUserLogin:      "spammer",
+	})
+	if err := h.routeEvent(context.Background(), "channel.chat.clear_user_messages", ev); err != nil {
+		t.Fatalf("routeEvent: %v", err)
+	}
+
+	rm := firstStreamRawMessage(t, rc)
+	if rm.EventData["deletion_type"] != "batch" || rm.EventData["target_user_id"] != "u123" {
+		t.Fatalf("published event = %v/%v, want batch/u123", rm.EventData["deletion_type"], rm.EventData["target_user_id"])
+	}
+}
+
+func TestRouteEvent_ClearDeletionPublished(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+
+	ev, _ := json.Marshal(eventsub.ChatClearEvent{BroadcasterUserLogin: "CaesarLP"})
+	if err := h.routeEvent(context.Background(), "channel.chat.clear", ev); err != nil {
+		t.Fatalf("routeEvent: %v", err)
+	}
+
+	rm := firstStreamRawMessage(t, rc)
+	if rm.EventData["deletion_type"] != "clear" {
+		t.Fatalf("deletion_type = %v, want clear", rm.EventData["deletion_type"])
+	}
+	if rm.ChannelID != "caesarlp" {
+		t.Errorf("ChannelID = %q, want caesarlp", rm.ChannelID)
+	}
+}
+
+// A delivered chat message must register native-id → internal-UUID, and the registered UUID must
+// equal the published message's UUID — otherwise a later single-message delete resolves to the
+// wrong (or no) overlay message. This is the registration the IRC listener does at capture and the
+// EventSub listener previously omitted.
+func TestHandleChatMessage_RegistersNativeIDForSingleDelete(t *testing.T) {
+	mr, h := newClaimTestHandler(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	ctx := context.Background()
+
+	if err := h.handleChatMessage(ctx, chatEventJSON(t, "CaesarLP", "67241623", "native-abc")); err != nil {
+		t.Fatalf("handleChatMessage: %v", err)
+	}
+
+	// Registry resolves the native id to the internal UUID, keyed by the lower-cased login.
+	internalUUID, err := h.registry.Lookup(ctx, "twitch", "caesarlp", "native-abc")
+	if err != nil {
+		t.Fatalf("expected registry mapping for native-abc: %v", err)
+	}
+
+	// The registered UUID must be the UUID actually delivered to the overlay.
+	rm := firstStreamRawMessage(t, rc)
+	if rm.MessageID != internalUUID {
+		t.Fatalf("registry UUID %q != published MessageID %q — a single delete would miss the message",
+			internalUUID, rm.MessageID)
+	}
+}


### PR DESCRIPTION
## Problem

The IRC↔EventSub partition (ADR-0015) hands chat for chat-scoped channels to EventSub **exclusively** — `twitch-listener` (IRC) explicitly excludes them. But IRC was the only path that handled Twitch deletions: it parsed `CLEARMSG`/`CLEARCHAT` into `message_deletion` events **and** populated the native-id→internal-UUID registry that single-message deletes resolve against.

The EventSub listener did **neither**, so on EventSub-owned channels, moderation (delete / timeout / ban / clear) never reached the overlay — messages just stayed on screen.

## Fix (parity with the IRC path)

- **Subscribe** to `channel.chat.message_delete`, `channel.chat.clear_user_messages`, `channel.chat.clear` — created/torn down alongside `channel.chat.message` (same `user:read:chat` scope, condition, and demand-gated lifecycle). Existing chat-active channels pick up the new subs on the next sync.
- **Route** them into the existing `message_deletion` raw-event shape (`single`/`batch`/`clear`), byte-compatible with `twitch-listener`'s parser, so message-processor + overlay handle EventSub- and IRC-sourced deletions identically.
- **Register** native id → internal UUID for each delivered chat message (shared `message-processor/registry`, 1h TTL — same as IRC's capture-point registration) so single-message deletes resolve to the displayed message.

### Known limitation (documented)
`channel.chat.clear_user_messages` carries no duration, so a timeout is reported downstream as a ban (messages are removed either way; only the mod-log label differs). Restoring the distinction would need a broader-scope `channel.ban` subscription — out of scope here. See ADR-0015.

## Tests
- Unit: pure deletion-builder shape tests + nil-on-missing-fields.
- Integration (miniredis): `routeEvent` → `chat:raw` publish for each type; `handleChatMessage` writes the registry mapping **and** the registered UUID equals the published message UUID (proves a single-delete resolves).
- Existing message-processor deletion/consumer tests still pass against the shared registry contract.

**E2E note:** a full cross-process E2E (mod action → webhook → message-processor → api-gateway WS → frontend removal) isn't an in-repo automated test — these are separate Go modules + a TS frontend with no combined harness, and it'd need a signed Twitch webhook + live overlay socket. The contract is covered at each seam instead (producer here, resolver in message-processor/consumer, applier in frontend overlayViewModel). Realistic full-path check is deploying and moderating on a chat-scoped channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)