### PR TITLE
feat: configurable event-feed position + send-from-monitor (/overlay/[id]/view)

### DIFF
--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -725,6 +725,39 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
     }
   }
 
+  // Platform badge — single platform, or a combined badge when a message carries
+  // multiple (a streamer's "send to all" echo collapsed into one message). Honors
+  // the configured style (icon | text); for length ≤ 1 it renders exactly as before.
+  const PlatformBadge = ({ message }: { message: ChatMessage }) => {
+    const multi = Array.isArray(message.platforms) && message.platforms.length > 1
+    const platforms = multi ? (message.platforms as string[]) : [message.platform]
+    const title = platforms.join(', ')
+
+    if (platformBadgeStyle === 'icon') {
+      return (
+        <span
+          className="platform-badge platform-badge-icon flex items-center gap-0.5"
+          title={title}
+        >
+          {platforms.map((p) => (
+            <PlatformIcon key={p} platform={p} />
+          ))}
+        </span>
+      )
+    }
+    // Text style: join multiple platforms with '+', colored by the primary platform.
+    return (
+      <span
+        className={clsx(
+          'platform-badge platform-badge-text text-xs font-semibold uppercase',
+          getPlatformColor(message.platform)
+        )}
+      >
+        {platforms.join('+')}
+      </span>
+    )
+  }
+
   return (
     <div className="min-h-screen w-full bg-transparent p-4">
       {/* Hide scrollbars and ensure transparent background */}
@@ -807,25 +840,9 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                   {/* Username and Platform */}
                   <div className="mb-1 flex flex-wrap items-center gap-2">
                     {/* Platform badge - render based on position and style settings */}
-                    {showPlatformBadge &&
-                      platformBadgePosition === 'before' &&
-                      (platformBadgeStyle === 'icon' ? (
-                        <span
-                          className="platform-badge platform-badge-icon flex items-center"
-                          title={message.platform}
-                        >
-                          <PlatformIcon platform={message.platform} />
-                        </span>
-                      ) : (
-                        <span
-                          className={clsx(
-                            'platform-badge platform-badge-text text-xs font-semibold uppercase',
-                            getPlatformColor(message.platform)
-                          )}
-                        >
-                          {message.platform}
-                        </span>
-                      ))}
+                    {showPlatformBadge && platformBadgePosition === 'before' && (
+                      <PlatformBadge message={message} />
+                    )}
 
                     {/* Regular Badges (before username when position is 'before') */}
                     {showBadges &&
@@ -920,25 +937,9 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                     )}
 
                     {/* Platform badge after username (original position) */}
-                    {showPlatformBadge &&
-                      platformBadgePosition === 'after' &&
-                      (platformBadgeStyle === 'icon' ? (
-                        <span
-                          className="platform-badge platform-badge-icon flex items-center"
-                          title={message.platform}
-                        >
-                          <PlatformIcon platform={message.platform} />
-                        </span>
-                      ) : (
-                        <span
-                          className={clsx(
-                            'platform-badge platform-badge-text text-xs font-semibold uppercase',
-                            getPlatformColor(message.platform)
-                          )}
-                        >
-                          {message.platform}
-                        </span>
-                      ))}
+                    {showPlatformBadge && platformBadgePosition === 'after' && (
+                      <PlatformBadge message={message} />
+                    )}
 
                     {/* Shared Chat Indicator */}
                     {isSharedChat && (

--- a/frontend/src/app/overlay/[id]/view/__tests__/viewLayout.test.ts
+++ b/frontend/src/app/overlay/[id]/view/__tests__/viewLayout.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DEFAULT_VIEW_LAYOUT,
+  LAYOUT_CONFIG,
+  layoutStorageKey,
+  loadViewLayout,
+  saveViewLayout,
+} from '../viewLayout'
+
+// jsdom in this project does not ship a working localStorage; stub one.
+function stubLocalStorage() {
+  const store: Record<string, string> = {}
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v
+    },
+    removeItem: (k: string) => {
+      delete store[k]
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k])
+    },
+  })
+}
+
+beforeEach(() => stubLocalStorage())
+afterEach(() => vi.unstubAllGlobals())
+
+describe('viewLayout', () => {
+  it('defaults to chat-left when nothing is stored', () => {
+    expect(loadViewLayout('o1')).toBe(DEFAULT_VIEW_LAYOUT)
+    expect(DEFAULT_VIEW_LAYOUT).toBe('chat-left')
+  })
+
+  it('keys storage per overlay id', () => {
+    expect(layoutStorageKey('abc')).toBe('overlay-view-layout-abc')
+  })
+
+  it('round-trips a saved layout through save → load', () => {
+    saveViewLayout('o1', 'events-top')
+    expect(loadViewLayout('o1')).toBe('events-top')
+    // A different overlay is unaffected.
+    expect(loadViewLayout('o2')).toBe(DEFAULT_VIEW_LAYOUT)
+  })
+
+  it('falls back to the default for an unknown stored value', () => {
+    localStorage.setItem(layoutStorageKey('o1'), 'garbage')
+    expect(loadViewLayout('o1')).toBe(DEFAULT_VIEW_LAYOUT)
+  })
+
+  it('maps each preset to the expected orientation/reversed pair', () => {
+    expect(LAYOUT_CONFIG['chat-left']).toEqual({ orientation: 'horizontal', reversed: false })
+    expect(LAYOUT_CONFIG['chat-right']).toEqual({ orientation: 'horizontal', reversed: true })
+    expect(LAYOUT_CONFIG['events-top']).toEqual({ orientation: 'vertical', reversed: true })
+    expect(LAYOUT_CONFIG['chat-top']).toEqual({ orientation: 'vertical', reversed: false })
+  })
+})

--- a/frontend/src/app/overlay/[id]/view/page.tsx
+++ b/frontend/src/app/overlay/[id]/view/page.tsx
@@ -42,12 +42,15 @@ import { MaintenanceInfoButton } from '@/components/MaintenanceInfoButton'
 import PlatformStatusIndicators from '@/components/PlatformStatusIndicators'
 import { ActivityPanel } from '@/components/overlay/ActivityPanel'
 import { ChatPanel, type ChatPanelModeration } from '@/components/overlay/ChatPanel'
+import { ChatSendBar } from '@/components/overlay/ChatSendBar'
 import { ConnectionBadge } from '@/components/overlay/ConnectionBadge'
+import { LayoutPicker } from '@/components/overlay/LayoutPicker'
 import { ObservabilitySummary } from '@/components/overlay/ObservabilitySummary'
 import { OverlayViewThemeToggle } from '@/components/overlay/OverlayViewThemeToggle'
 import { ViewSettingsBar } from '@/components/overlay/ViewSettingsBar'
 import { ResizableSplit } from '@/components/ResizableSplit'
 import { useOverlayStream } from '@/hooks/useOverlayStream'
+import { authApi } from '@/lib/api/auth'
 import { startDiscordModerationReinvite } from '@/lib/api/discord'
 import {
   buildBanRequest,
@@ -71,6 +74,13 @@ import {
 } from '@/lib/utils/overlayViewModel'
 
 import {
+  DEFAULT_VIEW_LAYOUT,
+  LAYOUT_CONFIG,
+  loadViewLayout,
+  saveViewLayout,
+  type ViewLayout,
+} from './viewLayout'
+import {
   DEFAULT_VIEW_PREFS,
   loadViewPrefs,
   saveViewPrefs,
@@ -92,6 +102,7 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
   const [light, setLight] = useState(false)
   const [showDetails, setShowDetails] = useState(false)
   const [prefs, setPrefs] = useState<MonitorViewPrefs>(DEFAULT_VIEW_PREFS)
+  const [layout, setLayout] = useState<ViewLayout>(DEFAULT_VIEW_LAYOUT)
   const [capabilities, setCapabilities] = useState<ModerationCapabilities | null>(null)
   const modSeqRef = useRef(0)
   // Signatures of deletions we applied optimistically, awaiting their WS echo —
@@ -186,6 +197,21 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     saveViewPrefs(next)
   }, [])
 
+  // Restore the saved panel layout after mount (per-overlay; localStorage,
+  // client only — guards against SSR hydration mismatch like the prefs/theme).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time restore from localStorage
+    setLayout(loadViewLayout(id))
+  }, [id])
+
+  const updateLayout = useCallback(
+    (next: ViewLayout) => {
+      setLayout(next)
+      saveViewLayout(id, next)
+    },
+    [id]
+  )
+
   // Start the opt-in moderation setup (ADR-0017). For the OAuth platforms this fetches a
   // consent URL (auth-service requests only the minimal moderation scopes for the actions
   // the platform supports) and redirects to it: Twitch grants all four actions; Kick
@@ -214,6 +240,20 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     },
     [id]
   )
+
+  // Re-login when a send fails with `reauth_required` (the platform OAuth token
+  // was revoked). Re-runs the platform's OAuth login (the canonical entry the
+  // landing page uses); falls back to Twitch when no platform is reported.
+  const reauthenticate = useCallback(async (platform?: string) => {
+    const p =
+      platform === 'twitch' || platform === 'youtube' || platform === 'kick' ? platform : 'twitch'
+    try {
+      const url = await authApi.getLoginUrl(p)
+      window.location.href = url
+    } catch {
+      toast.error('Could not start re-login. Please try again.')
+    }
+  }, [])
 
   // Restore the saved theme once on mount.
   useEffect(() => {
@@ -249,6 +289,18 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
   // Sources the owner could moderate but hasn't granted the scope for.
   const missingScopeSources = useMemo(
     () => (capabilities?.sources ?? []).filter((s) => s.reason === 'missing_scope'),
+    [capabilities]
+  )
+
+  // Whether any source can currently send chat from the monitor (gates the send
+  // bar). TikTok/Discord have no send path, so only twitch/youtube/kick count.
+  const hasSendableSource = useMemo(
+    () =>
+      (capabilities?.sources ?? []).some(
+        (s) =>
+          s.can_send === true &&
+          (s.platform === 'twitch' || s.platform === 'youtube' || s.platform === 'kick')
+      ),
     [capabilities]
   )
 
@@ -404,6 +456,7 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
             <SlidersHorizontal className="h-3.5 w-3.5" />
             Details
           </button>
+          <LayoutPicker layout={layout} onChange={updateLayout} />
           <ViewSettingsBar prefs={prefs} onChange={updatePrefs} />
           <OverlayViewThemeToggle light={light} onToggle={() => setLight((v) => !v)} />
           <Link
@@ -463,7 +516,9 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
                 onClick={() => enableModeration(s.platform)}
                 className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
               >
-                {s.platform === 'discord' ? 'Re-invite the bot' : 'Enable moderation'}
+                {s.platform === 'discord'
+                  ? 'Re-invite the bot'
+                  : 'Enable moderation & chat sending'}
               </button>
             ) : (
               <span className="text-text-dim">(coming soon for {s.platform})</span>
@@ -481,9 +536,11 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         />
       )}
 
-      {/* Resizable Chat | Activity */}
+      {/* Resizable Chat | Activity — orientation/order driven by the layout picker. */}
       <ResizableSplit
         storageKey={`overlay-view-split-${id}`}
+        orientation={LAYOUT_CONFIG[layout].orientation}
+        reversed={LAYOUT_CONFIG[layout].reversed}
         left={
           <ChatPanel
             items={chat}
@@ -494,6 +551,15 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         }
         right={<ActivityPanel events={events} system={system} moderationLog={moderationLog} />}
       />
