### PR TITLE
feat: nudge IRC-only Twitch channels to migrate to EventSub

### DIFF
--- a/docs/adr/0015-eventsub-chat-ownership-claim.md
+++ b/docs/adr/0015-eventsub-chat-ownership-claim.md
@@ -145,6 +145,26 @@ discipline the previous byte-identical SQL predicate aimed for.
   total-outage case is bounded by this).
 - **Timeline**: 2026-06-03.
 
+## Migration UX (2026-06-20 addendum)
+
+The claim mechanism makes the partition *safe*, but a channel only leaves IRC once its owner has
+granted the chat scopes (`user:read:chat` + `user:bot` + `channel:bot`). Channels added before the
+chat-scope consent flow existed never re-consented, so the majority of registered Twitch channels
+remained on IRC — which matters because IRC's shared bot is capped (~100 channels) and silently
+drops the overflow once more than that are live at once. The migration is therefore driven from the
+product UI, not automatically:
+
+- `overlay-manager` exposes two per-source booleans on `GET /api/v1/overlays/:id/sources`:
+  `chat_via_eventsub` (any owner consent satisfies the partition predicate) and `is_own_channel`
+  (the *requesting* user owns this channel and can re-consent — computed for both Twitch-login and
+  ADR-0016 linked-credential owners via `ListByOverlayIDForUser`).
+- The frontend surfaces a dismissible dashboard banner plus a per-source CTA for sources where
+  `is_own_channel && !chat_via_eventsub`, linking the existing add-source re-consent reflow
+  (`auth-service` `GetAuthURLWithChatScopes`, `force_verify=true`). One re-consent migrates all of
+  that account's own-channel sources on the next sync.
+
+This is UX layered on the existing partition; it does not change the claim/fallback mechanism above.
+
 ## Related Decisions
 
 - ADR-0014 (Demand linger) — the demand window during which a chat sub exists; this ADR makes the

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -33,6 +33,7 @@ import { Dialog } from '@/components/ui/dialog'
 import { PlatformBadge } from '@/components/ui/badge'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { MaintenanceBanner } from '@/components/MaintenanceBanner'
+import { EventSubMigrationBanner } from '@/components/EventSubMigrationBanner'
 import type { ChatSource } from '@/lib/types/overlay'
 
 // Extended overlay type that includes sources when available
@@ -216,8 +217,9 @@ function DashboardContent() {
     <div className="min-h-screen bg-bg">
       <AppNav />
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <div className="mb-4">
+        <div className="mb-4 space-y-4">
           <MaintenanceBanner />
+          <EventSubMigrationBanner sourcesByOverlay={sourcesByOverlay} />
         </div>
         <div className="mb-8 flex items-center justify-between">
           <h1 className="text-2xl font-bold text-text">Overlays</h1>

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -2433,9 +2433,13 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                             setStreamSelectExpandedSourceId((prev) => (prev === s.id ? null : s.id))
                           }
                           isOwnChannel={
-                            user?.auth_provider === 'twitch' &&
-                            !!user?.username &&
-                            user.username.toLowerCase() === source.channel_id.toLowerCase()
+                            // Prefer the server-computed flag (covers linked/non-Twitch-login
+                            // owners per ADR-0016); fall back to the username heuristic only if
+                            // the field is absent (older API responses).
+                            source.is_own_channel ??
+                            (user?.auth_provider === 'twitch' &&
+                              !!user?.username &&
+                              user.username.toLowerCase() === source.channel_id.toLowerCase())
                           }
                           onReconnectChat={handleReconnectTwitchChat}
                         />

