### PR TITLE
✨ feat(frontend): premium upsell page + wire all premium gates

### DIFF
--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -61,6 +61,7 @@ import { toastManager } from '@/lib/toast'
 import { trackEvent } from '@/lib/analytics'
 import { AppNav } from '@/components/AppNav'
 import { SplitView } from '@/components/SplitView'
+import { PremiumUpsellLink } from '@/components/PremiumUpsellLink'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -501,6 +502,11 @@ function StreamSelectionPanel({
           {STREAM_STRATEGIES.find((s) => s.value === strategy) && (
             <p className="mt-1 text-xs text-text-sub/60">
               {STREAM_STRATEGIES.find((s) => s.value === strategy)?.description}
+            </p>
+          )}
+          {!isPremium && (
+            <p className="mt-1 text-xs text-text-dim">
+              <PremiumUpsellLink /> to use advanced stream selection.
             </p>
           )}
         </div>
@@ -2245,11 +2251,21 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                   </button>
                 </div>
                 <p className="mb-4 text-sm text-text-sub">
-                  Sharing your overlay is a premium feature. Upgrade your account to share your chat
+                  Sharing your overlay is a premium feature.{' '}
+                  <PremiumUpsellLink>Upgrade your account</PremiumUpsellLink> to share your chat
                   with other streamers.
                 </p>
                 <p className="mb-5 text-sm text-text-sub">
-                  For more information and to get access, join our Discord community.
+                  Questions? Join our{' '}
+                  <a
+                    href="https://discord.gg/xCGBSuz39P"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium text-twitch hover:underline"
+                  >
+                    Discord community
+                  </a>
+                  .
                 </p>
                 <div className="flex gap-2">
                   <Button
@@ -2259,14 +2275,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                   >
                     Close
                   </Button>
-                  <a
-                    href="https://discord.gg/xCGBSuz39P"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex-1"
-                  >
-                    <Button className="w-full">Join Discord</Button>
-                  </a>
+                  <Link href="/upgrade" className="flex-1">
+                    <Button className="w-full">Upgrade</Button>
+                  </Link>
                 </div>
               </div>
             </div>

--- a/frontend/src/app/settings/premium/page.tsx
+++ b/frontend/src/app/settings/premium/page.tsx
@@ -28,6 +28,7 @@ import { Card } from '@/components/ui/card'
 import { Dialog } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toastManager } from '@/lib/toast'
+import { PATREON_JOIN_URL } from '@/lib/constants'
 import {
   disconnectPatreon,
   getPaymentStatus,
@@ -147,7 +148,7 @@ function PremiumContent() {
               <p className="text-sm text-text-sub">
                 Not a patron yet?{' '}
                 <a
-                  href="https://patreon.com/all_chat"
+                  href={PATREON_JOIN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-twitch hover:underline"

--- a/frontend/src/app/settings/viewer/page.tsx
+++ b/frontend/src/app/settings/viewer/page.tsx
@@ -20,6 +20,7 @@
 
 
 import { useState, useEffect, useCallback, useRef } from 'react'
+import Link from 'next/link'
 import { AppNav } from '@/components/AppNav'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -318,6 +319,18 @@ function ColorGradientCard({ claims }: { claims: ViewerJWTClaims }) {
         </button>
       </div>
 
+      {!claims.is_premium && (
+        <p className="mb-4 text-xs text-text-dim">
+          Gradient names are a viewer premium cosmetic.{' '}
+          <Link
+            href="/settings/viewer/premium"
+            className="font-medium text-twitch hover:underline"
+          >
+            Unlock viewer premium
+          </Link>
+        </p>
+      )}
+
       {/* Solid Color tab panel */}
       {activeTab === 'solid' && (
         <div>
@@ -615,6 +628,18 @@ function AvatarCosmeticsCard({ claims }: { claims: ViewerJWTClaims }) {
       <p className="text-text-sub text-sm mb-4">
         Choose a frame and flair for your avatar
       </p>
+
+      {!isPremium && (
+        <p className="mb-4 text-xs text-text-dim">
+          Some frames and flairs are viewer premium.{' '}
+          <Link
+            href="/settings/viewer/premium"
+            className="font-medium text-twitch hover:underline"
+          >
+            Unlock viewer premium
+          </Link>
+        </p>
+      )}
 
       {/* Avatar Frame section */}
       <div className="mb-6">

--- a/frontend/src/app/settings/viewer/premium/page.tsx
+++ b/frontend/src/app/settings/viewer/premium/page.tsx
@@ -28,6 +28,7 @@ import { Dialog } from '@/components/ui/dialog'
 import { Skeleton } from '@/components/ui/skeleton'
 import { toastManager } from '@/lib/toast'
 import { viewerApi } from '@/lib/api/viewer'
+import { PATREON_JOIN_URL } from '@/lib/constants'
 import type { PaymentStatus } from '@/lib/api/payment'
 
 function statusLabel(status?: string): string {
@@ -146,7 +147,7 @@ function ViewerPremiumContent() {
               <p className="text-sm text-text-sub">
                 Not a patron yet?{' '}
                 <a
-                  href="https://patreon.com/all_chat"
+                  href={PATREON_JOIN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-medium text-twitch hover:underline"

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -1,0 +1,169 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Check, MessagesSquare, Radio, ShieldCheck, Sparkles, Volume2 } from 'lucide-react'
+import Link from 'next/link'
+import { AppNav } from '@/components/AppNav'
+import { Card } from '@/components/ui/card'
+import { buttonVariants } from '@/components/ui/button'
+import { PATREON_JOIN_URL } from '@/lib/constants'
+
+export const metadata = {
+  title: 'Upgrade to Premium | All-Chat',
+  description:
+    'Back All-Chat on Patreon to unlock premium features: moderate from your overlay, ElevenLabs TTS, YouTube stream selection, shared chat, and viewer flairs.',
+  alternates: { canonical: '/upgrade' },
+}
+
+interface PremiumFeature {
+  icon: React.ComponentType<{ className?: string }>
+  title: string
+  description: string
+}
+
+const features: PremiumFeature[] = [
+  {
+    icon: ShieldCheck,
+    title: 'Moderate from your overlay',
+    description:
+      'Delete, timeout, and ban across Twitch, YouTube, Kick, and Discord straight from the monitor view — no second dashboard.',
+  },
+  {
+    icon: Volume2,
+    title: 'ElevenLabs text-to-speech',
+    description:
+      'Read chat aloud with high-quality ElevenLabs voices, with full control over priority and pronunciation.',
+  },
+  {
+    icon: Radio,
+    title: 'YouTube stream selection',
+    description:
+      'Pick exactly which YouTube broadcast an overlay listens to instead of relying on auto-detection.',
+  },
+  {
+    icon: MessagesSquare,
+    title: 'Shared chat',
+    description: 'Combine several channels into one shared conversation across your overlays.',
+  },
+  {
+    icon: Sparkles,
+    title: 'Viewer flairs',
+    description:
+      'Stand out in any chat you appear in with premium cosmetics like animated name gradients.',
+  },
+]
+
+export default function UpgradePage() {
+  return (
+    <div className="min-h-screen bg-bg">
+      <AppNav />
+      <main className="mx-auto max-w-3xl space-y-10 px-4 py-12">
+        {/* Hero */}
+        <header className="space-y-4 text-center">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-3 py-1 text-xs font-medium text-text-sub">
+            <Sparkles className="h-3.5 w-3.5 text-twitch" />
+            All-Chat Premium
+          </span>
+          <h1 className="text-3xl font-bold text-text sm:text-4xl">
+            Unlock the full power of your overlay
+          </h1>
+          <p className="mx-auto max-w-xl text-text-sub">
+            Premium is funded entirely through Patreon — it keeps All-Chat running and unlocks the
+            features that make multistream moderation effortless. Back the project once, and premium
+            applies automatically to your account.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-3 pt-2 sm:flex-row">
+            <a
+              href={PATREON_JOIN_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: 'gradient', size: 'lg' })}
+            >
+              Subscribe on Patreon
+            </a>
+            <Link
+              href="/settings/premium"
+              className={buttonVariants({ variant: 'outline', size: 'lg' })}
+            >
+              Already a patron? Connect Patreon
+            </Link>
+          </div>
+        </header>
+
+        {/* Feature list */}
+        <Card className="divide-y divide-border p-0">
+          {features.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex items-start gap-4 p-5">
+              <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-2 text-twitch">
+                <Icon className="h-5 w-5" />
+              </span>
+              <div className="space-y-1">
+                <h2 className="font-semibold text-text">{title}</h2>
+                <p className="text-sm text-text-sub">{description}</p>
+              </div>
+            </div>
+          ))}
+        </Card>
+
+        {/* How it works */}
+        <Card className="space-y-4 p-6">
+          <h2 className="text-lg font-semibold text-text">How it works</h2>
+          <ol className="space-y-3 text-sm text-text-sub">
+            <li className="flex gap-3">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-twitch" />
+              <span>
+                Back All-Chat on{' '}
+                <a
+                  href={PATREON_JOIN_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-twitch hover:underline"
+                >
+                  Patreon
+                </a>{' '}
+                at the premium tier.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-twitch" />
+              <span>
+                Connect your Patreon account on the{' '}
+                <Link href="/settings/premium" className="font-medium text-twitch hover:underline">
+                  Premium settings
+                </Link>{' '}
+                page.
+              </span>
+            </li>
+            <li className="flex gap-3">
+              <Check className="mt-0.5 h-4 w-4 shrink-0 text-twitch" />
+              <span>Premium unlocks automatically — no codes, no waiting.</span>
+            </li>
+          </ol>
+        </Card>
+
+        <p className="text-center text-xs text-text-dim">
+          Just want viewer cosmetics?{' '}
+          <Link href="/settings/viewer/premium" className="text-text-sub hover:underline">
+            See viewer premium
+          </Link>
+          .
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/PremiumUpsellLink.tsx
+++ b/frontend/src/components/PremiumUpsellLink.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Link from 'next/link'
+import { cn } from '@/lib/utils'
+
+/**
+ * Inline link that sends users to the premium upsell page (`/upgrade`).
+ *
+ * Use this anywhere a feature is locked behind premium so every gate funnels to
+ * the same upsell → Patreon flow. Defaults to the text "Upgrade to Premium";
+ * pass children to fit it into a sentence (e.g. "Premium" or "Upgrade your
+ * account").
+ */
+export function PremiumUpsellLink({
+  children = 'Upgrade to Premium',
+  className,
+}: {
+  children?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <Link
+      href="/upgrade"
+      className={cn(
+        'font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none',
+        className
+      )}
+    >
+      {children}
+    </Link>
+  )
+}

--- a/frontend/src/components/appearance/SoundGroup.tsx
+++ b/frontend/src/components/appearance/SoundGroup.tsx
@@ -23,6 +23,7 @@ import React from 'react'
 import { ToggleSwitch } from './ToggleSwitch'
 import { SliderControl } from './SliderControl'
 import { PremiumBadge } from '@/components/PremiumBadge'
+import { PremiumUpsellLink } from '@/components/PremiumUpsellLink'
 import { PRESET_NAMES } from '@/lib/utils/soundPlayer'
 import type { DisplaySettings } from '@/lib/types/overlay'
 import { trackEvent } from '@/lib/analytics'
@@ -113,7 +114,7 @@ export function SoundGroup({ displaySettings, onChange, isPremium, onPreview }: 
                 Custom sound URL
                 {!isPremium && (
                   <span className="ml-1 text-xs text-text-dim">
-                    — Upload your own notification sound (Premium)
+                    — Upload your own notification sound (<PremiumUpsellLink>Premium</PremiumUpsellLink>)
                   </span>
                 )}
               </p>

--- a/frontend/src/components/appearance/TTSGroup.tsx
+++ b/frontend/src/components/appearance/TTSGroup.tsx
@@ -24,6 +24,7 @@ import { trackEvent } from '@/lib/analytics'
 import { ToggleSwitch } from './ToggleSwitch'
 import { SliderControl } from './SliderControl'
 import { PremiumBadge } from '@/components/PremiumBadge'
+import { PremiumUpsellLink } from '@/components/PremiumUpsellLink'
 import { useBrowserVoices } from '@/lib/hooks/useBrowserVoices'
 import type { DisplaySettings } from '@/lib/types/overlay'
 
@@ -323,9 +324,13 @@ function ApiKeyInput({
       {!hasSavedKey && (
         <div>
           <p className="mb-1 text-xs text-text-dim">
-            {isPremium
-              ? 'Your key is encrypted server-side and never returned.'
-              : 'Upgrade to Premium to use ElevenLabs voices.'}
+            {isPremium ? (
+              'Your key is encrypted server-side and never returned.'
+            ) : (
+              <>
+                <PremiumUpsellLink /> to use ElevenLabs voices.
+              </>
+            )}
           </p>
           <div className="flex gap-2">
             <input
@@ -690,7 +695,7 @@ export function TTSGroup(props: TTSGroupProps): React.ReactElement {
             <div className="flex flex-col items-center gap-2 text-center">
               <PremiumBadge />
               <span className="text-xs text-text-dim">
-                Upgrade to Premium to use ElevenLabs voices.
+                <PremiumUpsellLink /> to use ElevenLabs voices.
               </span>
             </div>
           </div>
@@ -828,7 +833,7 @@ export function TTSGroup(props: TTSGroupProps): React.ReactElement {
             </label>
             {!isPremium && (
               <p className="text-xs text-text-dim">
-                Upgrade to Premium to use ElevenLabs voices.
+                <PremiumUpsellLink /> to use ElevenLabs voices.
               </p>
             )}
           </fieldset>

--- a/frontend/src/components/appearance/__tests__/TTSGroup.test.tsx
+++ b/frontend/src/components/appearance/__tests__/TTSGroup.test.tsx
@@ -964,9 +964,10 @@ describe('TTSGroup', () => {
       isPremium: false,
       hasElevenLabsConfig: false,
     })
-    // The upgrade-to-premium copy renders (overlay message)
-    const upgradeMatches = screen.getAllByText(/Upgrade to Premium to use ElevenLabs voices\./)
-    expect(upgradeMatches.length).toBeGreaterThan(0)
+    // The upgrade-to-premium copy renders as an upsell link to /upgrade
+    const upgradeLinks = screen.getAllByRole('link', { name: /Upgrade to Premium/i })
+    expect(upgradeLinks.length).toBeGreaterThan(0)
+    expect(upgradeLinks[0].getAttribute('href')).toBe('/upgrade')
     // API-key input exists but is disabled
     const input = screen.queryByLabelText(/ElevenLabs API key/i) as HTMLInputElement | null
     if (input) {

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Canonical Patreon join/checkout URL for All-Chat premium.
+ *
+ * This is the direct "join" deep link (campaign 16269405) so the upsell CTA
+ * drops patrons straight into the pledge flow. Keep this as the single source
+ * of truth for every "Subscribe on Patreon" link in the app.
+ */
+export const PATREON_JOIN_URL = 'https://www.patreon.com/16269405/join'


### PR DESCRIPTION
## Why
The moderation monitor (`/overlay/[id]/view`) linked premium-gated users to `/upgrade`, which **404'd**. Other premium gates were inline-only badges with no path forward.

## What
- **New `/upgrade` page** — proper upsell with a feature list and a "Subscribe on Patreon" CTA → `https://www.patreon.com/16269405/join`.
- **New `PremiumUpsellLink` component** — single source for streamer-premium gate links.
- **New `PATREON_JOIN_URL` constant** — replaces the stale `patreon.com/all_chat` links on both premium settings pages.
- **Wired streamer-premium gates → `/upgrade`**: TTS/ElevenLabs (3 spots), custom sound upload, overlay sharing dialog (now has an Upgrade button), YouTube stream selection.
- **Wired viewer-cosmetics gates → `/settings/viewer/premium`** (the cheaper viewer-premium product): gradient names, avatar cosmetics.
- Decorative `PremiumBadge` chat badges left untouched (they mark a premium *user*, not a gate).

## Verification
- `tsc --noEmit`: clean
- `eslint`: zero new errors (pre-existing repo lint unchanged)
- `vitest` (TTSGroup/SoundGroup/viewer): 73 passed; updated one test for the new link markup

## Deploy
Merging to `main` builds `allchat-frontend:main`; Keel (`policy: force`, `poll`) auto-redeploys.