+
+      {/* Send bar — owner only, and only when ≥1 platform source can send. */}
+      {isOwner && hasSendableSource && capabilities && (
+        <ChatSendBar
+          sources={capabilities.sources}
+          onEnable={enableModeration}
+          onReauth={reauthenticate}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/overlay/[id]/view/viewLayout.ts
+++ b/frontend/src/app/overlay/[id]/view/viewLayout.ts
@@ -1,0 +1,88 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Layout presets for the overlay monitor's Chat | Activity split (`.../view`).
+ *
+ * Each preset maps to an `orientation` + `reversed` pair understood by
+ * `ResizableSplit`. Like `MonitorViewPrefs`, the chosen preset is a moderator's
+ * personal, browser-local preference (persisted only to localStorage) and never
+ * touches the overlay's saved settings.
+ */
+
+import type { SplitOrientation } from '@/components/ResizableSplit'
+
+/** Identifier for one of the four split layouts offered in the view header. */
+export type ViewLayout = 'chat-left' | 'chat-right' | 'events-top' | 'chat-top'
+
+export interface LayoutConfig {
+  orientation: SplitOrientation
+  reversed: boolean
+}
+
+export const DEFAULT_VIEW_LAYOUT: ViewLayout = 'chat-left'
+
+/**
+ * Maps each preset to the `ResizableSplit` orientation/reversed pair. Recall
+ * the split's first child is `left` when `reversed` is false, else `right`; the
+ * page passes Chat as `left` and Activity as `right`.
+ */
+export const LAYOUT_CONFIG: Record<ViewLayout, LayoutConfig> = {
+  // Chat left, events right — the original default.
+  'chat-left': { orientation: 'horizontal', reversed: false },
+  // Chat right, events left.
+  'chat-right': { orientation: 'horizontal', reversed: true },
+  // Events on top, chat below (reversed puts Activity first).
+  'events-top': { orientation: 'vertical', reversed: true },
+  // Chat on top, events below.
+  'chat-top': { orientation: 'vertical', reversed: false },
+}
+
+const VALID_LAYOUTS: ReadonlySet<string> = new Set<ViewLayout>([
+  'chat-left',
+  'chat-right',
+  'events-top',
+  'chat-top',
+])
+
+/** localStorage key prefix; the overlay id is appended per the task spec. */
+export function layoutStorageKey(overlayId: string): string {
+  return `overlay-view-layout-${overlayId}`
+}
+
+/** Load the saved layout for an overlay, falling back to the default. */
+export function loadViewLayout(overlayId: string): ViewLayout {
+  if (typeof window === 'undefined') return DEFAULT_VIEW_LAYOUT
+  try {
+    const raw = localStorage.getItem(layoutStorageKey(overlayId))
+    if (raw && VALID_LAYOUTS.has(raw)) return raw as ViewLayout
+  } catch {
+    /* storage unavailable — fall back to default */
+  }
+  return DEFAULT_VIEW_LAYOUT
+}
+
+/** Persist the layout for an overlay. No-ops if storage is unavailable. */
+export function saveViewLayout(overlayId: string, layout: ViewLayout): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(layoutStorageKey(overlayId), layout)
+  } catch {
+    /* storage unavailable; selection stays in-session only */
+  }
+}

