### PR TITLE
feat(frontend): integrate cookieless Umami analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,14 @@ APP_VERSION=0.1.0
 # Frontend URL (used to generate OAuth redirect URIs)
 FRONTEND_URL=http://localhost:3000
 
+# Umami analytics (frontend, cookieless, optional)
+# Baked into the frontend at BUILD time (NEXT_PUBLIC_*), not read at runtime.
+# In CI these come from GitHub Actions repo variables (UMAMI_WEBSITE_ID, UMAMI_SRC)
+# — see .github/workflows/build-and-push.yml. Leave unset to disable the tracker.
+# Website ID is created in the shared Umami dashboard (Settings → Websites).
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+NEXT_PUBLIC_UMAMI_SRC=https://analytics.allch.at/script.js
+
 # CORS (Frontend URL)
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -230,6 +230,8 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             GIT_COMMIT=${{ github.sha }}
+            NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ vars.UMAMI_WEBSITE_ID }}
+            NEXT_PUBLIC_UMAMI_SRC=${{ vars.UMAMI_SRC }}
 
       - name: Output image details
         if: matrix.service.changed == 'true' || needs.detect-changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,6 +29,14 @@ ARG GIT_COMMIT
 ENV NEXT_PUBLIC_BUILD_DATE=$BUILD_DATE
 ENV NEXT_PUBLIC_GIT_COMMIT=$GIT_COMMIT
 
+# Umami analytics (cookieless). Baked in at build time; when unset the tracker
+# is not rendered (see src/components/Analytics.tsx). The Website ID is created
+# in the shared Umami dashboard and passed via the build-and-push workflow.
+ARG NEXT_PUBLIC_UMAMI_WEBSITE_ID
+ARG NEXT_PUBLIC_UMAMI_SRC
+ENV NEXT_PUBLIC_UMAMI_WEBSITE_ID=$NEXT_PUBLIC_UMAMI_WEBSITE_ID
+ENV NEXT_PUBLIC_UMAMI_SRC=$NEXT_PUBLIC_UMAMI_SRC
+
 # Clean Next.js cache before build to prevent stale Server Actions
 RUN rm -rf .next
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -32,6 +32,7 @@ import type { Metadata } from 'next'
 import { Barlow, DM_Mono } from 'next/font/google'
 import './globals.css'
 import '@/styles/events.css'
+import Analytics from '@/components/Analytics'
 import CookieBanner from '@/components/CookieBanner'
 import ImpersonationBanner from '@/components/ImpersonationBanner'
 import { ToastProvider } from '@/components/ui/toast'
@@ -103,6 +104,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={cn(barlow.variable, dmMono.variable)}>
       <body>
+        <Analytics />
         <ToastProvider>
           <ImpersonationBanner />
           {children}

