### PR TITLE
fix(twitch-eventsub): keep chat-ownership claim alive for quiet channels

### DIFF
--- a/services/twitch-eventsub-listener/channels/manager.go
+++ b/services/twitch-eventsub-listener/channels/manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/caesar/all-chat/services/twitch-eventsub-listener/status"
 	"github.com/caesar/all-chat/shared/encryption"
 	"github.com/caesar/all-chat/shared/listener"
+	"github.com/caesar/all-chat/shared/twitchchat"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 )
@@ -69,6 +70,21 @@ type Manager struct {
 	// webhook handler when Twitch verifies the chat subscription (it is actually enabled by
 	// then). nil disables status publishing.
 	statusPublisher *status.Publisher
+
+	// claims keeps the EventSub chat-ownership claim (ADR-0015) alive for every channel that
+	// currently holds a live channel.chat.message subscription, independent of chat volume. The
+	// webhook handler also refreshes on delivered chat, but a low-traffic channel can go many
+	// minutes between messages and let its claim (5-min TTL) lapse, which hands the channel back
+	// to IRC and produces the IRC↔EventSub flapping seen for quiet streams. Refreshing on the
+	// sync tick (ClaimRefreshInterval ≪ TTL) ties liveness to subscription existence instead. nil
+	// disables claim management.
+	claims *twitchchat.ClaimStore
+
+	// isLeader reports whether this pod currently owns the EventSub subscriptions. The manager
+	// runs on every pod, but only the leader holds real subscriptions, so only the leader may
+	// write/release claims — a standby refreshing would keep a channel off IRC even though no pod
+	// is actually delivering its chat. nil means "always leader" (single-pod / tests).
+	isLeader func() bool
 
 	mu       sync.RWMutex
 	channels map[string]*Channel // broadcaster_id -> Channel
@@ -157,6 +173,25 @@ func (m *Manager) SetSubscriptionCallback(callback SubscriptionCallback) {
 // teardown. Safe to leave unset (publishing becomes a no-op).
 func (m *Manager) SetStatusPublisher(pub *status.Publisher) {
 	m.statusPublisher = pub
+}
+
+// SetClaimStore injects the EventSub chat-ownership claim store (ADR-0015). With it set, the
+// manager keeps a live claim for every channel holding an active chat subscription, refreshed on
+// each sync tick so a low-traffic channel never lets its claim lapse and flap to IRC. Safe to
+// leave unset (claim management becomes a no-op).
+func (m *Manager) SetClaimStore(claims *twitchchat.ClaimStore) {
+	m.claims = claims
+}
+
+// SetLeaderFunc injects the leadership predicate. Only the leader writes/releases claims, mirroring
+// the subscription callback which is a no-op on standbys. nil (the default) is treated as leader.
+func (m *Manager) SetLeaderFunc(isLeader func() bool) {
+	m.isLeader = isLeader
+}
+
+// leads reports whether this pod may manage claims (it owns the real subscriptions).
+func (m *Manager) leads() bool {
+	return m.isLeader == nil || m.isLeader()
 }
 
 // ResetTracking drops the in-memory channel map so the next SyncChannels treats every active
@@ -282,6 +317,52 @@ func isChatDemanded(sourceIDs []string, demanded map[string]listener.DemandedSou
 	return false
 }
 
+// refreshClaims renews the chat-ownership claim for every channel that currently holds a live chat
+// subscription, keeping it off IRC regardless of how sparse its chat is (ADR-0015). Called once per
+// sync tick (ClaimRefreshInterval ≪ claim TTL). Only the leader writes claims. Channels are
+// snapshotted under the read lock and the (per-channel, bounded) Redis writes happen outside it so
+// a slow Redis never blocks syncing.
+func (m *Manager) refreshClaims(ctx context.Context) {
+	if m.claims == nil || !m.leads() {
+		return
+	}
+
+	type claim struct{ login, broadcasterID string }
+	m.mu.RLock()
+	pending := make([]claim, 0, len(m.channels))
+	for broadcasterID, ch := range m.channels {
+		if ch.ChatActive {
+			pending = append(pending, claim{ch.BroadcasterName, broadcasterID})
+		}
+	}
+	m.mu.RUnlock()
+
+	for _, c := range pending {
+		wctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := m.claims.Claim(wctx, c.login, c.broadcasterID); err != nil {
+			m.logger.Warn("Failed to refresh EventSub chat-ownership claim",
+				zap.String("login", c.login), zap.Error(err))
+		}
+		cancel()
+	}
+}
+
+// releaseClaim drops a channel's chat-ownership claim so IRC resumes it promptly instead of waiting
+// out the TTL. Called when a chat subscription is torn down (demand lost or channel removed). Only
+// the leader releases; a standby releasing would yank a channel the leader is still serving back to
+// IRC. nil-safe and leader-gated.
+func (m *Manager) releaseClaim(login string) {
+	if m.claims == nil || login == "" || !m.leads() {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := m.claims.Release(ctx, login); err != nil {
+		m.logger.Warn("Failed to release EventSub chat-ownership claim",
+			zap.String("login", login), zap.Error(err))
+	}
+}
+
 // reconcileChatLocked creates or deletes channel.chat.message subscriptions so that a chat
 // subscription exists exactly for channels that (a) have the chat scope and (b) have live
 // overlay demand. Must be called with m.mu held. Only the leader's callback performs real
@@ -305,7 +386,9 @@ func (m *Manager) reconcileChatLocked(demanded map[string]listener.DemandedSourc
 				continue
 			}
 			ch.ChatActive = false
-			// Chat reading stopped for this channel — clear its overlay indicator.
+			// EventSub stopped serving this channel — drop the claim so IRC can resume it without
+			// waiting out the TTL, and clear its overlay indicator.
+			m.releaseClaim(ch.BroadcasterName)
 			m.publishChatOffline(ch.BroadcasterName)
 		}
 	}
@@ -321,6 +404,7 @@ func (m *Manager) Start(ctx context.Context) error {
 	if err := m.SyncChannels(ctx); err != nil {
 		m.logger.Error("Initial channel sync failed", zap.Error(err))
 	}
+	m.refreshClaims(ctx)
 
 	// Periodic sync
 	m.wg.Add(1)
@@ -340,10 +424,12 @@ func (m *Manager) Start(ctx context.Context) error {
 				if err := m.SyncChannels(ctx); err != nil {
 					m.logger.Error("Channel sync failed (demand-triggered)", zap.Error(err))
 				}
+				m.refreshClaims(ctx)
 			case <-ticker.C:
 				if err := m.SyncChannels(ctx); err != nil {
 					m.logger.Error("Channel sync failed", zap.Error(err))
 				}
+				m.refreshClaims(ctx)
 			}
 		}
 	}()