--- a/frontend/src/components/ResizableSplit.tsx
+++ b/frontend/src/components/ResizableSplit.tsx
@@ -18,27 +18,47 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import clsx from 'clsx'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useHydrated } from '@/hooks/useHydrated'
+
+/**
+ * Layout orientation for the split on desktop.
+ * - `horizontal`: panels side-by-side with a vertical divider (the persisted
+ *   ratio drives the first panel's WIDTH). This is the original behavior.
+ * - `vertical`: panels stacked top/bottom with a horizontal divider (the
+ *   persisted ratio drives the first panel's HEIGHT).
+ */
+export type SplitOrientation = 'horizontal' | 'vertical'
 
 interface ResizableSplitProps {
   /** localStorage key used to persist the split ratio across reloads. */
   storageKey: string
   left: React.ReactNode
   right: React.ReactNode
-  /** Minimum / maximum percentage width of the left panel (desktop only). */
+  /** Minimum / maximum percentage size of the first panel (desktop only). */
   min?: number
   max?: number
-  /** Initial left-panel width percentage before any stored value is restored. */
+  /** Initial first-panel size percentage before any stored value is restored. */
   initial?: number
+  /**
+   * Desktop layout direction (default `horizontal`). `vertical` stacks the
+   * panels top/bottom with a horizontal (row-resize) divider.
+   */
+  orientation?: SplitOrientation
+  /**
+   * Swap which panel comes first: false (default) keeps `left` first
+   * (left / top); true puts `right` first (right / bottom).
+   */
+  reversed?: boolean
 }
 
 /**
- * Two-pane resizable split: side-by-side with a draggable divider on desktop,
- * stacked (no divider) on mobile. Keyboard-accessible (Arrow keys move the
- * divider ±5%) and persists the ratio to localStorage. Generalized from
- * SplitView; no external dependency.
+ * Two-pane resizable split: side-by-side (or stacked, via `orientation`) with a
+ * draggable divider on desktop, stacked (no divider) on mobile. Keyboard-accessible
+ * (Arrow keys move the divider ±5%) and persists the ratio to localStorage.
+ * Generalized from SplitView; no external dependency.
  */
 export function ResizableSplit({
   storageKey,
@@ -47,13 +67,16 @@ export function ResizableSplit({
   min = 25,
   max = 70,
   initial = 45,
+  orientation = 'horizontal',
+  reversed = false,
 }: ResizableSplitProps) {
   const hydrated = useHydrated()
   const containerRef = useRef<HTMLDivElement>(null)
-  const [leftPct, setLeftPct] = useState(initial)
+  const [firstPct, setFirstPct] = useState(initial)
   const [isDesktop, setIsDesktop] = useState(true)
   const isDragging = useRef(false)
-  const leftPctRef = useRef(initial)
+  const firstPctRef = useRef(initial)
+  const isVertical = orientation === 'vertical'
 
   const clamp = useCallback((pct: number) => Math.min(max, Math.max(min, pct)), [min, max])
 
@@ -71,8 +94,8 @@ export function ResizableSplit({
   const setPct = useCallback(
     (pct: number) => {
       const clamped = clamp(pct)
-      leftPctRef.current = clamped
-      setLeftPct(clamped)
+      firstPctRef.current = clamped
+      setFirstPct(clamped)
       return clamped
     },
     [clamp],
@@ -91,7 +114,7 @@ export function ResizableSplit({
     }
   }, [hydrated, storageKey, setPct])
 
-  // Track the md breakpoint so the inline width only applies on desktop.
+  // Track the md breakpoint so the inline size only applies on desktop.
   useEffect(() => {
     if (typeof window.matchMedia !== 'function') return
     const mq = window.matchMedia('(min-width: 768px)')
@@ -110,54 +133,84 @@ export function ResizableSplit({
     (e: React.PointerEvent) => {
       if (!isDragging.current || !containerRef.current) return
       const rect = containerRef.current.getBoundingClientRect()
-      setPct(((e.clientX - rect.left) / rect.width) * 100)
+      // Compute the pointer position along the resize axis as a percentage of
+      // the container. When reversed, the first (sized) panel is on the far
+      // side, so invert the measurement.
+      const raw = isVertical
+        ? ((e.clientY - rect.top) / rect.height) * 100
+        : ((e.clientX - rect.left) / rect.width) * 100
+      setPct(reversed ? 100 - raw : raw)
     },
-    [setPct],
+    [setPct, isVertical, reversed],
   )
 
   const onPointerUp = useCallback(() => {
     if (!isDragging.current) return
     isDragging.current = false
-    persist(leftPctRef.current)
+    persist(firstPctRef.current)
   }, [persist])
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'ArrowLeft') {
-        persist(setPct(leftPctRef.current - 5))
-      } else if (e.key === 'ArrowRight') {
-        persist(setPct(leftPctRef.current + 5))
+      // Use the keys that match the divider's axis. Decrease/increase the first
+      // panel's size by 5% per press.
+      const decreaseKey = isVertical ? 'ArrowUp' : 'ArrowLeft'
+      const increaseKey = isVertical ? 'ArrowDown' : 'ArrowRight'
+      if (e.key === decreaseKey) {
+        persist(setPct(firstPctRef.current - 5))
+      } else if (e.key === increaseKey) {
+        persist(setPct(firstPctRef.current + 5))
       }
     },
-    [persist, setPct],
+    [persist, setPct, isVertical],
   )
+
+  // The first panel renders `right` when reversed, else `left`.
+  const firstPanel = reversed ? right : left
+  const secondPanel = reversed ? left : right
+
+  // Inline size only applies on desktop; vertical sizes height, horizontal width.
+  const firstStyle = isDesktop
+    ? isVertical
+      ? { height: `${firstPct}%` }
+      : { width: `${firstPct}%` }
+    : undefined
 
   return (
     <div
       ref={containerRef}
-      className="flex min-h-0 flex-1 flex-col overflow-hidden md:flex-row"
+      className={clsx(
+        'flex min-h-0 flex-1 flex-col overflow-hidden',
+        isVertical ? 'md:flex-col' : 'md:flex-row',
+      )}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
     >
       <div
-        className="min-h-0 flex-1 overflow-hidden md:flex-none"
-        style={isDesktop ? { width: `${leftPct}%` } : undefined}
+        className={clsx(
+          'min-h-0 flex-1 overflow-hidden',
+          isVertical ? 'md:flex-none' : 'md:flex-none',
+        )}
+        style={firstStyle}
       >
-        {left}
+        {firstPanel}
       </div>
 
       {/* Draggable divider — hidden on mobile (stacked layout) */}
       <div
-        className="hidden w-1 flex-shrink-0 cursor-col-resize bg-border transition-colors select-none hover:bg-twitch/50 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none md:block"
+        className={clsx(
+          'hidden flex-shrink-0 bg-border transition-colors select-none hover:bg-twitch/50 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none md:block',
+          isVertical ? 'h-1 w-full cursor-row-resize' : 'w-1 cursor-col-resize',
+        )}
         onPointerDown={onPointerDown}
         onKeyDown={onKeyDown}
         role="separator"
         aria-label="Drag to resize panels"
-        aria-orientation="vertical"
+        aria-orientation={isVertical ? 'horizontal' : 'vertical'}
         tabIndex={0}
       />
 
-      <div className="min-h-0 flex-1 overflow-hidden">{right}</div>
+      <div className="min-h-0 flex-1 overflow-hidden">{secondPanel}</div>
     </div>
   )
 }

--- a/frontend/src/components/__tests__/ResizableSplit.test.tsx
+++ b/frontend/src/components/__tests__/ResizableSplit.test.tsx
@@ -96,4 +96,40 @@ describe('ResizableSplit', () => {
     const leftPanel = container.firstChild?.firstChild as HTMLElement
     await waitFor(() => expect(leftPanel.style.width).toBe('62%'))
   })
+
+  it('sizes height (not width) and uses Up/Down keys when orientation is vertical', () => {
+    const { container } = render(
+      <ResizableSplit
+        storageKey="k"
+        left={<div>L</div>}
+        right={<div>R</div>}
+        initial={45}
+        orientation="vertical"
+      />,
+    )
+    const firstPanel = container.firstChild?.firstChild as HTMLElement
+    expect(firstPanel.style.height).toBe('45%')
+    expect(firstPanel.style.width).toBe('')
+
+    const separator = screen.getByRole('separator')
+    expect(separator.getAttribute('aria-orientation')).toBe('horizontal')
+
+    fireEvent.keyDown(separator, { key: 'ArrowDown' })
+    expect(firstPanel.style.height).toBe('50%')
+    fireEvent.keyDown(separator, { key: 'ArrowUp' })
+    expect(firstPanel.style.height).toBe('45%')
+  })
+
+  it('renders the right panel first when reversed', () => {
+    const { container } = render(
+      <ResizableSplit storageKey="k" left={<div>L</div>} right={<div>R</div>} reversed />,
+    )
+    const firstPanel = container.firstChild?.firstChild as HTMLElement
+    expect(firstPanel.textContent).toBe('R')
+  })
+
+  it('keeps aria-orientation vertical for the default horizontal layout', () => {
+    render(<ResizableSplit storageKey="k" left={<div>L</div>} right={<div>R</div>} />)
+    expect(screen.getByRole('separator').getAttribute('aria-orientation')).toBe('vertical')
+  })
 })

--- a/frontend/src/components/overlay/ChatRow.tsx
+++ b/frontend/src/components/overlay/ChatRow.tsx
@@ -22,7 +22,7 @@ import clsx from 'clsx'
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { PremiumBadge } from '@/components/PremiumBadge'
 import { UserAvatar } from '@/components/UserAvatar'
-import { PlatformGlyph } from '@/components/overlay/PlatformGlyph'
+import { PlatformGlyph, PlatformGlyphs } from '@/components/overlay/PlatformGlyph'
 import {
   ModerationControls,
   type ModerationControlsProps,
@@ -87,7 +87,11 @@ export function ChatRow({
       )}
       {prefs.showPlatformGlyph && (
         <span className="shrink-0 pt-0.5">
-          <PlatformGlyph platform={item.platform} />
+          {item.platforms && item.platforms.length > 1 ? (
+            <PlatformGlyphs platforms={item.platforms} />
+          ) : (
+            <PlatformGlyph platform={item.platform} />
+          )}
         </span>
       )}
       {prefs.showAvatars && (

--- a/frontend/src/components/overlay/ChatSendBar.tsx
+++ b/frontend/src/components/overlay/ChatSendBar.tsx
@@ -1,0 +1,340 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import clsx from 'clsx'
+import { Lock, Send } from 'lucide-react'
+import { useId, useMemo, useState } from 'react'
+
+import { PlatformGlyph } from '@/components/overlay/PlatformGlyph'
+import { ApiError } from '@/lib/api/client'
+import {
+  MAX_MESSAGE_LENGTH,
+  isSendToAllResponse,
+  sendStreamerMessage,
+  type SendErrorBody,
+  type SendPlatform,
+} from '@/lib/api/chat'
+import type { SourceCapability } from '@/lib/types/moderation'
+
+/** Platforms the send bar supports (TikTok/Discord are hidden — no send path). */
+const SENDABLE_PLATFORMS: ReadonlySet<string> = new Set(['twitch', 'youtube', 'kick'])
+
+/** A platform string the send endpoint accepts as a single target. */
+type SingleSendPlatform = Exclude<SendPlatform, 'all'>
+
+/** Currently-selected target: a single source's platform, or fan-out to all. */
+type Selection = { kind: 'platform'; platform: SingleSendPlatform } | { kind: 'all' }
+
+interface ChatSendBarProps {
+  /** All moderation/source capabilities for the overlay. */
+  sources: SourceCapability[]
+  /** Re-consent / bot-reinvite flow (shared with moderation) to grant scopes. */
+  onEnable: (platform: string) => void
+  /** Re-login entry when the platform OAuth token was revoked (`reauth_required`). */
+  onReauth: (platform?: string) => void
+}
+
+/** Pretty platform label for inline feedback. */
+function platformLabel(platform: string): string {
+  switch (platform) {
+    case 'twitch':
+      return 'Twitch'
+    case 'youtube':
+      return 'YouTube'
+    case 'kick':
+      return 'Kick'
+    default:
+      return platform
+  }
+}
+
+type Feedback =
+  | { kind: 'success'; text: string }
+  | { kind: 'partial'; text: string }
+  | { kind: 'error'; text: string; platform?: string; action?: 'enable' | 'reauth' }
+
+/**
+ * Bottom send bar for the overlay monitor. Lets the overlay owner post a chat
+ * message to one platform or fan it out to all sendable platforms. A source's
+ * pill is enabled only when the backend reports `can_send`; clicking a disabled
+ * pill kicks off the consent flow (which also grants send scopes, ADR-0017).
+ */
+export function ChatSendBar({ sources, onEnable, onReauth }: ChatSendBarProps) {
+  const inputId = useId()
+
+  // Sendable sources in a stable order, deduped by platform (one pill per platform).
+  const platformSources = useMemo(() => {
+    const byPlatform = new Map<SingleSendPlatform, SourceCapability>()
+    for (const s of sources) {
+      if (!SENDABLE_PLATFORMS.has(s.platform)) continue
+      const platform = s.platform as SingleSendPlatform
+      // Prefer a sendable source if several share a platform.
+      const existing = byPlatform.get(platform)
+      if (!existing || (!existing.can_send && s.can_send)) byPlatform.set(platform, s)
+    }
+    return Array.from(byPlatform.values())
+  }, [sources])
+
+  const sendablePlatforms = useMemo(
+    () => platformSources.filter((s) => s.can_send === true).map((s) => s.platform),
+    [platformSources]
+  )
+
+  const [selection, setSelection] = useState<Selection>(() =>
+    sendablePlatforms.length > 1
+      ? { kind: 'all' }
+      : sendablePlatforms.length === 1
+        ? { kind: 'platform', platform: sendablePlatforms[0] as SingleSendPlatform }
+        : { kind: 'all' }
+  )
+  const [text, setText] = useState('')
+  const [sending, setSending] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+
+  const showAll = sendablePlatforms.length > 1
+  const trimmed = text.trim()
+  const canSubmit =
+    !sending &&
+    trimmed.length > 0 &&
+    (selection.kind === 'all'
+      ? sendablePlatforms.length > 0
+      : sendablePlatforms.includes(selection.platform))
+
+  const handleDisabledPill = (platform: SingleSendPlatform) => {
+    // A disabled pill means the scope isn't granted yet — start consent for it.
+    setFeedback(null)
+    onEnable(platform)
+  }
+
+  const targetPlatform: SendPlatform =
+    selection.kind === 'all' ? 'all' : selection.platform
+
+  const handleError = (err: unknown) => {
+    if (!(err instanceof ApiError)) {
+      setFeedback({ kind: 'error', text: 'Could not send. Please try again.' })
+      return
+    }
+    const body = (err.data ?? {}) as Partial<SendErrorBody>
+    const code = body.error
+    const platform = body.platform
+
+    if (code === 'missing_scope') {
+      setFeedback({
+        kind: 'error',
+        text: `Sending isn't enabled${platform ? ` for ${platformLabel(platform)}` : ''} yet.`,
+        platform,
+        action: 'enable',
+      })
+      return
+    }
+    if (code === 'reauth_required') {
+      setFeedback({
+        kind: 'error',
+        text: `Your ${platform ? platformLabel(platform) : 'platform'} login expired. Please reconnect.`,
+        platform,
+        action: 'reauth',
+      })
+      return
+    }
+    if (err.status === 429) {
+      const retry = body.retry_after_seconds
+      setFeedback({
+        kind: 'error',
+        text: retry
+          ? `Rate limited — try again in ${retry}s.`
+          : 'Rate limited — please slow down.',
+      })
+      return
+    }
+    if (err.status === 422) {
+      setFeedback({
+        kind: 'error',
+        text: body.details || 'That channel is not live right now.',
+      })
+      return
+    }
+    setFeedback({
+      kind: 'error',
+      text: body.details || err.message || 'Could not send. Please try again.',
+    })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSending(true)
+    setFeedback(null)
+    try {
+      const res = await sendStreamerMessage({ message: trimmed, platform: targetPlatform })
+      if (isSendToAllResponse(res)) {
+        const parts = res.results.map(
+          (r) =>
+            `${platformLabel(r.platform)} ${r.success ? '✓' : `✗${r.error_kind ? ` ${r.error_kind}` : ''}`}`
+        )
+        const allOk = res.results.every((r) => r.success)
+        setFeedback({
+          kind: allOk ? 'success' : 'partial',
+          text: parts.join(' · '),
+        })
+      } else {
+        setFeedback({ kind: 'success', text: 'Sent ✓' })
+      }
+      setText('')
+    } catch (err) {
+      handleError(err)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-2 border-t border-border bg-surface px-4 py-2.5"
+      aria-label="Send a chat message"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Platform target pills */}
+        <div role="radiogroup" aria-label="Send to" className="flex flex-wrap items-center gap-1.5">
+          {platformSources.map((s) => {
+            const platform = s.platform as SingleSendPlatform
+            const enabled = s.can_send === true
+            const active = enabled && selection.kind === 'platform' && selection.platform === platform
+            return (
+              <button
+                key={platform}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                aria-label={
+                  enabled
+                    ? `Send to ${platformLabel(platform)}`
+                    : `Enable sending for ${platformLabel(platform)}`
+                }
+                title={
+                  enabled
+                    ? platformLabel(platform)
+                    : `Enable sending for ${platformLabel(platform)}`
+                }
+                onClick={() =>
+                  enabled
+                    ? setSelection({ kind: 'platform', platform })
+                    : handleDisabledPill(platform)
+                }
+                className={clsx(
+                  'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none',
+                  active
+                    ? 'border-twitch bg-twitch/15 text-text'
+                    : enabled
+                      ? 'border-border text-text-sub hover:border-border-md hover:text-text'
+                      : 'border-border/60 text-text-dim hover:border-border-md hover:text-text-sub'
+                )}
+              >
+                <PlatformGlyph platform={platform} className="h-3.5 w-3.5" />
+                <span>{platformLabel(platform)}</span>
+                {!enabled && <Lock className="h-3 w-3" aria-hidden="true" />}
+              </button>
+            )
+          })}
+
+          {showAll && (
+            <button
+              type="button"
+              role="radio"
+              aria-checked={selection.kind === 'all'}
+              aria-label="Send to all platforms"
+              onClick={() => setSelection({ kind: 'all' })}
+              className={clsx(
+                'rounded-full border px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none',
+                selection.kind === 'all'
+                  ? 'border-twitch bg-twitch/15 text-text'
+                  : 'border-border text-text-sub hover:border-border-md hover:text-text'
+              )}
+            >
+              All
+            </button>
+          )}
+        </div>
+
+        {/* Message input + send */}
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <label htmlFor={inputId} className="sr-only">
+            Chat message
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            maxLength={MAX_MESSAGE_LENGTH}
+            disabled={sending}
+            placeholder={
+              selection.kind === 'all' ? 'Message all platforms…' : 'Send a message…'
+            }
+            autoComplete="off"
+            className="min-w-0 flex-1 rounded-lg border border-border bg-bg px-3 py-1.5 text-sm text-text placeholder:text-text-dim focus-visible:border-border-md focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="flex shrink-0 items-center gap-1.5 rounded-lg bg-twitch px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Send className="h-3.5 w-3.5" />
+            Send
+          </button>
+        </div>
+      </div>
+
+      {/* Inline feedback (success / partial / error). */}
+      {feedback && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={clsx(
+            'flex flex-wrap items-center gap-2 text-xs',
+            feedback.kind === 'success' && 'text-kick',
+            feedback.kind === 'partial' && 'text-text-sub',
+            feedback.kind === 'error' && 'text-youtube'
+          )}
+        >
+          <span>{feedback.text}</span>
+          {feedback.kind === 'error' && feedback.action === 'enable' && (
+            <button
+              type="button"
+              onClick={() => feedback.platform && onEnable(feedback.platform)}
+              className="font-semibold text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+            >
+              Enable sending
+            </button>
+          )}
+          {feedback.kind === 'error' && feedback.action === 'reauth' && (
+            <button
+              type="button"
+              onClick={() => onReauth(feedback.platform)}
+              className="font-semibold text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+            >
+              Reconnect
+            </button>
+          )}
+        </div>
+      )}
+    </form>
+  )
+}

--- a/frontend/src/components/overlay/LayoutPicker.tsx
+++ b/frontend/src/components/overlay/LayoutPicker.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import clsx from 'clsx'
+import { PanelBottom, PanelLeft, PanelRight, PanelTop, type LucideIcon } from 'lucide-react'
+
+import type { ViewLayout } from '@/app/overlay/[id]/view/viewLayout'
+
+interface LayoutPickerProps {
+  layout: ViewLayout
+  onChange: (layout: ViewLayout) => void
+}
+
+/** The four presets, each with an icon hinting where the chat panel sits. */
+const OPTIONS: ReadonlyArray<{ value: ViewLayout; label: string; Icon: LucideIcon }> = [
+  { value: 'chat-left', label: 'Chat left, events right', Icon: PanelLeft },
+  { value: 'chat-right', label: 'Chat right, events left', Icon: PanelRight },
+  { value: 'chat-top', label: 'Chat top, events below', Icon: PanelTop },
+  { value: 'events-top', label: 'Events top, chat below', Icon: PanelBottom },
+]
+
+/**
+ * Compact segmented control for the overlay monitor's layout. Picks one of four
+ * Chat | Activity arrangements; the page wires the choice into ResizableSplit and
+ * persists it. Visual style matches the other header controls (ViewSettingsBar,
+ * Details, theme toggle).
+ */
+export function LayoutPicker({ layout, onChange }: LayoutPickerProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Panel layout"
+      className="flex items-center rounded-lg border border-border p-0.5"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => {
+        const active = layout === value
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            title={label}
+            onClick={() => onChange(value)}
+            className={clsx(
+              'flex items-center rounded-md px-1.5 py-1 transition-colors focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none',
+              active
+                ? 'bg-surface-2 text-text'
+                : 'text-text-sub hover:text-text',
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/overlay/PlatformGlyph.tsx
+++ b/frontend/src/components/overlay/PlatformGlyph.tsx
@@ -16,17 +16,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import type { ReactElement } from 'react'
+
 /**
- * Small platform brand glyph for the observability view. Uses official brand
- * colors so the platform is identifiable at a glance regardless of theme.
+ * The single per-platform SVG switch, factored out so both the single-glyph
+ * `PlatformGlyph` and the combined `PlatformGlyphs` share one source of truth
+ * (no duplicated SVG paths).
  */
-export function PlatformGlyph({
-  platform,
-  className = 'h-4 w-4',
-}: {
-  platform: string
-  className?: string
-}) {
+function platformSvg(platform: string, className: string): ReactElement | null {
   switch (platform) {
     case 'twitch':
       return (
@@ -88,4 +85,50 @@ export function PlatformGlyph({
     default:
       return null
   }
+}
+
+/**
+ * Small platform brand glyph for the observability view. Uses official brand
+ * colors so the platform is identifiable at a glance regardless of theme.
+ */
+export function PlatformGlyph({
+  platform,
+  className = 'h-4 w-4',
+}: {
+  platform: string
+  className?: string
+}) {
+  return platformSvg(platform, className)
+}
+
+/**
+ * Combined platform badge: renders several brand glyphs in a tight horizontal
+ * row. Used when a single message carries multiple platforms (a streamer's
+ * "send to all" echo collapsed into one message). Unknown platforms are skipped.
+ */
+export function PlatformGlyphs({
+  platforms,
+  className = 'h-4 w-4',
+}: {
+  platforms: string[]
+  className?: string
+}) {
+  const glyphs = platforms
+    .map((platform) => ({ platform, svg: platformSvg(platform, className) }))
+    .filter((g): g is { platform: string; svg: ReactElement } => g.svg !== null)
+
+  if (glyphs.length === 0) return null
+
+  return (
+    <span
+      className="inline-flex items-center gap-0.5"
+      aria-label={`Platforms: ${glyphs.map((g) => g.platform).join(', ')}`}
+    >
+      {glyphs.map(({ platform, svg }) => (
+        <span key={platform} className="inline-flex">
+          {svg}
+        </span>
+      ))}
+    </span>
+  )
 }

--- a/frontend/src/lib/api/chat.ts
+++ b/frontend/src/lib/api/chat.ts
@@ -1,0 +1,97 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Streamer chat-send API client.
+ *
+ * Mirrors the shape of `lib/api/moderation.ts`: a thin wrapper over the shared
+ * `apiClient` (which attaches `Authorization: Bearer <jwt>`) that sends a fresh
+ * `Idempotency-Key` so a double-click only sends once. Error responses propagate
+ * as `ApiError`; the parsed body is on `error.data` (see `apiClient`).
+ */
+
+import { apiClient } from './client'
+
+/** Platforms the streamer can target. `all` fans out to every sendable source. */
+export type SendPlatform = 'twitch' | 'youtube' | 'kick' | 'all'
+
+/** Backend message-length cap; mirror it client-side to avoid a doomed request. */
+export const MAX_MESSAGE_LENGTH = 500
+
+/** Request body for POST /api/v1/auth/chat/send. */
+export interface SendStreamerMessageRequest {
+  message: string
+  platform: SendPlatform
+}
+
+/** Single-platform success envelope (200). */
+export interface SingleSendResponse {
+  success: true
+  message: string
+}
+
+/** Per-platform outcome within a send-to-all response. */
+export interface SendToAllResult {
+  platform: string
+  success: boolean
+  error?: string
+  error_kind?: string
+}
+
+/** Send-to-all success envelope (200); `success` is true if ≥1 platform sent. */
+export interface SendToAllResponse {
+  success: boolean
+  results: SendToAllResult[]
+}
+
+/** Union of the two 200 shapes; discriminate on the `results` array. */
+export type StreamerSendResponse = SingleSendResponse | SendToAllResponse
+
+/**
+ * Error body shape carried on a non-2xx response (`ApiError.data`). `error` is
+ * the discriminant: `missing_scope` (403) and `reauth_required` (401) get
+ * special UI; others (`not_live` 422, rate-limit 429 with `retry_after_seconds`,
+ * 502, …) surface inline.
+ */
+export interface SendErrorBody {
+  error: string
+  platform?: string
+  details?: string
+  retry_after_seconds?: number
+}
+
+/** Type guard: is this 200 envelope the multi-platform (send-to-all) shape? */
+export function isSendToAllResponse(res: StreamerSendResponse): res is SendToAllResponse {
+  return Array.isArray((res as SendToAllResponse).results)
+}
+
+/** A fresh idempotency header for one send request. */
+function idempotencyHeader(): Record<string, string> {
+  return { 'Idempotency-Key': crypto.randomUUID() }
+}
+
+/**
+ * Send a chat message as the overlay's streamer. POSTs to the auth-service
+ * (which applies its own JWT + send scopes). On failure throws `ApiError`; read
+ * `error.status` and `error.data` (typed as `SendErrorBody`) to branch.
+ */
+export function sendStreamerMessage(
+  body: SendStreamerMessageRequest
+): Promise<StreamerSendResponse> {
+  return apiClient.post<StreamerSendResponse>('/api/v1/auth/chat/send', body, idempotencyHeader())
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -47,7 +47,14 @@ const API_URL = getApiUrl()
 export class ApiError extends Error {
   constructor(
     public status: number,
-    message: string
+    message: string,
+    /**
+     * The parsed JSON error body, when the server returned one. Lets callers
+     * inspect contract-specific fields (e.g. the chat-send endpoint's `error`
+     * discriminant, `platform`, `details`, `retry_after_seconds`) instead of
+     * only the flattened `message`. Undefined if the body wasn't JSON.
+     */
+    public data?: Record<string, unknown>
   ) {
     super(message)
     this.name = 'ApiError'
@@ -78,18 +85,25 @@ class ApiClient {
       headers,
     })
 
-    if (response.status === 401) {
-      // Token expired or invalid, clear it
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('jwt_token')
-        window.location.href = '/'
-      }
-      throw new ApiError(401, 'Unauthorized')
-    }
-
     if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
-      throw new ApiError(response.status, errorData.error || response.statusText)
+      const errorData: Record<string, unknown> = await response
+        .json()
+        .catch(() => ({ error: 'Unknown error' }))
+      const errorValue = typeof errorData.error === 'string' ? errorData.error : undefined
+
+      if (response.status === 401) {
+        // A `reauth_required` 401 is an application-level signal (the platform
+        // OAuth token was revoked) that the caller surfaces inline — it must NOT
+        // trigger the generic "JWT expired → log out" path. Every other 401 means
+        // our own session token is invalid: clear it and bounce to the landing page.
+        if (errorValue !== 'reauth_required' && typeof window !== 'undefined') {
+          localStorage.removeItem('jwt_token')
+          window.location.href = '/'
+        }
+        throw new ApiError(401, errorValue || 'Unauthorized', errorData)
+      }
+
+      throw new ApiError(response.status, errorValue || response.statusText, errorData)
     }
 
     return response

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -76,7 +76,13 @@ export interface EventInfo {
 export interface ChatMessage {
   id: string;
   overlay_id: string;
-  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'discord' | 'system';
+  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'discord' | 'system'; // Primary platform
+  /**
+   * All platforms this message was delivered to. Length > 1 for a streamer's
+   * "send to all" echo collapsed into one message; absent/length ≤ 1 ⇒ render
+   * just the singular `platform`.
+   */
+  platforms?: string[];
   channel_id: string;
   channel_name: string;
   user: UserInfo;

--- a/frontend/src/lib/types/moderation.ts
+++ b/frontend/src/lib/types/moderation.ts
@@ -43,6 +43,11 @@ export interface SourceCapability {
   moderatable: boolean
   reason?: ModerationUnavailableReason
   actions: ModerationAction[]
+  /**
+   * Whether the streamer can send chat messages on this source from the monitor.
+   * Optional; absent ⇒ treat as false (no send scope granted / unsupported).
+   */
+  can_send?: boolean
 }
 
 /** Overlay-wide moderation capabilities for the logged-in viewer. */

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -522,6 +522,10 @@ func main() {
 		protectedAPI.POST("/auth/logout", proxyHandler.ForwardRequest)
 		protectedAPI.DELETE("/auth/me", proxyHandler.ForwardRequest)
 
+		// Streamer chat send (monitor view sends using the streamer's own OAuth
+		// tokens) -> auth-service POST /chat/send.
+		protectedAPI.POST("/auth/chat/send", proxyHandler.ForwardRequest)
+
 		// Discord guild management
 		protectedAPI.GET("/auth/discord/connect", proxyHandler.ForwardRequest)
 		protectedAPI.GET("/auth/guilds", proxyHandler.ForwardRequest)

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -243,7 +243,7 @@ func main() {
 	healthHandler := handlers.NewHealthHandler(db, redisClient)
 	adminHandler := handlers.NewAdminHandler(userRepo, db, log, userKeyChain)
 	viewerCosmeticsHandler := handlers.NewViewerCosmeticsHandler(viewerIdentityRepo, redisClient, log)
-	chatSendHandler := handlers.NewChatSendHandler(log, viewerRepo, userRepo, db, twitchClientID, viewerTwitchOAuth, viewerYouTubeOAuth, viewerKickOAuth, tokenCipher, youtubeAPIKey, redisClient)
+	chatSendHandler := handlers.NewChatSendHandler(log, viewerRepo, userRepo, db, twitchClientID, viewerTwitchOAuth, viewerYouTubeOAuth, viewerKickOAuth, tokenCipher, youtubeAPIKey, redisClient, getEnvOrDefault("YOUTUBE_LISTENER_URL", ""))
 	streamerInfoHandler := handlers.NewStreamerInfoHandler(log, userRepo, db)
 	adminViewerHandler := handlers.NewAdminViewerHandler(log, viewerRepo)
 	adminCosmeticsHandler := handlers.NewAdminCosmeticsHandler(log, db)

--- a/services/auth-service/handlers/chat_send.go
+++ b/services/auth-service/handlers/chat_send.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"time"
 
 	"github.com/caesar/all-chat/services/auth-service/models"
+	"github.com/caesar/all-chat/shared/sendall"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -39,7 +41,73 @@ const (
 	maxMessageLength = 500
 	rateLimit1Min    = 20
 	rateLimit1Hour   = 100
+	// quotaCostYouTubeSend mirrors youtube-listener quota.QuotaCostLiveChatMessages —
+	// a liveChatMessages.insert costs 5 quota units.
+	quotaCostYouTubeSend = 5
 )
+
+// sendErrKind classifies a streamer-send failure so HandleStreamerSendMessage can map
+// it to the right HTTP status and a machine-readable code the monitor view reacts to
+// (e.g. prompt the advanced-controls opt-in on a missing scope).
+type sendErrKind string
+
+const (
+	sendErrUpstream     sendErrKind = "send_failed"     // platform 5xx / network → 502
+	sendErrMissingScope sendErrKind = "missing_scope"   // platform 403 → 403, prompt opt-in
+	sendErrReauth       sendErrKind = "reauth_required" // platform 401 → 401, prompt re-login
+	sendErrOffline      sendErrKind = "stream_offline"  // not live → 422
+	sendErrQuota        sendErrKind = "quota_exhausted" // YouTube send quota depleted → 422
+)
+
+// streamerSendError carries a classified streamer-send failure.
+type streamerSendError struct {
+	kind sendErrKind
+	msg  string
+}
+
+func (e *streamerSendError) Error() string { return e.msg }
+
+// classifyPlatformStatus maps a platform HTTP error response to a typed send error:
+// 401 ⇒ re-auth (token expired/invalid), 403 ⇒ missing scope (prompt the opt-in),
+// anything else ⇒ an upstream failure. Previously every platform error surfaced as a
+// raw 502, so the monitor could not tell "needs re-consent" from "platform hiccup".
+func classifyPlatformStatus(platform string, status int, body string) *streamerSendError {
+	switch status {
+	case http.StatusUnauthorized:
+		return &streamerSendError{kind: sendErrReauth, msg: fmt.Sprintf("%s auth rejected (401): %s", platform, body)}
+	case http.StatusForbidden:
+		return &streamerSendError{kind: sendErrMissingScope, msg: fmt.Sprintf("%s missing send scope (403): %s", platform, body)}
+	default:
+		return &streamerSendError{kind: sendErrUpstream, msg: fmt.Sprintf("%s API error: status=%d body=%s", platform, status, body)}
+	}
+}
+
+// streamerSendHTTPResponse maps a send error to (HTTP status, JSON body) for the
+// streamer endpoint. Typed errors map directly; an untyped error falls back to the
+// text-based classifier (e.g. "not currently live" → 422).
+func streamerSendHTTPResponse(platform string, err error) (int, gin.H) {
+	var se *streamerSendError
+	if errors.As(err, &se) {
+		switch se.kind {
+		case sendErrMissingScope:
+			return http.StatusForbidden, gin.H{"error": string(sendErrMissingScope), "platform": platform}
+		case sendErrReauth:
+			return http.StatusUnauthorized, gin.H{"error": string(sendErrReauth), "platform": platform}
+		case sendErrOffline:
+			return http.StatusUnprocessableEntity, gin.H{"error": string(sendErrOffline), "platform": platform, "details": "The streamer is not currently live."}
+		case sendErrQuota:
+			return http.StatusUnprocessableEntity, gin.H{"error": string(sendErrQuota), "platform": platform, "details": "YouTube send quota is exhausted. Please try again later."}
+		}
+	}
+	status, desc := classifySendError(err.Error())
+	code := string(sendErrUpstream)
+	if status == http.StatusUnauthorized {
+		code = string(sendErrReauth)
+	} else if status == http.StatusUnprocessableEntity {
+		code = "unavailable"
+	}
+	return status, gin.H{"error": code, "platform": platform, "details": desc}
+}
 
 // classifySendError returns the appropriate HTTP status code and a user-friendly
 // description based on the error message. Prevents returning 502 for errors that
@@ -117,6 +185,11 @@ type ChatSendHandler struct {
 	cipher          StringEncryptor
 	youtubeAPIKey   string
 	redisClient     *redis.Client
+	// youtubeListenerURL is the in-cluster base URL of youtube-listener (e.g.
+	// http://youtube-listener:8086). When set, YouTube sends reserve/confirm quota
+	// against its coordination API so the quota monitor reflects send usage and a
+	// depleted quota blocks sends. Empty ⇒ quota accounting is skipped (fail-open).
+	youtubeListenerURL string
 }
 
 // NewChatSendHandler creates a new chat send handler
@@ -132,20 +205,22 @@ func NewChatSendHandler(
 	cipher StringEncryptor,
 	youtubeAPIKey string,
 	redisClient *redis.Client,
+	youtubeListenerURL string,
 ) *ChatSendHandler {
 	return &ChatSendHandler{
-		log:             log.Named("chat-send"),
-		viewerRepo:      viewerRepo,
-		userRepo:        userRepo,
-		db:              db,
-		httpClient:      &http.Client{Timeout: 10 * time.Second},
-		clientID:        clientID,
-		twitchProvider:  twitchProvider,
-		youtubeProvider: youtubeProvider,
-		kickProvider:    kickProvider,
-		cipher:          cipher,
-		youtubeAPIKey:   youtubeAPIKey,
-		redisClient:     redisClient,
+		log:                log.Named("chat-send"),
+		viewerRepo:         viewerRepo,
+		userRepo:           userRepo,
+		db:                 db,
+		httpClient:         &http.Client{Timeout: 10 * time.Second},
+		clientID:           clientID,
+		twitchProvider:     twitchProvider,
+		youtubeProvider:    youtubeProvider,
+		kickProvider:       kickProvider,
+		cipher:             cipher,
+		youtubeAPIKey:      youtubeAPIKey,
+		redisClient:        redisClient,
+		youtubeListenerURL: strings.TrimSuffix(youtubeListenerURL, "/"),
 	}
 }
 
@@ -394,6 +469,18 @@ func (h *ChatSendHandler) HandleStreamerSendMessage(c *gin.Context) {
 		zap.String("user_id", userID),
 		zap.String("username", user.Username))
 
+	// "all" fans out to every connected platform and returns per-platform results.
+	if req.Platform == "all" {
+		h.handleStreamerSendToAll(c, ctx, user, req.Message)
+		return
+	}
+
+	// Single-platform send. Rate-limit against the streamer's own limits (one unit).
+	if ok, retryAfter := h.reserveStreamerRate(ctx, user.ID, 1); !ok {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited", "retry_after_seconds": retryAfter})
+		return
+	}
+
 	// Send message based on target platform
 	var messageErr error
 	switch req.Platform {
@@ -412,8 +499,9 @@ func (h *ChatSendHandler) HandleStreamerSendMessage(c *gin.Context) {
 	}
 
 	if messageErr != nil {
-		h.log.Error("Failed to send streamer message", zap.Error(messageErr), zap.String("platform", req.Platform))
-		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to send message", "details": messageErr.Error()})
+		status, body := streamerSendHTTPResponse(req.Platform, messageErr)
+		h.log.Warn("Failed to send streamer message", zap.Error(messageErr), zap.String("platform", req.Platform), zap.Int("status", status))
+		c.JSON(status, body)
 		return
 	}
 
@@ -505,7 +593,7 @@ func (h *ChatSendHandler) sendStreamerTwitchMessage(ctx context.Context, user *m
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("twitch API error: status=%d body=%s", resp.StatusCode, string(body))
+		return classifyPlatformStatus("twitch", resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -523,6 +611,15 @@ func (h *ChatSendHandler) sendStreamerYouTubeMessage(ctx context.Context, user *
 		return fmt.Errorf("failed to get live chat ID: %w", err)
 	}
 
+	// Account the send against the shared YouTube quota (a send costs 5 units) via the
+	// youtube-listener coordination API, so the quota monitor reflects send usage and a
+	// depleted quota blocks the send. Reserve before sending, then confirm on success /
+	// roll back on failure. Fails open when not configured / listener unreachable.
+	reservationID, ok := h.reserveYouTubeSendQuota(ctx, quotaCostYouTubeSend)
+	if !ok {
+		return &streamerSendError{kind: sendErrQuota, msg: "youtube send blocked: daily quota exhausted"}
+	}
+
 	reqBody := map[string]interface{}{
 		"snippet": map[string]interface{}{
 			"liveChatId": liveChatID,
@@ -535,12 +632,14 @@ func (h *ChatSendHandler) sendStreamerYouTubeMessage(ctx context.Context, user *
 
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
+		h.settleYouTubeSendQuota(ctx, reservationID, quotaCostYouTubeSend, false)
 		return fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
 	url := "https://www.googleapis.com/youtube/v3/liveChat/messages?part=snippet"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(bodyBytes))
 	if err != nil {
+		h.settleYouTubeSendQuota(ctx, reservationID, quotaCostYouTubeSend, false)
 		return fmt.Errorf("failed to create request: %w", err)
 	}
 
@@ -549,15 +648,18 @@ func (h *ChatSendHandler) sendStreamerYouTubeMessage(ctx context.Context, user *
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
+		h.settleYouTubeSendQuota(ctx, reservationID, quotaCostYouTubeSend, false)
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("youtube API error: status=%d body=%s", resp.StatusCode, string(body))
+		h.settleYouTubeSendQuota(ctx, reservationID, quotaCostYouTubeSend, false)
+		return classifyPlatformStatus("youtube", resp.StatusCode, string(body))
 	}
 
+	h.settleYouTubeSendQuota(ctx, reservationID, quotaCostYouTubeSend, true)
 	return nil
 }
 
@@ -595,10 +697,227 @@ func (h *ChatSendHandler) sendStreamerKickMessage(ctx context.Context, user *mod
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("kick API error: status=%d body=%s", resp.StatusCode, string(body))
+		return classifyPlatformStatus("kick", resp.StatusCode, string(body))
 	}
 
 	return nil
+}
+
+// streamerSendResult is one platform's outcome in a send-to-all response.
+type streamerSendResult struct {
+	Platform  string `json:"platform"`
+	Success   bool   `json:"success"`
+	Error     string `json:"error,omitempty"`
+	ErrorKind string `json:"error_kind,omitempty"`
+}
+
+// handleStreamerSendToAll fans the message out to every platform the streamer is
+// connected on (Twitch/YouTube/Kick — TikTok has no send API, Discord no streamer
+// path), pre-registers the dedup group so the echoed-back copies collapse into one
+// combined-pill message, and returns per-platform results. Partial success is normal
+// (e.g. YouTube quota-blocked while Twitch + Kick succeed).
+func (h *ChatSendHandler) handleStreamerSendToAll(c *gin.Context, ctx context.Context, user *models.User, message string) {
+	// Candidate platforms: those the streamer has a platform identity on. senderID is
+	// the platform-native id that appears as the author on the echoed-back message.
+	idsByPlatform := map[string]string{}
+	if user.TwitchID != nil && *user.TwitchID != "" {
+		idsByPlatform["twitch"] = *user.TwitchID
+	}
+	if user.KickID != nil && *user.KickID != "" {
+		idsByPlatform["kick"] = *user.KickID
+	}
+	if ytChannelID, ytErr := h.getActiveYouTubeChannelID(ctx, user.ID); ytErr == nil && ytChannelID != "" {
+		idsByPlatform["youtube"] = ytChannelID
+	}
+
+	if len(idsByPlatform) == 0 {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "no_sendable_platform", "details": "No connected platform is configured for sending."})
+		return
+	}
+
+	// Rate-limit per platform (the plan's send-to-all accounting): N platforms = N units.
+	if ok, retryAfter := h.reserveStreamerRate(ctx, user.ID, len(idsByPlatform)); !ok {
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "rate_limited", "retry_after_seconds": retryAfter})
+		return
+	}
+
+	// Deterministic platform order so the combined pill / primary platform is stable.
+	platforms := make([]string, 0, len(idsByPlatform))
+	for _, p := range []string{"twitch", "youtube", "kick"} {
+		if _, ok := idsByPlatform[p]; ok {
+			platforms = append(platforms, p)
+		}
+	}
+
+	// Pre-register the echoes (only meaningful for ≥2 targets) BEFORE sending, so the
+	// message-processor recognises each platform's echo and collapses them into one.
+	if len(platforms) >= 2 {
+		h.preRegisterSendAll(ctx, idsByPlatform, message, platforms)
+	}
+
+	results := make([]streamerSendResult, 0, len(platforms))
+	anySuccess := false
+	for _, platform := range platforms {
+		var sendErr error
+		switch platform {
+		case "twitch":
+			sendErr = h.sendStreamerTwitchMessage(ctx, user, message)
+		case "kick":
+			sendErr = h.sendStreamerKickMessage(ctx, user, message)
+		case "youtube":
+			sendErr = h.sendStreamerYouTubeMessage(ctx, user, message)
+		}
+		if sendErr != nil {
+			kind := string(sendErrUpstream)
+			var se *streamerSendError
+			if errors.As(sendErr, &se) {
+				kind = string(se.kind)
+			}
+			results = append(results, streamerSendResult{Platform: platform, Success: false, Error: kind, ErrorKind: kind})
+			h.log.Warn("send-to-all platform failed", zap.String("platform", platform), zap.Error(sendErr))
+		} else {
+			anySuccess = true
+			results = append(results, streamerSendResult{Platform: platform, Success: true})
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": anySuccess, "results": results})
+}
+
+// preRegisterSendAll writes one short-TTL Redis key per target platform identity, all
+// pointing at one group id, so the message-processor recognises the echoed-back copies
+// and renders a single combined-pill message instead of N. Best-effort: a write failure
+// just means that platform's echo shows as its own message. See shared/sendall.
+func (h *ChatSendHandler) preRegisterSendAll(ctx context.Context, idsByPlatform map[string]string, message string, platforms []string) {
+	if h.redisClient == nil {
+		return
+	}
+	payload, err := json.Marshal(sendall.Registration{GroupID: uuid.NewString(), Platforms: platforms})
+	if err != nil {
+		h.log.Warn("send-to-all: failed to marshal registration", zap.Error(err))
+		return
+	}
+	for platform, senderID := range idsByPlatform {
+		if senderID == "" {
+			continue
+		}
+		if err := h.redisClient.Set(ctx, sendall.Key(platform, senderID, message), payload, sendall.TTL).Err(); err != nil {
+			h.log.Warn("send-to-all: failed to pre-register echo key", zap.String("platform", platform), zap.Error(err))
+		}
+	}
+}
+
+// reserveStreamerRate enforces the streamer's send rate limits (rateLimit1Min per
+// minute, rateLimit1Hour per hour) using fixed Redis windows, charging n units (a
+// send-to-all charges one per target platform). Returns (allowed, retryAfterSeconds).
+// Fails open if Redis is unavailable — rate limiting is a safeguard, not a gate.
+func (h *ChatSendHandler) reserveStreamerRate(ctx context.Context, userID string, n int) (bool, int) {
+	if h.redisClient == nil || n <= 0 {
+		return true, 0
+	}
+	check := func(key string, limit int, window time.Duration) (bool, int) {
+		val, err := h.redisClient.IncrBy(ctx, key, int64(n)).Result()
+		if err != nil {
+			return true, 0 // fail open
+		}
+		if val == int64(n) {
+			h.redisClient.Expire(ctx, key, window)
+		}
+		if val > int64(limit) {
+			ttl, _ := h.redisClient.TTL(ctx, key).Result()
+			secs := int(ttl.Seconds())
+			if secs < 1 {
+				secs = 1
+			}
+			return false, secs
+		}
+		return true, 0
+	}
+	if ok, retry := check("streamer_send_rl:min:"+userID, rateLimit1Min, time.Minute); !ok {
+		return false, retry
+	}
+	if ok, retry := check("streamer_send_rl:hr:"+userID, rateLimit1Hour, time.Hour); !ok {
+		return false, retry
+	}
+	return true, 0
+}
+
+// reserveQuotaResp is the youtube-listener /api/v1/quota/reserve response.
+type reserveQuotaResp struct {
+	Success       bool   `json:"success"`
+	ReservationID string `json:"reservation_id"`
+	Reason        string `json:"reason"`
+}
+
+// reserveYouTubeSendQuota reserves units against the youtube-listener global quota
+// before a send. Returns (reservationID, ok); ok=false means the send must be BLOCKED
+// (quota depleted / emergency shutoff). FAILS OPEN (returns "", true) when quota
+// accounting is not configured or the listener is unreachable — a coordination hiccup
+// must never block a streamer's own chat, and a send is cheap vs. the daily quota.
+func (h *ChatSendHandler) reserveYouTubeSendQuota(ctx context.Context, units int) (string, bool) {
+	if h.youtubeListenerURL == "" {
+		return "", true
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"units":          units,
+		"service":        "auth-service",
+		"operation":      "liveChatMessages.insert",
+		"allow_critical": false,
+	})
+	if err != nil {
+		return "", true
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.youtubeListenerURL+"/api/v1/quota/reserve", bytes.NewReader(body))
+	if err != nil {
+		return "", true
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.log.Warn("youtube quota reserve failed; allowing send", zap.Error(err))
+		return "", true
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		h.log.Warn("youtube quota reserve returned non-200; allowing send", zap.Int("status", resp.StatusCode))
+		return "", true
+	}
+	var out reserveQuotaResp
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", true
+	}
+	if !out.Success {
+		return "", false // depleted / emergency shutoff
+	}
+	return out.ReservationID, true
+}
+
+// settleYouTubeSendQuota confirms (success=true) or rolls back (success=false) a prior
+// reservation. Best-effort: a settle failure only skews the quota counter slightly.
+func (h *ChatSendHandler) settleYouTubeSendQuota(ctx context.Context, reservationID string, units int, success bool) {
+	if h.youtubeListenerURL == "" || reservationID == "" {
+		return
+	}
+	body, err := json.Marshal(map[string]interface{}{
+		"reservation_id": reservationID,
+		"units":          units,
+		"service":        "auth-service",
+		"success":        success,
+	})
+	if err != nil {
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, h.youtubeListenerURL+"/api/v1/quota/confirm", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		h.log.Warn("youtube quota settle failed", zap.Bool("success", success), zap.Error(err))
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 // checkRateLimit checks if the viewer is within rate limits

--- a/services/auth-service/handlers/chat_send_streamer_test.go
+++ b/services/auth-service/handlers/chat_send_streamer_test.go
@@ -1,0 +1,64 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestClassifyPlatformStatus(t *testing.T) {
+	cases := []struct {
+		status int
+		want   sendErrKind
+	}{
+		{http.StatusUnauthorized, sendErrReauth},
+		{http.StatusForbidden, sendErrMissingScope},
+		{http.StatusInternalServerError, sendErrUpstream},
+		{http.StatusBadGateway, sendErrUpstream},
+	}
+	for _, tc := range cases {
+		if got := classifyPlatformStatus("twitch", tc.status, "body"); got.kind != tc.want {
+			t.Errorf("status %d: kind = %q, want %q", tc.status, got.kind, tc.want)
+		}
+	}
+}
+
+func TestStreamerSendHTTPResponse(t *testing.T) {
+	// Typed missing-scope ⇒ 403 + machine code + platform (drives the opt-in prompt).
+	if status, body := streamerSendHTTPResponse("kick", &streamerSendError{kind: sendErrMissingScope, msg: "x"}); status != http.StatusForbidden || body["error"] != string(sendErrMissingScope) || body["platform"] != "kick" {
+		t.Errorf("missing_scope mapping wrong: status=%d body=%v", status, body)
+	}
+	// Typed re-auth ⇒ 401.
+	if status, _ := streamerSendHTTPResponse("twitch", &streamerSendError{kind: sendErrReauth, msg: "x"}); status != http.StatusUnauthorized {
+		t.Errorf("reauth status = %d, want 401", status)
+	}
+	// Typed quota ⇒ 422 + quota code.
+	if status, body := streamerSendHTTPResponse("youtube", &streamerSendError{kind: sendErrQuota, msg: "x"}); status != http.StatusUnprocessableEntity || body["error"] != string(sendErrQuota) {
+		t.Errorf("quota mapping wrong: status=%d body=%v", status, body)
+	}
+	// Untyped "not live" message ⇒ classifier maps to 422.
+	if status, _ := streamerSendHTTPResponse("twitch", fmt.Errorf("the streamer is not currently live")); status != http.StatusUnprocessableEntity {
+		t.Errorf("offline fallback status = %d, want 422", status)
+	}
+	// Untyped generic failure ⇒ 502.
+	if status, _ := streamerSendHTTPResponse("twitch", errors.New("kaboom")); status != http.StatusBadGateway {
+		t.Errorf("generic fallback status = %d, want 502", status)
+	}
+}

--- a/services/auth-service/handlers/platform_auth_v2.go
+++ b/services/auth-service/handlers/platform_auth_v2.go
@@ -370,13 +370,18 @@ func (h *PlatformAuthHandlerV2) HandleEnableModeration(platform oauth.Platform) 
 		// one scope and has no single-message delete. Unsupported platforms are rejected.
 		actions := splitActions(c.Query("actions"))
 		var modScopes []string
+		var sendScope string
 		switch provider.(type) {
 		case *oauth.TwitchOAuth:
 			modScopes = oauth.ModerationScopesForActions(actions)
+			sendScope = oauth.TwitchSendScope
 		case *oauth.KickOAuth:
 			modScopes = oauth.KickModerationScopesForActions(actions)
+			sendScope = oauth.KickSendScope
 		case *oauth.YouTubeOAuth:
 			modScopes = oauth.YouTubeModerationScopesForActions(actions)
+			// YouTube's force-ssl grant (requested for the ban action) already
+			// authorizes live-chat send, so there is no separate send scope.
 		default:
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("moderation is not supported for %s", platform)})
 			return
@@ -384,6 +389,12 @@ func (h *PlatformAuthHandlerV2) HandleEnableModeration(platform oauth.Platform) 
 		if len(modScopes) == 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "no valid moderation actions; expected ?actions=delete,timeout,ban,unban"})
 			return
+		}
+		// This opt-in is the unified "advanced controls" consent: a single re-consent
+		// grants moderation AND chat sending (the monitor view's send bar). Always fold
+		// in the platform's send scope so the issued token covers both at once.
+		if sendScope != "" {
+			modScopes = append(modScopes, sendScope)
 		}
 
 		// Union with the scopes already granted FOR THIS PLATFORM so the new token is a
@@ -1119,9 +1130,11 @@ func linkMayReplacePrimaryCredentials(authProvider string, platform oauth.Platfo
 // never blocked by this guard.
 var preservableScopes = []string{
 	"user:read:chat",
+	"user:write:chat", // Twitch chat-send grant (advanced-controls opt-in)
 	"moderator:manage:chat_messages",
 	"moderator:manage:banned_users",
 	"moderation:ban",                                    // Kick moderation grant (opt-in re-consent, ADR-0017)
+	"chat:write",                                        // Kick chat-send grant (advanced-controls opt-in)
 	"https://www.googleapis.com/auth/youtube.force-ssl", // YouTube moderation grant (ADR-0017)
 }
 

--- a/services/auth-service/oauth/kick.go
+++ b/services/auth-service/oauth/kick.go
@@ -88,6 +88,11 @@ func (k *KickOAuth) GetAuthURL(state string) string {
 	return kickAuthURL + "?" + params.Encode()
 }
 
+// KickSendScope authorizes the Kick public "Send Chat Message" API
+// (POST /public/v1/chat). Requested ONLY through the opt-in advanced-controls
+// re-consent (alongside moderation:ban), never bundled into login/add-source.
+const KickSendScope = "chat:write"
+
 // kickModerationScopeByAction maps a moderation action to the Kick OAuth scope it
 // requires. Kick gates ban/timeout/unban behind a single scope and has no
 // single-message delete, so delete maps to nothing. Requested ONLY through the opt-in

--- a/services/auth-service/oauth/twitch.go
+++ b/services/auth-service/oauth/twitch.go
@@ -37,6 +37,12 @@ import (
 // (broadcaster side). See services/twitch-eventsub-listener for the consumer.
 var TwitchChatScopes = []string{"user:read:chat", "user:bot", "channel:bot"}
 
+// TwitchSendScope authorizes the Helix "Send Chat Message" API
+// (POST /helix/chat/messages) for a user token where the broadcaster is also the
+// sender. Requested ONLY through the opt-in advanced-controls re-consent (alongside
+// the moderation scopes), never bundled into login/add-source (least privilege).
+const TwitchSendScope = "user:write:chat"
+
 // TwitchOAuth handles Twitch OAuth 2.0 flow
 type TwitchOAuth struct {
 	config *oauth2.Config

--- a/services/message-processor/cmd/main.go
+++ b/services/message-processor/cmd/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/caesar/all-chat/shared/database"
 	"github.com/caesar/all-chat/shared/logger"
 	"github.com/caesar/all-chat/shared/metrics"
+	"github.com/caesar/all-chat/shared/sendall"
 	"github.com/caesar/all-chat/shared/tracing"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -303,6 +304,19 @@ func main() {
 					)
 				}
 			}()
+		}
+
+		// Send-to-all detection (once per raw message): if this is a streamer's own
+		// message echoed back after a "send to all", auth-service pre-registered it so
+		// the N platform echoes collapse into one combined-pill message. Only chat
+		// messages participate — events never fan out this way.
+		var sendAllGroup *sendall.Registration
+		if rawMsg.EventType == "" || rawMsg.EventType == "chat" {
+			if reg, lookupErr := deduplicator.LookupSendAllGroup(ctx, rawMsg.Platform, rawMsg.UserID, rawMsg.Text); lookupErr != nil {
+				log.Debug("send-to-all lookup failed, treating as ordinary message", zap.Error(lookupErr))
+			} else {
+				sendAllGroup = reg
+			}
 		}
 
 		// Process message for each overlay.
@@ -577,6 +591,27 @@ func main() {
 			}
 
 		publish:
+			// Streamer send-to-all: collapse the per-platform echoes into one combined
+			// message. Reuse the shared group id (so all echoes share an id), attach the
+			// full platform set for the combined pill, and publish at most once per
+			// overlay — the first echo to arrive wins, later siblings are dropped here.
+			if sendAllGroup != nil {
+				unified.ID = sendAllGroup.GroupID
+				unified.Platforms = sendAllGroup.Platforms
+				if len(sendAllGroup.Platforms) > 0 {
+					unified.Platform = sendAllGroup.Platforms[0]
+				}
+				if won, claimErr := deduplicator.ClaimSendAllOverlay(ctx, overlay.OverlayID, sendAllGroup.GroupID); claimErr == nil && !won {
+					log.Debug("send-to-all echo already published to overlay, skipping",
+						zap.String("overlay_id", overlay.OverlayID),
+						zap.String("group_id", sendAllGroup.GroupID),
+						zap.String("platform", rawMsg.Platform),
+					)
+					processorMetrics.RecordMessageProcessed("message-processor", rawMsg.Platform, "sendall_deduplicated", "skipped")
+					continue
+				}
+			}
+
 			// Check for duplicate messages per overlay (Phase 15-03: overlay-specific deduplication)
 			// Prevents duplicates from overlapping sources (e.g., Twitch Shared Chat)
 			// Extract platform message ID from tags for better fingerprinting

--- a/services/message-processor/dedup/dedup.go
+++ b/services/message-processor/dedup/dedup.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/caesar/all-chat/shared/sendall"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 )
@@ -177,4 +179,44 @@ func (d *Deduplicator) ClearForOverlay(ctx context.Context, overlayID, platform,
 	key := fmt.Sprintf("%s:%s", dedupPrefix, fingerprint)
 
 	return d.client.Del(ctx, key).Err()
+}
+
+// LookupSendAllGroup checks whether an incoming message matches a streamer "send to
+// all" pre-registration written by auth-service just before fan-out (keyed on the
+// platform, the streamer's platform-native sender id, and the normalized text). On a
+// match it returns the shared group (id + full platform set) so the echo can be
+// collapsed into one combined-pill message. Returns nil (treat as an ordinary message)
+// when there is no registration, and fails to nil on any Redis/parse error.
+func (d *Deduplicator) LookupSendAllGroup(ctx context.Context, platform, senderID, text string) (*sendall.Registration, error) {
+	if senderID == "" || text == "" {
+		return nil, nil
+	}
+	val, err := d.client.Get(ctx, sendall.Key(platform, senderID, text)).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var reg sendall.Registration
+	if err := json.Unmarshal([]byte(val), &reg); err != nil {
+		return nil, err
+	}
+	if reg.GroupID == "" {
+		return nil, nil
+	}
+	return &reg, nil
+}
+
+// ClaimSendAllOverlay reports whether THIS echo is the first of its send-to-all group
+// to reach the given overlay (atomic SETNX). The winner publishes the combined-pill
+// message; losing siblings are dropped so the overlay shows one message, not N. Fails
+// open (returns true) on a Redis error so a blip never silently drops the message.
+func (d *Deduplicator) ClaimSendAllOverlay(ctx context.Context, overlayID, groupID string) (bool, error) {
+	wasSet, err := d.client.SetNX(ctx, sendall.PublishedKey(overlayID, groupID), "1", sendall.TTL).Result()
+	if err != nil {
+		d.logger.Error("sendall overlay claim SetNX failed, failing open", zap.Error(err))
+		return true, err
+	}
+	return wasSet, nil
 }

--- a/services/message-processor/models/message.go
+++ b/services/message-processor/models/message.go
@@ -45,6 +45,11 @@ type UnifiedChatMessage struct {
 	ID          string                 `json:"id"`
 	OverlayID   string                 `json:"overlay_id"`
 	Platform    string                 `json:"platform"`
+	// Platforms is set only for a streamer "send to all" message whose per-platform
+	// echoes were collapsed into one: it lists every platform the message was sent to,
+	// so consumers can render a combined multi-platform pill. Omitted (nil) for ordinary
+	// single-platform messages, where the singular Platform above is authoritative.
+	Platforms   []string               `json:"platforms,omitempty"`
 	ChannelID   string                 `json:"channel_id"`
 	ChannelName string                 `json:"channel_name"`
 	User        UserInfo               `json:"user"`

--- a/services/moderation-service/cmd/main.go
+++ b/services/moderation-service/cmd/main.go
@@ -115,6 +115,9 @@ func main() {
 	// configures the credentials and gets real platform calls.
 	dispatchers := map[string]dispatch.PlatformDispatcher{}
 	scopeCheckers := map[string]handler.ScopeChecker{}
+	// sendCheckers parallels scopeCheckers: the same per-platform checker instances
+	// also report the chat-send capability (can_send) for the monitor view's send bar.
+	sendCheckers := map[string]handler.SendChecker{}
 
 	// Twitch (delete/timeout/ban/unban) needs the token cipher (to decrypt broadcaster
 	// tokens) AND the Twitch app credentials (Client-Id header + refresh grant).
@@ -128,7 +131,9 @@ func main() {
 		twitchSource := tokens.NewTwitchSource(dbPool, cipher, cfg.TwitchClientID, cfg.TwitchClientSecret)
 		twitchClient := clients.NewTwitchClient(cfg.TwitchClientID)
 		dispatchers["twitch"] = dispatch.NewTwitch(twitchSource, twitchClient, log)
-		scopeCheckers["twitch"] = tokens.NewTwitchScopeChecker(twitchSource)
+		twitchScopes := tokens.NewTwitchScopeChecker(twitchSource)
+		scopeCheckers["twitch"] = twitchScopes
+		sendCheckers["twitch"] = twitchScopes
 		log.Info("Twitch moderation enabled (real Helix calls)")
 	}
 
@@ -142,7 +147,9 @@ func main() {
 	default:
 		kickSource := tokens.NewKickSource(dbPool, cipher, cfg.KickClientID, cfg.KickClientSecret)
 		dispatchers["kick"] = dispatch.NewKick(kickSource, clients.NewKickClient(), log)
-		scopeCheckers["kick"] = tokens.NewKickScopeChecker(kickSource)
+		kickScopes := tokens.NewKickScopeChecker(kickSource)
+		scopeCheckers["kick"] = kickScopes
+		sendCheckers["kick"] = kickScopes
 		log.Info("Kick moderation enabled (real Kick API calls)")
 	}
 
@@ -158,7 +165,9 @@ func main() {
 		ytSource := tokens.NewYouTubeSource(dbPool, cipher, cfg.YouTubeClientID, cfg.YouTubeClientSecret)
 		ytQuota := quota.NewReserver(dbPool, getEnvInt("YOUTUBE_QUOTA_LIMIT_DAILY", quota.DefaultDailyLimit))
 		dispatchers["youtube"] = dispatch.NewYouTube(ytSource, clients.NewYouTubeClient(), clients.NewYouTubeLiveChatResolver(redisClient), ytQuota, log)
-		scopeCheckers["youtube"] = tokens.NewYouTubeScopeChecker(ytSource)
+		ytScopes := tokens.NewYouTubeScopeChecker(ytSource)
+		scopeCheckers["youtube"] = ytScopes
+		sendCheckers["youtube"] = ytScopes
 		log.Info("YouTube moderation enabled (ban-only, real Data API calls)")
 	}
 
@@ -187,6 +196,8 @@ func main() {
 	// Surface the cohort decision on the capabilities endpoint so the dashboard hides
 	// controls for users outside the rollout (the action routes are gated separately).
 	modHandler.SetFeatureGate(moderationGate{gates: gateCache, repo: repo})
+	// Wire the chat-send capability checker so capabilities report can_send per source.
+	modHandler.SetSendChecker(handler.MultiSendChecker(sendCheckers))
 
 	if cfg.GinMode == "release" {
 		gin.SetMode(gin.ReleaseMode)

--- a/services/moderation-service/handler/moderation.go
+++ b/services/moderation-service/handler/moderation.go
@@ -113,6 +113,7 @@ type Handler struct {
 	pub      DeletionEmitter
 	audit    Recorder
 	scopes   ScopeChecker
+	send     SendChecker
 	dispatch Dispatcher
 	gate     FeatureGate
 	logger   *zap.Logger
@@ -121,12 +122,16 @@ type Handler struct {
 // New creates a moderation Handler. The feature gate defaults to OpenGate (always
 // enabled); production overrides it with SetFeatureGate once the gate cache is up.
 func New(repo Authorizer, pub DeletionEmitter, rec Recorder, scopes ScopeChecker, dispatch Dispatcher, logger *zap.Logger) *Handler {
-	return &Handler{repo: repo, pub: pub, audit: rec, scopes: scopes, dispatch: dispatch, gate: OpenGate{}, logger: logger}
+	return &Handler{repo: repo, pub: pub, audit: rec, scopes: scopes, send: NoSendChecker{}, dispatch: dispatch, gate: OpenGate{}, logger: logger}
 }
 
 // SetFeatureGate overrides the moderation feature gate (ADR-0008). Call once at
 // startup before serving; the default is OpenGate.
 func (h *Handler) SetFeatureGate(g FeatureGate) { h.gate = g }
+
+// SetSendChecker overrides the chat-send capability checker (defaults to NoSendChecker,
+// which reports nothing sendable). Call once at startup before serving.
+func (h *Handler) SetSendChecker(s SendChecker) { h.send = s }
 
 // caller is the authenticated identity behind a request.
 type caller struct {
@@ -286,6 +291,15 @@ func (h *Handler) capabilityFor(ctx context.Context, userID string, s repository
 	if !models.PlatformSupported(s.Platform) {
 		sc.Reason = models.ReasonUnsupportedPlatform
 		return sc
+	}
+	// can_send is a SEPARATE capability from moderation (a different OAuth scope), so
+	// compute it up front: a source can be sendable without any moderation action
+	// granted, and vice versa. A send-check failure degrades to not-sendable.
+	if canSend, sErr := h.send.CanSend(ctx, userID, s.Platform, s.ChannelID); sErr != nil {
+		h.logger.Warn("capabilities: send-scope check failed; treating as not sendable",
+			zap.String("platform", s.Platform), zap.Error(sErr))
+	} else {
+		sc.CanSend = canSend
 	}
 	actions, err := h.scopes.GrantedActions(ctx, userID, s.Platform, s.ChannelID)
 	if err != nil {

--- a/services/moderation-service/handler/scopecheck.go
+++ b/services/moderation-service/handler/scopecheck.go
@@ -101,3 +101,33 @@ func (c *DiscordScopeChecker) GrantedActions(ctx context.Context, _ string, plat
 	}
 	return models.ActionsForDiscordPermissions(bits), nil
 }
+
+// SendChecker reports whether the overlay owner can send chat to a (platform, channel)
+// from the monitor view — i.e. whether their broadcaster credential's granted scopes
+// include the platform's chat-send scope. It mirrors ScopeChecker but for the send
+// capability, which rides on the same opt-in re-consent as moderation.
+type SendChecker interface {
+	CanSend(ctx context.Context, userID, platform, channelID string) (bool, error)
+}
+
+// MultiSendChecker routes a send-capability check to the checker registered for the
+// platform. A platform with no registered checker (Discord/TikTok — no streamer send
+// path) reports false, the correct default.
+type MultiSendChecker map[string]SendChecker
+
+// CanSend delegates to the per-platform checker.
+func (m MultiSendChecker) CanSend(ctx context.Context, userID, platform, channelID string) (bool, error) {
+	if c, ok := m[platform]; ok && c != nil {
+		return c.CanSend(ctx, userID, platform, channelID)
+	}
+	return false, nil
+}
+
+// NoSendChecker reports no send capability for any source. The default until send
+// checkers are wired.
+type NoSendChecker struct{}
+
+// CanSend always reports false.
+func (NoSendChecker) CanSend(context.Context, string, string, string) (bool, error) {
+	return false, nil
+}

--- a/services/moderation-service/models/moderation.go
+++ b/services/moderation-service/models/moderation.go
@@ -117,6 +117,44 @@ func RequiredTwitchScope(a Action) string {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Chat-send capability (advanced-controls opt-in).
+//
+// Sending a chat message from the monitor view needs a DIFFERENT OAuth scope than
+// moderation: Twitch user:write:chat, Kick chat:write. YouTube reuses the force-ssl
+// scope (ScopeYouTubeModeration) it already grants for bans. These scopes ride along
+// on the same opt-in re-consent that grants moderation, so a source is "sendable"
+// exactly when its granted scopes include the send scope.
+// ---------------------------------------------------------------------------
+
+// ScopeTwitchSend authorizes the Helix Send Chat Message API (user token).
+const ScopeTwitchSend = "user:write:chat"
+
+// ScopeKickSend authorizes the Kick public Send Chat Message API.
+const ScopeKickSend = "chat:write"
+
+// CanSendForTwitchScopes reports whether a Twitch token's scopes allow sending chat.
+func CanSendForTwitchScopes(scopes []string) bool { return scopesContain(scopes, ScopeTwitchSend) }
+
+// CanSendForKickScopes reports whether a Kick token's scopes allow sending chat.
+func CanSendForKickScopes(scopes []string) bool { return scopesContain(scopes, ScopeKickSend) }
+
+// CanSendForYouTubeScopes reports whether a YouTube token's scopes allow live-chat
+// send (force-ssl — the same scope that authorizes bans).
+func CanSendForYouTubeScopes(scopes []string) bool {
+	return scopesContain(scopes, ScopeYouTubeModeration)
+}
+
+// scopesContain reports whether want is present in scopes.
+func scopesContain(scopes []string, want string) bool {
+	for _, s := range scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 // Kick moderation OAuth scope. Kick's public API gates ban/timeout/unban behind a
 // single scope; there is no single-message delete endpoint, so Kick never grants
 // ActionDelete (see PlatformActions["kick"]). Requested only through the opt-in
@@ -311,8 +349,11 @@ type SourceCapability struct {
 	ChannelID   string   `json:"channel_id"`
 	ChannelName string   `json:"channel_name"`
 	Moderatable bool     `json:"moderatable"`
-	Reason      string   `json:"reason,omitempty"`
-	Actions     []Action `json:"actions"`
+	// CanSend reports whether the owner can send chat to this source from the monitor
+	// view (the chat-send scope is granted). Independent of Moderatable/Actions.
+	CanSend bool     `json:"can_send"`
+	Reason  string   `json:"reason,omitempty"`
+	Actions []Action `json:"actions"`
 }
 
 // Capabilities is the response of the capabilities endpoint: whether the caller

--- a/services/moderation-service/models/send_scopes_test.go
+++ b/services/moderation-service/models/send_scopes_test.go
@@ -1,0 +1,47 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import "testing"
+
+func TestCanSendForTwitchScopes(t *testing.T) {
+	if !CanSendForTwitchScopes([]string{"user:read:chat", ScopeTwitchSend}) {
+		t.Error("user:write:chat should grant Twitch send")
+	}
+	if CanSendForTwitchScopes([]string{"user:read:chat", "moderator:manage:banned_users"}) {
+		t.Error("Twitch send must require user:write:chat, not a read/mod scope")
+	}
+}
+
+func TestCanSendForKickScopes(t *testing.T) {
+	if !CanSendForKickScopes([]string{ScopeKickSend}) {
+		t.Error("chat:write should grant Kick send")
+	}
+	if CanSendForKickScopes([]string{"user:read", ScopeKickModeration}) {
+		t.Error("Kick send must require chat:write, not user:read/moderation:ban")
+	}
+}
+
+func TestCanSendForYouTubeScopes(t *testing.T) {
+	// YouTube send reuses the same force-ssl scope that authorizes bans.
+	if !CanSendForYouTubeScopes([]string{ScopeYouTubeModeration}) {
+		t.Error("force-ssl should grant YouTube send")
+	}
+	if CanSendForYouTubeScopes([]string{"https://www.googleapis.com/auth/youtube.readonly"}) {
+		t.Error("YouTube send must require force-ssl, not readonly")
+	}
+}

--- a/services/moderation-service/tokens/scopes.go
+++ b/services/moderation-service/tokens/scopes.go
@@ -60,6 +60,22 @@ func (c *TwitchScopeChecker) GrantedActions(ctx context.Context, userID, platfor
 	return models.ActionsForTwitchScopes(cred.GrantedScopes), nil
 }
 
+// CanSend reports whether the owner's Twitch credential grants the chat-send scope
+// (user:write:chat). A missing credential yields false, mirroring GrantedActions.
+func (c *TwitchScopeChecker) CanSend(ctx context.Context, userID, platform, channelID string) (bool, error) {
+	if platform != "twitch" {
+		return false, nil
+	}
+	cred, err := c.src.Resolve(ctx, userID, channelID)
+	if errors.Is(err, ErrNoCredential) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return models.CanSendForTwitchScopes(cred.GrantedScopes), nil
+}
+
 // kickCredentialResolver is the subset of KickSource the scope checker needs.
 type kickCredentialResolver interface {
 	Resolve(ctx context.Context, userID, channelID string) (*KickCredential, error)
@@ -94,6 +110,22 @@ func (c *KickScopeChecker) GrantedActions(ctx context.Context, userID, platform,
 	return models.ActionsForKickScopes(cred.GrantedScopes), nil
 }
 
+// CanSend reports whether the owner's Kick credential grants the chat-send scope
+// (chat:write). A missing credential yields false.
+func (c *KickScopeChecker) CanSend(ctx context.Context, userID, platform, channelID string) (bool, error) {
+	if platform != "kick" {
+		return false, nil
+	}
+	cred, err := c.src.Resolve(ctx, userID, channelID)
+	if errors.Is(err, ErrNoCredential) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return models.CanSendForKickScopes(cred.GrantedScopes), nil
+}
+
 // youtubeCredentialResolver is the subset of YouTubeSource the scope checker needs.
 type youtubeCredentialResolver interface {
 	Resolve(ctx context.Context, userID, channelID string) (*YouTubeCredential, error)
@@ -124,4 +156,20 @@ func (c *YouTubeScopeChecker) GrantedActions(ctx context.Context, userID, platfo
 		return nil, err
 	}
 	return models.ActionsForYouTubeScopes(cred.GrantedScopes), nil
+}
+
+// CanSend reports whether the owner's YouTube credential grants live-chat send
+// (force-ssl, the same scope used for bans). A missing credential yields false.
+func (c *YouTubeScopeChecker) CanSend(ctx context.Context, userID, platform, channelID string) (bool, error) {
+	if platform != "youtube" {
+		return false, nil
+	}
+	cred, err := c.src.Resolve(ctx, userID, channelID)
+	if errors.Is(err, ErrNoCredential) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return models.CanSendForYouTubeScopes(cred.GrantedScopes), nil
 }

--- a/services/youtube-listener/cmd/main.go
+++ b/services/youtube-listener/cmd/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/caesar/all-chat/services/message-processor/registry"
 	"github.com/caesar/all-chat/services/youtube-listener/handlers"
 	ytmetrics "github.com/caesar/all-chat/services/youtube-listener/metrics"
+	"github.com/caesar/all-chat/services/youtube-listener/notifications"
 	"github.com/caesar/all-chat/services/youtube-listener/oauth"
 	"github.com/caesar/all-chat/services/youtube-listener/publisher"
 	"github.com/caesar/all-chat/services/youtube-listener/quota"
@@ -171,6 +172,14 @@ func main() {
 	if err := quotaTracker.Start(ctx); err != nil {
 		log.Fatal("Failed to start quota tracker", zap.Error(err))
 	}
+
+	// Wire the quota notifier so threshold/state-transition events publish to the
+	// shared "quota:alerts" Redis channel the discord-bot subscribes to. Without this
+	// SetNotifier call the tracker's notifier stayed nil and quota alerts never fired.
+	// Gated by QUOTA_NOTIFIER_ENABLED (default on); the tracker no-ops on a nil notifier.
+	quotaNotifierEnabled := listener.Env("QUOTA_NOTIFIER_ENABLED", "true") == "true"
+	quotaNotifier := notifications.NewQuotaNotifier(redisClient, log, quotaNotifierEnabled, "quota:alerts")
+	quotaTracker.SetNotifier(quotaNotifier)
 
 	// Initialize per-channel quota tracker (new)
 	perChannelQuotaConfig := quota.Config{

--- a/shared/sendall/sendall.go
+++ b/shared/sendall/sendall.go
@@ -1,0 +1,72 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package sendall defines the shared Redis contract for the streamer "send to all"
+// feature: when a streamer sends one message to every connected platform, each
+// platform echoes that message back through chat:raw, so the message-processor would
+// otherwise emit N copies. To collapse them into ONE message with a combined platform
+// pill, auth-service PRE-REGISTERS the outgoing message (one key per target platform
+// identity) just before fanning out; message-processor then recognises each echo and
+// publishes the group exactly once per overlay.
+//
+// Both writer (auth-service) and reader (message-processor) import this package so the
+// key derivation and value schema can never drift apart.
+package sendall
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+)
+
+// TTL is how long a registration lives. It only needs to outlive the platform
+// round-trip plus echo latency for the streamer's own message, so it is deliberately
+// short — long enough to catch the echoes, short enough that an unrelated later message
+// with identical text never collides with a stale group.
+const TTL = 15 * time.Second
+
+// Registration is the value stored under each per-platform key. GroupID is reused as
+// the unified message id (so every echo collapses to one id) and Platforms is the full
+// set the message was sent to (rendered as the combined pill, known up front so the
+// processor never has to wait for all echoes).
+type Registration struct {
+	GroupID   string   `json:"group_id"`
+	Platforms []string `json:"platforms"`
+}
+
+// NormalizeText canonicalises message text for fingerprinting: collapse internal
+// whitespace runs to single spaces (this also trims) and lowercase. Writer and reader
+// MUST use this identical normalization or the echoes will not match.
+func NormalizeText(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// Key is the Redis key for a (platform, sender platform-id, message text) tuple. The
+// sender id is the platform-native id of the streamer on that platform (Twitch user id,
+// YouTube channel id, Kick user id) — the same id that appears as the author on the
+// echoed-back message, which is how the processor matches it.
+func Key(platform, senderID, text string) string {
+	sum := sha256.Sum256([]byte(NormalizeText(text)))
+	return "sendall:" + platform + ":" + senderID + ":" + hex.EncodeToString(sum[:])
+}
+
+// PublishedKey marks that the combined message for a group has already been published
+// to a given overlay, so later echoes of the same group are dropped for that overlay
+// (the message-processor SETNX-claims this key; the winner publishes once).
+func PublishedKey(overlayID, groupID string) string {
+	return "sendall:pub:" + overlayID + ":" + groupID
+}

--- a/shared/sendall/sendall_test.go
+++ b/shared/sendall/sendall_test.go
@@ -1,0 +1,64 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package sendall
+
+import "testing"
+
+func TestNormalizeText(t *testing.T) {
+	cases := map[string]string{
+		"  Hello   World  ": "hello world",
+		"HELLO":             "hello",
+		"a\tb\nc":           "a b c",
+		"":                  "",
+		"Already normal":    "already normal",
+	}
+	for in, want := range cases {
+		if got := NormalizeText(in); got != want {
+			t.Errorf("NormalizeText(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestKeyStableUnderNormalization(t *testing.T) {
+	// The writer (auth-service) and reader (message-processor) must derive the SAME key
+	// from differently-whitespaced/cased text, or the echoes never match.
+	if Key("twitch", "123", "Hello  World") != Key("twitch", "123", "hello world") {
+		t.Error("expected normalization to make keys equal")
+	}
+}
+
+func TestKeyDistinctByDimension(t *testing.T) {
+	base := Key("twitch", "123", "hi")
+	if base == Key("kick", "123", "hi") {
+		t.Error("platform should differentiate key")
+	}
+	if base == Key("twitch", "456", "hi") {
+		t.Error("sender id should differentiate key")
+	}
+	if base == Key("twitch", "123", "bye") {
+		t.Error("text should differentiate key")
+	}
+}
+
+func TestPublishedKeyDistinct(t *testing.T) {
+	if PublishedKey("ov1", "g1") == PublishedKey("ov2", "g1") {
+		t.Error("overlay id should differentiate published key")
+	}
+	if PublishedKey("ov1", "g1") == PublishedKey("ov1", "g2") {
+		t.Error("group id should differentiate published key")
+	}
+}


### PR DESCRIPTION
Implements `docs/plans/overlay-view-send-and-feed-position.md`.

## What

Three user-facing capabilities on the **authenticated monitor view** (`/overlay/[id]/view`), plus the quota safety net behind them.

### 1. Configurable event/activity feed position
`ResizableSplit` gains `orientation` + `reversed`; a header layout picker offers chat-left / chat-right / events-top / chat-top, persisted per-overlay in `localStorage`.

### 2. Send chat from the monitor
- New send bar with a platform selector (Twitch/YouTube/Kick + **All**). TikTok/Discord are not offered (no send path).
- Each pill is gated by a new **`can_send`** capability (moderation-service computes it per source from the owner's granted send scope). A missing scope triggers the **advanced-controls consent** — one re-consent grants moderation **and** sending (POLP: login stays minimal).
  - Twitch `user:write:chat`, Kick `chat:write` are folded into the existing moderation opt-in; YouTube `force-ssl` already covers send. All added to the scope-downgrade guard.
- `api-gateway` now proxies `POST /api/v1/auth/chat/send`.
- Structured send errors: 403 `missing_scope` (→ opt-in), 401 `reauth_required` (→ re-login), 422 offline/quota — replacing the old blanket 502.
- Streamer send rate limiting (20/min + 100/hr, Redis).

### 3. Send to all + combined platform pill
- `auth-service` fans out to every connected platform, returns per-platform results (partial success supported).
- Each platform echoes the message back, so before fan-out auth-service **pre-registers** a short-TTL Redis group (`shared/sendall`). `message-processor` recognises the echoes, collapses them into **one** message (`UnifiedChatMessage.Platforms`), published once per overlay.
- Frontend renders a combined multi-platform pill (`platforms[]`) on both the OBS overlay and the monitor chat list.

### Prerequisite — YouTube quota monitor (re-enabled)
- `youtube-listener` now wires the dormant `QuotaNotifier` → quota alerts publish to `quota:alerts` (discord-bot already subscribes). Gated by `QUOTA_NOTIFIER_ENABLED` (default on).
- Streamer YouTube sends reserve/confirm quota (5 units) via youtube-listener's coordination API, so the monitor reflects send usage and a depleted quota blocks sends. Fail-open if `YOUTUBE_LISTENER_URL` is unset.

## Deployment
- Images roll via Keel on merge to `main`.
- **Companion change in `caesar-deployment`**: adds `YOUTUBE_LISTENER_URL=http://youtube-listener:8086` to the auth-service deployment (enables send quota accounting; fail-open without it).
- No DB migrations (overlay config is JSONB; new scopes are code constants).

## Testing
- `go build` + `go vet` clean across all five touched services.
- New unit tests: `shared/sendall` (key derivation/normalization), moderation-service `can_send` scope mapping, auth-service send-error classification. All pass.
- Frontend `next build` + `tsc --noEmit` pass; 22 component/unit tests pass.
- Pre-existing `TestAuthHandlerLogout` failure is environmental (requires live Redis) and reproduces on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)