--- a/frontend/src/components/EventSubMigrationBanner.tsx
+++ b/frontend/src/components/EventSubMigrationBanner.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react'
+import { Radio, X } from 'lucide-react'
+import { useAuthStore } from '@/lib/stores/auth-store'
+import type { ChatSource } from '@/lib/types/overlay'
+
+const DISMISS_KEY = 'eventsub-migration-banner-dismissed'
+
+export interface MigratableChannel {
+  channelId: string
+  /** An overlay containing this source — used to start the per-channel re-consent reflow. */
+  overlayId: string
+}
+
+/**
+ * getMigratableChannels returns the distinct Twitch channels the requesting user owns that
+ * still read chat via the legacy IRC path (is_own_channel && !chat_via_eventsub). Each is
+ * paired with one overlay id usable to start the add-source re-consent reflow. A single
+ * re-consent grants the chat scopes for the user's whole Twitch account, so migrating any
+ * one entry migrates all of that account's own-channel sources.
+ */
+export function getMigratableChannels(
+  sourcesByOverlay: Record<string, ChatSource[]>
+): MigratableChannel[] {
+  const byChannel = new Map<string, MigratableChannel>()
+  for (const [overlayId, sources] of Object.entries(sourcesByOverlay)) {
+    for (const source of sources) {
+      if (source.platform === 'twitch' && source.is_own_channel && !source.chat_via_eventsub) {
+        const key = source.channel_id.toLowerCase()
+        if (!byChannel.has(key)) {
+          byChannel.set(key, { channelId: source.channel_id, overlayId })
+        }
+      }
+    }
+  }
+  return Array.from(byChannel.values())
+}
+
+/**
+ * EventSubMigrationBanner nudges streamers whose own Twitch channel still reads chat over the
+ * legacy IRC connection to re-consent and move to EventSub. IRC is capped (~100 channels) and
+ * silently drops the overflow once that many streams are live, so the migration prevents
+ * message loss. Dismissible (non-blocking) per the chosen informative tone.
+ */
+export function EventSubMigrationBanner({
+  sourcesByOverlay,
+}: {
+  sourcesByOverlay: Record<string, ChatSource[]>
+}) {
+  const { token } = useAuthStore()
+  const [dismissed, setDismissed] = useState(
+    () => typeof window !== 'undefined' && window.localStorage.getItem(DISMISS_KEY) === '1'
+  )
+
+  const channels = getMigratableChannels(sourcesByOverlay)
+  if (dismissed || channels.length === 0) return null
+
+  async function handleUpgrade() {
+    try {
+      const res = await fetch(`/api/v1/auth/twitch/add-source/${channels[0].overlayId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      const data = await res.json()
+      if (data.auth_url) {
+        window.location.href = data.auth_url
+      } else {
+        console.error('No auth_url returned for Twitch chat upgrade', data)
+      }
+    } catch (err) {
+      console.error('Failed to start Twitch chat upgrade', err)
+    }
+  }
+
+  function handleDismiss() {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(DISMISS_KEY, '1')
+    }
+    setDismissed(true)
+  }
+
+  const count = channels.length
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-twitch/30 bg-twitch/10 px-4 py-3 text-sm text-text"
+    >
+      <Radio className="mt-0.5 size-4 shrink-0 text-twitch" aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">
+          {count === 1
+            ? 'Your Twitch chat uses the legacy connection'
+            : `${count} of your Twitch channels use the legacy connection`}
+        </p>
+        <p className="mt-0.5 text-text-sub">
+          The old IRC chat connection is being retired and can drop messages when many streams
+          are live. Reconnect to move to the new connection and keep your chat reliable.
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          onClick={handleUpgrade}
+          className="rounded-md bg-twitch px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+        >
+          Reconnect now
+        </button>
+        <button
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="rounded p-0.5 text-text-sub opacity-60 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-current focus-visible:outline-none"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/__tests__/EventSubMigrationBanner.test.tsx
+++ b/frontend/src/components/__tests__/EventSubMigrationBanner.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  EventSubMigrationBanner,
+  getMigratableChannels,
+} from '@/components/EventSubMigrationBanner'
+import type { ChatSource } from '@/lib/types/overlay'
+
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: () => ({ token: 'test-token' }),
+}))
+
+// jsdom in this project does not ship a working localStorage; stub one.
+function stubLocalStorage() {
+  const store: Record<string, string> = {}
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v
+    },
+    removeItem: (k: string) => {
+      delete store[k]
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k])
+    },
+  })
+}
+
+function src(overrides: Partial<ChatSource>): ChatSource {
+  return {
+    id: Math.random().toString(36),
+    overlay_id: 'o1',
+    platform: 'twitch',
+    channel_id: 'caesarlp',
+    created_at: '',
+    updated_at: '',
+    is_active: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => stubLocalStorage())
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('getMigratableChannels', () => {
+  it('includes only owned twitch channels still on IRC', () => {
+    const result = getMigratableChannels({
+      o1: [
+        src({ channel_id: 'mine', is_own_channel: true, chat_via_eventsub: false }), // migratable
+        src({ channel_id: 'already', is_own_channel: true, chat_via_eventsub: true }), // already on eventsub
+        src({ channel_id: 'notmine', is_own_channel: false, chat_via_eventsub: false }), // not owned
+        src({ channel_id: 'yt', platform: 'youtube', is_own_channel: true }), // not twitch
+      ],
+    })
+    expect(result.map((c) => c.channelId)).toEqual(['mine'])
+    expect(result[0].overlayId).toBe('o1')
+  })
+
+  it('dedupes the same channel across overlays', () => {
+    const result = getMigratableChannels({
+      o1: [src({ channel_id: 'Mine', is_own_channel: true, chat_via_eventsub: false })],
+      o2: [src({ channel_id: 'mine', is_own_channel: true, chat_via_eventsub: false })],
+    })
+    expect(result).toHaveLength(1)
+  })
+})
+
+describe('EventSubMigrationBanner', () => {
+  it('renders nothing when no owned IRC channels exist', () => {
+    const { container } = render(
+      <EventSubMigrationBanner
+        sourcesByOverlay={{
+          o1: [src({ is_own_channel: true, chat_via_eventsub: true })],
+        }}
+      />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a nudge when an owned channel is still on IRC', () => {
+    render(
+      <EventSubMigrationBanner
+        sourcesByOverlay={{ o1: [src({ is_own_channel: true, chat_via_eventsub: false })] }}
+      />
+    )
+    expect(screen.getByText(/legacy connection/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /reconnect now/i })).toBeInTheDocument()
+  })
+
+  it('starts the add-source reflow on reconnect', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ auth_url: 'https://id.twitch.tv/oauth' }), { status: 200 })
+      )
+    render(
+      <EventSubMigrationBanner
+        sourcesByOverlay={{ o9: [src({ is_own_channel: true, chat_via_eventsub: false })] }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /reconnect now/i }))
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/auth/twitch/add-source/o9',
+        expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } })
+      )
+    )
+  })
+
+  it('stays dismissed after the dismiss button is clicked', () => {
+    const { container, rerender } = render(
+      <EventSubMigrationBanner
+        sourcesByOverlay={{ o1: [src({ is_own_channel: true, chat_via_eventsub: false })] }}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(container).toBeEmptyDOMElement()
+    expect(window.localStorage.getItem('eventsub-migration-banner-dismissed')).toBe('1')
+
+    // A fresh mount honors the persisted dismissal.
+    rerender(
+      <EventSubMigrationBanner
+        sourcesByOverlay={{ o1: [src({ is_own_channel: true, chat_via_eventsub: false })] }}
+      />
+    )
+    expect(screen.queryByText(/legacy connection/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/lib/types/overlay.ts
+++ b/frontend/src/lib/types/overlay.ts
@@ -204,6 +204,10 @@ export interface ChatSource {
   /** Twitch only: true when the channel owner granted user:read:chat, so chat is read via
    *  EventSub instead of IRC. Computed server-side on the overlay source list. */
   chat_via_eventsub?: boolean
+  /** Twitch only: true when the requesting user owns this channel and can re-consent to
+   *  enable EventSub chat (Twitch-login or linked credentials). Computed server-side per
+   *  requester; drives the IRC→EventSub migration nudge. */
+  is_own_channel?: boolean
 }
 
 export type StreamSelectionStrategy =

--- a/services/overlay-manager/README.md
+++ b/services/overlay-manager/README.md
@@ -176,6 +176,10 @@ Body: {
 # List sources for overlay
 GET /api/v1/overlays/:overlay_id/sources
 Authorization: Bearer <jwt-token>
+# Each Twitch source carries two computed booleans used by the IRC→EventSub migration UI:
+#   chat_via_eventsub — channel owner granted chat scopes, so chat is read via EventSub (else IRC)
+#   is_own_channel    — the requesting user owns this channel and can re-consent to migrate it
+#                       (true for Twitch-login owners and ADR-0016 linked-credential owners)
 
 # Activate/deactivate source
 PATCH /api/v1/overlays/:overlay_id/sources/:source_id

--- a/services/overlay-manager/handlers/sources.go
+++ b/services/overlay-manager/handlers/sources.go
@@ -37,6 +37,7 @@ type SourceRepository interface {
 	Create(ctx context.Context, source *models.ChatSource) error
 	CreateOrUpdateAuto(ctx context.Context, source *models.ChatSource) error
 	ListByOverlayID(ctx context.Context, overlayID string) ([]*models.ChatSource, error)
+	ListByOverlayIDForUser(ctx context.Context, overlayID, requestingUserID string) ([]*models.ChatSource, error)
 	GetByID(ctx context.Context, id string) (*models.ChatSource, error)
 	Delete(ctx context.Context, id string) error
 	UpdateConfig(ctx context.Context, id string, config map[string]interface{}) error
@@ -319,8 +320,9 @@ func (h *SourcesHandler) HandleListSources(c *gin.Context) {
 		return
 	}
 
-	// Get sources
-	sources, err := h.sourceRepo.ListByOverlayID(c.Request.Context(), overlayID)
+	// Get sources, computing IsOwnChannel for the authenticated user so the frontend can
+	// surface the IRC→EventSub re-consent nudge for channels this user can re-authorize.
+	sources, err := h.sourceRepo.ListByOverlayIDForUser(c.Request.Context(), overlayID, userID.(string))
 	if err != nil {
 		h.logger.Error("Failed to list sources", zap.Error(err), zap.String("overlay_id", overlayID))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list sources"})

--- a/services/overlay-manager/handlers/sources_patch_test.go
+++ b/services/overlay-manager/handlers/sources_patch_test.go
@@ -63,6 +63,10 @@ func (m *mockSourceRepositoryWithConfig) ListByOverlayID(ctx context.Context, ov
 	return nil, nil
 }
 
+func (m *mockSourceRepositoryWithConfig) ListByOverlayIDForUser(ctx context.Context, overlayID, _ string) ([]*models.ChatSource, error) {
+	return m.ListByOverlayID(ctx, overlayID)
+}
+
 func (m *mockSourceRepositoryWithConfig) GetByID(ctx context.Context, id string) (*models.ChatSource, error) {
 	if m.getByIDFunc != nil {
 		return m.getByIDFunc(ctx, id)

--- a/services/overlay-manager/handlers/sources_shared_overlay_test.go
+++ b/services/overlay-manager/handlers/sources_shared_overlay_test.go
@@ -60,6 +60,10 @@ func (m *mockSourceRepository) ListByOverlayID(ctx context.Context, overlayID st
 	return nil, nil
 }
 
+func (m *mockSourceRepository) ListByOverlayIDForUser(ctx context.Context, overlayID, _ string) ([]*models.ChatSource, error) {
+	return m.ListByOverlayID(ctx, overlayID)
+}
+
 func (m *mockSourceRepository) GetByID(ctx context.Context, id string) (*models.ChatSource, error) {
 	if m.getByIDFunc != nil {
 		return m.getByIDFunc(ctx, id)

--- a/services/overlay-manager/handlers/tts_test.go
+++ b/services/overlay-manager/handlers/tts_test.go
@@ -1107,6 +1107,9 @@ func (s *stubSourceRepo) CreateOrUpdateAuto(_ context.Context, _ *models.ChatSou
 func (s *stubSourceRepo) ListByOverlayID(_ context.Context, _ string) ([]*models.ChatSource, error) {
 	return nil, nil
 }
+func (s *stubSourceRepo) ListByOverlayIDForUser(_ context.Context, _, _ string) ([]*models.ChatSource, error) {
+	return nil, nil
+}
 func (s *stubSourceRepo) GetByID(_ context.Context, _ string) (*models.ChatSource, error) {
 	return nil, errors.New("not impl")
 }

--- a/services/overlay-manager/models/chat_source.go
+++ b/services/overlay-manager/models/chat_source.go
@@ -37,9 +37,15 @@ type ChatSource struct {
 	// scope (user:read:chat) and has a valid token — i.e. its chat is read via the
 	// EventSub listener rather than IRC. Computed (not stored); only populated by
 	// ListByOverlayID. The frontend uses it to show a badge / reconnect CTA.
-	ChatViaEventSub bool      `json:"chat_via_eventsub"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	ChatViaEventSub bool `json:"chat_via_eventsub"`
+	// IsOwnChannel is true when the requesting user owns this Twitch channel and can
+	// therefore re-consent to enable EventSub chat — either via their Twitch-login
+	// users row (username == channel_id) or a linked twitch_oauth_tokens row (ADR-0016).
+	// Computed per-requester; only populated by ListByOverlayIDForUser (false otherwise).
+	// Drives the IRC→EventSub re-consent nudge. Independent of ChatViaEventSub/token validity.
+	IsOwnChannel bool      `json:"is_own_channel"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // Valid platforms

--- a/services/overlay-manager/repository/source_repo.go
+++ b/services/overlay-manager/repository/source_repo.go
@@ -121,10 +121,19 @@ func (r *SourceRepository) CreateOrUpdateAuto(ctx context.Context, source *model
 	return nil
 }
 
-// ListByOverlayID retrieves all sources for an overlay.
+// ListByOverlayID retrieves all sources for an overlay without per-user ownership
+// context (IsOwnChannel is always false). Use ListByOverlayIDForUser when the caller
+// is an authenticated user that needs the re-consent nudge flag.
+func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string) ([]*models.ChatSource, error) {
+	return r.ListByOverlayIDForUser(ctx, overlayID, "")
+}
+
+// ListByOverlayIDForUser retrieves all sources for an overlay, computing IsOwnChannel
+// relative to requestingUserID (pass "" for public/admin callers — ownership is then
+// always false).
 // For shared_overlay sources, it JOINs share_requests to populate ShareStatus.
 // Non-shared_overlay sources have ShareStatus == nil (omitted from JSON).
-func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string) ([]*models.ChatSource, error) {
+func (r *SourceRepository) ListByOverlayIDForUser(ctx context.Context, overlayID, requestingUserID string) ([]*models.ChatSource, error) {
 	// chat_via_eventsub mirrors the IRC/EventSub partition predicate (see
 	// twitch-eventsub-listener/channels/manager.go and twitch-listener/channels/repository.go):
 	// a Twitch source is read via EventSub when its channel owner granted user:read:chat
@@ -132,6 +141,13 @@ func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string
 	// linked Twitch credentials in twitch_oauth_tokens (ADR-0016: YouTube/Kick-login
 	// accounts that completed the Twitch add-source consent). The frontend uses it to
 	// show a badge / reconnect CTA.
+	//
+	// is_own_channel is whether requestingUserID ($2) owns this Twitch channel and can
+	// re-consent to enable EventSub chat. Unlike chat_via_eventsub it ignores scope/expiry
+	// (re-consent is exactly what fixes an expired/narrow grant) and is matched per-user,
+	// so it also covers non-Twitch-login owners via twitch_oauth_tokens (ADR-0016) — the
+	// case the old frontend username heuristic silently missed. NULLIF keeps an empty
+	// requesting user from matching (NULL = no row owns it).
 	query := `
 		SELECT ocs.id, ocs.overlay_id, ocs.platform, ocs.channel_id, ocs.channel_name,
 		       ocs.channel_handle, ocs.auth_required, ocs.config, ocs.is_active,
@@ -151,7 +167,20 @@ func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string
 		                 AND 'user:read:chat' = ANY(t.granted_scopes)
 		                 AND t.token_expires_at > NOW()
 		           )
-		       )) AS chat_via_eventsub
+		       )) AS chat_via_eventsub,
+		       (ocs.platform = 'twitch' AND (
+		           EXISTS (
+		               SELECT 1 FROM users u
+		               WHERE u.id = NULLIF($2, '')::uuid
+		                 AND u.auth_provider = 'twitch'
+		                 AND LOWER(u.username) = LOWER(ocs.channel_id)
+		           )
+		           OR EXISTS (
+		               SELECT 1 FROM twitch_oauth_tokens t
+		               WHERE t.user_id = NULLIF($2, '')::uuid
+		                 AND LOWER(t.twitch_login) = LOWER(ocs.channel_id)
+		           )
+		       )) AS is_own_channel
 		FROM overlay_chat_sources ocs
 		LEFT JOIN share_requests sr
 		    ON ocs.platform = 'shared_overlay'