@@ -572,8 +658,10 @@ func (m *Manager) SyncChannels(ctx context.Context) error {
 				}
 			}
 
-			// Removing the channel deletes its chat subscription too — clear the indicator.
+			// Removing the channel deletes its chat subscription too — drop the claim and clear
+			// the indicator.
 			if ch.ChatActive {
+				m.releaseClaim(ch.BroadcasterName)
 				m.publishChatOffline(ch.BroadcasterName)
 			}
 

--- a/services/twitch-eventsub-listener/channels/manager_claimrefresh_test.go
+++ b/services/twitch-eventsub-listener/channels/manager_claimrefresh_test.go
@@ -1,0 +1,118 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package channels
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/shared/listener"
+	"github.com/caesar/all-chat/shared/twitchchat"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+func newClaimTestStore(t *testing.T) (*miniredis.Miniredis, *twitchchat.ClaimStore) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(mr.Close)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, twitchchat.NewClaimStore(rc)
+}
+
+// TestRefreshClaims_KeepsActiveChatChannelsClaimed verifies the leader refreshes a claim for every
+// channel holding a live chat subscription — independent of chat volume. This is the fix for the
+// IRC↔EventSub flapping a low-traffic channel exhibited when its claim was only refreshed on
+// delivered chat (ADR-0015).
+func TestRefreshClaims_KeepsActiveChatChannelsClaimed(t *testing.T) {
+	mr, claims := newClaimTestStore(t)
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetClaimStore(claims)
+	m.SetLeaderFunc(func() bool { return true })
+
+	// Mixed-case login proves the claim key is lowercased; an inactive channel proves we only
+	// claim channels EventSub is actually serving.
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "CaesarLP", ChatActive: true}
+	m.channels["222"] = &Channel{BroadcasterID: "222", BroadcasterName: "quietnochat", ChatActive: false}
+
+	m.refreshClaims(context.Background())
+
+	if !mr.Exists(twitchchat.ClaimKey("caesarlp")) {
+		t.Fatal("active chat channel should hold a live claim after refresh")
+	}
+	if v, err := mr.Get(twitchchat.ClaimKey("caesarlp")); err != nil || v != "111" {
+		t.Fatalf("claim value = %q (err %v), want broadcaster id 111", v, err)
+	}
+	if mr.Exists(twitchchat.ClaimKey("quietnochat")) {
+		t.Fatal("channel without an active chat subscription must not be claimed")
+	}
+}
+
+// TestRefreshClaims_StandbyDoesNotWrite verifies a non-leader never writes claims: only the pod
+// that actually owns the subscriptions may keep a channel off IRC.
+func TestRefreshClaims_StandbyDoesNotWrite(t *testing.T) {
+	mr, claims := newClaimTestStore(t)
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetClaimStore(claims)
+	m.SetLeaderFunc(func() bool { return false })
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "caesarlp", ChatActive: true}
+
+	m.refreshClaims(context.Background())
+
+	if mr.Exists(twitchchat.ClaimKey("caesarlp")) {
+		t.Fatal("standby pod must not write chat-ownership claims")
+	}
+}
+
+// TestReconcileChat_ReleasesClaimOnTeardown verifies that when a chat subscription is torn down
+// (demand lost) the leader drops the claim immediately so IRC resumes the channel without waiting
+// out the TTL.
+func TestReconcileChat_ReleasesClaimOnTeardown(t *testing.T) {
+	mr, claims := newClaimTestStore(t)
+
+	// Seed a live claim as if the channel had been served by EventSub.
+	if err := claims.Claim(context.Background(), "caesarlp", "111"); err != nil {
+		t.Fatal(err)
+	}
+	if !mr.Exists(twitchchat.ClaimKey("caesarlp")) {
+		t.Fatal("precondition: claim should exist")
+	}
+
+	cb := &recordingCallback{}
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetClaimStore(claims)
+	m.SetLeaderFunc(func() bool { return true })
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "CaesarLP", SourceIDs: []string{"s1"}, HasChatScope: true, ChatActive: true}
+
+	// Empty (non-nil) demand → channel loses demand → chat unsubscribed → claim released.
+	m.mu.Lock()
+	m.reconcileChatLocked(map[string]listener.DemandedSource{})
+	m.mu.Unlock()
+
+	if mr.Exists(twitchchat.ClaimKey("caesarlp")) {
+		t.Fatal("claim should be released when the chat subscription is torn down")
+	}
+}

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -183,6 +183,22 @@ func main() {
 	subscriptionMgr := eventsub.NewSubscriptionManager(twitchClientID, twitchClientSecret, webhookSecret, callbackURL, log)
 	channelManager := channels.NewManager(db, log, subscriptionMgr, tokenCipher, ChannelSyncInterval)
 	channelManager.SetStatusPublisher(statusPublisher)
+	channelManager.SetClaimStore(chatClaims)
+
+	// isLeader tracks whether this pod currently holds EventSub leadership.
+	// Protected by mu; read by subscription callback and HTTP handlers.
+	//
+	// Defined BEFORE ll.Start because that call synchronously starts the channel manager's sync
+	// loop (and its initial sync), which refreshes chat-ownership claims. Wiring the leader gate
+	// first ensures a standby never writes claims (a nil gate would be treated as "always leader").
+	var isLeaderMu sync.RWMutex
+	isLeader := false
+	isLeaderFn := func() bool {
+		isLeaderMu.RLock()
+		defer isLeaderMu.RUnlock()
+		return isLeader
+	}
+	channelManager.SetLeaderFunc(isLeaderFn)
 
 	// Start LeadershipListener — runs demand subscriber; channel manager started after leadership
 	if err := ll.Start(ctx, channelManager); err != nil {
@@ -191,16 +207,6 @@ func main() {
 
 	// Create webhook handler
 	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, chatClaims, msgRegistry, log)
-
-	// isLeader tracks whether this pod currently holds EventSub leadership.
-	// Protected by mu; read by subscription callback and HTTP handlers.
-	var isLeaderMu sync.RWMutex
-	isLeader := false
-	isLeaderFn := func() bool {
-		isLeaderMu.RLock()
-		defer isLeaderMu.RUnlock()
-		return isLeader
-	}
 
 	// Set up channel manager callback. Actions: "subscribe" creates the event subscriptions
 	// for every active channel; "subscribe_chat"/"unsubscribe_chat" manage the


### PR DESCRIPTION
## Problem

The EventSub chat-ownership claim (ADR-0015) — the Redis key that keeps a channel *off* IRC — was only refreshed **when a chat message was delivered** (`refreshChatClaim`, throttled 60s, 5-min TTL). That tied claim liveness to **chat volume**, not subscription health.

A low-traffic channel (e.g. `caesarlp`, ~9 messages over a 5-hour stream) goes longer than the 5-minute TTL between messages, so its claim lapses → the always-on IRC listener resumes the channel → the next EventSub message re-claims it → IRC parts again. This **flapping** is what surfaced the channel on the *Twitch IRC → EventSub Migration* dashboard's "unmigrated" panel, even though EventSub was carrying essentially all of its chat.

## Fix

Drive claim liveness off the chat-subscription state the manager already tracks (`ChatActive`):

- **`refreshClaims()`** renews the claim for every channel with a live chat subscription, on each 30s sync tick (≪ TTL). Leader-only.
- **`releaseClaim()`** drops the claim on chat-subscription teardown (demand lost / channel removed) so IRC resumes promptly instead of waiting out the TTL.
- Claim store + leader predicate wired into the manager; the leader gate is defined **before** `ll.Start` so a standby never writes claims during its initial sync.
- The webhook handler's on-delivery refresh is kept as a complementary fast-path.

## Tests

New `manager_claimrefresh_test.go`: leader keeps active-chat channels claimed (and skips inactive ones), standby writes nothing, teardown releases the claim. Full module `go build` / `go vet` / `go test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)