### PR TITLE
🐛 fix(auth): streamer YouTube send no longer requires a public overlay

### DIFF
--- a/services/auth-service/handlers/chat_send.go
+++ b/services/auth-service/handlers/chat_send.go
@@ -1608,9 +1608,16 @@ func (h *ChatSendHandler) getYouTubeLiveChatIDFromAPI(ctx context.Context, chann
 	return videoResult.Items[0].LiveStreamingDetails.ActiveLiveChatID, nil
 }
 
-// getActiveYouTubeChannelID gets the channel ID of the active YouTube source for a streamer
+// getActiveYouTubeChannelID gets the channel ID of the active YouTube source for a streamer.
 // This is retrieved from overlay_chat_sources rather than users.google_id because the
-// active channel may change when streamers switch between different YouTube channels
+// active channel may change when streamers switch between different YouTube channels (and a
+// streamer whose All-Chat login is not YouTube has no google_id at all).
+//
+// It deliberately does NOT gate on overlays.is_public_for_viewers: chat send is now only
+// driven by the streamer's own monitor view, where they send to their own live chat, so
+// whether the overlay is shared with viewers is irrelevant. Requiring public previously made
+// a streamer with a private overlay get the misleading "The streamer has not configured this
+// platform in All-Chat." error despite YouTube being configured.
 func (h *ChatSendHandler) getActiveYouTubeChannelID(ctx context.Context, streamerUserID string) (string, error) {
 	query := `
 		SELECT ocs.channel_id
@@ -1619,7 +1626,6 @@ func (h *ChatSendHandler) getActiveYouTubeChannelID(ctx context.Context, streame
 		WHERE o.user_id = $1
 		  AND ocs.platform = 'youtube'
 		  AND ocs.is_active = true
-		  AND o.is_public_for_viewers = true
 		LIMIT 1
 	`
 


### PR DESCRIPTION
## Problem

A streamer (reported by **lejoe_ttv**) tried sending a message to their own YouTube chat from the monitor view and got **"The streamer has not configured this platform in All-Chat."** — even though YouTube *was* configured. The error gave no clear way to fix it.

## Root cause

The streamer's own-send path (`HandleStreamerSendMessage → sendStreamerYouTubeMessage → getActiveYouTubeChannelID`) resolved the active YouTube channel with a query gated on `overlays.is_public_for_viewers = true`. lejoe has YouTube configured (channel active, overlay active) but no overlay marked public-for-viewers, so the lookup returned zero rows → `"no active YouTube source found"` → `classifySendError` mapped it to the misleading "not configured" message.

`is_public_for_viewers` was the streamer's opt-in for **viewers** to send into their chat (the `/chat/send` viewer path keyed on `streamer_username`). That viewer path now has **no live caller** — the frontend only calls the streamer's own send (`sendStreamerMessage({message, platform})`). Sending to your own live chat has no reason to depend on viewer-facing visibility.

## Fix

Removed the `AND o.is_public_for_viewers = true` clause from `getActiveYouTubeChannelID`. Twitch/Kick sends were unaffected (they use `users.twitch_id` / `kick_id` directly).

## Notes

- This only removes the misleading gate; a send still requires the channel to actually be live on YouTube (the liveChatID lookup), which now returns the correct "not currently live" message instead of "not configured".
- Builds clean; chat-send handler tests pass. (`TestAuthHandlerLogout` fails locally only due to no local Redis — pre-existing, unrelated.)