### PR TITLE
fix(auth-service): stop logging streamer-not-found as error; 500 on real DB errors

### DIFF
--- a/services/auth-service/handlers/streamer_info.go
+++ b/services/auth-service/handlers/streamer_info.go
@@ -17,23 +17,31 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"net/http"
 
-	"github.com/caesar/all-chat/services/auth-service/repository"
 	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5"
 	"go.uber.org/zap"
 )
+
+// streamerInfoDB is a minimal interface over *pgxpool.Pool so the lookup
+// branches can be unit-tested without a live database.
+type streamerInfoDB interface {
+	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
+}
 
 // StreamerInfoHandler handles requests for streamer information
 type StreamerInfoHandler struct {
 	log      *zap.Logger
-	userRepo *repository.UserRepository
-	db       *pgxpool.Pool
+	userRepo UserRepositoryInterface
+	db       streamerInfoDB
 }
 
 // NewStreamerInfoHandler creates a new streamer info handler
-func NewStreamerInfoHandler(log *zap.Logger, userRepo *repository.UserRepository, db *pgxpool.Pool) *StreamerInfoHandler {
+func NewStreamerInfoHandler(log *zap.Logger, userRepo UserRepositoryInterface, db streamerInfoDB) *StreamerInfoHandler {
 	return &StreamerInfoHandler{
 		log:      log.Named("streamer-info"),
 		userRepo: userRepo,
@@ -98,10 +106,21 @@ func (h *StreamerInfoHandler) HandleGetStreamerInfo(c *gin.Context) {
 		var userID, foundUsername string
 		err = h.db.QueryRow(ctx, channelQuery, username).Scan(&userID, &foundUsername)
 		if err != nil {
-			h.log.Error("Streamer not found by username or channel_id",
+			if errors.Is(err, pgx.ErrNoRows) {
+				// Expected: a viewer/extension looked up a streamer or channel
+				// that isn't configured in All-Chat. This is a normal 404, not an
+				// error — log at debug to avoid flooding error logs (and the
+				// stacktrace the production logger attaches at error level).
+				h.log.Debug("Streamer not found by username or channel_id",
+					zap.String("lookup_value", username))
+				c.JSON(http.StatusNotFound, gin.H{"error": "streamer not found"})
+				return
+			}
+			// Unexpected database error — surface as 500 rather than a misleading 404.
+			h.log.Error("Channel_id lookup query failed",
 				zap.Error(err),
 				zap.String("lookup_value", username))
-			c.JSON(http.StatusNotFound, gin.H{"error": "streamer not found"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to look up streamer"})
 			return
 		}
 

--- a/services/auth-service/handlers/streamer_info_test.go
+++ b/services/auth-service/handlers/streamer_info_test.go
@@ -1,0 +1,109 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// streamerInfoStubRow satisfies pgx.Row; Scan always returns the configured error.
+type streamerInfoStubRow struct{ err error }
+
+func (r streamerInfoStubRow) Scan(dest ...interface{}) error { return r.err }
+
+// stubStreamerInfoDB satisfies streamerInfoDB; QueryRow returns a row whose
+// Scan yields queryRowErr (Query is unused by the paths under test).
+type stubStreamerInfoDB struct{ queryRowErr error }
+
+func (d *stubStreamerInfoDB) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (d *stubStreamerInfoDB) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return streamerInfoStubRow{err: d.queryRowErr}
+}
+
+func newStreamerInfoTestHandler(t *testing.T, queryRowErr error) (*gin.Engine, *observer.ObservedLogs) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	userRepo := new(MockUserRepository)
+	// Force the username lookup to miss so the handler falls through to the
+	// channel_id lookup branch we are exercising.
+	userRepo.On("GetByUsername", mock.Anything, mock.Anything).Return(nil, repository.ErrUserNotFound)
+
+	h := NewStreamerInfoHandler(zap.New(core), userRepo, &stubStreamerInfoDB{queryRowErr: queryRowErr})
+
+	router := gin.New()
+	router.GET("/streamer/:username", h.HandleGetStreamerInfo)
+	return router, logs
+}
+
+// A normal "streamer not found" (pgx.ErrNoRows) must return 404 and log at
+// debug level — not error — so the production logger attaches no stacktrace.
+func TestHandleGetStreamerInfo_NotFound_LogsDebugReturns404(t *testing.T) {
+	router, logs := newStreamerInfoTestHandler(t, pgx.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/streamer/ghost", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for not-found streamer, got %d", w.Code)
+	}
+
+	entries := logs.FilterMessage("Streamer not found by username or channel_id").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 not-found log entry, got %d", len(entries))
+	}
+	if entries[0].Level != zapcore.DebugLevel {
+		t.Errorf("not-found must log at debug (no stacktrace), got level %v", entries[0].Level)
+	}
+}
+
+// A real database error (anything other than pgx.ErrNoRows) must surface as 500
+// — not a misleading 404 — and be logged at error level.
+func TestHandleGetStreamerInfo_DBError_LogsErrorReturns500(t *testing.T) {
+	router, logs := newStreamerInfoTestHandler(t, errors.New("connection refused"))
+
+	req := httptest.NewRequest(http.MethodGet, "/streamer/ghost", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for real DB error, got %d", w.Code)
+	}
+
+	entries := logs.FilterMessage("Channel_id lookup query failed").All()
+	if len(entries) != 1 || entries[0].Level != zapcore.ErrorLevel {
+		t.Fatalf("expected exactly 1 error-level db-failure log, got %+v", entries)
+	}
+}


### PR DESCRIPTION
## Summary
Cleanup of the noisy `auth-service` log spam found while verifying the #478 deploy on the cluster.

`HandleGetStreamerInfo` logged `pgx.ErrNoRows` at **error** level (with a full stacktrace) for every viewer/extension lookup of a streamer or channel not configured in All-Chat — a normal 404. In prod this fired several times per minute (e.g. `UCW72…`, `KinTamashii`), flooding the error logs. It also returned **404 for genuine DB errors**, masking real failures as "streamer not found".

## Change
- Discriminate `pgx.ErrNoRows` → **debug** log, 404 (no stacktrace) from a real DB error → **error** log, **500**.
- Introduce a minimal `streamerInfoDB` interface (mirroring the existing `admin_cosmetics.go` pattern) and depend on the existing `UserRepositoryInterface` so the lookup branches are unit-testable. `*pgxpool.Pool` and `*repository.UserRepository` still satisfy them, so `cmd/main.go` is unchanged.

## Tests
- New `streamer_info_test.go`: asserts not-found → 404 at **debug** level, and real DB error → 500 at **error** level. The 500 assertion fails on the old code (which returned 404 for all errors) → genuine red→green.
- Full `auth-service` module `go test ./... -short`: green.

Not in scope: the endpoint's 404 contract for not-found is unchanged; only the misleading 404-on-DB-error is corrected.