### PR TITLE
fix(moderation): return to overlay monitor after enabling moderation

### DIFF
--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -79,20 +79,27 @@ function AuthCallbackContent() {
         const user = await authApi.getMe()
         setUser(user)
 
-        // Check for redirect_to parameter (used when adding sources via OAuth)
+        // Check for redirect_to parameter (used when adding sources / enabling
+        // moderation via OAuth). `moderation_enabled` marks an opt-in moderation
+        // re-consent (ADR-0017) that returns to the overlay monitor, not settings.
         const redirectTo = params.get('redirect_to')
         const sourceAdded = params.get('source_added')
+        const moderationEnabled = params.get('moderation_enabled')
 
-        // A `source_added` callback means an OAuth source-add completed rather than
-        // a fresh sign-in; track them as distinct funnel steps.
-        if (sourceAdded) {
+        // Distinct funnel steps: a completion marker means an OAuth source-add or
+        // moderation re-consent finished, rather than a fresh sign-in.
+        if (moderationEnabled) {
+          trackEvent('moderation_enabled', { via: 'oauth', platform: moderationEnabled })
+        } else if (sourceAdded) {
           trackEvent('source_added', { via: 'oauth' })
         } else {
           trackEvent('signin_completed', { platform: user.auth_provider ?? 'unknown' })
         }
 
         if (redirectTo) {
-          // Redirect to specific page (e.g., overlay page after adding source)
+          // Source-add returns to overlay settings with a confirmation marker; the
+          // moderation monitor reflects the new scope on its own capabilities fetch,
+          // so it just navigates back cleanly.
           const redirectURL = sourceAdded ? `${redirectTo}?source_added=${sourceAdded}` : redirectTo
           router.push(redirectURL)
         } else {

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -39,6 +39,7 @@ export type AnalyticsEvent =
   | 'overlay_created'
   | 'source_added'
   | 'source_add_failed'
+  | 'moderation_enabled'
   | 'obs_url_copied'
   // Feature adoption
   | 'theme_applied'

--- a/services/auth-service/handlers/platform_auth_v2.go
+++ b/services/auth-service/handlers/platform_auth_v2.go
@@ -406,7 +406,7 @@ func (h *PlatformAuthHandlerV2) HandleEnableModeration(platform oauth.Platform) 
 			return
 		}
 
-		oauthState := oauth.NewAddSourceState(csrfToken, overlayID, userIDStr)
+		oauthState := oauth.NewModerationState(csrfToken, overlayID, userIDStr)
 		if err := oauthState.Validate(); err != nil {
 			h.logger.Error("Invalid OAuth state", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -764,24 +764,33 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 					zap.String("overlay_id", oauthState.OverlayID),
 					zap.Error(err),
 				)
-				// Redirect with error
-				redirectURL := fmt.Sprintf("%s/overlays/%s?error=failed_to_add_source",
-					h.frontendURL,
-					oauthState.OverlayID,
-				)
-				h.redirectWithTombstone(c, platform, oauthState.CSRFToken, redirectURL)
+				// Redirect with error. Moderation re-consent returns to the overlay
+				// monitor it was launched from, not the overlay settings page.
+				errRedirect := fmt.Sprintf("%s/overlays/%s?error=failed_to_add_source", h.frontendURL, oauthState.OverlayID)
+				if oauthState.IsModeration() {
+					errRedirect = fmt.Sprintf("%s/overlay/%s/view?error=moderation_setup_failed", h.frontendURL, oauthState.OverlayID)
+				}
+				h.redirectWithTombstone(c, platform, oauthState.CSRFToken, errRedirect)
 				return
 			}
 
-			// Redirect through auth callback to preserve authentication, then to overlay page
-			// The frontend auth callback will store the JWT and then redirect to the overlay
-			redirectURL := fmt.Sprintf("%s/auth/callback#access_token=%s&refresh_token=%s&expires_in=%d&token_type=Bearer&redirect_to=/overlays/%s&source_added=%s",
+			// Redirect through auth callback to preserve authentication, then to the
+			// originating page. Moderation re-consent returns to the overlay monitor
+			// (/overlay/{id}/view) where the streamer enabled it; a real source-add
+			// returns to overlay settings (ADR-0017).
+			redirectTo := fmt.Sprintf("/overlays/%s", oauthState.OverlayID)
+			completionMarker := fmt.Sprintf("source_added=%s", platform)
+			if oauthState.IsModeration() {
+				redirectTo = fmt.Sprintf("/overlay/%s/view", oauthState.OverlayID)
+				completionMarker = fmt.Sprintf("moderation_enabled=%s", platform)
+			}
+			redirectURL := fmt.Sprintf("%s/auth/callback#access_token=%s&refresh_token=%s&expires_in=%d&token_type=Bearer&redirect_to=%s&%s",
 				h.frontendURL,
 				jwtToken,
 				token.RefreshToken,
 				int64(h.jwtExpiry.Seconds()),
-				oauthState.OverlayID,
-				platform,
+				redirectTo,
+				completionMarker,
 			)
 
 			h.logger.Info("Source added successfully via OAuth",

--- a/services/auth-service/oauth/state.go
+++ b/services/auth-service/oauth/state.go
@@ -31,12 +31,19 @@ const (
 	ActionAddSource OAuthAction = "add_source"
 )
 
+// PurposeModeration marks an add-source flow that is really an opt-in moderation
+// re-consent (ADR-0017). It reuses the add-source action so the callback runs the
+// same token/scope persistence, but the marker lets the callback return the user to
+// the overlay monitor (/overlay/{id}/view) instead of the overlay settings page.
+const PurposeModeration = "moderation"
+
 // OAuthState represents the state parameter for OAuth flow
 type OAuthState struct {
 	CSRFToken string      `json:"csrf_token"` // Random string for CSRF protection
 	OverlayID string      `json:"overlay_id,omitempty"` // Target overlay for source addition
 	UserID    string      `json:"user_id,omitempty"` // Current user ID for account linking
 	Action    OAuthAction `json:"action"` // Action to take after callback
+	Purpose   string      `json:"purpose,omitempty"` // Sub-flow marker (e.g. moderation re-consent)
 }
 
 // NewLoginState creates a new state for login flow
@@ -55,6 +62,21 @@ func NewAddSourceState(csrfToken, overlayID, userID string) *OAuthState {
 		UserID:    userID,
 		Action:    ActionAddSource,
 	}
+}
+
+// NewModerationState creates a state for the opt-in moderation re-consent flow
+// (ADR-0017). It is an add-source state — so the shared callback persists the new
+// token/scopes and overlay link unchanged — tagged with PurposeModeration so the
+// callback returns the user to the overlay monitor rather than overlay settings.
+func NewModerationState(csrfToken, overlayID, userID string) *OAuthState {
+	s := NewAddSourceState(csrfToken, overlayID, userID)
+	s.Purpose = PurposeModeration
+	return s
+}
+
+// IsModeration reports whether this state is an opt-in moderation re-consent flow.
+func (s *OAuthState) IsModeration() bool {
+	return s.Purpose == PurposeModeration
 }
 
 // Encode serializes the state to JSON string

--- a/services/auth-service/oauth/state_test.go
+++ b/services/auth-service/oauth/state_test.go
@@ -51,6 +51,54 @@ func TestNewAddSourceState(t *testing.T) {
 	}
 }
 
+func TestNewModerationState(t *testing.T) {
+	state := NewModerationState("test-csrf-token", "overlay-123", "user-456")
+
+	// Moderation re-consent reuses the add-source action so the callback runs the
+	// same token/scope persistence; only the Purpose marker differs (ADR-0017).
+	if state.Action != ActionAddSource {
+		t.Errorf("Expected Action to be ActionAddSource (reuses add-source persistence), got '%s'", state.Action)
+	}
+	if !state.IsAddSource() {
+		t.Error("Expected IsAddSource() to be true for a moderation state")
+	}
+	if !state.IsModeration() {
+		t.Error("Expected IsModeration() to be true for a moderation state")
+	}
+	if state.OverlayID != "overlay-123" {
+		t.Errorf("Expected OverlayID to be 'overlay-123', got '%s'", state.OverlayID)
+	}
+	if state.UserID != "user-456" {
+		t.Errorf("Expected UserID to be 'user-456', got '%s'", state.UserID)
+	}
+	if err := state.Validate(); err != nil {
+		t.Errorf("Expected moderation state to validate, got %v", err)
+	}
+}
+
+func TestOAuthState_IsModeration(t *testing.T) {
+	if NewAddSourceState("csrf", "overlay-123", "user-456").IsModeration() {
+		t.Error("Expected a plain add-source state to NOT be a moderation state")
+	}
+	if NewLoginState("csrf").IsModeration() {
+		t.Error("Expected a login state to NOT be a moderation state")
+	}
+}
+
+func TestModerationState_RoundTripPreservesPurpose(t *testing.T) {
+	encoded, err := NewModerationState("csrf", "overlay-123", "user-456").Encode()
+	if err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	decoded, err := DecodeOAuthState(encoded)
+	if err != nil {
+		t.Fatalf("DecodeOAuthState() error = %v", err)
+	}
+	if !decoded.IsModeration() {
+		t.Errorf("Expected decoded state to remain a moderation state, got purpose %q", decoded.Purpose)
+	}
+}
+
 func TestOAuthState_Encode(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Problem
Clicking **Enable moderation** on the overlay monitor (`/overlay/{id}/view`) and completing OAuth consent dropped the streamer on the overlay **settings** page (`/overlays/{id}`) instead of returning them to the monitor where they started.

## Root cause
The opt-in moderation re-consent (ADR-0017) reuses the add-source OAuth state (`NewAddSourceState`) so the shared callback persists the new token/scopes unchanged. But that also made the callback take the add-source redirect → `redirect_to=/overlays/{id}`.

## Fix
- Add a `Purpose=moderation` marker to the OAuth state (still `Action=add_source`, so persistence is untouched).
- Branch the callback: moderation re-consent returns to `/overlay/{id}/view` with a `moderation_enabled` marker (success **and** error paths); plain source-add is unchanged.
- Frontend `/auth/callback` recognizes `moderation_enabled` (new analytics event) and navigates back to the monitor; its capabilities fetch then reflects the granted scope and shows the live mod controls.

## Tests
- New `oauth` unit tests: `NewModerationState`, `IsModeration`, encode/decode round-trip.
- `go test ./oauth/ ./handlers/` green; frontend `tsc`/eslint/vitest green.

## Verification
Manual Playwright run after deploy: enable moderation on the monitor, complete consent, confirm landing back on `/overlay/{id}/view` with controls active. (Full E2E isn't automatable — it requires live Twitch/YouTube OAuth consent.)