### PR TITLE
feat(themes): reference theme by id, render CSS from the bundle (Phase 2)

### DIFF
--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -48,6 +48,7 @@ import PlatformStatusIndicators from '@/components/PlatformStatusIndicators'
 import { useOverlayStream } from '@/hooks/useOverlayStream'
 import { buildGradientCSS } from '@/lib/utils/gradient'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
 import { isDisplayVisible } from '@/lib/utils/displayVisibility'
 import type { VisualSettings } from '@/lib/types/visual-settings'
@@ -115,6 +116,10 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   const [messageDuration, setMessageDuration] = useState(15)
   const [disableMessageFade, setDisableMessageFade] = useState(false)
   const [customCss, setCustomCss] = useState('')
+  // Theme CSS resolved from the build bundle by config.theme_id, so a theme fix
+  // ships with a deploy instead of being frozen per-overlay. Legacy overlays
+  // (no theme_id) leave this empty and still render via custom_css.
+  const [themeCss, setThemeCss] = useState('')
   const [visualSettingsCss, setVisualSettingsCss] = useState('')
   // Body font-size for message text. Prefer the visual-customizer `fontSize`
   // (e.g. "18px") when set, otherwise fall back to the legacy display-settings
@@ -320,6 +325,11 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
     }
 
     setCustomCss(typeof config.custom_css === 'string' ? config.custom_css : '')
+    setThemeCss(
+      typeof config.theme_id === 'string' && config.theme_id
+        ? (getBundledTheme(config.theme_id)?.css ?? '')
+        : ''
+    )
 
     if (config.visual_settings && typeof config.visual_settings === 'object') {
       const vs = config.visual_settings as Partial<VisualSettings>
@@ -738,6 +748,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       {visualSettingsCss.length > 0 && (
         <style dangerouslySetInnerHTML={{ __html: visualSettingsCss }} />
       )}
+      {/* Bundled theme CSS first, then the user's raw custom_css overrides it. */}
+      {themeCss.length > 0 && <style dangerouslySetInnerHTML={{ __html: themeCss }} />}
       {customCss.trim().length > 0 && <style dangerouslySetInnerHTML={{ __html: customCss }} />}
 
       {/* Platform Status Indicators */}

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -56,6 +56,7 @@ import type { VisualSettings } from '@/lib/types/visual-settings'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { parseCssToVisualSettings } from '@/lib/utils/theme-css-parser'
+import type { Theme } from '@/lib/theme-marketplace/types'
 import { toastManager } from '@/lib/toast'
 import { trackEvent } from '@/lib/analytics'
 import { AppNav } from '@/components/AppNav'
@@ -1151,15 +1152,19 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   const [mockForm, setMockForm] = useState<MockMessageFormState>(DEFAULT_MOCK_FORM)
 
   // --- Custom CSS state ---
+  // customCss/useCustomCss are the user's RAW override CSS only. The applied
+  // marketplace theme is referenced by themeId (resolved from the build bundle
+  // at render) rather than copied here, so theme fixes propagate on deploy.
   const [customCss, setCustomCss] = useState('')
   const [useCustomCss, setUseCustomCss] = useState(false)
+  const [themeId, setThemeId] = useState('')
 
   // --- Visual appearance settings state ---
   const [visualSettings, setVisualSettings] = useState<Partial<VisualSettings>>({})
   const [iframeVisibilityDefaults, setIframeVisibilityDefaults] = useState<Partial<VisualSettings>>({})
   const [parsedThemeSettings, setParsedThemeSettings] = useState<Partial<VisualSettings>>({})
   const [showThemeConfirm, setShowThemeConfirm] = useState(false)
-  const [pendingTheme, setPendingTheme] = useState<{ css: string; parsed: Partial<VisualSettings> } | null>(null)
+  const [pendingTheme, setPendingTheme] = useState<Theme | null>(null)
 
   // --- Iframe ref for live preview communication ---
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
@@ -1391,15 +1396,21 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     )
   }, [])
 
