### PR TITLE
fix(twitch-eventsub): show prediction badges on overlays

### DIFF
--- a/services/twitch-eventsub-listener/webhooks/handler.go
+++ b/services/twitch-eventsub-listener/webhooks/handler.go
@@ -924,10 +924,11 @@ func buildChatTags(e *eventsub.ChatMessageEvent) map[string]string {
 	// Boolean flags are derived from badges (EventSub has no separate sub/mod/turbo fields).
 	tags["subscriber"], tags["mod"], tags["turbo"] = "0", "0", "0"
 	if len(e.Badges) > 0 {
-		// "set_id/id,set_id/id" — EventSub's badge id IS the version the badge enricher expects.
+		// "set_id/id,set_id/id" — for most sets EventSub's badge id IS the version the
+		// badge enricher expects, but predictions are special (see badgeTagVersion).
 		parts := make([]string, 0, len(e.Badges))
 		for _, b := range e.Badges {
-			parts = append(parts, b.SetID+"/"+b.ID)
+			parts = append(parts, b.SetID+"/"+badgeTagVersion(b))
 			switch b.SetID {
 			case "subscriber":
 				tags["subscriber"] = "1"
@@ -978,13 +979,48 @@ func buildChatTags(e *eventsub.ChatMessageEvent) map[string]string {
 		if len(e.SourceBadges) > 0 {
 			parts := make([]string, 0, len(e.SourceBadges))
 			for _, b := range e.SourceBadges {
-				parts = append(parts, b.SetID+"/"+b.ID)
+				parts = append(parts, b.SetID+"/"+badgeTagVersion(b))
 			}
 			tags["source-badges"] = strings.Join(parts, ",")
 		}
 	}
 
 	return tags
+}
+
+// badgeTagVersion returns the badge version to put in the IRC-style "badges" tag.
+// For most sets EventSub's badge id already equals the version the badge enricher
+// looks up. The "predictions" set is the exception: EventSub sends the numeric
+// outcome index (e.g. "0", "1") rather than the color-coded version that the badge
+// image API keys on ("blue-1", "pink-2", ...), so the index can never be resolved
+// to an icon and the badge silently vanishes from overlays. IRC always delivered
+// the color version directly; this restores parity by translating the index.
+func badgeTagVersion(b eventsub.ChatBadge) string {
+	if b.SetID == "predictions" {
+		return predictionBadgeVersion(b.ID)
+	}
+	return b.ID
+}
+
+// predictionBadgeVersion maps an EventSub prediction outcome index to the
+// color-coded badge version Twitch uses for the image CDN. It follows Twitch's
+// two-outcome convention (outcome 0 = "blue-1", outcome 1 = "pink-2"); predictions
+// with additional outcomes use "blue-N" (badge set: blue-1..blue-10). The outcome
+// count is not present on the chat message, so a multi-outcome prediction's second
+// outcome (index 1) renders as "pink-2" rather than "blue-2" — a rare cosmetic
+// edge case that still shows a badge instead of none. Unknown ids pass through.
+func predictionBadgeVersion(id string) string {
+	switch id {
+	case "0":
+		return "blue-1"
+	case "1":
+		return "pink-2"
+	default:
+		if n, err := strconv.Atoi(id); err == nil && n >= 2 && n <= 9 {
+			return fmt.Sprintf("blue-%d", n+1)
+		}
+		return id
+	}
 }
 
 // buildEmotesTag renders the IRC "emotes" tag ("id:start-end,start-end/id:...") from the

--- a/services/twitch-eventsub-listener/webhooks/handler_chat_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_chat_test.go
@@ -185,6 +185,53 @@ func TestBuildChatTags_SharedChat(t *testing.T) {
 	}
 }
 
+// TestBuildChatTags_PredictionBadgeIndexTranslatedToColor verifies that the
+// EventSub-only "predictions" badge id (a numeric outcome index) is translated
+// into the color-coded version Twitch's badge image API uses (e.g. "blue-1",
+// "pink-2"). Without this, the badge enricher cannot resolve an icon URL and the
+// prediction badge silently disappears from overlays.
+func TestBuildChatTags_PredictionBadgeIndexTranslatedToColor(t *testing.T) {
+	cases := []struct {
+		id   string
+		want string
+	}{
+		{"0", "blue-1"},  // first outcome (Blue) in the common two-outcome prediction
+		{"1", "pink-2"},  // second outcome (Pink) in the common two-outcome prediction
+		{"2", "blue-3"},  // additional multi-outcome outcomes use blue-N
+		{"9", "blue-10"}, // tenth (max) outcome
+	}
+	for _, tc := range cases {
+		event := &eventsub.ChatMessageEvent{
+			BroadcasterUserID: "12345",
+			MessageID:         "msg-pred",
+			ChatterUserLogin:  "viewer",
+			Message:           eventsub.ChatMessageBody{Text: "hi"},
+			Badges:            []eventsub.ChatBadge{{SetID: "predictions", ID: tc.id, Info: "outcome title"}},
+		}
+		want := "predictions/" + tc.want
+		if got := buildChatTags(event)["badges"]; got != want {
+			t.Errorf("prediction id %q: badges tag = %q, want %q", tc.id, got, want)
+		}
+	}
+}
+
+// TestBuildChatTags_PredictionBadgeInSharedChat verifies the same translation is
+// applied to source badges on shared-chat messages.
+func TestBuildChatTags_PredictionBadgeInSharedChat(t *testing.T) {
+	tags := buildChatTags(&eventsub.ChatMessageEvent{
+		BroadcasterUserID:       "1",
+		MessageID:               "m",
+		ChatterUserLogin:        "v",
+		Message:                 eventsub.ChatMessageBody{Text: "hi"},
+		SourceBroadcasterUserID: "999",
+		SourceMessageID:         "src-msg",
+		SourceBadges:            []eventsub.ChatBadge{{SetID: "predictions", ID: "1", Info: "outcome title"}},
+	})
+	if got := tags["source-badges"]; got != "predictions/pink-2" {
+		t.Errorf("source-badges = %q, want %q", got, "predictions/pink-2")
+	}
+}
+
 func TestConditionBroadcasterID(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Problem

Twitch prediction badges never appeared on overlays. Confirmed live on channel `blvtumi` (active prediction): the badge enricher logged `"Some badges could not be enriched" missing=["predictions/0"]` continuously.

## Root cause

EventSub `channel.chat.message` delivers the `predictions` badge `id` as a **numeric outcome index** (`0`, `1`, …) — verified in the raw Redis `chat:raw` stream (`predictions/0` for every predicting user). Twitch's badge-image API, however, keys prediction versions by **color code** (`blue-1`, `pink-2`, `gray-1`, … — verified against the live global badge set). There is no version `0`.

`buildChatTags` assumed "EventSub's badge id IS the version the enricher expects", which is true for most sets but not predictions. So it emitted `predictions/0`, the enricher/overlay could never resolve an `icon_url`, and `ChatRow` renders `null` for badges without an icon → the prediction badge silently vanished.

This is an IRC-vs-EventSub difference: the legacy IRC `badges` tag already carried the color code; EventSub sends the raw index only for predictions.

## Fix

Translate the prediction outcome index to Twitch's color version when building the `badges` / `source-badges` tags, restoring IRC parity:

- `0` → `blue-1`, `1` → `pink-2` (the common two-outcome convention)
- `2`..`9` → `blue-3`..`blue-10` (additional multi-outcome outcomes)

The outcome count isn't present on the chat message, so a multi-outcome prediction's *second* outcome (index 1) renders as `pink-2` rather than `blue-2` — a rare cosmetic edge case that still shows a badge instead of none. Documented in the helper.

## Tests

TDD: added `TestBuildChatTags_PredictionBadgeIndexTranslatedToColor` and `TestBuildChatTags_PredictionBadgeInSharedChat` (red → green). Full service suite passes.