### PR TITLE
fix(frontend): stop emotes overlapping at larger font/emote sizes (#438)

### DIFF
--- a/frontend/src/lib/renderMessage.tsx
+++ b/frontend/src/lib/renderMessage.tsx
@@ -86,7 +86,7 @@ export function renderMessageContent(message: ChatMessage): React.ReactNode {
 
     if (!emote.url) {
       nodes.push(
-        <span key={`${emote.key}-text`} className="mx-0.5">
+        <span key={`${emote.key}-text`} className="mx-[0.2em]">
           {text.slice(emote.start, emote.end + 1)}
         </span>
       )
@@ -99,7 +99,7 @@ export function renderMessageContent(message: ChatMessage): React.ReactNode {
           title={`${emote.code} (${emote.provider})`}
           width={28}
           height={28}
-          className="mx-0.5 inline-block h-[1.4em] w-auto align-text-bottom"
+          className="mx-[0.2em] inline-block h-[1.4em] w-auto align-text-bottom"
         />
       )
     }

--- a/frontend/src/styles/__tests__/events-customizer-parity.test.ts
+++ b/frontend/src/styles/__tests__/events-customizer-parity.test.ts
@@ -101,4 +101,27 @@ describe('events.css visual-customizer scope parity', () => {
     const live = varsConsumedUnderScope('.overlay-live-body')
     expect(live.has('--chat-emote-scale')).toBe(true)
   })
+
+  /**
+   * Regression guard for #438 (emotes overlap at larger sizes). Emote scale must
+   * grow the layout box (height), NOT `transform: scale()` — a transform grows
+   * the emote visually without reserving space, so scaled emotes overlap text and
+   * wrap-lines. And the line box must be floored at the emote height so a tall
+   * emote can't bleed into adjacent lines.
+   */
+  it('scales emotes via the layout box, never transform: scale()', () => {
+    expect(CSS).not.toMatch(/transform:\s*scale\(var\(--chat-emote-scale/)
+    // both scopes size the emote height by the scale factor
+    const heightScaleRules = CSS.match(
+      /height:\s*calc\(1\.4em \* var\(--chat-emote-scale, 1\)\)/g
+    )
+    expect(heightScaleRules?.length).toBe(2)
+  })
+
+  it('floors the message line-height at the scaled emote height', () => {
+    const floorRules = CSS.match(
+      /line-height:\s*max\(\s*calc\(var\(--chat-line-height, 1\.5\) \* 1em\),\s*calc\(1\.4em \* var\(--chat-emote-scale, 1\)\)\s*\)/g
+    )
+    expect(floorRules?.length).toBe(2)
+  })
 })

--- a/frontend/src/styles/events.css
+++ b/frontend/src/styles/events.css
@@ -380,7 +380,13 @@
     font-size: var(--chat-font-size, 1rem) !important;
     font-family: var(--chat-font-family, inherit) !important;
     font-weight: var(--chat-font-weight, inherit) !important;
-    line-height: var(--chat-line-height, 1.5) !important;
+    /* Floor the line box at the (scaled) emote height so a scaled-up emote can't
+       bleed into the wrap-line above/below. At emote-scale 1 this is exactly the
+       user's line-height (1.4 < 1.5). See #438. */
+    line-height: max(
+      calc(var(--chat-line-height, 1.5) * 1em),
+      calc(1.4em * var(--chat-emote-scale, 1))
+    ) !important;
     letter-spacing: var(--chat-letter-spacing, normal) !important;
     color: var(--chat-message-color, inherit) !important;
   }
@@ -396,7 +402,13 @@
   /* ── Emotes (inline images inside message text) ────────────────────── */
   .overlay-preview-body .break-words img {
     display: var(--chat-show-emotes, inline) !important;
-    transform: scale(var(--chat-emote-scale, 1)) !important;
+    /* Scale via the box, not `transform`. `transform: scale()` grows the emote
+       visually without reserving layout space, so a scaled-up emote overlaps the
+       neighbouring text and the wrap-lines above/below. Sizing `height` (× the
+       emote scale) keeps the layout box in sync, so margins and line-height
+       absorb the growth instead of colliding. See issue #438. */
+    height: calc(1.4em * var(--chat-emote-scale, 1)) !important;
+    width: auto !important;
     vertical-align: middle !important;
   }
 }
