### PR TITLE
fix: emote delivery reliability (backend SWR + client pre-caching)

### DIFF
--- a/frontend/src/hooks/useOverlayStream.ts
+++ b/frontend/src/hooks/useOverlayStream.ts
@@ -39,6 +39,7 @@ import { sortMessageBadges } from '@/lib/badgeOrder'
 import { resolveTwitchBadgeIcons } from '@/lib/twitchBadges'
 import type { ChatMessage, DeletionMetadata, PlatformStatus } from '@/lib/types/message'
 import type { PublicOverlayConfig } from '@/lib/types/overlay'
+import { preloadOverlayEmotes } from '@/lib/utils/preloadEmotes'
 import {
   advanceWatermark,
   classifyEnvelope,
@@ -113,6 +114,10 @@ export function useOverlayStream(
   // drop instead of escalating from wherever the last burst left off.
   const attemptsRef = useRef(0)
 
+  // Whether we've already warmed the browser emote cache for this mount. Gated
+  // so the 30s config refresh doesn't re-trigger the preload burst.
+  const emotesPreloadedRef = useRef(false)
+
   // Keep callbacks fresh without re-subscribing the socket (mirrors the
   // filterSettingsRef/maxMessagesRef trick the overlay page used inline).
   const optsRef = useRef(options)
@@ -142,6 +147,20 @@ export function useOverlayStream(
             })
           })
           setSources(next)
+
+          // Warm the browser image cache with this overlay's emotes before the
+          // first chat message arrives, so emotes render instead of briefly
+          // flashing their text fallback. Fire-and-forget, once per mount.
+          if (!emotesPreloadedRef.current && data.sources.length > 0) {
+            emotesPreloadedRef.current = true
+            void preloadOverlayEmotes(
+              data.sources.map((source) => ({
+                platform: source.platform,
+                channelId: source.channel_id,
+              })),
+              { seventvSetId: data.seventv_emote_set_id }
+            )
+          }
         }
       } catch (error) {
         console.warn('[useOverlayStream] Failed to load config', error)

--- a/frontend/src/lib/utils/__tests__/preloadEmotes.test.ts
+++ b/frontend/src/lib/utils/__tests__/preloadEmotes.test.ts
@@ -1,0 +1,145 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { preloadOverlayEmotes } from '@/lib/utils/preloadEmotes'
+
+function mockFetch(byChannel: Record<string, { ok: boolean; emotes?: Array<{ url?: string }> }>) {
+  return vi.fn(async (input: string | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    // Path is /api/v1/emotes/channel/<channel>?...
+    const match = url.match(/\/emotes\/channel\/([^?]+)/)
+    const channel = match ? decodeURIComponent(match[1]) : ''
+    const entry = byChannel[channel]
+    if (!entry) return { ok: false, json: async () => ({}) } as Response
+    return {
+      ok: entry.ok,
+      json: async () => ({ emotes: entry.emotes ?? [] }),
+    } as Response
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('preloadOverlayEmotes', () => {
+  it('fetches each channel and starts an image load per distinct emote URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        '123': { ok: true, emotes: [{ url: 'https://cdn/a.webp' }, { url: 'https://cdn/b.webp' }] },
+        xyz: { ok: true, emotes: [{ url: 'https://cdn/c.webp' }] },
+      })
+    )
+    const loaded: string[] = []
+
+    const count = await preloadOverlayEmotes(
+      [
+        { platform: 'twitch', channelId: '123' },
+        { platform: 'kick', channelId: 'xyz' },
+      ],
+      { loadImage: (u) => loaded.push(u) }
+    )
+
+    expect(count).toBe(3)
+    expect(loaded.sort()).toEqual(['https://cdn/a.webp', 'https://cdn/b.webp', 'https://cdn/c.webp'])
+  })
+
+  it('deduplicates URLs shared across channels', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        a: { ok: true, emotes: [{ url: 'https://cdn/shared.webp' }] },
+        b: { ok: true, emotes: [{ url: 'https://cdn/shared.webp' }] },
+      })
+    )
+    const loaded: string[] = []
+
+    const count = await preloadOverlayEmotes(
+      [
+        { platform: 'twitch', channelId: 'a' },
+        { platform: 'twitch', channelId: 'b' },
+      ],
+      { loadImage: (u) => loaded.push(u) }
+    )
+
+    expect(count).toBe(1)
+    expect(loaded).toEqual(['https://cdn/shared.webp'])
+  })
+
+  it('passes platform and the 7TV override as query params', async () => {
+    const fetchSpy = mockFetch({ a: { ok: true, emotes: [] } })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await preloadOverlayEmotes([{ platform: 'youtube', channelId: 'a' }], {
+      seventvSetId: 'set-42',
+      loadImage: () => {},
+    })
+
+    const calledUrl = fetchSpy.mock.calls[0][0] as string
+    expect(calledUrl).toContain('platform=youtube')
+    expect(calledUrl).toContain('seventv_set_id=set-42')
+  })
+
+  it('honors the maxUrls cap', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({
+        a: {
+          ok: true,
+          emotes: [{ url: 'https://cdn/1' }, { url: 'https://cdn/2' }, { url: 'https://cdn/3' }],
+        },
+      })
+    )
+    let count = 0
+
+    const started = await preloadOverlayEmotes([{ platform: 'twitch', channelId: 'a' }], {
+      maxUrls: 2,
+      loadImage: () => {
+        count++
+      },
+    })
+
+    expect(started).toBe(2)
+    expect(count).toBe(2)
+  })
+
+  it('swallows fetch failures and skips channels without ids', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      })
+    )
+    const loaded: string[] = []
+
+    const count = await preloadOverlayEmotes(
+      [
+        { platform: 'twitch', channelId: '' },
+        { platform: 'twitch', channelId: 'a' },
+      ],
+      { loadImage: (u) => loaded.push(u) }
+    )
+
+    expect(count).toBe(0)
+    expect(loaded).toEqual([])
+  })
+})

