### PR TITLE
fix(tiktok-listener): orphaned streams, backoff herd, unbounded request body

### DIFF
--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -87,6 +87,11 @@ const TIKTOK_MAX_ERROR_BACKOFF_MS = parseInt(process.env.TIKTOK_MAX_ERROR_BACKOF
 const TIKTOK_HEARTBEAT_INTERVAL_MS = parseInt(process.env.TIKTOK_HEARTBEAT_INTERVAL_MS || '30000');
 const TIKTOK_HEARTBEAT_TIMEOUT_MS = parseInt(process.env.TIKTOK_HEARTBEAT_TIMEOUT_MS || '90000');
 
+// Hard cap on internal admin HTTP request bodies (/api/retry, /api/reset-backoff).
+// These accept small JSON payloads; capping prevents an oversized POST from spiking
+// process memory and risking an OOMKill.
+const MAX_REQUEST_BODY_BYTES = parseInt(process.env.MAX_REQUEST_BODY_BYTES || '65536'); // 64 KB
+
 // Message deduplication configuration
 const TIKTOK_DEDUP_TTL_MS = parseInt(process.env.TIKTOK_DEDUP_TTL_MS || '300000'); // 5 minutes
 const TIKTOK_DEDUP_CLEANUP_INTERVAL_MS = parseInt(process.env.TIKTOK_DEDUP_CLEANUP_INTERVAL_MS || '60000'); // 1 minute
@@ -200,6 +205,12 @@ class TikTokListenerService {
 
   // Connection state tracking to prevent concurrent connections
   private connectingStreams: Set<string> = new Set();
+
+  // Latest demanded usernames from the most recent DemandUpdate (the authoritative
+  // snapshot). connectToStream() re-checks this after its async live-status pre-check
+  // so a stream that loses demand mid-connection bails out instead of becoming an
+  // orphan (a live WebSocket + leadership lease with no downstream consumer).
+  private demandedUsernames: Set<string> = new Set();
 
   // Leadership coordination
   private sourceManagerClient?: SourceManagerClient;
@@ -420,9 +431,7 @@ class TikTokListenerService {
         }));
       } else if (req.url === '/api/retry' && req.method === 'POST') {
         // Force retry for a username
-        let body = '';
-        req.on('data', chunk => { body += chunk.toString(); });
-        req.on('end', () => {
+        this.readJsonBody(req, res, (body) => {
           try {
             const data = JSON.parse(body);
             if (!data.username) {
@@ -445,9 +454,7 @@ class TikTokListenerService {
         });
       } else if (req.url === '/api/reset-backoff' && req.method === 'POST') {
         // Reset backoff for username or all
-        let body = '';
-        req.on('data', chunk => { body += chunk.toString(); });
-        req.on('end', () => {
+        this.readJsonBody(req, res, (body) => {
           try {
             const data = body ? JSON.parse(body) : {};
 
@@ -487,6 +494,44 @@ class TikTokListenerService {
   }
 
   /**
+   * Read a request body as a string with a hard size cap.
+   *
+   * Bodies larger than MAX_REQUEST_BODY_BYTES are rejected with 413 and the socket
+   * is destroyed; onComplete only fires for requests that stay within the limit.
+   * The `exceeded` guard ensures we send the 413 response exactly once even if more
+   * 'data' chunks arrive before the socket finishes tearing down.
+   *
+   * @param req Incoming request
+   * @param res Response (used to send 413 if the cap is exceeded)
+   * @param onComplete Called with the full body once received within the limit
+   */
+  private readJsonBody(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    onComplete: (body: string) => void
+  ): void {
+    let body = '';
+    let exceeded = false;
+
+    req.on('data', (chunk) => {
+      if (exceeded) return;
+      body += chunk.toString();
+      if (body.length > MAX_REQUEST_BODY_BYTES) {
+        exceeded = true;
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Request body too large' }));
+        req.destroy();
+      }
+    });
+
+    req.on('end', () => {
+      if (!exceeded) {
+        onComplete(body);
+      }
+    });
+  }
+
+  /**
    * Handle a demand update from source-manager (Phase 5).
    * Called on every DemandUpdate received via Redis Pub/Sub "source:demand".
    * Full-replacement snapshot: connects new streams, disconnects removed ones.
@@ -497,14 +542,38 @@ class TikTokListenerService {
 
     logger.info('Demand update received', { demanded_count: demanded.size });
 
-    if (demanded.size === 0) {
-      // Full idle: release leadership and disconnect all streams
-      for (const [username] of this.activeStreams.entries()) {
-        if (this.leadershipCoordinator) {
-          await this.leadershipCoordinator.release(username);
-        }
+    // Record the authoritative demand snapshot first, so any connection attempt
+    // already in flight (suspended on its async live-status pre-check) sees the
+    // updated set when it resumes and aborts if it lost demand.
+    this.demandedUsernames = new Set(demanded.keys());
+
+    // Prune every tracked stream that lost demand. A stream can be tracked in
+    // three places: active (connected), parked in the poller (offline, awaiting
+    // re-check), or mid-connection in connectingStreams. The previous code only
+    // iterated activeStreams, so a stream sitting in the poller — which may still
+    // hold a leadership lease claimed before it was found offline — was never
+    // released, and a stream mid-connection could go active with no demand at all.
+    // Here we release leadership and drop poller/active state for active and
+    // polled streams; connectingStreams entries abort themselves via the
+    // demandedUsernames check in connectToStream().
+    const trackedUsernames = new Set<string>([
+      ...this.activeStreams.keys(),
+      ...this.livePoller.getTargets().map(t => t.username),
+    ]);
+    for (const username of trackedUsernames) {
+      if (this.demandedUsernames.has(username)) continue;
+
+      if (this.leadershipCoordinator) {
+        await this.leadershipCoordinator.release(username);
+      }
+      this.livePoller.removeTarget(username);
+      if (this.activeStreams.has(username)) {
         await this.disconnectFromStream(username);
       }
+    }
+
+    // Go fully idle when there is no demand: stop the poller entirely.
+    if (demanded.size === 0) {
       if (this.livePollerRunning) {
         this.livePoller.stop();
         this.livePollerRunning = false;
@@ -518,17 +587,6 @@ class TikTokListenerService {
       this.livePoller.start();
       this.livePollerRunning = true;
       logger.info('LiveStreamPoller started (demand present)');
-    }
-
-    // Disconnect streams that lost demand and release their leadership
-    const demandedUsernames = new Set(demanded.keys());
-    for (const [username] of this.activeStreams.entries()) {
-      if (!demandedUsernames.has(username)) {
-        if (this.leadershipCoordinator) {
-          await this.leadershipCoordinator.release(username);
-        }
-        await this.disconnectFromStream(username);
-      }
     }
 
     // Claim leadership and connect new demanded streams
@@ -606,6 +664,18 @@ class TikTokListenerService {
 
       // NEW: Pre-check if user is live before attempting connection
       const statusResult = await this.statusChecker.checkLiveStatus(username);
+
+      // Demand may have been removed while we awaited the live-status check above
+      // (handleDemandUpdate runs on the same event loop and updates demandedUsernames).
+      // Abort before going active or re-parking in the poller so we don't leave an
+      // orphaned connection behind. Release any leadership lease we hold (no-op if none).
+      if (!this.demandedUsernames.has(username)) {
+        logger.info('Demand removed during connection attempt, aborting', { username, overlay_id: overlayId });
+        if (this.leadershipCoordinator) {
+          await this.leadershipCoordinator.release(username);
+        }
+        return;
+      }
 
       if (!statusResult.isLive) {
         // Distinguish between "user is offline" and "API/network error"
@@ -741,8 +811,14 @@ class TikTokListenerService {
       // Record error for backoff
       this.backoffManager.recordConnectionError(username, error as Error);
 
-      // Add to poller for retry
-      this.livePoller.addTarget(username, overlayId);
+      // Only schedule a retry if the stream is still demanded. If demand was pulled
+      // while we were connecting, re-parking it in the poller would re-create the
+      // orphan we are trying to avoid — release leadership instead.
+      if (this.demandedUsernames.has(username)) {
+        this.livePoller.addTarget(username, overlayId);
+      } else if (this.leadershipCoordinator) {
+        await this.leadershipCoordinator.release(username);
+      }
 
       // Don't delete from activeStreams - keep it for tracking
     } finally {

--- a/services/tiktok-listener/src/livestream/backoff-manager.test.ts
+++ b/services/tiktok-listener/src/livestream/backoff-manager.test.ts
@@ -1,0 +1,137 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * BackoffManager unit tests
+ *
+ * Focuses on the ±10% scheduling jitter that prevents a thundering herd of
+ * live-status checks when many channels share the same backoff interval, and
+ * verifies that the jitter is purely additive (the exponential progression and
+ * caps are unchanged).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { BackoffManager } from './backoff-manager.js';
+import { Logger } from '../types/logger.js';
+
+const noopLogger: Logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+};
+
+describe('BackoffManager scheduling jitter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('adds +10% jitter at the top of the random range for offline checks', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    vi.spyOn(Math, 'random').mockReturnValue(1); // jitter = +10%
+
+    const mgr = new BackoffManager(noopLogger);
+    mgr.recordOfflineCheck('user');
+
+    const state = mgr.getState('user')!;
+    expect(state.currentBackoffMs).toBe(20000); // first offline check = base (20s)
+    expect(state.nextCheckTime).toBe(1_000_000 + 20000 + 2000);
+  });
+
+  it('subtracts 10% jitter at the bottom of the random range for offline checks', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    vi.spyOn(Math, 'random').mockReturnValue(0); // jitter = -10%
+
+    const mgr = new BackoffManager(noopLogger);
+    mgr.recordOfflineCheck('user');
+
+    expect(mgr.getState('user')!.nextCheckTime).toBe(1_000_000 + 20000 - 2000);
+  });
+
+  it('applies zero jitter at the midpoint (random = 0.5)', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+
+    const mgr = new BackoffManager(noopLogger);
+    mgr.recordOfflineCheck('user');
+
+    expect(mgr.getState('user')!.nextCheckTime).toBe(1_000_000 + 20000);
+  });
+
+  it('jitters connection-error backoff scheduling', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(500_000);
+    vi.spyOn(Math, 'random').mockReturnValue(1); // +10%
+
+    const mgr = new BackoffManager(noopLogger);
+    mgr.recordConnectionError('user', new Error('boom'));
+
+    const state = mgr.getState('user')!;
+    expect(state.currentBackoffMs).toBe(2000); // first error: 2^1 * 1000ms
+    expect(state.nextCheckTime).toBe(500_000 + 2000 + 200);
+  });
+
+  it('jitters the reset-to-base backoff on disconnection', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(700_000);
+    vi.spyOn(Math, 'random').mockReturnValue(0); // -10%
+
+    const mgr = new BackoffManager(noopLogger);
+    mgr.recordDisconnection('user');
+
+    const state = mgr.getState('user')!;
+    expect(state.currentBackoffMs).toBe(20000);
+    expect(state.nextCheckTime).toBe(700_000 + 20000 - 2000);
+  });
+
+  it('keeps next-check within ±10% and decorrelates many channels', () => {
+    // Freeze the clock so the only source of variation is the jitter itself
+    // (real Math.random, not mocked).
+    vi.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const mgr = new BackoffManager(noopLogger);
+    const schedules = new Set<number>();
+
+    for (let i = 0; i < 200; i++) {
+      const user = `user-${i}`;
+      mgr.recordOfflineCheck(user);
+      const state = mgr.getState(user)!;
+
+      expect(state.currentBackoffMs).toBe(20000);
+      const offset = state.nextCheckTime - 1_000_000 - 20000;
+      expect(Math.abs(offset)).toBeLessThanOrEqual(2000); // ±10% of 20s
+
+      schedules.add(state.nextCheckTime);
+    }
+
+    // With real randomness, the 200 channels must not all land on the same tick.
+    expect(schedules.size).toBeGreaterThan(150);
+  });
+
+  it('preserves the exponential offline progression (jitter is additive only)', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5); // no jitter — isolate the curve
+
+    const mgr = new BackoffManager(noopLogger);
+    const progression: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      mgr.recordOfflineCheck('user');
+      progression.push(mgr.getState('user')!.currentBackoffMs);
+    }
+
+    // 20s, 40s, 80s, 160s, then capped at the 3-minute max.
+    expect(progression).toEqual([20000, 40000, 80000, 160000, 180000, 180000]);
+  });
+});

--- a/services/tiktok-listener/src/livestream/backoff-manager.ts
+++ b/services/tiktok-listener/src/livestream/backoff-manager.ts
@@ -98,7 +98,7 @@ export class BackoffManager {
       this.MAX_OFFLINE_BACKOFF_MS
     );
 
-    state.nextCheckTime = Date.now() + state.currentBackoffMs;
+    state.nextCheckTime = Date.now() + state.currentBackoffMs + this.jitterMs(state.currentBackoffMs);
 
     this.logger.info('User offline - increasing backoff', {
       username,
@@ -129,7 +129,7 @@ export class BackoffManager {
       this.MAX_ERROR_BACKOFF_MS
     );
 
-    state.nextCheckTime = Date.now() + state.currentBackoffMs;
+    state.nextCheckTime = Date.now() + state.currentBackoffMs + this.jitterMs(state.currentBackoffMs);
 
     this.logger.warn('Connection error - increasing backoff', {
       username,
@@ -190,7 +190,7 @@ export class BackoffManager {
     state.consecutiveErrors = 0;
     state.currentBackoffMs = this.BASE_OFFLINE_BACKOFF_MS; // Start at 20 seconds
     state.lastCheckTime = Date.now();
-    state.nextCheckTime = Date.now() + state.currentBackoffMs;
+    state.nextCheckTime = Date.now() + state.currentBackoffMs + this.jitterMs(state.currentBackoffMs);
   }
 
   /**
@@ -273,6 +273,23 @@ export class BackoffManager {
         ? states.reduce((sum, s) => sum + s.consecutiveErrors, 0) / states.length
         : 0
     };
+  }
+
+  /**
+   * Compute ±10% random jitter for a backoff delay.
+   *
+   * Without jitter, every channel that reaches the same backoff interval (e.g.
+   * many channels capped at MAX_OFFLINE_BACKOFF_MS, or all channels failing at
+   * once during a TikTok API blip) schedules its next check at the exact same
+   * wall-clock instant and fires simultaneously — a thundering herd against
+   * TikTok's API. Spreading each next-check by ±10% decorrelates them.
+   *
+   * @param delayMs Backoff delay the jitter is relative to
+   * @returns Offset in the range [-delayMs*0.1, +delayMs*0.1]
+   * @private
+   */
+  private jitterMs(delayMs: number): number {
+    return delayMs * 0.1 * (Math.random() * 2 - 1);
   }
 
   /**


### PR DESCRIPTION
Closes #460.

Fixes the three TikTok-listener bugs from the review issue. All were confirmed against source; my evaluation found the issue's proposed fix for Bug 1 was **incomplete** (it would have leaked a leadership lease) and that a **sibling leak** (poller-parked streams) shared the same root cause — both are handled here.

## Bug 1 — orphaned streams on demand removal (moderate)
`handleDemandUpdate()` only iterated `activeStreams` when pruning streams that lost demand. A stream could instead be:
- **mid-connection** in `connectingStreams` (the reported case), or
- **parked in the poller** (offline, awaiting re-check) — *and a polled stream can still hold a leadership lease* claimed before it was found offline. The lease heartbeat renews every 5s, so it is **actively kept alive forever**, not expired.

The issue's proposed `cancelledConnections` fix bailed out of `connectToStream` **without releasing leadership**, which would have leaked that renewed lease (this pod holds leadership for a stream it isn't serving → no other pod can serve it either).

**Fix:**
- Record the authoritative demand snapshot in a new `demandedUsernames` field at the top of `handleDemandUpdate`.
- Prune **active + polled** streams in a single pass, releasing leadership for each.
- `connectToStream` re-checks `demandedUsernames` right after its async live-status pre-check (and in its error path); if demand was pulled mid-connection it aborts and **releases the lease** instead of going live with no downstream consumer.

This also closes the pre-existing path where a poller target that lost demand was never pruned (it would keep burning TikTok API quota and could briefly connect with no demand).

## Bug 2 — backoff thundering herd (low)
`nextCheckTime` was `Date.now() + backoff` with no jitter, so many channels sharing a backoff interval (e.g. all capped at max offline backoff, or all failing during a TikTok API blip) fired live-status checks on the same tick. Added a `jitterMs()` helper applying **±10% jitter to all backoff scheduling** (offline, error, and disconnect resets — not just the offline path the issue called out).

## Bug 3 — unbounded HTTP request body (low)
`/api/retry` and `/api/reset-backoff` accumulated the body string with no cap. Added a shared `readJsonBody()` helper that rejects bodies over **64 KB** (`MAX_REQUEST_BODY_BYTES`, env-overridable) with `413` and destroys the socket, guarded so the response is sent exactly once even if more `data` chunks arrive during teardown.

## Tests
- New `backoff-manager.test.ts`: jitter at the random-range extremes/midpoint, applied to all three scheduling paths, the ±10% bound + decorrelation across 200 channels, and that the exponential progression/caps are unchanged.
- Full service suite green: `19 passed`.
- `tsc` clean on changed files (a pre-existing `tracing.ts` error only reproduces with locally-drifted `@opentelemetry/resources@2.x`; Docker builds via `npm ci` with the lockfile-pinned `1.30.1`, where it compiles).

## Notes
- Not yet merged — merging deploys to production via Keel, so I left that for your call.
- A stale `dist/` build artifact is also picked up by vitest (pre-existing, unrelated); left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)