-  // --- applyThemeImmediately: atomically apply CSS + parsed settings ---
+  // --- applyThemeImmediately: reference the theme by id + apply its parsed
+  // settings. The theme CSS is NOT copied into custom_css — it's resolved from
+  // the bundle at render (and pushed to the preview iframe here). Raw custom CSS
+  // is cleared so a freshly applied theme is exactly the bundled theme; users
+  // re-add overrides in the Custom CSS box afterwards. ---
   const applyThemeImmediately = useCallback(
-    (css: string, parsed: Partial<VisualSettings>) => {
-      setCustomCss(css)
-      setUseCustomCss(true)
+    (theme: Theme) => {
+      const parsed = parseCssToVisualSettings(theme.css)
+      setThemeId(theme.id)
+      setCustomCss('')
+      setUseCustomCss(false)
       setVisualSettings(parsed)
       setParsedThemeSettings(parsed)
       sendCssToIframe(parsed)
-      sendCustomCssToIframe(css)
+      sendCustomCssToIframe(theme.css)
     },
     [sendCssToIframe, sendCustomCssToIframe]
   )
@@ -1410,16 +1421,15 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     sendCssToIframe(parsedThemeSettings)
   }, [parsedThemeSettings, sendCssToIframe])
 
-  // --- handleThemeApply: apply a theme CSS string from ThemeContent ---
+  // --- handleThemeApply: apply a marketplace theme from ThemeContent ---
   // Prompts for confirmation if visual settings are already customized.
