### PR TITLE
fix(overlay): scale emotes via height so they grow without overlapping

### DIFF
--- a/frontend/src/styles/events.css
+++ b/frontend/src/styles/events.css
@@ -394,9 +394,17 @@
   }
 
   /* ── Emotes (inline images inside message text) ────────────────────── */
+  /* Scale via `height` (layout-affecting) rather than `transform: scale`.
+     A transform is visual-only: it leaves the emote's layout box pinned at the
+     base 1.4em, so scaled emotes overflow it — colliding with adjacent emotes
+     and bleeding into neighbouring lines — while never actually reserving the
+     larger size. Sizing the height (in em, so it still tracks message
+     font-size) reflows the line box to fit: emotes grow without a cap and lines
+     space out to match. `width: auto` preserves aspect ratio. */
   .overlay-preview-body .break-words img {
     display: var(--chat-show-emotes, inline) !important;
-    transform: scale(var(--chat-emote-scale, 1)) !important;
+    height: calc(1.4em * var(--chat-emote-scale, 1)) !important;
+    width: auto !important;
     vertical-align: middle !important;
   }
 }
@@ -488,9 +496,13 @@
   }
 
   /* ── Emotes (inline images inside message text) ────────────────────── */
+  /* See the matching .overlay-preview-body rule above: scale via `height`
+     (layout-affecting) instead of `transform: scale` so the line box reflows to
+     fit, emotes grow without a cap, and adjacent emotes/lines never overlap. */
   .overlay-live-body .break-words img {
     display: var(--chat-show-emotes, inline) !important;
-    transform: scale(var(--chat-emote-scale, 1)) !important;
+    height: calc(1.4em * var(--chat-emote-scale, 1)) !important;
+    width: auto !important;
     vertical-align: middle !important;
   }
 }


### PR DESCRIPTION
## Problem
Emote scale was applied as `transform: scale(--chat-emote-scale)`. Transforms are visual-only and don't participate in layout, so the emote's layout box stayed pinned at the base `1.4em`: scaled emotes overflowed it (colliding with adjacent emotes and neighbouring lines) yet never reserved the larger size — so they appeared capped while line spacing kept responding.

## Fix
Scale via `height: calc(1.4em * var(--chat-emote-scale, 1))` (in `em`, so it still tracks message font-size) with `width: auto`. The line box now reflows to fit: emotes grow without a cap and lines space out to match, with no overlap. Applied to both the `.overlay-preview-body` and `.overlay-live-body` rules.

Verified empirically (Playwright, exact production CSS): at 3× scale the line box grows from 24px→67px to match the emote, and adjacent emotes keep a +8px gap (was −36px / overlapping). Customizer-parity tests pass (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)