### PR TITLE
fix(frontend): self-healing socket for overlay owner notifications

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8566,6 +8566,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14296,6 +14297,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -54,6 +54,7 @@ import type { ChatMessage } from '@/lib/types/message'
 import type { AcceptedShare } from '@/lib/types/share'
 import type { VisualSettings } from '@/lib/types/visual-settings'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { parseCssToVisualSettings } from '@/lib/utils/theme-css-parser'
 import { toastManager } from '@/lib/toast'
 import { trackEvent } from '@/lib/analytics'
@@ -1665,41 +1666,23 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     }
   }, [id, token]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // WebSocket listener for share_revoked notifications (real-time update)
-  useEffect(() => {
-    if (!token || !id) return
-
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const wsUrl = `${protocol}//${window.location.host}/ws/overlay/${id}?token=${token}`
-    const ws = new WebSocket(wsUrl)
-
-    ws.onmessage = (event) => {
-      try {
-        const envelope = JSON.parse(event.data)
-        if (envelope.type === 'share_revoked') {
-          const revoker = envelope.data?.revoked_by_username || 'someone'
-          toastManager.add({
-            title: 'Share revoked',
-            description: `Your share with ${revoker} was revoked`,
-            type: 'error',
-          })
-          overlaysApi.getSources(id).then(setSources).catch(console.error)
-        }
-      } catch {
-        // Ignore parse errors
-      }
+  // Real-time owner notifications (e.g. share_revoked) over a self-healing
+  // authenticated socket. The previous inline socket had no reconnect and no
+  // liveness detection, so a single drop — clean or half-open — silently killed
+  // these notifications for the rest of the session; useNotificationSocket
+  // reconnects with backoff and detects half-open paths via a heartbeat watchdog.
+  useNotificationSocket(id, token, (envelope) => {
+    if (envelope.type === 'share_revoked') {
+      const data = envelope.data as { revoked_by_username?: string } | undefined
+      const revoker = data?.revoked_by_username || 'someone'
+      toastManager.add({
+        title: 'Share revoked',
+        description: `Your share with ${revoker} was revoked`,
+        type: 'error',
+      })
+      overlaysApi.getSources(id).then(setSources).catch(console.error)
     }
-
-    ws.onerror = () => {
-      console.warn('[OverlayEditor] Notification WS error')
-    }
-
-    return () => {
-      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-        ws.close()
-      }
-    }
-  }, [id, token])
+  })
 
   // Handle OAuth callback query params (source_added / error)
   useEffect(() => {

--- a/frontend/src/hooks/__tests__/useNotificationSocket.test.tsx
+++ b/frontend/src/hooks/__tests__/useNotificationSocket.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useNotificationSocket } from '@/hooks/useNotificationSocket'
+import { HEARTBEAT_INTERVAL_MS, LIVENESS_TIMEOUT_MS } from '@/lib/utils/overlayStreamCore'
+
+// --- Mock WebSocket -------------------------------------------------------
+class MockWebSocket {
+  static OPEN = 1
+  static CONNECTING = 0
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  url: string
+  readyState = MockWebSocket.CONNECTING
+  closed = false
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onerror: ((ev?: unknown) => void) | null = null
+  onclose: ((ev?: unknown) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+  send(data: string) {
+    this.sent.push(data)
+  }
+  close() {
+    this.closed = true
+    this.readyState = MockWebSocket.CLOSED
+    // Real close() fires onclose asynchronously; tests drive that explicitly via
+    // simulateServerClose() to keep reconnect scheduling deterministic.
+  }
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+  simulateMessage(obj: unknown) {
+    this.onmessage?.({ data: JSON.stringify(obj) })
+  }
+  simulateServerClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({ code: 1006, reason: 'gone' })
+  }
+}
+
+const latest = () => MockWebSocket.instances[MockWebSocket.instances.length - 1]
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe('useNotificationSocket', () => {
+  it('does not connect without an id or token', () => {
+    renderHook(() => useNotificationSocket(undefined, 't', () => {}))
+    renderHook(() => useNotificationSocket('o1', undefined, () => {}))
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('opens an authenticated socket for the overlay', () => {
+    renderHook(() => useNotificationSocket('o1', 'tok', () => {}))
+    expect(latest().url).toContain('/ws/overlay/o1')
+    expect(latest().url).toContain('token=tok')
+  })
+
+  it('delivers parsed envelopes to the callback', async () => {
+    const onEnvelope = vi.fn()
+    renderHook(() => useNotificationSocket('o1', 'tok', onEnvelope))
+    await act(async () => {
+      latest().simulateOpen()
+      latest().simulateMessage({ type: 'share_revoked', data: { revoked_by_username: 'bob' } })
+    })
+    expect(onEnvelope).toHaveBeenCalledWith({
+      type: 'share_revoked',
+      data: { revoked_by_username: 'bob' },
+    })
+  })
+
+  it('ignores malformed frames without throwing', async () => {
+    const onEnvelope = vi.fn()
+    renderHook(() => useNotificationSocket('o1', 'tok', onEnvelope))
+    await act(async () => {
+      latest().simulateOpen()
+      latest().onmessage?.({ data: 'not json' })
+    })
+    expect(onEnvelope).not.toHaveBeenCalled()
+  })
+
+  it('sends an app-level ping heartbeat once open', async () => {
+    vi.useFakeTimers()
+    renderHook(() => useNotificationSocket('o1', 'tok', () => {}))
+    await act(async () => {
+      latest().simulateOpen()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS + 100)
+    })
+    expect(latest().sent.some((m) => JSON.parse(m).type === 'ping')).toBe(true)
+  })
+
+  it('reconnects on a clean server close (never gives up)', async () => {
+    vi.useFakeTimers()
+    renderHook(() => useNotificationSocket('o1', 'tok', () => {}))
+    expect(MockWebSocket.instances).toHaveLength(1)
+    await act(async () => {
+      latest().simulateOpen()
+      latest().simulateServerClose()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('forces a reconnect when the socket goes silent (half-open)', async () => {
+    vi.useFakeTimers()
+    renderHook(() => useNotificationSocket('o1', 'tok', () => {}))
+    const first = latest()
+    await act(async () => {
+      first.simulateOpen()
+    })
+    // No inbound frames at all: the watchdog must declare the path dead and the
+    // backoff must then fire a fresh socket — all without any onclose.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(LIVENESS_TIMEOUT_MS + 5000)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500)
+    })
+    expect(first.closed).toBe(true)
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('closes the socket and cancels reconnect on unmount', async () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() => useNotificationSocket('o1', 'tok', () => {}))
+    const ws = latest()
+    await act(async () => {
+      ws.simulateOpen()
+    })
+    unmount()
+    expect(ws.closed).toBe(true)
+    const countAfterUnmount = MockWebSocket.instances.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000)
+    })
+    expect(MockWebSocket.instances.length).toBe(countAfterUnmount)
+  })
+})

--- a/frontend/src/hooks/useNotificationSocket.ts
+++ b/frontend/src/hooks/useNotificationSocket.ts
@@ -1,0 +1,209 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client'
+
+/**
+ * useNotificationSocket — an authenticated, self-healing realtime socket for
+ * owner-facing overlay notifications on the dashboard (e.g. `share_revoked`).
+ *
+ * Same liveness contract as `useOverlayStream` and the legacy `WebSocketClient`:
+ * browsers never surface the WebSocket protocol-level ping/pong to JS, so a
+ * half-open path (Wi-Fi blip, NAT/proxy idle timeout, sleep/wake, background-tab
+ * throttling) leaves `readyState === OPEN` with `onclose` never firing — frames
+ * silently stop arriving and the page is none the wiser. We send an app-level
+ * `ping` the gateway echoes as a `pong`, treat ANY inbound frame as proof of
+ * life, and a watchdog forces a reconnect after prolonged silence.
+ *
+ * The inline socket this replaced had NO `onclose` handler and NO reconnect at
+ * all, so a single drop — clean or half-open — killed realtime notifications
+ * for the whole session until a manual reload. This hook reconnects with capped
+ * exponential backoff and never permanently gives up.
+ */
+
+import { useEffect, useRef } from 'react'
+
+import {
+  computeBackoffDelay,
+  HEARTBEAT_INTERVAL_MS,
+  isConnectionStale,
+  WATCHDOG_INTERVAL_MS,
+} from '@/lib/utils/overlayStreamCore'
+
+export interface NotificationEnvelope {
+  type?: string
+  data?: unknown
+}
+
+/**
+ * Subscribe to owner notifications for `id` on the authenticated overlay socket.
+ * `onEnvelope` is invoked with each parsed inbound envelope (parse failures are
+ * swallowed). The socket is torn down and rebuilt only when `id` or `token`
+ * change; the callback is kept fresh via a ref so updating it never re-subscribes.
+ */
+export function useNotificationSocket(
+  id: string | null | undefined,
+  token: string | null | undefined,
+  onEnvelope: (envelope: NotificationEnvelope) => void,
+): void {
+  const onEnvelopeRef = useRef(onEnvelope)
+  useEffect(() => {
+    onEnvelopeRef.current = onEnvelope
+  })
+
+  useEffect(() => {
+    if (!id || !token) return
+
+    let stopped = false
+    let ws: WebSocket | null = null
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+    let watchdogTimer: ReturnType<typeof setInterval> | null = null
+    // Consecutive failed reconnects since the last successful open — drives the
+    // backoff curve; reset to 0 on every successful handshake.
+    let attempts = 0
+    // Wall-clock of the last inbound frame on the current socket; 0 means "no
+    // frame yet" (socket still opening), which isConnectionStale treats as live.
+    let lastActivity = 0
+
+    const clearLivenessTimers = () => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer)
+        heartbeatTimer = null
+      }
+      if (watchdogTimer) {
+        clearInterval(watchdogTimer)
+        watchdogTimer = null
+      }
+    }
+
+    // Detach handlers before closing so the browser's asynchronous onclose
+    // (fired after close()) can't re-enter and schedule a second reconnect.
+    const teardown = (sock: WebSocket | null) => {
+      if (!sock) return
+      sock.onopen = null
+      sock.onmessage = null
+      sock.onerror = null
+      sock.onclose = null
+      try {
+        sock.close()
+      } catch {
+        /* already closing */
+      }
+    }
+
+    // `immediate` (online/visibility recovery) collapses the backoff and resets
+    // the curve so a returning tab reconnects at once.
+    const scheduleReconnect = (immediate = false) => {
+      if (stopped || reconnectTimer) return
+      clearLivenessTimers()
+      const delay = immediate ? 0 : computeBackoffDelay(attempts)
+      if (immediate) attempts = 0
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null
+        attempts++
+        connect()
+      }, delay)
+    }
+
+    const connect = () => {
+      if (stopped) return
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+      const wsUrl = `${protocol}//${window.location.host}/ws/overlay/${id}?token=${token}`
+      const sock = new WebSocket(wsUrl)
+      ws = sock
+      lastActivity = 0 // no inbound frame yet on this socket
+
+      sock.onopen = () => {
+        attempts = 0 // success resets the backoff curve for the next drop
+        lastActivity = Date.now()
+        clearLivenessTimers()
+
+        // Heartbeat: an app-level ping the gateway echoes as a pong. That pong
+        // (or any other inbound frame) refreshes lastActivity below.
+        heartbeatTimer = setInterval(() => {
+          if (sock.readyState === WebSocket.OPEN) {
+            try {
+              sock.send(JSON.stringify({ type: 'ping', timestamp: new Date().toISOString() }))
+            } catch {
+              /* a failed send means the socket is gone; the watchdog will catch it */
+            }
+          }
+        }, HEARTBEAT_INTERVAL_MS)
+
+        // Watchdog: prolonged inbound silence means a half-open socket (no
+        // onclose). Force the reconnect ourselves.
+        watchdogTimer = setInterval(() => {
+          if (isConnectionStale(lastActivity, Date.now())) {
+            teardown(sock)
+            scheduleReconnect()
+          }
+        }, WATCHDOG_INTERVAL_MS)
+      }
+
+      sock.onmessage = (event) => {
+        lastActivity = Date.now() // ANY inbound frame proves liveness
+        try {
+          onEnvelopeRef.current(JSON.parse(event.data) as NotificationEnvelope)
+        } catch {
+          /* ignore parse errors — malformed frame still counts as liveness */
+        }
+      }
+
+      sock.onerror = () => {
+        /* surfaced via onclose / the watchdog; nothing actionable here */
+      }
+
+      sock.onclose = () => {
+        scheduleReconnect()
+      }
+    }
+
+    connect()
+
+    // Recover instantly when the OS reports connectivity or a backgrounded tab
+    // is refocused — a throttled background tab's watchdog timer is also
+    // throttled, so without this a dead socket lingers until the tab is active.
+    const reconnectIfDead = () => {
+      if (!ws || ws.readyState === WebSocket.CONNECTING) return
+      const healthy =
+        ws.readyState === WebSocket.OPEN && !isConnectionStale(lastActivity, Date.now())
+      if (healthy) return
+      teardown(ws)
+      scheduleReconnect(true)
+    }
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') reconnectIfDead()
+    }
+    window.addEventListener('online', reconnectIfDead)
+    document.addEventListener('visibilitychange', onVisible)
+
+    return () => {
+      stopped = true
+      clearLivenessTimers()
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      window.removeEventListener('online', reconnectIfDead)
+      document.removeEventListener('visibilitychange', onVisible)
+      teardown(ws)
+      ws = null
+    }
+  }, [id, token])
+}