@@ -160,7 +189,7 @@ func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string
 		ORDER BY ocs.created_at DESC
 	`
 
-	rows, err := r.pool.Query(ctx, query, overlayID)
+	rows, err := r.pool.Query(ctx, query, overlayID, requestingUserID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list sources: %w", err)
 	}
@@ -183,6 +212,7 @@ func (r *SourceRepository) ListByOverlayID(ctx context.Context, overlayID string
 			&source.UpdatedAt,
 			&source.ShareStatus,
 			&source.ChatViaEventSub,
+			&source.IsOwnChannel,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan source: %w", err)

--- a/services/overlay-manager/repository/source_repo_test.go
+++ b/services/overlay-manager/repository/source_repo_test.go
@@ -377,3 +377,83 @@ func TestListByOverlayID_ChatViaEventSub_LinkedCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, sources[0].ChatViaEventSub, "expired linked credentials must not claim EventSub")
 }
+
+// TestListByOverlayIDForUser_IsOwnChannel covers the per-requesting-user ownership flag
+// that drives the IRC→EventSub re-consent nudge. Ownership is independent of whether the
+// channel already reads via EventSub or whether tokens are valid — it only means "the
+// requester can re-consent for this channel". Two ownership paths must both work: a
+// Twitch-login users row, and a linked twitch_oauth_tokens row (ADR-0016, the case the
+// old frontend isOwnChannel heuristic missed).
+func TestListByOverlayIDForUser_IsOwnChannel(t *testing.T) {
+	repo, cleanup := setupSourceTestDatabase(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	overlayID := createTestOverlay(t, repo)
+	source := &models.ChatSource{
+		OverlayID:   overlayID,
+		Platform:    "twitch",
+		ChannelID:   "caesarlp",
+		ChannelName: "CaesarLP",
+		Config:      map[string]interface{}{},
+	}
+	require.NoError(t, repo.Create(ctx, source))
+
+	// No identity passed: never owned (public/admin callers).
+	sources, err := repo.ListByOverlayIDForUser(ctx, overlayID, "")
+	require.NoError(t, err)
+	require.False(t, sources[0].IsOwnChannel, "empty requesting user must never own a channel")
+
+	// A different user does not own this channel.
+	stranger := uuid.New().String()
+	_, err = repo.pool.Exec(ctx,
+		`INSERT INTO users (id, username, auth_provider) VALUES ($1, 'someoneelse', 'twitch')`, stranger)
+	require.NoError(t, err)
+	sources, err = repo.ListByOverlayIDForUser(ctx, overlayID, stranger)
+	require.NoError(t, err)
+	require.False(t, sources[0].IsOwnChannel, "unrelated user must not own the channel")
+
+	// Twitch-login path: a users row whose username matches the channel id.
+	twitchOwner := uuid.New().String()
+	_, err = repo.pool.Exec(ctx,
+		`INSERT INTO users (id, username, auth_provider) VALUES ($1, 'CaesarLP', 'twitch')`, twitchOwner)
+	require.NoError(t, err)
+	sources, err = repo.ListByOverlayIDForUser(ctx, overlayID, twitchOwner)
+	require.NoError(t, err)
+	require.True(t, sources[0].IsOwnChannel, "twitch-login owner (username == channel_id) must own the channel")
+
+	// Linked-credentials path: a non-Twitch-login user who linked this Twitch channel.
+	linkedOwner := uuid.New().String()
+	_, err = repo.pool.Exec(ctx,
+		`INSERT INTO users (id, username, auth_provider) VALUES ($1, 'kicklogin', 'kick')`, linkedOwner)
+	require.NoError(t, err)
+	_, err = repo.pool.Exec(ctx, `
+		INSERT INTO twitch_oauth_tokens
+			(user_id, twitch_user_id, twitch_login, access_token, refresh_token, token_expires_at, granted_scopes)
+		VALUES ($1, '777', 'CaesarLP', 'enc-access', 'enc-refresh', NOW() - INTERVAL '1 hour', ARRAY['user:read:chat'])
+	`, linkedOwner)
+	require.NoError(t, err)
+	sources, err = repo.ListByOverlayIDForUser(ctx, overlayID, linkedOwner)
+	require.NoError(t, err)
+	require.True(t, sources[0].IsOwnChannel,
+		"linked twitch_oauth_tokens owner must own the channel even with an expired token (re-consent is the point)")
+}
+
+// TestListByOverlayID_DefaultsIsOwnChannelFalse ensures the back-compat method that omits a
+// requesting user never reports ownership.
+func TestListByOverlayID_DefaultsIsOwnChannelFalse(t *testing.T) {
+	repo, cleanup := setupSourceTestDatabase(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	overlayID := createTestOverlay(t, repo)
+	require.NoError(t, repo.Create(ctx, &models.ChatSource{
+		OverlayID: overlayID, Platform: "twitch", ChannelID: "caesarlp",
+		ChannelName: "CaesarLP", Config: map[string]interface{}{},
+	}))
+
+	sources, err := repo.ListByOverlayID(ctx, overlayID)
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	require.False(t, sources[0].IsOwnChannel)
+}


### PR DESCRIPTION
## Why

The shared Twitch **IRC bot is capped (~100 channels)** and silently drops the overflow once more than that are live at once — message loss. But the migration off IRC has barely started:

| Metric | Value |
|---|---|
| Distinct Twitch channels registered | 336 |
| Granted `user:read:chat` (EventSub-eligible) | 56 (~17%) |
| Stuck on IRC (need re-consent) | ~280 (~83%) |

The re-consent flow already exists (`auth-service` `GetAuthURLWithChatScopes`, `force_verify`), but nothing drives existing streamers to it:
1. The only CTA was a subtle text link buried on the per-overlay detail page.
2. `isOwnChannel` was gated on `auth_provider === 'twitch'`, so **YouTube/Kick-login owners who linked a Twitch channel (ADR-0016) never saw it at all**.

## What

- **overlay-manager**: add a per-requester `is_own_channel` boolean to `GET /api/v1/overlays/:id/sources` (`ListByOverlayIDForUser`). Computed for both Twitch-login and linked-credential owners; independent of scope/token validity (re-consent is exactly what fixes a missing/expired grant). `ListByOverlayID` kept as a thin back-compat wrapper (public/admin callers → `is_own_channel=false`).
- **frontend**: dismissible **dashboard banner** for owned Twitch channels still on IRC, and the per-source reconnect CTA now uses the server `is_own_channel` flag so linked owners get it too. Both start the existing add-source re-consent reflow; one re-consent migrates all of that account's own-channel sources.
- **docs**: ADR-0015 migration-UX addendum; overlay-manager README field notes.

## Tests

- **overlay-manager** (testcontainers): `TestListByOverlayIDForUser_IsOwnChannel` covers empty user, stranger, Twitch-login owner, and linked-credential owner (incl. expired token); `TestListByOverlayID_DefaultsIsOwnChannelFalse`. Full suite green.
- **frontend** (vitest/jsdom): banner visibility, channel dedup, reflow initiation, persisted dismissal. New files lint-clean.

**E2E limitation (per the TDD/E2E rule):** the OAuth reflow redirects to Twitch's external consent screen, which can't be driven in CI, so automated coverage stops at reflow initiation. The end-to-end migration also depends on the streamer completing Twitch consent.

## Scope notes
- Does **not** raise IRC's ~100 cap / add sharding — separate workstream.
- Pre-existing `react-hooks/refs` lint errors in `overlays/[id]/page.tsx` (lines ~1184/1193) are untouched and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)