### PR TITLE
fix(token-refresh-service): label revoked Twitch tokens as token_revoked, not other

### DIFF
--- a/services/token-refresh-service/refresher/categorize_test.go
+++ b/services/token-refresh-service/refresher/categorize_test.go
@@ -1,0 +1,86 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package refresher
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestCategorizeRefreshError_MatchesNonRetryable guards against the metric
+// category and the retry decision drifting apart. Every error that is treated as
+// non-retryable because the user's grant is gone must also be reported under the
+// "token_revoked" metric label — otherwise revocations hide in the "other" bucket
+// and never trip a dashboard/alert keyed on token_revoked.
+func TestCategorizeRefreshError_MatchesNonRetryable(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCat  string
+		wantPerm bool // expected isNonRetryableErrorString result
+	}{
+		{
+			// Twitch's revocation signal is this literal string, NOT invalid_grant.
+			name:     "twitch invalid refresh token",
+			err:      errors.New("non-retryable error: failed to refresh token: oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"status\":400,\"message\":\"Invalid refresh token\"}"),
+			wantCat:  "token_revoked",
+			wantPerm: true,
+		},
+		{
+			name:     "oauth invalid_grant",
+			err:      errors.New("oauth2: \"invalid_grant\""),
+			wantCat:  "token_revoked",
+			wantPerm: true,
+		},
+		{
+			name:     "access_denied",
+			err:      errors.New("oauth2: \"access_denied\""),
+			wantCat:  "token_revoked",
+			wantPerm: true,
+		},
+		{
+			name:     "invalid_client",
+			err:      errors.New("oauth2: \"invalid_client\""),
+			wantCat:  "invalid_client",
+			wantPerm: true,
+		},
+		{
+			name:     "network timeout is retryable",
+			err:      errors.New("connection timeout: upstream unreachable"),
+			wantCat:  "network_error",
+			wantPerm: false,
+		},
+		{
+			// Twitch transient error — retryable, lands in "other".
+			name:     "internal_failure is retryable",
+			err:      errors.New("failed to refresh token: oauth2: \"internal_failure\""),
+			wantCat:  "other",
+			wantPerm: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := categorizeRefreshError(tc.err); got != tc.wantCat {
+				t.Errorf("categorizeRefreshError() = %q, want %q", got, tc.wantCat)
+			}
+			if got := isNonRetryableErrorString(tc.err.Error()); got != tc.wantPerm {
+				t.Errorf("isNonRetryableErrorString() = %v, want %v", got, tc.wantPerm)
+			}
+		})
+	}
+}

--- a/services/token-refresh-service/refresher/manager.go
+++ b/services/token-refresh-service/refresher/manager.go
@@ -401,6 +401,40 @@ func (m *Manager) refreshWithRetry(ctx context.Context, provider oauth.OAuthProv
 	return nil, fmt.Errorf("refresh failed after %d attempts", m.retryAttempts)
 }
 
+// Non-retryable error classification. These substrings (matched case-insensitively)
+// indicate a permanently invalid token: retrying cannot help, the user must
+// re-authenticate. They are grouped by metric category so the retry decision
+// (isNonRetryableErrorString) and the error_type metric label (categorizeRefreshError)
+// are derived from a SINGLE source of truth and cannot drift apart — a past drift
+// silently filed every revoked Twitch token under "other" instead of "token_revoked".
+var (
+	// revokedTokenPatterns mean the user's grant is gone (revoked / expired / denied).
+	// Twitch signals this with the literal "invalid refresh token"; the OAuth2 spec
+	// uses "invalid_grant" / "access_denied".
+	revokedTokenPatterns = []string{
+		"invalid_grant",
+		"token_revoked",
+		"access_denied",
+		"invalid refresh token",
+	}
+	// invalidClientPatterns mean OUR client credentials/config are wrong, not the
+	// user's token. Still non-retryable, but operationally distinct.
+	invalidClientPatterns = []string{
+		"unauthorized_client",
+		"invalid_client",
+	}
+)
+
+// containsAny reports whether s contains any of the substrings in patterns.
+func containsAny(s string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // categorizeRefreshError classifies a refresh error into a label-safe category string
 func categorizeRefreshError(err error) string {
 	if err == nil {
@@ -408,9 +442,9 @@ func categorizeRefreshError(err error) string {
 	}
 	errStr := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(errStr, "invalid_grant") || strings.Contains(errStr, "token_revoked"):
+	case containsAny(errStr, revokedTokenPatterns):
 		return "token_revoked"
-	case strings.Contains(errStr, "unauthorized_client") || strings.Contains(errStr, "invalid_client"):
+	case containsAny(errStr, invalidClientPatterns):
 		return "invalid_client"
 	case strings.Contains(errStr, "network") || strings.Contains(errStr, "connection") || strings.Contains(errStr, "timeout"):
 		return "network_error"
@@ -428,25 +462,12 @@ func (m *Manager) isNonRetryableError(err error) bool {
 }
 
 // isNonRetryableErrorString is the pure-string form used both by isNonRetryableError
-// and by the permanent-failure marking path.
+// and by the permanent-failure marking path. An error is non-retryable when it
+// indicates either a revoked user grant or an invalid client — exactly the patterns
+// categorizeRefreshError reports as "token_revoked" / "invalid_client".
 func isNonRetryableErrorString(errStr string) bool {
 	lower := strings.ToLower(errStr)
-	// OAuth errors that indicate revoked/invalid tokens — these cannot be resolved
-	// by retrying; the user must re-authenticate.
-	nonRetryable := []string{
-		"invalid_grant",
-		"unauthorized_client",
-		"invalid_client",
-		"token_revoked",
-		"access_denied",
-		"invalid refresh token",
-	}
-	for _, pattern := range nonRetryable {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-	return false
+	return containsAny(lower, revokedTokenPatterns) || containsAny(lower, invalidClientPatterns)
 }
 
 // markTokenPermanentlyFailed pushes the token's expiry far into the future so


### PR DESCRIPTION
## Problem

Twitch signals a dead grant with the literal string `Invalid refresh token` (not the OAuth-standard `invalid_grant`), and `access_denied` was missing from `categorizeRefreshError`. Both fell through to `error_type="other"`, so **every revoked Twitch token was invisible** to dashboards/alerts keyed on `token_revoked`. Production metrics showed 8 such Twitch errors mislabeled as `other`.

## Root cause

`categorizeRefreshError` and `isNonRetryableErrorString` maintained two independent substring lists that had drifted apart.

## Fix

Both functions now derive from shared `revokedTokenPatterns` / `invalidClientPatterns` slices, so the retry decision and the metric label can never drift again. Refresh/suppress **behaviour is unchanged** — this is a metrics-label correction only.

Adds a white-box test (`categorize_test.go`) pinning the metric category to the non-retryable patterns; it failed on the `Invalid refresh token` and `access_denied` cases against the old code.

## Verification

- `go test ./...`, `go build ./...`, `go vet ./refresher/` all green.