@@ -475,7 +487,13 @@
   .overlay-live-body .break-words {
     font-family: var(--chat-font-family, inherit) !important;
     font-weight: var(--chat-font-weight, inherit) !important;
-    line-height: var(--chat-line-height, 1.5) !important;
+    /* Floor the line box at the (scaled) emote height so a scaled-up emote can't
+       bleed into the wrap-line above/below. At emote-scale 1 this is exactly the
+       user's line-height (1.4 < 1.5). See #438. */
+    line-height: max(
+      calc(var(--chat-line-height, 1.5) * 1em),
+      calc(1.4em * var(--chat-emote-scale, 1))
+    ) !important;
     letter-spacing: var(--chat-letter-spacing, normal) !important;
     color: var(--chat-message-color, #ffffff) !important;
   }
@@ -490,7 +508,10 @@
   /* ── Emotes (inline images inside message text) ────────────────────── */
   .overlay-live-body .break-words img {
     display: var(--chat-show-emotes, inline) !important;
-    transform: scale(var(--chat-emote-scale, 1)) !important;
+    /* Scale via the box, not `transform` — keeps the layout box in sync with the
+       visual size so scaled emotes don't overlap text or wrap-lines. See #438. */
+    height: calc(1.4em * var(--chat-emote-scale, 1)) !important;
+    width: auto !important;
     vertical-align: middle !important;
   }
 }


### PR DESCRIPTION
Fixes #438.

## Diagnosis (verified with Playwright, not just the filed proposal)

The filed issue proposed changing the emote margin `mx-0.5` → `mx-[0.2em]`. That's correct but only addresses *horizontal cramping* — it does **not** fix the actual overlap. Rendering the real `.overlay-live-body` CSS in a browser showed the overlap has three causes:

1. **Fixed margin** (`mx-0.5` = 2px) on an em-scaled emote (`h-[1.4em]`) → spacing stays cramped as font size grows.
2. **`transform: scale()`** drives the emote-scale slider (events.css) — a transform grows the emote *visually without reserving layout space*, so scaled emotes overlap text and each other.
3. A scaled emote can exceed the **line-height**, so with `vertical-align: middle` it bleeds into the wrap-line above/below.

## Fix

1. `renderMessage.tsx`: both emote nodes `mx-0.5` → `mx-[0.2em]` (gap scales with text: 4px → 12.8px at 32px).
2. `events.css` (both `.overlay-live-body` and `.overlay-preview-body`): emote-scale via `height: calc(1.4em * var(--chat-emote-scale,1))` instead of `transform: scale()`, so the layout box grows.
3. `events.css`: floor the message `line-height` at `max(line-height, 1.4em * emote-scale)` so tall emotes can't bleed across lines. No-op at emote-scale 1.

The emote-scale slider still works — it just reserves space now (no feature disabled).

## Verification

Faithful Playwright comparison using the real `.overlay-live-body > .break-words` nesting and verbatim events.css rules, across font sizes 16–48px and emote scales 1–2:
- **Before:** severe overlap at scale ≥ 1.5 (emotes over text, over each other, across lines).
- **After:** 0 horizontal / 0 vertical overlaps at every size; spacing proportional and readable.

Added a regression guard in `events-customizer-parity.test.ts` (no `transform: scale()` for emotes; height-scale + line-height floor present). All style/parser tests pass; `tsc` + eslint clean.

## Follow-up (not in this repo)

The same `mx-0.5` → `mx-[0.2em]` change is also needed in the separate **all-chat-extension** repo (`src/lib/renderMessage.tsx`), per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)