--- a/frontend/src/lib/utils/preloadEmotes.ts
+++ b/frontend/src/lib/utils/preloadEmotes.ts
@@ -1,0 +1,124 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Browser-side emote pre-caching.
+ *
+ * Emote images are loaded lazily — the first chat message that uses an emote
+ * triggers the CDN fetch, and until it resolves the browser shows the alt/text
+ * fallback. This warms the browser image cache ahead of time: on overlay
+ * connect we fetch each source channel's emote set (the same `/emotes/channel`
+ * endpoint the message-processor enricher uses) and kick off hidden image loads
+ * for every emote URL, so by the time a message references one it's already
+ * decoded and cached. Complements the backend stale-while-revalidate cache —
+ * that keeps server-side emote metadata warm, this keeps the client warm.
+ *
+ * Best-effort throughout: any network/parse failure is swallowed so it can
+ * never affect rendering.
+ */
+
+/** Minimal source descriptor: enough to query the channel emote set. */
+export interface EmotePreloadSource {
+  platform: string
+  channelId: string
+}
+
+interface ChannelEmoteResponse {
+  emotes?: Array<{ url?: string }>
+}
+
+export interface PreloadEmotesOptions {
+  /** Per-overlay 7TV emote-set override, merged into every channel query so the
+   *  preloaded set matches what the enricher will attach to messages. */
+  seventvSetId?: string
+  /** Cap on the number of distinct image loads kicked off, to avoid hammering
+   *  the CDN when an overlay aggregates several large emote sets. */
+  maxUrls?: number
+  /** Injectable image loader, primarily for tests. Defaults to `new Image()`. */
+  loadImage?: (url: string) => void
+  signal?: AbortSignal
+}
+
+const DEFAULT_MAX_URLS = 400
+
+function defaultLoadImage(url: string): void {
+  // A detached Image whose src is set still populates the HTTP cache without
+  // ever entering the DOM, so it can't affect layout.
+  const img = new Image()
+  img.decoding = 'async'
+  img.src = url
+}
+
+/**
+ * Fetch the emote sets for the given source channels and warm the browser image
+ * cache by requesting each emote URL. Returns the number of image loads started
+ * (deduplicated across channels). Never throws.
+ */
+export async function preloadOverlayEmotes(
+  sources: EmotePreloadSource[],
+  options: PreloadEmotesOptions = {}
+): Promise<number> {
+  if (typeof window === 'undefined') return 0
+
+  const maxUrls = options.maxUrls ?? DEFAULT_MAX_URLS
+  const loadImage = options.loadImage ?? defaultLoadImage
+
+  // Deduplicate the channel queries (an overlay can list the same channel twice
+  // across platforms, and shared-overlay sources can repeat a channel id).
+  const seenChannels = new Set<string>()
+  const queries = sources.filter((s) => {
+    if (!s.channelId) return false
+    const key = `${s.platform}:${s.channelId}`
+    if (seenChannels.has(key)) return false
+    seenChannels.add(key)
+    return true
+  })
+
+  const urls = new Set<string>()
+
+  await Promise.all(
+    queries.map(async (q) => {
+      try {
+        const params = new URLSearchParams()
+        if (q.platform) params.set('platform', q.platform)
+        if (options.seventvSetId) params.set('seventv_set_id', options.seventvSetId)
+        const qs = params.toString()
+        const res = await fetch(
+          `/api/v1/emotes/channel/${encodeURIComponent(q.channelId)}${qs ? `?${qs}` : ''}`,
+          { signal: options.signal }
+        )
+        if (!res.ok) return
+        const data = (await res.json()) as ChannelEmoteResponse
+        for (const emote of data.emotes ?? []) {
+          if (emote.url) urls.add(emote.url)
+        }
+      } catch {
+        // Best-effort: a failed channel fetch just means those emotes load on
+        // demand as before.
+      }
+    })
+  )
+
+  let started = 0
+  for (const url of urls) {
+    if (started >= maxUrls) break
+    loadImage(url)
+    started++
+  }
+  return started
+}

