### PR TITLE
fix(themes): make emote max-height scale-aware so emote scale isn't capped

### DIFF
--- a/docs/overlay-themes/cyberpunk-theme.css
+++ b/docs/overlay-themes/cyberpunk-theme.css
@@ -176,7 +176,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 28px !important;
+  max-height: calc(28px * var(--chat-emote-scale, 1)) !important;
   filter: drop-shadow(0 0 6px rgba(255, 237, 78, 0.3)) !important;
 }
 

--- a/docs/overlay-themes/high-contrast-theme.css
+++ b/docs/overlay-themes/high-contrast-theme.css
@@ -251,7 +251,7 @@ body {
 .text-white.break-words img,
 .message-content img,
 .emote {
-  max-height: 36px !important;
+  max-height: calc(36px * var(--chat-emote-scale, 1)) !important;
   filter: contrast(1.2) brightness(1.1) !important;
   margin: 0 4px !important;
   vertical-align: middle !important;

--- a/docs/overlay-themes/minecraft-theme.css
+++ b/docs/overlay-themes/minecraft-theme.css
@@ -177,7 +177,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 24px !important;
+  max-height: calc(24px * var(--chat-emote-scale, 1)) !important;
   image-rendering: pixelated !important;
   image-rendering: crisp-edges !important;
   filter: drop-shadow(2px 2px 0 rgba(0, 0, 0, 0.8)) !important;

--- a/docs/overlay-themes/minimal-theme-fixed.css
+++ b/docs/overlay-themes/minimal-theme-fixed.css
@@ -228,7 +228,7 @@ body {
 .text-white.break-words img {
   display: inline-block !important;
   vertical-align: middle !important;
-  max-height: 28px !important;
+  max-height: calc(28px * var(--chat-emote-scale, 1)) !important;
   margin: 0 2px !important;
   image-rendering: -webkit-optimize-contrast !important;
   image-rendering: crisp-edges !important;

--- a/docs/overlay-themes/minimal-theme.css
+++ b/docs/overlay-themes/minimal-theme.css
@@ -283,7 +283,7 @@ body {
 .text-white.break-words img {
   display: inline-block !important;
   vertical-align: middle !important;
-  max-height: 28px !important;
+  max-height: calc(28px * var(--chat-emote-scale, 1)) !important;
   margin: 0 2px !important;
   image-rendering: -webkit-optimize-contrast !important;
   image-rendering: crisp-edges !important;

--- a/docs/overlay-themes/modern-dark-theme.css
+++ b/docs/overlay-themes/modern-dark-theme.css
@@ -146,7 +146,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 28px !important;
+  max-height: calc(28px * var(--chat-emote-scale, 1)) !important;
   filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.3)) !important;
   margin: 0 4px !important;
   vertical-align: middle !important;

--- a/docs/overlay-themes/neon-glass-theme.css
+++ b/docs/overlay-themes/neon-glass-theme.css
@@ -171,7 +171,7 @@ body {
 .text-white.break-words img {
   display: inline-block !important;
   vertical-align: middle !important;
-  max-height: 32px !important;
+  max-height: calc(32px * var(--chat-emote-scale, 1)) !important;
   margin: 0 4px !important;
   image-rendering: -webkit-optimize-contrast !important;
   image-rendering: crisp-edges !important;

--- a/docs/overlay-themes/noita-minimal-theme.css
+++ b/docs/overlay-themes/noita-minimal-theme.css
@@ -278,7 +278,7 @@ body {
 .text-white.break-words img {
   display: inline-block !important;
   vertical-align: middle !important;
-  max-height: 28px !important;
+  max-height: calc(28px * var(--chat-emote-scale, 1)) !important;
   margin: 0 2px !important;
   filter: drop-shadow(0 0 2px rgba(212, 175, 55, 0.3));
   image-rendering: -webkit-optimize-contrast !important;

--- a/docs/overlay-themes/pastel-cute-theme.css
+++ b/docs/overlay-themes/pastel-cute-theme.css
@@ -163,7 +163,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 32px !important;
+  max-height: calc(32px * var(--chat-emote-scale, 1)) !important;
   filter: drop-shadow(0 2px 4px rgba(255, 182, 193, 0.3)) !important;
   margin: 0 4px !important;
 }

--- a/docs/overlay-themes/terminal-hacker-theme.css
+++ b/docs/overlay-themes/terminal-hacker-theme.css
@@ -210,7 +210,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 24px !important;
+  max-height: calc(24px * var(--chat-emote-scale, 1)) !important;
   filter:
     grayscale(100%)
     brightness(1.5)

--- a/docs/overlay-themes/vaporwave-theme.css
+++ b/docs/overlay-themes/vaporwave-theme.css
@@ -213,7 +213,7 @@ body {
 }
 
 .text-white.break-words img {
-  max-height: 32px !important;
+  max-height: calc(32px * var(--chat-emote-scale, 1)) !important;
   filter:
     saturate(1.5)
     drop-shadow(0 0 10px rgba(255, 0, 128, 0.5))


### PR DESCRIPTION
## Problem
Overlay themes pin inline emotes with `max-height: <N>px !important` on `.text-white.break-words img`. That theme CSS is injected unlayered, and an unlayered `!important` beats the layered `!important` emote-height rule in `events.css`. So a scaled-up emote was clamped to the fixed cap at any emote scale, while the (uncapped) line-height floor still grew — lines spaced out but emotes never grew past the cap.

## Fix
Make each theme's emote cap scale-aware: `max-height: calc(<N>px * var(--chat-emote-scale, 1)) !important`. Preserves the base size at scale 1 (no visual change) and tracks the emote-scale control so it never clamps the events.css emote height.

Verified in-browser: a 28px-capped emote now scales 22→34→67→112px at 1/1.5/3/5×.

Note: themes are fetched from `main`, so merging fixes all *future* theme applies. Existing overlays carry a frozen CSS copy and are handled separately (theme-management refactor / backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)