### PR DESCRIPTION
## Problem

The latest debug issue (`view-connection-flaky-indicator-stale.md`) describes a half-open / no-liveness-detection bug class for the public overlay stream. That fix is already shipped for `useOverlayStream`, the gateway pong reply, and the legacy `WebSocketClient`.

Applying the same lens to **other** WebSocket clients surfaced one more instance: the dashboard overlay editor's `share_revoked` notification socket (`overlays/[id]/page.tsx`). It was actually a *worse* case — it had **no `onclose` handler and no reconnect at all**, plus no liveness detection. A single drop (clean or half-open: Wi-Fi blip, NAT/proxy idle timeout, sleep/wake, background-tab throttling) silently killed realtime owner notifications for the rest of the session until a manual reload.

## Fix

Extract `useNotificationSocket` — an authenticated, self-healing socket that:
- sends an app-level `ping` heartbeat the gateway echoes as a `pong`;
- treats any inbound frame as proof of life;
- runs a watchdog that forces a reconnect after prolonged silence (the half-open case, where `onclose` never fires);
- reconnects with capped exponential backoff and **never permanently gives up**;
- forces an immediate reconnect on `online` / `visibilitychange→visible` so a backgrounded tab recovers the instant it returns.

It reuses the shared liveness helpers in `overlayStreamCore` rather than hand-rolling a third copy of the logic.

## Tests

New deterministic unit tests (`useNotificationSocket.test.tsx`) drive a mock socket that goes silent *without* firing `onclose`, asserting the watchdog reconnects, the heartbeat fires, clean-close reconnects, and unmount cancels everything. All 60 tests across the WS suite pass; `tsc --noEmit` and eslint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)