### PR TITLE
feat(premium): surface the Patreon campaign link

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Built on the shoulders of:
 
 ## Support
 
+- [Back us on Patreon](https://patreon.com/all_chat) — unlock premium (streamer €5 / viewer €2)
 - [Discord community](https://discord.gg/xCGBSuz39P)
 - [GitHub Issues](https://github.com/caesarakalaeii/all-chat/issues)
 - [GitHub Discussions](https://github.com/caesarakalaeii/all-chat/discussions)

--- a/frontend/src/app/settings/premium/page.tsx
+++ b/frontend/src/app/settings/premium/page.tsx
@@ -135,13 +135,27 @@ function PremiumContent() {
           {loading ? (
             <Skeleton className="h-10 w-full" />
           ) : !status?.connected ? (
-            <div className="flex items-center justify-between gap-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-4">
+                <p className="text-sm text-text-sub">
+                  Back All-Chat on Patreon to unlock premium features automatically.
+                </p>
+                <Button onClick={handleConnect} disabled={connecting}>
+                  {connecting ? 'Redirecting…' : 'Connect Patreon'}
+                </Button>
+              </div>
               <p className="text-sm text-text-sub">
-                Back All-Chat on Patreon to unlock premium features automatically.
+                Not a patron yet?{' '}
+                <a
+                  href="https://patreon.com/all_chat"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-twitch hover:underline"
+                >
+                  Subscribe on Patreon
+                </a>
+                , then connect.
               </p>
-              <Button onClick={handleConnect} disabled={connecting}>
-                {connecting ? 'Redirecting…' : 'Connect Patreon'}
-              </Button>
             </div>
           ) : (
             <div className="space-y-4">

--- a/frontend/src/app/settings/viewer/premium/page.tsx
+++ b/frontend/src/app/settings/viewer/premium/page.tsx
@@ -134,13 +134,27 @@ function ViewerPremiumContent() {
           {loading ? (
             <Skeleton className="h-10 w-full" />
           ) : !status?.connected ? (
-            <div className="flex items-center justify-between gap-4">
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-4">
+                <p className="text-sm text-text-sub">
+                  Back All-Chat on Patreon to unlock your viewer premium cosmetics automatically.
+                </p>
+                <Button onClick={handleConnect} disabled={connecting}>
+                  {connecting ? 'Redirecting…' : 'Connect Patreon'}
+                </Button>
+              </div>
               <p className="text-sm text-text-sub">
-                Back All-Chat on Patreon to unlock your viewer premium cosmetics automatically.
+                Not a patron yet?{' '}
+                <a
+                  href="https://patreon.com/all_chat"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-twitch hover:underline"
+                >
+                  Subscribe on Patreon
+                </a>{' '}
+                (viewer tier from €2), then connect.
               </p>
-              <Button onClick={handleConnect} disabled={connecting}>
-                {connecting ? 'Redirecting…' : 'Connect Patreon'}
-              </Button>
             </div>
           ) : (
             <div className="space-y-4">


### PR DESCRIPTION
Follow-up to the premium stack (#457). The premium settings pages only offered "Connect Patreon" (the OAuth link to attach an *existing* pledge) — there was no path for a new user to actually subscribe.

- **Frontend**: add a "Subscribe on Patreon" link to https://patreon.com/all_chat in the not-connected state of both the streamer (`/settings/premium`) and viewer (`/settings/viewer/premium`) pages. Viewer page notes the cheaper "from €2" tier.
- **README**: list the Patreon campaign in the Support section (streamer €5 / viewer €2).

Verified: eslint + `tsc --noEmit` clean; 493 vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)