### PR TITLE
fix(frontend): correct Umami website ID (was attributed to wrong site)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,13 +51,9 @@ APP_VERSION=0.1.0
 # Frontend URL (used to generate OAuth redirect URIs)
 FRONTEND_URL=http://localhost:3000
 
-# Umami analytics (frontend, cookieless, optional)
-# Baked into the frontend at BUILD time (NEXT_PUBLIC_*), not read at runtime.
-# In CI these come from GitHub Actions repo variables (UMAMI_WEBSITE_ID, UMAMI_SRC)
-# — see .github/workflows/build-and-push.yml. Leave unset to disable the tracker.
-# Website ID is created in the shared Umami dashboard (Settings → Websites).
-NEXT_PUBLIC_UMAMI_WEBSITE_ID=
-NEXT_PUBLIC_UMAMI_SRC=https://analytics.allch.at/script.js
+# Umami analytics (frontend, cookieless): configured directly in
+# frontend/src/components/Analytics.tsx (Website ID + script host are pinned
+# there — not secrets) and only active in production builds. No env var needed.
 
 # CORS (Frontend URL)
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -230,8 +230,6 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             GIT_COMMIT=${{ github.sha }}
-            NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ vars.UMAMI_WEBSITE_ID }}
-            NEXT_PUBLIC_UMAMI_SRC=${{ vars.UMAMI_SRC }}
 
       - name: Output image details
         if: matrix.service.changed == 'true' || needs.detect-changes.outputs.shared == 'true' || github.event_name == 'workflow_dispatch'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,13 +29,8 @@ ARG GIT_COMMIT
 ENV NEXT_PUBLIC_BUILD_DATE=$BUILD_DATE
 ENV NEXT_PUBLIC_GIT_COMMIT=$GIT_COMMIT
 
-# Umami analytics (cookieless). Baked in at build time; when unset the tracker
-# is not rendered (see src/components/Analytics.tsx). The Website ID is created
-# in the shared Umami dashboard and passed via the build-and-push workflow.
-ARG NEXT_PUBLIC_UMAMI_WEBSITE_ID
-ARG NEXT_PUBLIC_UMAMI_SRC
-ENV NEXT_PUBLIC_UMAMI_WEBSITE_ID=$NEXT_PUBLIC_UMAMI_WEBSITE_ID
-ENV NEXT_PUBLIC_UMAMI_SRC=$NEXT_PUBLIC_UMAMI_SRC
+# Umami analytics (cookieless) is configured directly in src/components/Analytics.tsx
+# (Website ID + script host are pinned there, not secrets), so no build args needed.
 
 # Clean Next.js cache before build to prevent stale Server Actions
 RUN rm -rf .next

--- a/frontend/src/components/Analytics.tsx
+++ b/frontend/src/components/Analytics.tsx
@@ -22,11 +22,13 @@
  * Umami Analytics
  *
  * Privacy-friendly, cookieless web analytics, self-hosted at analytics.allch.at.
- * All-Chat has its own Website ID; the analytics backend keeps its data isolated.
+ * The Website ID and script host are pinned here directly — they aren't secrets
+ * (the ID is sent in every tracking request), and hardcoding them avoids the
+ * Next.js build-time-inlining gotcha that comes with NEXT_PUBLIC_* env vars in
+ * client components (a runtime/manifest env would never reach the browser).
  *
- * The tracker is loaded only when NEXT_PUBLIC_UMAMI_WEBSITE_ID is set (baked in
- * at build time, see Dockerfile + the build-and-push workflow), so local dev
- * and any build without the variable ship without analytics.
+ * The tracker is only rendered in production builds, so local dev (`next dev`,
+ * NODE_ENV=development) ships without analytics.
  *
  * Public overlay views (/overlay/...) are OBS browser sources, not real
  * visitors, so we skip them to keep the stats meaningful.
@@ -35,26 +37,17 @@
 import Script from 'next/script'
 import { usePathname } from 'next/navigation'
 
-const DEFAULT_SRC = 'https://analytics.allch.at/script.js'
+const WEBSITE_ID = 'c7a2e7ad-be45-4de3-954f-f15fd8e7dc97'
+const SRC = 'https://analytics.allch.at/script.js'
 
 export default function Analytics() {
   const pathname = usePathname()
 
-  const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID
-  const src = process.env.NEXT_PUBLIC_UMAMI_SRC || DEFAULT_SRC
-
-  // No website configured (local dev / builds without the variable) → no-op.
-  if (!websiteId) return null
+  // Local dev / non-production builds → no-op, so dev traffic stays out of stats.
+  if (process.env.NODE_ENV !== 'production') return null
 
   // Don't count OBS browser-source loads of public overlays as page views.
   if (pathname === '/overlay' || pathname.startsWith('/overlay/')) return null
 
-  return (
-    <Script
-      src={src}
-      data-website-id={websiteId}
-      strategy="afterInteractive"
-      defer
-    />
-  )
+  return <Script src={SRC} data-website-id={WEBSITE_ID} strategy="afterInteractive" defer />
 }


### PR DESCRIPTION
## Problem
Umami analytics showed **0 visitors** for All-Chat. Page views were actually being tracked fine, but attributed to the **wrong website**: the build-time `UMAMI_WEBSITE_ID` GitHub Actions variable held **caesar's** website ID (`30ca9b33-…`), so All-Chat's hits accrued to caesar's stats instead.

## Investigation
Verified against live `analytics.allch.at` with a real browser:
- Script loads (HTTP 200), `window.umami` defined, auto-tracked `/api/send` returns **200** on a clean page load → the pipeline works end-to-end.
- The baked-in ID is a real, accepted website (bogus ID → HTTP 400; the baked-in ID → valid session token) — it just wasn't All-Chat's.

## Fix
Pin the correct All-Chat website ID (`c7a2e7ad-…`) directly in `Analytics.tsx` instead of sourcing it from a GH Actions variable / build arg. The ID isn't a secret (it's sent in every tracking request), and hardcoding sidesteps the Next.js **build-time-inlining gotcha**: `Analytics.tsx` is a `'use client'` component, so `NEXT_PUBLIC_*` is inlined into the browser bundle at build time — a runtime/manifest env would never reach it.

- **`Analytics.tsx`** — hardcode `WEBSITE_ID` + script host; gate on `NODE_ENV === 'production'` so local `next dev` still ships without analytics. `/overlay/*` skip unchanged.
- **`Dockerfile` + `build-and-push.yml`** — drop the `NEXT_PUBLIC_UMAMI_*` build args.
- **`.env.example`** — replace the Umami env block with a pointer to the component.
- Deleted the orphaned `UMAMI_WEBSITE_ID` GH Actions repo variable (out of band).

## Verification
- `tsc --noEmit` ✅ · ESLint ✅ · Prettier ✅

## Notes
- After merge, Keel (`keel.sh/policy: force`) rolls out the rebuilt frontend; confirm via Umami **Realtime** with a fresh incognito visit.
- Caesar's stats contain All-Chat's views from `eb1c52ae` until this ships; no clean per-source delete in Umami, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)