### PR TITLE
fix(frontend): repair eslint config and lockfile after dev-group bump (#498)

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -58,7 +58,8 @@ export default defineConfig([
   // classnames-order is disabled — Prettier (prettier-plugin-tailwindcss) handles class ordering.
   // no-contradicting-classname disabled (false positives with v4 custom tokens).
   // getSourceCode() used by classnames-order is deprecated in ESLint v10 — disable to avoid crash.
-  ...tailwind.configs['flat/recommended'],
+  // v4.0.4 exports a single flat config object (configs['flat/recommended'] was removed)
+  tailwind.configs.recommended,
   {
     rules: {
       // Disabled — Prettier (prettier-plugin-tailwindcss) handles class ordering
@@ -77,7 +78,8 @@ export default defineConfig([
       tailwindcss: {
         // Point to Tailwind v4 CSS entry point (not tailwind.config.js)
         // Must be absolute path — plugin runs as worker from a different cwd
-        config: join(__dirname, 'src/app/globals.css'),
+        // v4.0.4 renamed the setting from `config` to `cssConfigPath`
+        cssConfigPath: join(__dirname, 'src/app/globals.css'),
       },
     },
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3394,9 +3394,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,9 +3411,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3434,9 +3428,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3454,9 +3445,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3474,9 +3462,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3494,9 +3479,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4111,9 +4093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4131,9 +4110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4151,9 +4127,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4171,9 +4144,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8339,6 +8309,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13882,6 +13853,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fsevents": {


### PR DESCRIPTION
Two follow-up fixes for the dev-dependency group bump in #498:

## 1. ESLint config crash (eslint-plugin-tailwindcss 4.0.4)

Plugin 4.0.4 removed `configs['flat/recommended']` (now a single flat-config object at `configs.recommended`) and renamed the `settings.tailwindcss.config` key to `cssConfigPath`. Since #498 every ESLint run crashed with `TypeError: tailwind.configs.flat/recommended is not iterable`. This adapts `eslint.config.mjs` to the new API.

Note: with the crash fixed, `npx eslint . --max-warnings 0` still exits 1 — 39 errors / 4 warnings from `eslint-plugin-react-hooks` 7.1.1 across 18 files. These are **pre-existing** (verified identical on pre-#498 state) and are left for a separate cleanup. The `frontend-quality` workflow is currently `workflow_dispatch`-only, so nothing is gated either way.

## 2. Frontend Docker image build broken on main (npm 10 vs 11 lockfile)

The #498 lockfile was generated with npm 11. npm 10.9.8 (node:22-alpine in `frontend/Dockerfile`) fails `npm ci` with:

```
npm error Missing: typescript@5.9.3 from lock file
```

because `vite-tsconfig-paths` peers on `typescript ^5`, unsatisfied by the bumped typescript 6.0.3 — npm 10 records a nested optional-peer `typescript@5.9.3`, npm 11 does not. The last three `Build and Push Docker Images` runs on main failed on the frontend image because of this. Regenerated `package-lock.json` with npm 10; verified `npm ci` passes under both npm 10.9.8 and npm 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)