--- a/services/api-gateway/models/service_config_test.go
+++ b/services/api-gateway/models/service_config_test.go
@@ -69,11 +69,12 @@ func TestNewServiceRegistry(t *testing.T) {
 			},
 			wantErr: false,
 			checkFunc: func(t *testing.T, sr *ServiceRegistry) {
-				assert.Len(t, sr.Services, 16) // 4 base + 6 admin + 4 share-service + 2 maintenance routes
+				assert.Len(t, sr.Services, 17) // 4 base + 6 admin + 4 share-service + 2 maintenance routes + 1 test-stream
 				assert.NotNil(t, sr.Services["auth-service"])
 				assert.NotNil(t, sr.Services["overlay-manager"])
 				assert.NotNil(t, sr.Services["youtube-resolver"])
 				assert.NotNil(t, sr.Services["emote-service"])
+				assert.NotNil(t, sr.Services["message-processor-test-stream"])
 				assert.NotNil(t, sr.Services["admin-users"])
 				assert.NotNil(t, sr.Services["admin-overlays"])
 				assert.NotNil(t, sr.Services["admin-sources"])

--- a/services/message-processor/cache/emote_cache.go
+++ b/services/message-processor/cache/emote_cache.go
@@ -31,7 +31,20 @@ import (
 // ErrCacheMiss indicates no cached emote entry was found for a channel.
 var ErrCacheMiss = errors.New("emote cache miss")
 
-const cacheNamespace = "mp:emotes:v2:"
+// Namespace is the Redis key prefix for cached emote entries. It is exported so
+// callers that build key patterns (e.g. for invalidation) stay in sync with the
+// cache implementation. The version suffix is bumped whenever the stored value
+// format changes; v3 introduced the freshness envelope (stale-while-revalidate).
+const Namespace = "mp:emotes:v3:"
+
+// userTTL is the freshness window for user-specific cache entries. User emote
+// sets change more often than channel sets, so they go stale sooner.
+const userTTL = 1 * time.Hour
+
+// defaultStaleGrace is how long an entry remains servable as "stale" past its
+// freshness window. During this window reads return the stale value immediately
+// and trigger a background refresh instead of blocking on the emote service.
+const defaultStaleGrace = 12 * time.Hour
 
 // CachedEmote stores the minimum metadata needed to reconstruct emote markup.
 type CachedEmote struct {
@@ -40,21 +53,37 @@ type CachedEmote struct {
 	Provider string `json:"provider"`
 }
 
+// Entry is the result of a cache lookup: the cached emotes plus whether the
+// entry is past its freshness window and should be refreshed in the background.
+type Entry struct {
+	Emotes []CachedEmote
+	Stale  bool
+}
+
+// envelope is the on-disk representation of a cache entry. The soft expiry lets
+// reads distinguish a fresh entry from a stale-but-servable one even though the
+// Redis key itself lives longer (soft TTL + stale grace).
+type envelope struct {
+	Emotes      []CachedEmote `json:"emotes"`
+	SoftExpires int64         `json:"soft_expires_unix"`
+}
+
 // Store defines the emote cache behaviour expected by consumers.
 type Store interface {
-	Get(ctx context.Context, channel string) ([]CachedEmote, error)
+	GetEntry(ctx context.Context, channel string) (Entry, error)
 	Set(ctx context.Context, channel string, emotes []CachedEmote) error
 	Delete(ctx context.Context, channel string) error
-	GetWithUser(ctx context.Context, channel, userID string) ([]CachedEmote, error)
+	GetEntryWithUser(ctx context.Context, channel, userID string) (Entry, error)
 	SetWithUser(ctx context.Context, channel, userID string, emotes []CachedEmote) error
 	DeletePattern(ctx context.Context, pattern string) error
 }
 
 type EmoteCache struct {
-	client *redis.Client
-	logger *zap.Logger
-	ttl    time.Duration
-	prefix string
+	client     *redis.Client
+	logger     *zap.Logger
+	ttl        time.Duration
+	staleGrace time.Duration
+	prefix     string
 }
 
 func NewEmoteCache(client *redis.Client, logger *zap.Logger, ttl time.Duration) *EmoteCache {
@@ -62,10 +91,11 @@ func NewEmoteCache(client *redis.Client, logger *zap.Logger, ttl time.Duration) 
 		ttl = 6 * time.Hour
 	}
 	return &EmoteCache{
-		client: client,
-		logger: logger.With(zap.String("component", "emote-cache")),
-		ttl:    ttl,
-		prefix: cacheNamespace,
+		client:     client,
+		logger:     logger.With(zap.String("component", "emote-cache")),
+		ttl:        ttl,
+		staleGrace: defaultStaleGrace,
+		prefix:     Namespace,
 	}
 }
 
@@ -76,7 +106,7 @@ func (c *EmoteCache) key(channel string) string {
 	}
 	prefix := c.prefix
 	if prefix == "" {
-		prefix = cacheNamespace
+		prefix = Namespace
 	}
 	return prefix + channel
 }
@@ -92,35 +122,53 @@ func (c *EmoteCache) keyWithUser(channel, userID string) string {
 	}
 	prefix := c.prefix
 	if prefix == "" {
-		prefix = cacheNamespace
+		prefix = Namespace
 	}
 	return fmt.Sprintf("%s%s:%s", prefix, channel, userID)
 }
 