-  function handleThemeApply(css: string): void {
-    const parsed = parseCssToVisualSettings(css)
+  function handleThemeApply(theme: Theme): void {
     const hasExisting = Object.keys(visualSettings).length > 0
     if (hasExisting) {
-      setPendingTheme({ css, parsed })
+      setPendingTheme(theme)
       setShowThemeConfirm(true)
     } else {
-      applyThemeImmediately(css, parsed)
+      applyThemeImmediately(theme)
     }
   }
 
@@ -1549,6 +1559,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           const css = config.custom_css || ''
           setCustomCss(css)
           setUseCustomCss(Boolean(css.trim().length))
+          setThemeId(typeof config.theme_id === 'string' ? config.theme_id : '')
 
           // Parse theme CSS — always set parsedThemeSettings so "Reset to theme defaults" works
           // after save+reload (when visual_settings is non-empty, theme defaults are still needed)
@@ -1999,6 +2010,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
         enable_bttv: enableBttv,
         enable_ffz: enableFfz,
         custom_css: useCustomCss ? customCss : '',
+        theme_id: themeId,
         visual_settings: visualSettings,
         filter_settings: filterSettings,
         // Send the (already-resolved) override only when the user touched it.
@@ -2959,7 +2971,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               size="sm"
               onClick={() => {
                 if (pendingTheme) {
-                  applyThemeImmediately(pendingTheme.css, pendingTheme.parsed)
+                  applyThemeImmediately(pendingTheme)
                   setPendingTheme(null)
                 }
                 setShowThemeConfirm(false)

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -44,6 +44,7 @@ import { renderMessageContent } from '@/lib/renderMessage'
 import { resolveTwitchBadgeIcons } from '@/lib/twitchBadges'
 import { sortMessageBadges } from '@/lib/badgeOrder'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { PremiumBadge } from '@/components/PremiumBadge'
@@ -415,7 +416,14 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
           setShowPlatformBadge(display.show_platform_badge)
         }
 
-        const css = config.custom_css || ''
+        // Bundled theme CSS (resolved fresh from the build by theme_id) + the
+        // user's raw custom_css overrides. Both are scoped to the preview root
+        // by scopedPreviewCss, mirroring the live overlay's theme→custom order.
+        const themeCss =
+          typeof config.theme_id === 'string' && config.theme_id
+            ? (getBundledTheme(config.theme_id)?.css ?? '')
+            : ''
+        const css = [themeCss, config.custom_css || ''].filter((s) => s.trim().length).join('\n')
         setCustomCss(css)
         setUseCustomCss(Boolean(css.trim().length))
 

--- a/frontend/src/components/theme-marketplace/ThemeCard.tsx
+++ b/frontend/src/components/theme-marketplace/ThemeCard.tsx
@@ -34,7 +34,7 @@ interface ThemeCardProps {
   isFavorite: boolean
   messages: ChatMessagePreview[]
   onToggleFavorite: (themeId: string) => void
-  onApply: (css: string) => void
+  onApply: (theme: Theme) => void
   themeType?: 'overlay' | 'creditroll'
 }
 
@@ -104,7 +104,7 @@ export default function ThemeCard({
 
         {/* Apply Button */}
         <button
-          onClick={() => onApply(theme.css)}
+          onClick={() => onApply(theme)}
           className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-twitch px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-twitch/90"
         >
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/theme-marketplace/ThemeContent.tsx
+++ b/frontend/src/components/theme-marketplace/ThemeContent.tsx
@@ -25,9 +25,10 @@ import ThemeFilters from './ThemeFilters'
 import { useThemeMarketplace } from '@/hooks/useThemeMarketplace'
 import { SAMPLE_PREVIEW_MESSAGES } from '@/lib/theme-marketplace/constants'
 import { clearCache } from '@/lib/theme-marketplace/cache'
+import type { Theme } from '@/lib/theme-marketplace/types'
 
 interface ThemeContentProps {
-  onApply: (css: string) => void
+  onApply: (theme: Theme) => void
   isAdmin?: boolean
 }
 

--- a/frontend/src/components/theme-marketplace/ThemeMarketplaceModal.tsx
+++ b/frontend/src/components/theme-marketplace/ThemeMarketplaceModal.tsx
@@ -33,6 +33,7 @@ import { SAMPLE_PREVIEW_MESSAGES } from '@/lib/theme-marketplace/constants'
 import { useAuthStore } from '@/lib/stores/auth-store'
 import { clearCache } from '@/lib/theme-marketplace/cache'
 import { trackEvent } from '@/lib/analytics'
+import type { Theme } from '@/lib/theme-marketplace/types'
 
 interface ThemeMarketplaceModalProps {
   isOpen: boolean
@@ -146,9 +147,9 @@ export default function ThemeMarketplaceModal({
 
   if (!isOpen) return null
 
-  const handleApply = (css: string) => {
+  const handleApply = (theme: Theme) => {
     trackEvent('theme_applied', { source: 'marketplace' })
-    onApplyTheme(css)
+    onApplyTheme(theme.css)
     onClose()
   }
 

--- a/frontend/src/components/theme-marketplace/__tests__/ThemeContent.test.tsx
+++ b/frontend/src/components/theme-marketplace/__tests__/ThemeContent.test.tsx
@@ -50,11 +50,11 @@ vi.mock('../ThemeCard', () => ({
     onApply,
   }: {
     theme: { id: string; name: string; css: string }
-    onApply: (css: string) => void
+    onApply: (theme: { id: string; name: string; css: string }) => void
   }) => (
     <div data-testid={`theme-card-${theme.id}`}>
       <span>{theme.name}</span>
-      <button onClick={() => onApply(theme.css)}>Apply {theme.name}</button>
+      <button onClick={() => onApply(theme)}>Apply {theme.name}</button>
     </div>
   ),
 }))
@@ -119,7 +119,7 @@ describe('ThemeContent', () => {
     expect(screen.getByTestId('theme-filters')).toBeDefined()
   })
 
-  it('calls onApply with CSS string when a theme card apply button is clicked', () => {
+  it('calls onApply with the theme when a theme card apply button is clicked', () => {
     const testTheme = {
       id: 'theme-1',
       filename: 'dark-theme.css',
@@ -143,7 +143,7 @@ describe('ThemeContent', () => {
     const applyButton = screen.getByRole('button', { name: /Apply Dark Theme/i })
     fireEvent.click(applyButton)
 
-    expect(onApply).toHaveBeenCalledWith('.chat { color: white; }')
+    expect(onApply).toHaveBeenCalledWith(testTheme)
     expect(onApply).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/lib/types/overlay.ts
+++ b/frontend/src/lib/types/overlay.ts
@@ -49,6 +49,12 @@ export interface OverlayConfig {
   visual_settings?: Partial<VisualSettings>
   /** Optional 7TV emote-set ID override; lets users attach a 7TV set independent of source platforms. */
   seventv_emote_set_id?: string
+  /**
+   * Bundled marketplace theme id (e.g. "modern-dark-theme"). The renderer
+   * resolves the theme CSS fresh from the build bundle so theme fixes
+   * propagate on deploy; custom_css is only the user's raw overrides.
+   */
+  theme_id?: string
   created_at: string
   updated_at: string
 }
@@ -78,6 +84,8 @@ export interface PublicOverlayConfig {
   custom_css?: string
   visual_settings?: Partial<VisualSettings>
   seventv_emote_set_id?: string
+  /** Bundled theme id; renderer resolves its CSS from the build bundle. */
+  theme_id?: string
   sources?: PublicSourceStatus[]
 }
 

--- a/migrations/057_overlay_config_theme_id.sql
+++ b/migrations/057_overlay_config_theme_id.sql
@@ -1,0 +1,28 @@
+-- All-Chat Migration 057: Reference applied theme by id instead of copying its CSS
+-- Migration: 057
+--
+-- Until now, applying a marketplace theme copied the theme's full CSS into
+-- overlay_configs.custom_css. That froze a private snapshot per overlay, so an
+-- upstream theme fix never reached existing overlays without a data migration
+-- (see the emote max-height cap bug). Themes now ship bundled in the frontend
+-- build; an overlay only needs to record WHICH theme it uses, and the renderer
+-- resolves the (always current) CSS from the bundle at load time.
+--
+-- theme_id is the bundled theme's id (e.g. 'modern-dark-theme'); NULL means no
+-- bundled theme (legacy overlays whose custom_css still holds a frozen copy,
+-- until the Phase 3 backfill, or overlays using only raw custom CSS).
+-- visual_settings keeps holding the user's per-overlay customization diff;
+-- custom_css is reduced to genuinely custom raw overrides.
+--
+-- IDEMPOTENCY: the runner re-executes every migration on each pod start, so
+-- this is ADD COLUMN IF NOT EXISTS and safe to re-run.
+
+BEGIN;
+
+ALTER TABLE overlay_configs
+    ADD COLUMN IF NOT EXISTS theme_id TEXT;
+
+COMMENT ON COLUMN overlay_configs.theme_id IS
+    'Bundled marketplace theme id applied to this overlay (e.g. ''modern-dark-theme''). The renderer resolves theme CSS fresh from the frontend bundle so theme fixes propagate on deploy. NULL = no bundled theme (raw custom_css only / legacy frozen copy pending backfill).';
+
+COMMIT;

--- a/migrations/057_overlay_config_theme_id_down.sql
+++ b/migrations/057_overlay_config_theme_id_down.sql
@@ -1,0 +1,8 @@
+-- All-Chat Migration 057 DOWN: drop the overlay theme reference column
+
+BEGIN;
+
+ALTER TABLE overlay_configs
+    DROP COLUMN IF EXISTS theme_id;
+
+COMMIT;

--- a/migrations/init/057_overlay_config_theme_id.sql
+++ b/migrations/init/057_overlay_config_theme_id.sql
@@ -1,0 +1,28 @@
+-- All-Chat Migration 057: Reference applied theme by id instead of copying its CSS
+-- Migration: 057
+--
+-- Until now, applying a marketplace theme copied the theme's full CSS into
+-- overlay_configs.custom_css. That froze a private snapshot per overlay, so an
+-- upstream theme fix never reached existing overlays without a data migration
+-- (see the emote max-height cap bug). Themes now ship bundled in the frontend
+-- build; an overlay only needs to record WHICH theme it uses, and the renderer
+-- resolves the (always current) CSS from the bundle at load time.
+--
+-- theme_id is the bundled theme's id (e.g. 'modern-dark-theme'); NULL means no
+-- bundled theme (legacy overlays whose custom_css still holds a frozen copy,
+-- until the Phase 3 backfill, or overlays using only raw custom CSS).
+-- visual_settings keeps holding the user's per-overlay customization diff;
+-- custom_css is reduced to genuinely custom raw overrides.
+--
+-- IDEMPOTENCY: the runner re-executes every migration on each pod start, so
+-- this is ADD COLUMN IF NOT EXISTS and safe to re-run.
+
+BEGIN;
+
+ALTER TABLE overlay_configs
+    ADD COLUMN IF NOT EXISTS theme_id TEXT;
+
+COMMENT ON COLUMN overlay_configs.theme_id IS
+    'Bundled marketplace theme id applied to this overlay (e.g. ''modern-dark-theme''). The renderer resolves theme CSS fresh from the frontend bundle so theme fixes propagate on deploy. NULL = no bundled theme (raw custom_css only / legacy frozen copy pending backfill).';
+
+COMMIT;

--- a/services/overlay-manager/handlers/config.go
+++ b/services/overlay-manager/handlers/config.go
@@ -112,6 +112,7 @@ func (h *ConfigHandler) HandleUpdateConfig(c *gin.Context) {
 		CustomCSS         *string        `json:"custom_css"`
 		VisualSettings    map[string]any `json:"visual_settings"`
 		SevenTVEmoteSetID *string        `json:"seventv_emote_set_id"`
+		ThemeID           *string        `json:"theme_id"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -139,6 +140,9 @@ func (h *ConfigHandler) HandleUpdateConfig(c *gin.Context) {
 	}
 	if req.VisualSettings != nil {
 		config.VisualSettings = req.VisualSettings
+	}
+	if req.ThemeID != nil {
+		config.ThemeID = *req.ThemeID
 	}
 	if req.SevenTVEmoteSetID != nil {
 		if h.seventvResolver == nil {
@@ -229,6 +233,7 @@ func (h *ConfigHandler) HandleGetPublicConfig(c *gin.Context) {
 		"custom_css":           config.CustomCSS,
 		"visual_settings":      config.VisualSettings,
 		"seventv_emote_set_id": config.SevenTVEmoteSetID,
+		"theme_id":             config.ThemeID,
 		"sources":              sourceStatus,
 	})
 }

--- a/services/overlay-manager/models/config.go
+++ b/services/overlay-manager/models/config.go
@@ -30,6 +30,10 @@ type OverlayConfig struct {
 	CustomCSS          string         `json:"custom_css"`
 	VisualSettings     map[string]any `json:"visual_settings"`
 	SevenTVEmoteSetID  string         `json:"seventv_emote_set_id"`
+	// ThemeID is the bundled marketplace theme applied to this overlay. The
+	// renderer resolves its CSS fresh from the frontend bundle so theme fixes
+	// propagate on deploy. Empty = no bundled theme (raw custom_css / legacy).
+	ThemeID            string         `json:"theme_id"`
 	CreatedAt          time.Time      `json:"created_at"`
 	UpdatedAt          time.Time      `json:"updated_at"`
 }

--- a/services/overlay-manager/repository/config_repo.go
+++ b/services/overlay-manager/repository/config_repo.go
@@ -52,7 +52,7 @@ func (r *OverlayConfigRepository) GetByOverlayID(ctx context.Context, overlayID 
 	query := `
 		SELECT id, overlay_id, display_settings, filter_settings,
 		       enable_7tv, enable_bttv, enable_ffz, custom_css, visual_settings,
-		       seventv_emote_set_id, created_at, updated_at
+		       seventv_emote_set_id, theme_id, created_at, updated_at
 		FROM overlay_configs
 		WHERE overlay_id = $1
 	`
@@ -84,6 +84,12 @@ func (r *OverlayConfigRepository) Update(ctx context.Context, config *models.Ove
 		seventvSetID = config.SevenTVEmoteSetID
 	}
 
+	// NULL when empty: "no bundled theme" is distinct from any theme id.
+	var themeID any
+	if config.ThemeID != "" {
+		themeID = config.ThemeID
+	}
+
 	query := `
 		UPDATE overlay_configs
 		SET display_settings = $1,
@@ -94,11 +100,12 @@ func (r *OverlayConfigRepository) Update(ctx context.Context, config *models.Ove
 		    custom_css = $6,
 		    visual_settings = $7,
 		    seventv_emote_set_id = $8,
+		    theme_id = $9,
 		    updated_at = NOW()
-		WHERE overlay_id = $9
+		WHERE overlay_id = $10
 		RETURNING id, overlay_id, display_settings, filter_settings,
 		          enable_7tv, enable_bttv, enable_ffz, custom_css, visual_settings,
-		          seventv_emote_set_id, created_at, updated_at
+		          seventv_emote_set_id, theme_id, created_at, updated_at
 	`
 
 	row := r.pool.QueryRow(ctx, query,
@@ -110,6 +117,7 @@ func (r *OverlayConfigRepository) Update(ctx context.Context, config *models.Ove
 		config.CustomCSS,
 		visualSettings,
 		seventvSetID,
+		themeID,
 		config.OverlayID,
 	)
 
@@ -126,6 +134,7 @@ func scanOverlayConfig(row pgx.Row) (*models.OverlayConfig, error) {
 	config := &models.OverlayConfig{}
 	var displaySettingsJSON, filterSettingsJSON, visualSettingsJSON []byte
 	var seventvSetID *string
+	var themeID *string
 
 	err := row.Scan(
 		&config.ID,
@@ -138,6 +147,7 @@ func scanOverlayConfig(row pgx.Row) (*models.OverlayConfig, error) {
 		&config.CustomCSS,
 		&visualSettingsJSON,
 		&seventvSetID,
+		&themeID,
 		&config.CreatedAt,
 		&config.UpdatedAt,
 	)
@@ -150,6 +160,9 @@ func scanOverlayConfig(row pgx.Row) (*models.OverlayConfig, error) {
 
 	if seventvSetID != nil {
 		config.SevenTVEmoteSetID = *seventvSetID
+	}
+	if themeID != nil {
+		config.ThemeID = *themeID
 	}
 
 	if err := json.Unmarshal(displaySettingsJSON, &config.DisplaySettings); err != nil {


### PR DESCRIPTION
Phase 2 of making theme fixes propagate without per-overlay migrations.

Overlays now store **which** theme they use (`overlay_configs.theme_id`) and the renderer resolves that theme's CSS fresh from the build bundle, instead of freezing a full CSS copy into `custom_css` on apply. A theme fix now reaches every overlay on the next deploy.

### Backend (overlay-manager)
- Migration **057**: `overlay_configs.theme_id TEXT` (nullable, idempotent, mirrored to init snapshot).
- Model + repository thread `ThemeID` (NULL when empty, mirroring `seventv_emote_set_id`).
- Handlers accept `theme_id` on update and expose it in the public config.

### Frontend
- Live overlay + embed preview resolve bundled theme CSS by `theme_id` and inject it **before** `custom_css` (now only the user's raw overrides). Legacy overlays (`theme_id` NULL, `custom_css` = frozen copy) render exactly as today.
- Editor tracks `themeId`; applying a theme stores `theme_id` + parsed `visual_settings` and clears `custom_css` instead of copying theme CSS; save sends `theme_id`.
- `onApply` now passes the `Theme` (id needed); credit-roll modal keeps its css-copy path.

### Compatibility
Legacy overlays are unchanged until they re-apply a theme or the **Phase 3 backfill** maps their frozen `custom_css` → `theme_id`. Frontend build + 45 theme/hook/component tests + overlay-manager repo/handler tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)