--- a/frontend/src/app/legal/privacy/page.tsx
+++ b/frontend/src/app/legal/privacy/page.tsx
@@ -28,13 +28,14 @@ const listClasses = 'list-disc pl-6 space-y-1 text-text-sub'
 
 export default function PrivacyPolicyPage() {
   return (
-    <LegalLayout title="Privacy Policy (Datenschutzerkl&auml;rung)" lastUpdated="April 22, 2026">
+    <LegalLayout title="Privacy Policy (Datenschutzerkl&auml;rung)" lastUpdated="June 8, 2026">
       <div className="space-y-4">
         <div className="rounded-xl border border-twitch/20 bg-twitch/5 p-5 text-text-sub">
           <strong className="text-text">TL;DR:</strong> All-Chat only collects the information we
           need to authenticate with your streaming platforms and render chat in your overlays. Tokens
           are encrypted, chat messages are automatically deleted after one hour, and we never sell
-          your data.
+          your data. We use cookieless, self-hosted analytics (no tracking cookies; see
+          Section&nbsp;5.6).
         </div>
         <div className="rounded-xl border border-tiktok/20 bg-tiktok/5 p-5 text-text-sub">
           <strong className="text-text">Open Source Transparency:</strong> All-Chat is licensed
@@ -279,6 +280,48 @@ export default function PrivacyPolicyPage() {
           We never sell or rent your data. We may disclose information when required by law or to
           respond to legitimate security incidents.
         </p>
+
+        <h3 className="text-lg font-semibold text-text">
+          5.6 Usage Analytics (Self-Hosted, Cookieless)
+        </h3>
+        <p>
+          To understand how the site is used and where to improve it, we run{' '}
+          <a
+            href="https://umami.is"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-twitch underline decoration-twitch/30 underline-offset-4"
+          >
+            Umami
+          </a>
+          , an open-source analytics tool that we{' '}
+          <strong className="text-text">host ourselves</strong>. It is{' '}
+          <strong className="text-text">cookieless</strong>: it sets no cookies, creates no
+          persistent identifier, and performs no cross-site or cross-device tracking. The data is
+          processed on our own infrastructure and is{' '}
+          <strong className="text-text">not shared with any third party</strong> (unlike Google
+          Analytics or similar services).
+        </p>
+        <p>For each page view it records aggregate, non-identifying information:</p>
+        <ul className={listClasses}>
+          <li>The page you visited and the referring URL</li>
+          <li>Browser, operating system, device type, and screen size</li>
+          <li>Approximate country, derived from your IP address at request time</li>
+        </ul>
+        <p className="text-sm text-text-dim">
+          Your <strong className="text-text">IP address is not stored</strong>: it is used only
+          momentarily to derive the country and to generate a daily, salted hash for counting unique
+          visits, after which it is discarded. We do{' '}
+          <strong className="text-text">not</strong> track public overlay views (the pages OBS loads
+          as a browser source). You can block the analytics script with any browser content blocker
+          without affecting the site.
+        </p>
+        <p className="text-sm text-text-dim">
+          Because the tracker stores no information on, and reads none from, your device, it does not
+          require consent under &sect;&nbsp;25 TTDSG; the processing of the resulting data rests on
+          Art.&nbsp;6(1)(f) DSGVO &ndash; our legitimate interest in measuring and improving the
+          service.
+        </p>
       </section>
 
       {/* --- Data Retention --- */}
@@ -373,7 +416,9 @@ export default function PrivacyPolicyPage() {
 
       {/* --- Cookies & Browser Storage --- */}
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-text">8. Cookies &amp; Browser Storage</h2>
+        <h2 className="text-2xl font-semibold text-text">
+          8. Cookies, Browser Storage &amp; Analytics
+        </h2>
         <p>
           All-Chat uses <strong className="text-text">browser localStorage</strong> (not cookies)
           for essential functionality:
@@ -383,10 +428,13 @@ export default function PrivacyPolicyPage() {
           <li>User preferences and last-visited state</li>
         </ul>
         <p>
-          We do not use advertising cookies, cross-site tracking, or analytics pixels. Fonts are
-          self-hosted (Section&nbsp;5.2) and do not set cookies. The third-party resources listed
-          in Section&nbsp;5.3 (UI Avatars, GitHub API) may cause the respective providers to set
-          their own cookies when loaded.
+          We do not use advertising cookies or cross-site tracking. We do use{' '}
+          <strong className="text-text">privacy-friendly, cookieless usage analytics</strong>{' '}
+          (self-hosted Umami) &ndash; it sets nothing on your device and stores no personal
+          identifier; see Section&nbsp;5.6 for the full description. Fonts are self-hosted
+          (Section&nbsp;5.2) and do not set cookies. The third-party resources listed in
+          Section&nbsp;5.3 (UI Avatars, GitHub API) may cause the respective providers to set their
+          own cookies when loaded.
         </p>
       </section>
 
@@ -427,7 +475,10 @@ export default function PrivacyPolicyPage() {
         <h2 className="text-2xl font-semibold text-text">12. Transparency &amp; Open Source</h2>
         <ul className={listClasses}>
           <li>All source code is publicly auditable under AGPL-3.0</li>
-          <li>No hidden tracking &mdash; verify yourself on GitHub</li>
+          <li>
+            No hidden tracking &mdash; our analytics are cookieless and documented (Section&nbsp;5.6),
+            and the whole stack is verifiable on GitHub
+          </li>
           <li>Privacy practices are open to community scrutiny</li>
         </ul>
         <p>

--- a/frontend/src/app/legal/terms/page.tsx
+++ b/frontend/src/app/legal/terms/page.tsx
@@ -28,7 +28,7 @@ const listClasses = 'list-disc pl-6 space-y-1 text-text-sub'
 
 export default function TermsOfServicePage() {
   return (
-    <LegalLayout title="Terms of Service (Nutzungsbedingungen)" lastUpdated="April 1, 2026">
+    <LegalLayout title="Terms of Service (Nutzungsbedingungen)" lastUpdated="June 8, 2026">
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">1. Acceptance of Terms</h2>
         <p>
@@ -123,7 +123,11 @@ export default function TermsOfServicePage() {
           >
             Privacy Policy
           </Link>
-          , which explains what we collect, how it is used, and your rights under the DSGVO.
+          , which explains what we collect, how it is used, and your rights under the DSGVO. For
+          transparency: All-Chat measures aggregate usage with{' '}
+          <strong className="text-text">self-hosted, cookieless analytics</strong> (Umami) that set
+          nothing on your device and store no personal identifier &ndash; see Section&nbsp;5.6 of the
+          Privacy Policy.
         </p>
       </section>
 

--- a/frontend/src/components/Analytics.tsx
+++ b/frontend/src/components/Analytics.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Umami Analytics
+ *
+ * Privacy-friendly, cookieless web analytics, self-hosted at analytics.allch.at.
+ * All-Chat has its own Website ID; the analytics backend keeps its data isolated.
+ *
+ * The tracker is loaded only when NEXT_PUBLIC_UMAMI_WEBSITE_ID is set (baked in
+ * at build time, see Dockerfile + the build-and-push workflow), so local dev
+ * and any build without the variable ship without analytics.
+ *
+ * Public overlay views (/overlay/...) are OBS browser sources, not real
+ * visitors, so we skip them to keep the stats meaningful.
+ */
+
+import Script from 'next/script'
+import { usePathname } from 'next/navigation'
+
+const DEFAULT_SRC = 'https://analytics.allch.at/script.js'
+
+export default function Analytics() {
+  const pathname = usePathname()
+
+  const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID
+  const src = process.env.NEXT_PUBLIC_UMAMI_SRC || DEFAULT_SRC
+
+  // No website configured (local dev / builds without the variable) → no-op.
+  if (!websiteId) return null
+
+  // Don't count OBS browser-source loads of public overlays as page views.
+  if (pathname === '/overlay' || pathname.startsWith('/overlay/')) return null
+
+  return (
+    <Script
+      src={src}
+      data-website-id={websiteId}
+      strategy="afterInteractive"
+      defer
+    />
+  )
+}

--- a/frontend/src/components/CookieBanner.tsx
+++ b/frontend/src/components/CookieBanner.tsx
@@ -26,7 +26,7 @@
  *
  * Current Cookie Usage in All-Chat:
  * - Essential: localStorage items for authentication (jwt_token, refresh_token)
- * - Analytics: None (no tracking scripts currently installed)
+ * - Analytics: Self-hosted Umami — cookieless, sets nothing on the device, stores no personal data
  * - Functional: None (no additional functional cookies)
  * - Third-party: None (no third-party cookies)
  *
@@ -86,7 +86,8 @@ export default function CookieBanner() {
               </p>
               <p className="mb-3 text-sm text-text-sub">
                 <strong className="text-text">
-                  We do not use cookies for tracking or analytics.
+                  We use no tracking cookies, and our usage analytics are cookieless and store no
+                  personal data.
                 </strong>{' '}
                 We do not share your data with third parties for advertising purposes.
               </p>
@@ -124,6 +125,14 @@ export default function CookieBanner() {
                     <div>
                       <strong className="text-text">No advertising cookies</strong> - We don&apos;t
                       serve ads or share data with advertisers
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-2">
+                    <span className="mt-0.5 text-kick">&#10003;</span>
+                    <div>
+                      <strong className="text-text">Cookieless analytics</strong> - We measure
+                      aggregate usage with self-hosted Umami. It sets no cookies, stores no personal
+                      identifier, and does not track public overlays
                     </div>
                   </div>
                   <div className="mt-3 border-t border-border pt-2">


### PR DESCRIPTION
## Summary

Adds privacy-friendly, self-hosted **Umami** web analytics to the frontend, loaded from the all-chat-owned host `analytics.allch.at`. (Umami runs as a shared instance in the cluster; all-chat is a separate website on it with its own Website ID and isolated data — the frontend never references any other product's domain.)

## What's included

- **`frontend/src/components/Analytics.tsx`** (new) — `next/script` tracker that is:
  - **env-gated** — renders nothing when `NEXT_PUBLIC_UMAMI_WEBSITE_ID` is unset, so local dev and any build without the variable ship without analytics (no data, no errors)
  - **overlay-aware** — skips `/overlay/*` so OBS browser-source loads don't pollute the stats
  - **cookieless** — sets nothing on the device, stores no personal identifier
- **`layout.tsx`** — mounts `<Analytics />`
- **`Dockerfile` + `build-and-push.yml`** — bakes `NEXT_PUBLIC_UMAMI_WEBSITE_ID` / `NEXT_PUBLIC_UMAMI_SRC` at build time from GitHub Actions repo variables (mirrors the existing `BUILD_DATE` / `GIT_COMMIT` pattern)
- **`.env.example`** — documents the new vars
- **Privacy policy / Terms / CookieBanner** — transparently disclose the cookieless analytics, correcting the previous "no analytics" wording. Grounded in how Umami actually behaves (no cookies, IP not stored, no cross-site tracking; legitimate interest under Art. 6(1)(f) DSGVO, no consent required under § 25 TTDSG since nothing is stored on/read from the device).

## Activation (ops, after merge — no code)

1. DNS: point `analytics.allch.at` at the cluster ingress (cert-manager issues the TLS cert)
2. In the Umami dashboard: create website `All-Chat` / `allch.at`, copy the Website ID
3. Set the `UMAMI_WEBSITE_ID` GitHub Actions **repository variable** to that UUID
4. Trigger a frontend build; keel rolls the deployment

Until step 3 the tracker is simply not rendered.

## Verification

- `npm run type-check` ✅
- `eslint` on changed files ✅ (clean)
- No `actease`/cross-product reference anywhere in the repo (working tree and full history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)