-func (c *EmoteCache) Get(ctx context.Context, channel string) ([]CachedEmote, error) {
-	raw, err := c.client.Get(ctx, c.key(channel)).Bytes()
+// getEntry reads and decodes an entry for an already-built key, flagging it
+// stale when it has passed its soft expiry.
+func (c *EmoteCache) getEntry(ctx context.Context, key string) (Entry, error) {
+	raw, err := c.client.Get(ctx, key).Bytes()
 	if err != nil {
 		if err == redis.Nil {
-			return nil, ErrCacheMiss
+			return Entry{}, ErrCacheMiss
 		}
-		return nil, err
+		return Entry{}, err
 	}
-	var emotes []CachedEmote
-	if err := json.Unmarshal(raw, &emotes); err != nil {
-		return nil, fmt.Errorf("failed to decode cached emotes: %w", err)
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return Entry{}, fmt.Errorf("failed to decode cached emotes: %w", err)
 	}
-	return emotes, nil
+	stale := env.SoftExpires > 0 && time.Now().Unix() > env.SoftExpires
+	return Entry{Emotes: env.Emotes, Stale: stale}, nil
 }
 
-func (c *EmoteCache) Set(ctx context.Context, channel string, emotes []CachedEmote) error {
-	data, err := json.Marshal(emotes)
+// setEntry marshals emotes into an envelope with the given freshness window and
+// stores it under key with a hard TTL of softTTL + staleGrace, so the value
+// survives long enough to be served stale while a background refresh runs.
+func (c *EmoteCache) setEntry(ctx context.Context, key string, emotes []CachedEmote, softTTL time.Duration) error {
+	env := envelope{
+		Emotes:      emotes,
+		SoftExpires: time.Now().Add(softTTL).Unix(),
+	}
+	data, err := json.Marshal(env)
 	if err != nil {
 		return fmt.Errorf("failed to marshal emotes: %w", err)
 	}
-	if err := c.client.Set(ctx, c.key(channel), data, c.ttl).Err(); err != nil {
+	if err := c.client.Set(ctx, key, data, softTTL+c.staleGrace).Err(); err != nil {
 		return fmt.Errorf("failed to store emotes: %w", err)
 	}
 	return nil
+}
+
+func (c *EmoteCache) GetEntry(ctx context.Context, channel string) (Entry, error) {
+	return c.getEntry(ctx, c.key(channel))
+}
+
+func (c *EmoteCache) Set(ctx context.Context, channel string, emotes []CachedEmote) error {
+	return c.setEntry(ctx, c.key(channel), emotes, c.ttl)
 }
 
 func (c *EmoteCache) Delete(ctx context.Context, channel string) error {
@@ -130,32 +178,13 @@ func (c *EmoteCache) Delete(ctx context.Context, channel string) error {
 	return nil
 }
 
-func (c *EmoteCache) GetWithUser(ctx context.Context, channel, userID string) ([]CachedEmote, error) {
-	raw, err := c.client.Get(ctx, c.keyWithUser(channel, userID)).Bytes()
-	if err != nil {
-		if err == redis.Nil {
-			return nil, ErrCacheMiss
-		}
-		return nil, err
-	}
-	var emotes []CachedEmote
-	if err := json.Unmarshal(raw, &emotes); err != nil {
-		return nil, fmt.Errorf("failed to decode cached emotes: %w", err)
-	}
-	return emotes, nil
+func (c *EmoteCache) GetEntryWithUser(ctx context.Context, channel, userID string) (Entry, error) {
+	return c.getEntry(ctx, c.keyWithUser(channel, userID))
 }
 
 func (c *EmoteCache) SetWithUser(ctx context.Context, channel, userID string, emotes []CachedEmote) error {
-	data, err := json.Marshal(emotes)
-	if err != nil {
-		return fmt.Errorf("failed to marshal emotes: %w", err)
-	}
-	// Use shorter TTL for user-specific caches (1 hour instead of 6)
-	ttl := 1 * time.Hour
-	if err := c.client.Set(ctx, c.keyWithUser(channel, userID), data, ttl).Err(); err != nil {
-		return fmt.Errorf("failed to store emotes: %w", err)
-	}
-	return nil
+	// User-specific entries use a shorter freshness window than channel entries.
+	return c.setEntry(ctx, c.keyWithUser(channel, userID), emotes, userTTL)
 }
 
 func (c *EmoteCache) DeletePattern(ctx context.Context, pattern string) error {

--- a/services/message-processor/enricher/emote_enricher.go
+++ b/services/message-processor/enricher/emote_enricher.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/caesar/all-chat/services/message-processor/cache"
@@ -157,10 +158,13 @@ func (c *HTTPEmoteClient) GetEmotesForChannelWithUser(ctx context.Context, chann
 
 // Enricher enriches messages with third-party emotes
 type Enricher struct {
-	client          EmoteServiceClient
-	cache           cache.Store
+	client           EmoteServiceClient
+	cache            cache.Store
 	processorMetrics *metrics.ProcessorMetrics
-	logger          *zap.Logger
+	logger           *zap.Logger
+	// refreshing tracks cache keys with an in-flight background refresh so a burst
+	// of messages on a channel with a stale entry only triggers one re-fetch.
+	refreshing sync.Map
 }
 
 // NewEnricher creates a new emote enricher
@@ -274,50 +278,55 @@ func (e *Enricher) fetchEmotes(ctx context.Context, channel, platform, userID, t
 	// caches at its own layer.
 	useCache := seventvSetID == "" && e.cache != nil
 
-	// If user ID is provided, use user-specific cache
-	if userID != "" && useCache {
-		if cached, err := e.cache.GetWithUser(ctx, channel, userID); err == nil {
-			e.logger.Debug("Emote cache hit (with user)",
-				zap.String("channel", channel),
-				zap.String("user_id", userID),
-				zap.Int("count", len(cached)),
-			)
-			if e.processorMetrics != nil {
-				e.processorMetrics.RecordEmoteCacheOperation("message-processor", "hit", "all")
-			}
-			return cached, nil
-		} else if !errors.Is(err, cache.ErrCacheMiss) {
-			e.logger.Warn("Emote cache error",
-				zap.String("channel", channel),
-				zap.String("user_id", userID),
-				zap.Error(err),
-			)
+	if useCache {
+		var entry cache.Entry
+		var err error
+		if userID != "" {
+			entry, err = e.cache.GetEntryWithUser(ctx, channel, userID)
+		} else {
+			entry, err = e.cache.GetEntry(ctx, channel)
 		}
-	} else if useCache {
-		// No user ID, use regular cache
-		if cached, err := e.cache.Get(ctx, channel); err == nil {
+
+		switch {
+		case err == nil:
+			// Cache hit. Serve the entry immediately; if it's past its freshness
+			// window, refresh it in the background so the next message is fresh
+			// without ever blocking this one on the emote service.
 			e.logger.Debug("Emote cache hit",
 				zap.String("channel", channel),
-				zap.Int("count", len(cached)),
+				zap.String("user_id", userID),
+				zap.Int("count", len(entry.Emotes)),
+				zap.Bool("stale", entry.Stale),
 			)
 			if e.processorMetrics != nil {
 				e.processorMetrics.RecordEmoteCacheOperation("message-processor", "hit", "all")
 			}
-			return cached, nil
-		} else if !errors.Is(err, cache.ErrCacheMiss) {
+			if entry.Stale {
+				e.refreshAsync(channel, platform, userID, twitchChannel)
+			}
+			return entry.Emotes, nil
+		case !errors.Is(err, cache.ErrCacheMiss):
 			e.logger.Warn("Emote cache error",
 				zap.String("channel", channel),
+				zap.String("user_id", userID),
 				zap.Error(err),
 			)
 		}
 	}
 
-	// Cache miss — record and fetch from emote service
+	// True cache miss (no entry at all) — record and fetch from the emote service
+	// synchronously, since we have nothing to serve yet.
 	if e.processorMetrics != nil {
 		e.processorMetrics.RecordEmoteCacheOperation("message-processor", "miss", "all")
 	}
 
-	// Fetch from emote service
+	return e.fetchFromService(ctx, channel, platform, userID, twitchChannel, seventvSetID, useCache)
+}
+
+// fetchFromService fetches emotes from the emote service, records lookup metrics,
+// and (when writeCache is set) populates the cache. It is shared by the blocking
+// cache-miss path and the background stale-refresh path.
+func (e *Enricher) fetchFromService(ctx context.Context, channel, platform, userID, twitchChannel, seventvSetID string, writeCache bool) ([]cache.CachedEmote, error) {
 	var thirdPartyEmotes []EmoteServiceEmote
 	var err error
 
@@ -353,7 +362,7 @@ func (e *Enricher) fetchEmotes(ctx context.Context, channel, platform, userID, t
 	converted := convertToCached(thirdPartyEmotes)
 
 	// Store in cache (skip when an override is in play to avoid poisoning shared keys)
-	if useCache {
+	if writeCache {
 		if userID != "" {
 			if err := e.cache.SetWithUser(ctx, channel, userID, converted); err != nil {
 				e.logger.Warn("Failed to populate emote cache",
@@ -384,6 +393,40 @@ func (e *Enricher) fetchEmotes(ctx context.Context, channel, platform, userID, t
 	}
 
 	return converted, nil
+}
+
+// refreshAsync re-fetches emotes for a stale cache entry in the background and
+// repopulates the cache. It is rate-limited to one in-flight refresh per cache
+// key so a burst of messages doesn't stampede the emote service. The refresh
+// runs on a fresh context independent of any message so it can't be cancelled
+// by the message that triggered it returning.
+func (e *Enricher) refreshAsync(channel, platform, userID, twitchChannel string) {
+	key := channel + "\x00" + userID
+	if _, inFlight := e.refreshing.LoadOrStore(key, struct{}{}); inFlight {
+		return
+	}
+
+	go func() {
+		defer e.refreshing.Delete(key)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// seventvSetID is always empty here: stale-while-revalidate only runs for
+		// cacheable lookups, and per-overlay overrides bypass the cache entirely.
+		if _, err := e.fetchFromService(ctx, channel, platform, userID, twitchChannel, "", true); err != nil {
+			e.logger.Warn("Background emote cache refresh failed",
+				zap.String("channel", channel),
+				zap.String("user_id", userID),
+				zap.Error(err),
+			)
+		} else {
+			e.logger.Debug("Background emote cache refresh complete",
+				zap.String("channel", channel),
+				zap.String("user_id", userID),
+			)
+		}
+	}()
 }
 
 func convertToCached(emotes []EmoteServiceEmote) []cache.CachedEmote {

--- a/services/message-processor/enricher/emote_enricher_enrich_test.go
+++ b/services/message-processor/enricher/emote_enricher_enrich_test.go
@@ -18,7 +18,9 @@ package enricher
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/caesar/all-chat/services/message-processor/cache"
 	"github.com/caesar/all-chat/services/message-processor/models"
@@ -26,6 +28,7 @@ import (
 )
 
 type mockEmoteServiceClient struct {
+	mu          sync.Mutex
 	emotes      []EmoteServiceEmote
 	err         error
 	lastChannel string
@@ -33,8 +36,10 @@ type mockEmoteServiceClient struct {
 }
 
 func (m *mockEmoteServiceClient) GetEmotesForChannel(ctx context.Context, channelID string) ([]EmoteServiceEmote, error) {
+	m.mu.Lock()
 	m.lastChannel = channelID
 	m.calls++
+	m.mu.Unlock()
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -42,26 +47,41 @@ func (m *mockEmoteServiceClient) GetEmotesForChannel(ctx context.Context, channe
 }
 
 func (m *mockEmoteServiceClient) GetEmotesForChannelWithUser(ctx context.Context, channel, platform, userID, twitchChannel, seventvSetID string) ([]EmoteServiceEmote, error) {
+	m.mu.Lock()
 	m.lastChannel = channel
 	m.calls++
+	m.mu.Unlock()
 	if m.err != nil {
 		return nil, m.err
 	}
 	return m.emotes, nil
 }
 
+func (m *mockEmoteServiceClient) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
 type mockEmoteCacheStore struct {
+	mu       sync.Mutex
 	getData  []cache.CachedEmote
 	getErr   error
+	getStale bool
 	setCalls int
 	setData  []cache.CachedEmote
 }
 
-func (m *mockEmoteCacheStore) Get(ctx context.Context, channel string) ([]cache.CachedEmote, error) {
-	return m.getData, m.getErr
+func (m *mockEmoteCacheStore) GetEntry(ctx context.Context, channel string) (cache.Entry, error) {
+	if m.getErr != nil {
+		return cache.Entry{}, m.getErr
+	}
+	return cache.Entry{Emotes: m.getData, Stale: m.getStale}, nil
 }
 
 func (m *mockEmoteCacheStore) Set(ctx context.Context, channel string, emotes []cache.CachedEmote) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.setCalls++
 	m.setData = emotes
 	return nil
@@ -71,11 +91,16 @@ func (m *mockEmoteCacheStore) Delete(ctx context.Context, channel string) error 
 	return nil
 }
 
-func (m *mockEmoteCacheStore) GetWithUser(ctx context.Context, channel, userID string) ([]cache.CachedEmote, error) {
-	return m.getData, m.getErr
+func (m *mockEmoteCacheStore) GetEntryWithUser(ctx context.Context, channel, userID string) (cache.Entry, error) {
+	if m.getErr != nil {
+		return cache.Entry{}, m.getErr
+	}
+	return cache.Entry{Emotes: m.getData, Stale: m.getStale}, nil
 }
 
 func (m *mockEmoteCacheStore) SetWithUser(ctx context.Context, channel, userID string, emotes []cache.CachedEmote) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.setCalls++
 	m.setData = emotes
 	return nil
@@ -83,6 +108,12 @@ func (m *mockEmoteCacheStore) SetWithUser(ctx context.Context, channel, userID s
 
 func (m *mockEmoteCacheStore) DeletePattern(ctx context.Context, pattern string) error {
 	return nil
+}
+
+func (m *mockEmoteCacheStore) setCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.setCalls
 }
 
 func TestEnrichAddsEmotesForLaterOccurrences(t *testing.T) {
@@ -165,12 +196,77 @@ func TestFetchEmotesUsesCache(t *testing.T) {
 	if len(got) != 1 || got[0].Code != "LUL" {
 		t.Fatalf("unexpected cached result: %#v", got)
 	}
-	if client.calls != 0 {
-		t.Fatalf("expected cache hit to skip client call, got %d", client.calls)
+	if client.callCount() != 0 {
+		t.Fatalf("expected cache hit to skip client call, got %d", client.callCount())
 	}
-	if store.setCalls != 0 {
-		t.Fatalf("expected cache hit to skip set, got %d", store.setCalls)
+	if store.setCallCount() != 0 {
+		t.Fatalf("expected cache hit to skip set, got %d", store.setCallCount())
 	}
+}
+
+func TestFetchEmotesStaleServesImmediatelyAndRefreshes(t *testing.T) {
+	client := &mockEmoteServiceClient{
+		emotes: []EmoteServiceEmote{{Code: "KEKW", Provider: "7tv", URL: "https://example/fresh"}},
+	}
+	store := &mockEmoteCacheStore{
+		getData:  []cache.CachedEmote{{Code: "LUL", Provider: "twitch", URL: "https://example/stale"}},
+		getStale: true,
+	}
+
+	enricher := NewEnricher(client, store, zap.NewNop())
+	got, err := enricher.fetchEmotes(context.Background(), "123", "twitch", "", "", "")
+	if err != nil {
+		t.Fatalf("fetchEmotes returned error: %v", err)
+	}
+
+	// The stale entry is served immediately, without blocking on the client.
+	if len(got) != 1 || got[0].Code != "LUL" {
+		t.Fatalf("expected stale entry served immediately, got %#v", got)
+	}
+
+	// A background refresh should re-fetch from the service and repopulate the cache.
+	if !waitFor(func() bool { return client.callCount() == 1 && store.setCallCount() == 1 }) {
+		t.Fatalf("expected one background refresh fetch+set, got calls=%d sets=%d",
+			client.callCount(), store.setCallCount())
+	}
+}
+
+func TestFetchEmotesStaleRefreshIsRateLimited(t *testing.T) {
+	client := &mockEmoteServiceClient{
+		emotes: []EmoteServiceEmote{{Code: "KEKW", Provider: "7tv", URL: "https://example/fresh"}},
+	}
+	store := &mockEmoteCacheStore{
+		getData:  []cache.CachedEmote{{Code: "LUL", Provider: "twitch", URL: "https://example/stale"}},
+		getStale: true,
+	}
+
+	enricher := NewEnricher(client, store, zap.NewNop())
+
+	// Mark a refresh as already in flight for this key; a concurrent stale read
+	// must not kick off a second one.
+	enricher.refreshing.Store("123\x00", struct{}{})
+
+	if _, err := enricher.fetchEmotes(context.Background(), "123", "twitch", "", "", ""); err != nil {
+		t.Fatalf("fetchEmotes returned error: %v", err)
+	}
+
+	// Give any (incorrectly) spawned goroutine a chance to run.
+	time.Sleep(50 * time.Millisecond)
+	if client.callCount() != 0 {
+		t.Fatalf("expected in-flight refresh to suppress duplicate fetch, got %d", client.callCount())
+	}
+}
+
+// waitFor polls cond for up to a second, returning true once it holds.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
 }
 
 func TestFetchEmotesCachesAfterMiss(t *testing.T) {
@@ -189,11 +285,11 @@ func TestFetchEmotesCachesAfterMiss(t *testing.T) {
 	if len(got) != 1 || got[0].Code != "KEKW" {
 		t.Fatalf("unexpected fetched result: %#v", got)
 	}
-	if client.calls != 1 {
-		t.Fatalf("expected single client call, got %d", client.calls)
+	if client.callCount() != 1 {
+		t.Fatalf("expected single client call, got %d", client.callCount())
 	}
-	if store.setCalls != 1 {
-		t.Fatalf("expected cache set to be invoked once, got %d", store.setCalls)
+	if store.setCallCount() != 1 {
+		t.Fatalf("expected cache set to be invoked once, got %d", store.setCallCount())
 	}
 	if len(store.setData) != 1 || store.setData[0].Code != "KEKW" {
 		t.Fatalf("cache stored wrong data: %#v", store.setData)

--- a/services/message-processor/seventv/manager.go
+++ b/services/message-processor/seventv/manager.go
@@ -47,10 +47,10 @@ type UserResponse struct {
 
 // Manager manages 7TV event subscriptions and cache invalidation
 type Manager struct {
-	client      *Client
-	cache       cache.Store
-	logger      *zap.Logger
-	httpClient  *http.Client
+	client     *Client
+	cache      cache.Store
+	logger     *zap.Logger
+	httpClient *http.Client
 
 	// Map of channel ID -> emote set ID
 	channelEmoteSets map[string]string
@@ -316,7 +316,7 @@ func (m *Manager) handleEmoteSetUpdate(ctx context.Context, update *EmoteSetUpda
 	// Invalidate cache for all affected users
 	// Use pattern matching to delete all cache entries for this user (across all channels)
 	for _, userID := range usersToInvalidate {
-		pattern := fmt.Sprintf("mp:emotes:v2:*:%s", userID)
+		pattern := fmt.Sprintf("%s*:%s", cache.Namespace, userID)
 		if err := m.cache.DeletePattern(ctx, pattern); err != nil {
 			m.logger.Error("Failed to invalidate user emote cache",
 				zap.String("user_id", userID),


### PR DESCRIPTION
Addresses the "emotes fall back to text after up to a minute" / "first letter flash" cases from #447.

## What this does

### Backend: stale-while-revalidate emote cache (proposal #3 — primary fix)
The message-processor enricher used to block a message on a fresh emote-service fetch whenever a cache entry expired mid-stream, forwarding the message with no emote metadata if the fetch was slow. This was the real driver of the "up to a minute" text fallback.

- Cache entries now carry a soft expiry; the Redis key lives `softTTL + staleGrace` so a past-freshness entry stays readable instead of vanishing into a miss.
- On a stale hit the entry is served **immediately** and refreshed in a background goroutine — the triggering message never blocks.
- Background refresh runs on its own `context` (independent of the message) and is rate-limited to one in-flight refresh per cache key, so a message burst can't stampede the emote service.
- Only a true first miss (no entry at all) blocks.
- Cache namespace bumped `v2 → v3` (value format changed) and exported as `cache.Namespace`, replacing a duplicated hardcoded prefix in `seventv/manager.go`.

### Frontend: pre-cache overlay emotes on connect (proposal #4 — feasible variant)
Emote images load lazily, so the first message using an emote shows the text fallback until the CDN fetch resolves. `useOverlayStream` now warms the browser image cache on connect: it fetches each source channel's emote set (the same `/emotes/channel` endpoint the enricher uses) and kicks off hidden image loads for every emote URL. Best-effort, fire-and-forget, once per mount, deduped across channels, capped to avoid hammering the CDN. Covers both the live overlay and the `view` page.

## Not included (deliberately)
- **Proposal #1** (detach emote fetch from message context) — dropped. The premise (a short request deadline silently cancelling the fetch) doesn't hold: the consumer runs on `context.Background()` with no deadline, and the HTTP client already has its own 5s timeout.
- **Proposal #2** (cache warm-up on `TrackChannel`) — skipped. The consumer is single-threaded sequential over a shared Redis cache, so only the first message of a new channel is ever cold, and warm-up triggered by that same message can't help it. It also would have warmed the wrong key (Twitch login vs `twitch_room_id`).

## Testing
- New enricher tests: stale entry served immediately + background revalidate; in-flight refresh suppresses duplicates. Existing cache-hit/miss tests updated to the new interface.
- Full `message-processor` Go suite passes.
- New `preloadEmotes` util: 5 vitest cases (per-URL load, dedup, query params, cap, failure swallowing). `useOverlayStream` suite still green. `tsc` and `eslint` clean.

Refs #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)