### PR TITLE
feat(premium): time-limited admin premium grants (streamer + viewer)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ PATREON_REDIRECT_URL=http://localhost:3000/api/v1/payment/patreon/callback
 PATREON_MIN_TIER_CENTS=500
 # Viewer premium (ADR-0019): a cheaper tier granting only viewer cosmetics.
 PATREON_VIEWER_MIN_TIER_CENTS=200
+# Time-limited admin premium grants (ADR-0027): cadence of the payment-service sweep
+# that reverts lapsed admin overrides. Optional; defaults to 5m.
+PAYMENT_OVERRIDE_SWEEP_INTERVAL=5m
 
 # JWT Secret (REQUIRED - Generate with: openssl rand -base64 32)
 # SECURITY: Never use "CHANGE_ME" or the dev default in production.

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Architecture decisions are documented as ADRs in [`docs/adr/`](./docs/adr/README
 - **ADR-0014**: Linger upstream capture demand symmetric with the downstream pub/sub linger
 - **ADR-0015**: Dynamic EventSub chat-ownership claim — IRC is the always-on fallback; EventSub owns a channel only while it is actively delivering chat (no silent loss across the partition)
 - **ADR-0026**: Two-phase deprecation of the Twitch IRC listener — `warn` nudges connected sources to re-add their Twitch source (in-overlay notice), `enforce` stops joining channels
+- **ADR-0027**: Time-limited admin premium grants — an optional expiry on the admin override (streamer + viewer) that reverts on its own; recompute ignores an expired override, and a single-replica payment-service sweep clears lapsed grants
 
 ### Documentation
 

--- a/docs/adr/0027-time-limited-admin-premium-overrides.md
+++ b/docs/adr/0027-time-limited-admin-premium-overrides.md
@@ -1,0 +1,81 @@
+# ADR-0027: Time-Limited Admin Premium Overrides
+
+**Date**: 2026-07-05
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+An admin can grant premium to a streamer (`users.is_premium`) or a viewer (`viewers.is_premium`) via the tri-state `premium_admin_override` (`NULL`=follow subscription, `TRUE`=force-grant, `FALSE`=reserved deny), from which `is_premium` is materialized by `shared/premium.Recompute` / `RecomputeViewer` (ADR-0018, ADR-0019). Today that grant is **permanent until an admin revokes it**.
+
+We want the admin to grant premium **for a limited amount of time** — e.g. a 7-day comp, a giveaway prize, a trial — for a user and/or a viewer, after which premium reverts on its own (to whatever the subscription warrants) with no second admin action.
+
+The wrinkle: ADR-0018 deliberately kept the entitlement rule **time-free** ("`RecomputePremium` therefore stays time-free"), because a subscription's grace is Patreon's own signal (`active_patron` through its retry window), not a timer we keep. Introducing an admin-set expiry adds time to the *override* input. And because `is_premium` is **materialized**, an expiry that passes with no other write would leave the column stale (still `TRUE`).
+
+## Decision Drivers
+
+- **Reuse the derived-column model.** Don't fork a parallel entitlement path — extend the ADR-0018/0019 override + recompute so readers (`shared/middleware/premium.go`, moderation-service, `ViewerBadgeEnricher`, viewer JWT) stay untouched.
+- **Clobber-free.** A lapse-driven revert must never clobber a fresh re-grant, and must not race the subscription writer (the exact hazard ADR-0018 eliminated).
+- **Convergent + correct on any recompute.** Whatever triggers a recompute (webhook, reconcile, admin write, override lapse), the result must be correct.
+- **One clock.** Expiry comparisons must not depend on per-pod wall-clock skew.
+- **Minimal blast radius.** Prefer the smallest change that is correct.
+
+## Considered Options
+
+1. **Optional expiry column on the override; recompute nullifies an expired override in SQL; a single-replica periodic sweep clears lapsed grants.**
+   - ✅ Tiny surface (two nullable columns); `Effective(override, active)` stays an unchanged pure boolean; correct on every recompute; converges even with no other write.
+   - ❌ Adds a materialization-refresh sweep (accepted — payment-service already runs one single-replica loop).
+2. **Compute `is_premium` on read instead of materializing.**
+   - ✅ No sweep; always current.
+   - ❌ Rewrites the whole read path (every reader, hot paths included) — exactly what ADR-0018/0019 chose *not* to do. Rejected.
+3. **Store an absolute expiry computed by the admin's browser and compare to app wall-clock.**
+   - ❌ Browser/app clock skew makes "grant for 7 days" imprecise and the compare ambiguous. Rejected in favour of a server-computed deadline (`NOW() + interval`) compared to DB `NOW()`.
+4. **Run the sweep in each write service (share-service / auth-service).**
+   - ❌ Both are multi-replica (2×): the periodic scan would run redundantly on every replica. payment-service is the single-replica entitlement authority — the natural home. Rejected.
+
+## Decision Outcome
+
+**Chosen**: Option 1.
+
+- **Schema (migration 067).** Add nullable `premium_admin_override_expires_at TIMESTAMP` to `users` and `viewers`, each with a partial index `WHERE … IS NOT NULL`. `NULL` = permanent (unchanged behaviour). Idempotent, writes no values (re-run-safe per the runner's re-run-everything contract; guarded by `migrations_rerun_test.go`).
+- **Recompute nullifies an expired override in SQL.** `recomputeUserTx` / `recomputeViewerTx` read
+  ```sql
+  CASE WHEN premium_admin_override_expires_at IS NOT NULL
+            AND premium_admin_override_expires_at <= NOW()
+       THEN NULL ELSE premium_admin_override END
+  ```
+  and feed that to the **unchanged** `Effective(override, hasActiveSub || …)`. So an expired grant is indistinguishable from "no admin opinion" and premium falls through to the subscription. `Effective` stays time-free and its truth table is untouched; the time lives in the read SQL against the **DB clock** (one clock). **Scope of the ADR-0018 amendment**: only the *admin-override* input gains an optional expiry — the *subscription* half stays time-free and still honors Patreon's own grace.
+- **Server-computed deadline.** The admin endpoints take an optional positive `duration_seconds` (capped ~10y); the repository sets `premium_admin_override_expires_at = NOW() + make_interval(secs => …)`, so a grant lasts exactly the requested duration regardless of the browser clock. Grant with no duration ⇒ `NULL` (permanent); revoke ⇒ both cleared.
+- **Single-replica expiry sweep (payment-service).** `reconcile.OverrideExpirySweeper` runs on its own short interval (`PAYMENT_OVERRIDE_SWEEP_INTERVAL`, default 5m) alongside the Patreon reconcile loop. It lists due rows (`… IS NOT NULL AND … <= NOW()`) and calls `Recomputer.ExpireUserOverrideIfDue` / `ExpireViewerOverrideIfDue`, each of which — in **one transaction** — runs a **guarded** clear (`UPDATE … SET override=NULL, expires_at=NULL WHERE … expires_at <= NOW()`) and, iff a row was cleared, recomputes `is_premium`. The `WHERE … <= NOW()` guard means a concurrent admin re-grant (fresh future expiry, or permanent) is **not clobbered**; the shared transaction means a crash can never strand a cleared-but-not-recomputed row.
+
+Because the recompute already nullifies an expired override, `is_premium` is correct the instant *anything* recomputes a subject; the sweep is purely the backstop for a subject that has no other write after its grant lapses, plus the column cleanup that makes the row stop matching.
+
+## Consequences
+
+### Positive
+- Admins can hand out temporary premium to users and viewers; it reverts on its own, clobber-free.
+- Readers and the `Effective` rule are unchanged; permanent grants behave exactly as before.
+- Correct on any recompute (webhook/reconcile/admin/lapse); converges with no other write via the sweep.
+- One clock (DB `NOW()`); grant length is exact and browser-clock-independent.
+
+### Negative
+- `is_premium` can lag a lapse by up to one sweep interval (≤5m default) *only* for a subject with no other write in that window — bounded and tunable.
+- One more single-replica loop in payment-service (cheap: an indexed scan + a few recomputes).
+- A narrow, documented amendment to ADR-0018's "time-free" property — scoped to the admin-override input only.
+
+## Implementation
+
+- **Migration**: `migrations/067_premium_admin_override_expiry.sql` (+ `_down`).
+- **Shared**: `shared/premium/recompute.go` — extracted `recomputeUserTx`/`recomputeViewerTx` (expired-override nullification), added `ExpireUserOverrideIfDue`/`ExpireViewerOverrideIfDue` (guarded atomic clear+recompute).
+- **payment-service**: `reconcile/override_expiry.go` (`OverrideExpirySweeper`) + wiring in `cmd/main.go` (`PAYMENT_OVERRIDE_SWEEP_INTERVAL`, `PAYMENT_OVERRIDE_SWEEP_BATCH_SIZE`).
+- **share-service**: `repository/premium_repo.go` `UpdateUserPremium(…, ttl)`, `handlers/admin.go` parses/validates `duration_seconds`.
+- **auth-service**: `repository/viewer_repository.go` `SetViewerPremium(…, ttl)`, `handlers/admin_viewers.go` parses/validates `duration_seconds`; `premium_expires_at` surfaced in the admin user + viewer lists.
+- **Gateway**: unchanged — the existing `POST /api/v1/admin/premium/users/:id` and `POST /api/v1/admin/viewers/:session_id/premium` routes only grow their request body.
+- **Frontend**: `components/admin/PremiumDurationChooser.tsx` (presets + custom days, pure `customDaysToSeconds`), wired into `admin/users` and `admin/viewers` grant dialogs; expiry shown on the active-premium panels.
+- **Tests**: unit (`customDaysToSeconds`; handler duration validation) + testcontainers integration (recompute expiry truth table, `ExpireXOverrideIfDue` guard, end-to-end sweep flips `is_premium` and clears columns).
+
+## Related Decisions
+
+- [ADR-0018](./0018-premium-entitlements-via-patreon.md) — the user-premium derived column + `Effective` this extends (and whose "time-free" property this narrowly amends).
+- [ADR-0019](./0019-split-streamer-viewer-premium.md) — the viewer-premium derived column + `RecomputeViewer` this extends.
+- [ADR-0020](./0020-beta-tester-role.md) — beta-tester role; intentionally **not** time-limited (a separate early-access role).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -367,6 +367,17 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0027: Time-Limited Admin Premium Overrides
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-05
+**Problem**: Admin premium grants (`users`/`viewers.premium_admin_override`, ADR-0018/0019) were permanent-until-revoked; we want to grant premium for a limited time (a comp/trial) that reverts on its own — but `is_premium` is materialized and ADR-0018 kept the rule time-free
+**Decision**: Add an optional `premium_admin_override_expires_at` to both tables; `Recompute`/`RecomputeViewer` nullify an expired override in SQL against the DB clock (so `Effective` stays an unchanged time-free boolean, subscription half untouched); a single-replica payment-service sweep clears lapsed grants with a guarded atomic clear+recompute (never clobbers a re-grant). Grant length is a server-computed `NOW()+duration`
+**Impact**: Time-limited grants for users and viewers; readers + `Effective` unchanged; correct on any recompute, converges within one sweep interval (≤5m) otherwise; narrow scoped amendment to ADR-0018's time-free property (override input only)
+**→ Read**: [0027-time-limited-admin-premium-overrides.md](./0027-time-limited-admin-premium-overrides.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -28,6 +28,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog } from '@/components/ui/dialog'
 import { toastManager } from '@/lib/toast'
 import { useAuthStore } from '@/lib/stores/auth-store'
+import { PremiumDurationChooser } from '@/components/admin/PremiumDurationChooser'
 
 interface User {
   id: string
@@ -41,6 +42,7 @@ interface User {
   kick_id?: string
   is_premium: boolean
   is_beta_tester: boolean
+  premium_expires_at?: string | null
   is_banned: boolean
   banned_at?: string
   banned_reason?: string
@@ -72,6 +74,10 @@ export default function UsersPage() {
   const [unbanDialogUser, setUnbanDialogUser] = useState<User | null>(null)
   const [premiumDialogUser, setPremiumDialogUser] = useState<User | null>(null)
   const [premiumLoading, setPremiumLoading] = useState(false)
+  // Time-limited grant selection (ADR-0027). null seconds = permanent; valid=false
+  // means the custom day count is empty/out of range and the grant is blocked.
+  const [grantDurationSeconds, setGrantDurationSeconds] = useState<number | null>(null)
+  const [grantDurationValid, setGrantDurationValid] = useState(true)
   const [betaDialogUser, setBetaDialogUser] = useState<User | null>(null)
   const [betaLoading, setBetaLoading] = useState(false)
 
@@ -218,17 +224,27 @@ export default function UsersPage() {
     }
   }
 
-  // Handle premium toggle
-  const handleSetPremium = async (userId: string, username: string, isPremium: boolean) => {
+  // Handle premium toggle. durationSeconds (grant only) makes it time-limited
+  // (ADR-0027); null/undefined grants permanently. Ignored when revoking.
+  const handleSetPremium = async (
+    userId: string,
+    username: string,
+    isPremium: boolean,
+    durationSeconds?: number | null
+  ) => {
     setPremiumLoading(true)
     try {
+      const body: { is_premium: boolean; duration_seconds?: number } = { is_premium: isPremium }
+      if (isPremium && durationSeconds != null) {
+        body.duration_seconds = durationSeconds
+      }
       const response = await fetch(`/api/v1/admin/premium/users/${userId}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         credentials: 'same-origin',
-        body: JSON.stringify({ is_premium: isPremium }),
+        body: JSON.stringify(body),
       })
 
       if (!response.ok) {
@@ -245,9 +261,18 @@ export default function UsersPage() {
       setPremiumDialogUser(null)
       await refetchUsers()
 
-      // Update selectedUser in place so the panel reflects the change immediately
+      // Update selectedUser in place so the panel reflects the change immediately.
+      // The server computes the exact deadline from its own clock; this local
+      // estimate (accurate to a few seconds) is refreshed by refetchUsers() on the
+      // next selection.
       if (selectedUser?.id === userId) {
-        setSelectedUser((u) => (u ? { ...u, is_premium: isPremium } : u))
+        const expiresAt =
+          isPremium && durationSeconds != null
+            ? new Date(Date.now() + durationSeconds * 1000).toISOString()
+            : null
+        setSelectedUser((u) =>
+          u ? { ...u, is_premium: isPremium, premium_expires_at: expiresAt } : u
+        )
       }
     } catch (err: any) {
       toastManager.add({ title: err.message || 'Failed to update premium status', type: 'error' })
@@ -622,6 +647,12 @@ export default function UsersPage() {
                         <p className="mt-1 text-xs text-amber-400/70">
                           This user can create and accept share requests.
                         </p>
+                        {selectedUser.premium_expires_at && (
+                          <p className="mt-1 text-xs font-medium text-amber-400/70">
+                            Time-limited &mdash; expires{' '}
+                            {new Date(selectedUser.premium_expires_at).toLocaleString()}
+                          </p>
+                        )}
                       </div>
                       <Dialog.Root
                         open={
@@ -686,7 +717,13 @@ export default function UsersPage() {
                           <Button
                             variant="outline"
                             className="w-full border-amber-500/40 text-amber-400 hover:border-amber-500/60 hover:bg-amber-500/10"
-                            onClick={() => setPremiumDialogUser(selectedUser)}
+                            onClick={() => {
+                              // Reset the duration selection to the default (Permanent)
+                              // each time the grant dialog opens.
+                              setGrantDurationSeconds(null)
+                              setGrantDurationValid(true)
+                              setPremiumDialogUser(selectedUser)
+                            }}
                           >
                             Grant Premium
                           </Button>
@@ -699,6 +736,13 @@ export default function UsersPage() {
                         <Dialog.Description>
                           They will be able to create and accept chat overlay share requests.
                         </Dialog.Description>
+                        <PremiumDurationChooser
+                          disabled={premiumLoading}
+                          onChange={(seconds, valid) => {
+                            setGrantDurationSeconds(seconds)
+                            setGrantDurationValid(valid)
+                          }}
+                        />
                         <div className="mt-6 flex justify-end gap-3">
                           <Dialog.Close
                             render={
@@ -709,9 +753,14 @@ export default function UsersPage() {
                           />
                           <Button
                             variant="default"
-                            disabled={premiumLoading}
+                            disabled={premiumLoading || !grantDurationValid}
                             onClick={() =>
-                              handleSetPremium(selectedUser.id, selectedUser.username, true)
+                              handleSetPremium(
+                                selectedUser.id,
+                                selectedUser.username,
+                                true,
+                                grantDurationSeconds
+                              )
                             }
                           >
                             {premiumLoading ? 'Saving...' : 'Grant Premium'}

--- a/frontend/src/app/admin/viewers/page.tsx
+++ b/frontend/src/app/admin/viewers/page.tsx
@@ -35,6 +35,7 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import clsx from 'clsx'
 import { useAuthStore } from '@/lib/stores/auth-store'
 import { apiClient } from '@/lib/api/client'
 import { formatDistanceToNow } from 'date-fns'
@@ -43,6 +44,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog } from '@/components/ui/dialog'
 import { toastManager } from '@/lib/toast'
+import { PremiumDurationChooser } from '@/components/admin/PremiumDurationChooser'
 
 interface ViewerSession {
   id: string
@@ -54,6 +56,7 @@ interface ViewerSession {
   message_count_1min: number
   message_count_1hour: number
   is_premium: boolean
+  premium_expires_at?: string | null
   viewer_id: string | null
   is_banned: boolean
   banned_at: string | null
@@ -74,6 +77,10 @@ export default function AdminViewersPage() {
   const [unbanDialogViewer, setUnbanDialogViewer] = useState<ViewerSession | null>(null)
   const [premiumDialogViewer, setPremiumDialogViewer] = useState<ViewerSession | null>(null)
   const [premiumLoading, setPremiumLoading] = useState(false)
+  // Time-limited grant selection (ADR-0027). null seconds = permanent; valid=false
+  // means the custom day count is empty/out of range and the grant is blocked.
+  const [grantDurationSeconds, setGrantDurationSeconds] = useState<number | null>(null)
+  const [grantDurationValid, setGrantDurationValid] = useState(true)
 
   useEffect(() => {
     if (!user?.is_admin) {
@@ -141,12 +148,17 @@ export default function AdminViewersPage() {
     }
   }
 
-  const handleTogglePremium = async (viewer: ViewerSession) => {
+  // durationSeconds (grant only) makes the grant time-limited (ADR-0027); null/
+  // undefined grants permanently. Ignored when revoking.
+  const handleTogglePremium = async (viewer: ViewerSession, durationSeconds?: number | null) => {
     try {
       setPremiumLoading(true)
-      await apiClient.post(`/api/v1/admin/viewers/${viewer.id}/premium`, {
-        is_premium: !viewer.is_premium,
-      })
+      const granting = !viewer.is_premium
+      const body: { is_premium: boolean; duration_seconds?: number } = { is_premium: granting }
+      if (granting && durationSeconds != null) {
+        body.duration_seconds = durationSeconds
+      }
+      await apiClient.post(`/api/v1/admin/viewers/${viewer.id}/premium`, body)
       toastManager.add({
         title: `${viewer.username} premium ${viewer.is_premium ? 'revoked' : 'granted'}`,
         type: 'success',
@@ -174,12 +186,18 @@ export default function AdminViewersPage() {
     }
     return (
       <button
-        className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium transition-colors ${
+        className={clsx(
+          'inline-flex items-center rounded px-2 py-0.5 text-xs font-medium transition-colors',
           viewer.is_premium
             ? 'bg-amber-400/10 text-amber-400 hover:bg-amber-400/20'
             : 'bg-surface-2 text-text-dim hover:bg-surface-2/80'
-        }`}
-        onClick={() => setPremiumDialogViewer(viewer)}
+        )}
+        onClick={() => {
+          // Reset the duration selection to the default (Permanent) each open.
+          setGrantDurationSeconds(null)
+          setGrantDurationValid(true)
+          setPremiumDialogViewer(viewer)
+        }}
       >
         {viewer.is_premium ? 'Premium' : 'Free'}
       </button>
@@ -386,12 +404,28 @@ export default function AdminViewersPage() {
                 ? 'They will lose access to gradients, avatar frames, and flairs.'
                 : 'They will be able to use gradients, avatar frames, and flairs.'}
             </Dialog.Description>
+            {premiumDialogViewer.is_premium ? (
+              premiumDialogViewer.premium_expires_at && (
+                <p className="mt-2 text-xs font-medium text-amber-400/80">
+                  Time-limited &mdash; expires{' '}
+                  {new Date(premiumDialogViewer.premium_expires_at).toLocaleString()}
+                </p>
+              )
+            ) : (
+              <PremiumDurationChooser
+                disabled={premiumLoading}
+                onChange={(seconds, valid) => {
+                  setGrantDurationSeconds(seconds)
+                  setGrantDurationValid(valid)
+                }}
+              />
+            )}
             <div className="mt-6 flex justify-end gap-3">
               <Dialog.Close render={<Button variant="outline">Cancel</Button>} />
               <Button
                 variant="default"
-                disabled={premiumLoading}
-                onClick={() => handleTogglePremium(premiumDialogViewer)}
+                disabled={premiumLoading || (!premiumDialogViewer.is_premium && !grantDurationValid)}
+                onClick={() => handleTogglePremium(premiumDialogViewer, grantDurationSeconds)}
               >
                 {premiumLoading
                   ? 'Updating...'

--- a/frontend/src/components/admin/PremiumDurationChooser.tsx
+++ b/frontend/src/components/admin/PremiumDurationChooser.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react'
+import clsx from 'clsx'
+import { Input } from '@/components/ui/input'
+
+export const DAY_SECONDS = 86400
+// Mirrors the backend cap (~10 years) in share-service / auth-service.
+export const MAX_DAYS = 3650
+
+interface Preset {
+  label: string
+  seconds: number | null // null = permanent
+}
+
+const PRESETS: Preset[] = [
+  { label: 'Permanent', seconds: null },
+  { label: '1 day', seconds: 1 * DAY_SECONDS },
+  { label: '7 days', seconds: 7 * DAY_SECONDS },
+  { label: '30 days', seconds: 30 * DAY_SECONDS },
+  { label: '90 days', seconds: 90 * DAY_SECONDS },
+]
+
+function presetKey(seconds: number | null): string {
+  return seconds === null ? 'permanent' : String(seconds)
+}
+
+/**
+ * customDaysToSeconds parses the custom day-count field into a grant duration.
+ * A blank, non-numeric, non-positive, or over-cap value is invalid (seconds=null,
+ * valid=false) so the caller can block submission; otherwise seconds is the exact
+ * duration to send as duration_seconds. Pure — unit-tested independently of render.
+ */
+export function customDaysToSeconds(daysStr: string): { seconds: number | null; valid: boolean } {
+  const days = Number(daysStr)
+  const valid = daysStr.trim() !== '' && Number.isFinite(days) && days >= 1 && days <= MAX_DAYS
+  return { seconds: valid ? Math.round(days * DAY_SECONDS) : null, valid }
+}
+
+export interface PremiumDurationChooserProps {
+  /**
+   * Fired whenever the selection changes. seconds=null means a permanent grant
+   * (no duration_seconds sent). valid=false means the custom input is empty or
+   * out of range — the caller should block submission until it is valid again.
+   */
+  onChange: (seconds: number | null, valid: boolean) => void
+  disabled?: boolean
+}
+
+/**
+ * PremiumDurationChooser lets an admin pick how long a premium grant lasts
+ * (ADR-0027): a set of quick presets plus a custom day count. It defaults to
+ * Permanent, matching the historical grant behaviour. It is uncontrolled — it owns
+ * its own selection and reports changes via onChange; mount it fresh (e.g. inside a
+ * dialog that unmounts on close) to reset it.
+ */
+export function PremiumDurationChooser({ onChange, disabled }: PremiumDurationChooserProps) {
+  const [choice, setChoice] = useState<string>('permanent')
+  const [customDays, setCustomDays] = useState('')
+
+  function selectPreset(preset: Preset) {
+    setChoice(presetKey(preset.seconds))
+    onChange(preset.seconds, true)
+  }
+
+  function selectCustom(daysStr: string) {
+    setChoice('custom')
+    setCustomDays(daysStr)
+    const { seconds, valid } = customDaysToSeconds(daysStr)
+    onChange(seconds, valid)
+  }
+
+  const chipClass = (active: boolean) =>
+    clsx(
+      'rounded border px-3 py-1 text-sm transition-colors',
+      active
+        ? 'border-amber-400 bg-amber-400/10 text-amber-400'
+        : 'border-border text-text-sub hover:border-amber-500/40 hover:text-text'
+    )
+
+  return (
+    <div className="mt-4">
+      <p className="mb-2 text-xs font-medium text-text-sub">Duration</p>
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={presetKey(preset.seconds)}
+            type="button"
+            disabled={disabled}
+            onClick={() => selectPreset(preset)}
+            className={chipClass(choice === presetKey(preset.seconds))}
+          >
+            {preset.label}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => selectCustom(customDays)}
+          className={chipClass(choice === 'custom')}
+        >
+          Custom
+        </button>
+      </div>
+      {choice === 'custom' && (
+        <div className="mt-3 flex items-center gap-2">
+          <Input
+            type="number"
+            min={1}
+            max={MAX_DAYS}
+            size="sm"
+            value={customDays}
+            disabled={disabled}
+            placeholder="days"
+            aria-label="Custom duration in days"
+            onChange={(e) => selectCustom(e.target.value)}
+            className="w-24"
+          />
+          <span className="text-xs text-text-dim">days (1&ndash;{MAX_DAYS})</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/admin/__tests__/premium-duration.test.ts
+++ b/frontend/src/components/admin/__tests__/premium-duration.test.ts
@@ -1,0 +1,46 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { customDaysToSeconds, DAY_SECONDS, MAX_DAYS } from '../PremiumDurationChooser'
+
+describe('customDaysToSeconds (ADR-0027 time-limited grant duration)', () => {
+  it('converts a valid whole-day count to seconds', () => {
+    expect(customDaysToSeconds('7')).toEqual({ seconds: 7 * DAY_SECONDS, valid: true })
+    expect(customDaysToSeconds('1')).toEqual({ seconds: DAY_SECONDS, valid: true })
+  })
+
+  it('accepts the maximum but rejects beyond it', () => {
+    expect(customDaysToSeconds(String(MAX_DAYS))).toEqual({
+      seconds: MAX_DAYS * DAY_SECONDS,
+      valid: true,
+    })
+    expect(customDaysToSeconds(String(MAX_DAYS + 1))).toEqual({ seconds: null, valid: false })
+  })
+
+  it('rejects blank, zero, negative, and non-numeric input', () => {
+    for (const bad of ['', '   ', '0', '-1', 'abc', 'NaN']) {
+      expect(customDaysToSeconds(bad)).toEqual({ seconds: null, valid: false })
+    }
+  })
+
+  it('rounds fractional days to whole seconds', () => {
+    expect(customDaysToSeconds('1.5')).toEqual({ seconds: Math.round(1.5 * DAY_SECONDS), valid: true })
+  })
+})

--- a/migrations/067_premium_admin_override_expiry.sql
+++ b/migrations/067_premium_admin_override_expiry.sql
@@ -1,0 +1,52 @@
+-- All-Chat Migration 067: Time-limited admin premium overrides (ADR-0027)
+-- Migration: 067
+--
+-- Problem (ADR-0027): the admin premium override (users.premium_admin_override /
+-- viewers.premium_admin_override, ADR-0018/0019) is a permanent-until-revoked
+-- tri-state. Admins want to grant premium for a LIMITED time (e.g. a 7-day comp)
+-- to a streamer (users.is_premium) and/or a viewer (viewers.is_premium).
+--
+-- This migration adds an optional expiry to each override:
+--
+--   - users.premium_admin_override_expires_at
+--   - viewers.premium_admin_override_expires_at
+--
+-- Semantics (implemented in shared/premium.Recompute / RecomputeViewer): when the
+-- expiry is set AND already past (<= NOW()), the override is treated as absent and
+-- premium falls through to the subscription half — exactly as if the admin had
+-- never set it. NULL expiry = permanent (today's behaviour, unchanged). Only the
+-- admin-override input gains time; the subscription half stays time-free and keeps
+-- honoring Patreon's own grace window (ADR-0018).
+--
+-- The materialized is_premium is refreshed on any recompute AND by the
+-- payment-service expiry sweep (single replica), which clears due overrides so a
+-- grant that lapses with no other write still converges to not-premium.
+--
+-- IDEMPOTENCY: the runner re-executes every migration on each pod start, so both
+-- adds are ADD COLUMN IF NOT EXISTS with no DEFAULT value written — no entitlement
+-- VALUES are set, so a re-run can never shorten or clobber a live grant. Guarded by
+-- services/auth-service/repository/migrations_rerun_test.go.
+
+BEGIN;
+
+-- 1. Streamer (users) override expiry.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS premium_admin_override_expires_at TIMESTAMP NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_premium_override_expiry
+    ON users(premium_admin_override_expires_at)
+    WHERE premium_admin_override_expires_at IS NOT NULL;
+
+COMMENT ON COLUMN users.premium_admin_override_expires_at IS
+    'Time-limited admin premium (ADR-0027): when set, premium_admin_override is ignored once past this instant (premium falls through to the subscription). NULL = permanent. Written by share-service admin endpoint; cleared by the payment-service expiry sweep. Only affects the override half of shared/premium.Recompute — the subscription half stays time-free.';
+
+-- 2. Viewer (viewers) override expiry, mirroring users.
+ALTER TABLE viewers ADD COLUMN IF NOT EXISTS premium_admin_override_expires_at TIMESTAMP NULL;
+
+CREATE INDEX IF NOT EXISTS idx_viewers_premium_override_expiry
+    ON viewers(premium_admin_override_expires_at)
+    WHERE premium_admin_override_expires_at IS NOT NULL;
+
+COMMENT ON COLUMN viewers.premium_admin_override_expires_at IS
+    'Time-limited admin premium (ADR-0027): when set, premium_admin_override is ignored once past this instant (premium falls through to the viewer subscription / linked-streamer inheritance). NULL = permanent. Written by auth-service admin endpoint; cleared by the payment-service expiry sweep.';
+
+COMMIT;

--- a/migrations/067_premium_admin_override_expiry_down.sql
+++ b/migrations/067_premium_admin_override_expiry_down.sql
@@ -1,0 +1,14 @@
+-- All-Chat Migration 067 DOWN: remove time-limited admin premium override expiry.
+-- Reverts 067_premium_admin_override_expiry.sql (ADR-0027). Dropping the columns
+-- discards any pending expiry, reverting every live admin override to permanent —
+-- acceptable for a rollback (it never removes premium, only its time limit).
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_viewers_premium_override_expiry;
+ALTER TABLE viewers DROP COLUMN IF EXISTS premium_admin_override_expires_at;
+
+DROP INDEX IF EXISTS idx_users_premium_override_expiry;
+ALTER TABLE users DROP COLUMN IF EXISTS premium_admin_override_expires_at;
+
+COMMIT;

--- a/services/auth-service/handlers/admin.go
+++ b/services/auth-service/handlers/admin.go
@@ -86,21 +86,22 @@ func (h *AdminHandler) ListUsers(c *gin.Context) {
 
 	// Return users without sensitive information
 	type UserResponse struct {
-		ID              string  `json:"id"`
-		Username        string  `json:"username"`
-		DisplayName     string  `json:"display_name"`
-		AuthProvider    string  `json:"auth_provider"`
-		ProfileImageURL string  `json:"profile_image_url"`
-		CreatedAt       string  `json:"created_at"`
-		TwitchID        *string `json:"twitch_id"`
-		YouTubeID       *string `json:"youtube_id"`
-		KickID          *string `json:"kick_id"`
-		IsPremium       bool    `json:"is_premium"`
-		IsBetaTester    bool    `json:"is_beta_tester"`
-		IsBanned        bool    `json:"is_banned"`
-		BannedAt        *string `json:"banned_at,omitempty"`
-		BannedReason    *string `json:"banned_reason,omitempty"`
-		BannedBy        *string `json:"banned_by,omitempty"`
+		ID               string  `json:"id"`
+		Username         string  `json:"username"`
+		DisplayName      string  `json:"display_name"`
+		AuthProvider     string  `json:"auth_provider"`
+		ProfileImageURL  string  `json:"profile_image_url"`
+		CreatedAt        string  `json:"created_at"`
+		TwitchID         *string `json:"twitch_id"`
+		YouTubeID        *string `json:"youtube_id"`
+		KickID           *string `json:"kick_id"`
+		IsPremium        bool    `json:"is_premium"`
+		IsBetaTester     bool    `json:"is_beta_tester"`
+		PremiumExpiresAt *string `json:"premium_expires_at,omitempty"`
+		IsBanned         bool    `json:"is_banned"`
+		BannedAt         *string `json:"banned_at,omitempty"`
+		BannedReason     *string `json:"banned_reason,omitempty"`
+		BannedBy         *string `json:"banned_by,omitempty"`
 	}
 
 	response := make([]UserResponse, len(users))
@@ -111,22 +112,31 @@ func (h *AdminHandler) ListUsers(c *gin.Context) {
 			bannedAt = &formatted
 		}
 
+		// premium_expires_at: the deadline of a time-limited admin grant (ADR-0027).
+		// Absent => permanent grant / not admin-granted.
+		var premiumExpiresAt *string
+		if user.PremiumExpiresAt != nil {
+			formatted := user.PremiumExpiresAt.Format("2006-01-02T15:04:05Z07:00")
+			premiumExpiresAt = &formatted
+		}
+
 		response[i] = UserResponse{
-			ID:              user.ID,
-			Username:        user.Username,
-			DisplayName:     user.DisplayName,
-			AuthProvider:    user.AuthProvider,
-			ProfileImageURL: user.ProfileImageURL,
-			CreatedAt:       user.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			TwitchID:        user.TwitchID,
-			YouTubeID:       user.GoogleID,
-			KickID:          user.KickID,
-			IsPremium:       user.IsPremium,
-			IsBetaTester:    user.IsBetaTester,
-			IsBanned:        user.IsBanned,
-			BannedAt:        bannedAt,
-			BannedReason:    user.BannedReason,
-			BannedBy:        user.BannedBy,
+			ID:               user.ID,
+			Username:         user.Username,
+			DisplayName:      user.DisplayName,
+			AuthProvider:     user.AuthProvider,
+			ProfileImageURL:  user.ProfileImageURL,
+			CreatedAt:        user.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			TwitchID:         user.TwitchID,
+			YouTubeID:        user.GoogleID,
+			KickID:           user.KickID,
+			IsPremium:        user.IsPremium,
+			IsBetaTester:     user.IsBetaTester,
+			PremiumExpiresAt: premiumExpiresAt,
+			IsBanned:         user.IsBanned,
+			BannedAt:         bannedAt,
+			BannedReason:     user.BannedReason,
+			BannedBy:         user.BannedBy,
 		}
 	}
 

--- a/services/auth-service/handlers/admin_viewers.go
+++ b/services/auth-service/handlers/admin_viewers.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/caesar/all-chat/services/auth-service/repository"
 	"github.com/gin-gonic/gin"
@@ -129,10 +130,17 @@ func (h *AdminViewerHandler) HandleUnbanViewer(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Viewer unbanned successfully"})
 }
 
-// SetPremiumRequest is the request body for setting viewer premium status
+// SetPremiumRequest is the request body for setting viewer premium status.
+// DurationSeconds (optional, positive) makes the grant time-limited (ADR-0027);
+// omit it for a permanent grant. It is ignored when revoking.
 type SetPremiumRequest struct {
-	IsPremium bool `json:"is_premium"`
+	IsPremium       bool   `json:"is_premium"`
+	DurationSeconds *int64 `json:"duration_seconds"`
 }
+
+// maxViewerPremiumGrantSeconds caps a time-limited viewer premium grant (ADR-0027)
+// at ~10 years, mirroring the streamer side (share-service).
+const maxViewerPremiumGrantSeconds int64 = 10 * 365 * 24 * 60 * 60
 
 // HandleSetViewerPremium grants or revokes premium status for a viewer
 func (h *AdminViewerHandler) HandleSetViewerPremium(c *gin.Context) {
@@ -149,8 +157,22 @@ func (h *AdminViewerHandler) HandleSetViewerPremium(c *gin.Context) {
 		return
 	}
 
+	var ttl *time.Duration
+	if req.DurationSeconds != nil {
+		if *req.DurationSeconds <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration_seconds must be positive"})
+			return
+		}
+		if *req.DurationSeconds > maxViewerPremiumGrantSeconds {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration_seconds exceeds maximum"})
+			return
+		}
+		d := time.Duration(*req.DurationSeconds) * time.Second
+		ttl = &d
+	}
+
 	ctx := c.Request.Context()
-	if err := h.viewerRepo.SetViewerPremium(ctx, sessionID, req.IsPremium); err != nil {
+	if err := h.viewerRepo.SetViewerPremium(ctx, sessionID, req.IsPremium, ttl); err != nil {
 		h.log.Error("Failed to set viewer premium", zap.Error(err), zap.String("session_id", sessionIDStr))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update viewer premium status"})
 		return
@@ -163,10 +185,15 @@ func (h *AdminViewerHandler) HandleSetViewerPremium(c *gin.Context) {
 	h.log.Info("Viewer premium status updated",
 		zap.String("session_id", sessionIDStr),
 		zap.Bool("is_premium", req.IsPremium),
+		zap.Bool("time_limited", ttl != nil),
 	)
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"message":    "Viewer premium " + action + " successfully",
 		"session_id": sessionIDStr,
 		"is_premium": req.IsPremium,
-	})
+	}
+	if ttl != nil && req.IsPremium {
+		resp["duration_seconds"] = int64(ttl.Seconds())
+	}
+	c.JSON(http.StatusOK, resp)
 }

--- a/services/auth-service/handlers/admin_viewers_test.go
+++ b/services/auth-service/handlers/admin_viewers_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -34,8 +35,8 @@ import (
 // mockViewerRepo implements the subset of ViewerRepository used by AdminViewerHandler.
 type mockViewerRepo struct {
 	repository.ViewerRepository
-	listAllFn         func(limit, offset int) ([]models.ViewerSession, error)
-	setViewerPremiumFn func(sessionID uuid.UUID, isPremium bool) error
+	listAllFn          func(limit, offset int) ([]models.ViewerSession, error)
+	setViewerPremiumFn func(sessionID uuid.UUID, isPremium bool, ttl *time.Duration) error
 }
 
 func setupAdminViewerRouter(t *testing.T, mock *mockViewerRepo) *gin.Engine {
@@ -93,5 +94,32 @@ func TestHandleSetViewerPremium_InvalidBody(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// TestHandleSetViewerPremium_RejectsBadDuration: a non-positive or over-cap
+// duration_seconds is rejected with 400 before any DB access (ADR-0027). A nil repo
+// proves the validation short-circuits before the repo is touched.
+func TestHandleSetViewerPremium_RejectsBadDuration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := zap.NewNop()
+	handler := &AdminViewerHandler{log: logger, viewerRepo: nil}
+	r := gin.New()
+	r.POST("/admin/viewers/:session_id/premium", handler.HandleSetViewerPremium)
+
+	sessionID := uuid.New().String()
+	// 0, negative, and 11 years (over the ~10y cap).
+	for _, body := range []string{
+		`{"is_premium":true,"duration_seconds":0}`,
+		`{"is_premium":true,"duration_seconds":-1}`,
+		`{"is_premium":true,"duration_seconds":346896000}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/admin/viewers/"+sessionID+"/premium", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected 400 for body %s, got %d", body, w.Code)
+		}
 	}
 }

--- a/services/auth-service/models/user.go
+++ b/services/auth-service/models/user.go
@@ -20,27 +20,28 @@ import "time"
 
 // User represents a user in the system
 type User struct {
-	ID              string     `json:"id"`
-	TwitchID        *string    `json:"twitch_id,omitempty"` // Nullable for other platform users
-	GoogleID        *string    `json:"google_id,omitempty"` // Nullable for non-YouTube users
-	KickID          *string    `json:"kick_id,omitempty"`   // Nullable for non-Kick users
-	AuthProvider    string     `json:"auth_provider"`       // "twitch", "youtube", or "kick"
-	Username        string     `json:"username"`
-	DisplayName     string     `json:"display_name"`
-	ProfileImageURL string     `json:"profile_image_url"`
-	IsAdmin         bool       `json:"is_admin"`                // Admin role for access control
-	IsPremium       bool       `json:"is_premium"`              // Premium feature access (derived)
-	IsBetaTester    bool       `json:"is_beta_tester"`          // Beta-tester role (ADR-0020): all premium + early-access
-	IsBanned        bool       `json:"is_banned"`               // Ban status
-	BannedAt        *time.Time `json:"banned_at,omitempty"`     // When user was banned
-	BannedReason    *string    `json:"banned_reason,omitempty"` // Reason for ban
-	BannedBy        *string    `json:"banned_by,omitempty"`     // Admin who banned (user ID)
-	AccessToken     string     `json:"-"`                       // Never expose in JSON
-	RefreshToken    string     `json:"-"`                       // Never expose in JSON
-	TokenExpiresAt  time.Time  `json:"-"`
-	GrantedScopes   []string   `json:"-"` // OAuth scopes granted at consent (TEXT[] in DB); gates EventSub chat reading
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID               string     `json:"id"`
+	TwitchID         *string    `json:"twitch_id,omitempty"` // Nullable for other platform users
+	GoogleID         *string    `json:"google_id,omitempty"` // Nullable for non-YouTube users
+	KickID           *string    `json:"kick_id,omitempty"`   // Nullable for non-Kick users
+	AuthProvider     string     `json:"auth_provider"`       // "twitch", "youtube", or "kick"
+	Username         string     `json:"username"`
+	DisplayName      string     `json:"display_name"`
+	ProfileImageURL  string     `json:"profile_image_url"`
+	IsAdmin          bool       `json:"is_admin"`                     // Admin role for access control
+	IsPremium        bool       `json:"is_premium"`                   // Premium feature access (derived)
+	IsBetaTester     bool       `json:"is_beta_tester"`               // Beta-tester role (ADR-0020): all premium + early-access
+	PremiumExpiresAt *time.Time `json:"premium_expires_at,omitempty"` // ADR-0027: time-limited admin premium override deadline (NULL = permanent)
+	IsBanned         bool       `json:"is_banned"`                    // Ban status
+	BannedAt         *time.Time `json:"banned_at,omitempty"`          // When user was banned
+	BannedReason     *string    `json:"banned_reason,omitempty"`      // Reason for ban
+	BannedBy         *string    `json:"banned_by,omitempty"`          // Admin who banned (user ID)
+	AccessToken      string     `json:"-"`                            // Never expose in JSON
+	RefreshToken     string     `json:"-"`                            // Never expose in JSON
+	TokenExpiresAt   time.Time  `json:"-"`
+	GrantedScopes    []string   `json:"-"` // OAuth scopes granted at consent (TEXT[] in DB); gates EventSub chat reading
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
 }
 
 // TwitchUserInfo represents Twitch user data from OAuth

--- a/services/auth-service/models/viewer.go
+++ b/services/auth-service/models/viewer.go
@@ -24,50 +24,51 @@ import (
 
 // ViewerSession represents a viewer's OAuth session for sending messages
 type ViewerSession struct {
-	ID               uuid.UUID  `json:"id"`
-	Platform         string     `json:"platform"`           // 'twitch', 'youtube', 'kick', 'tiktok'
-	PlatformUserID   string     `json:"platform_user_id"`   // Platform-specific user ID
-	Username         string     `json:"username"`           // Platform username
-	DisplayName      string     `json:"display_name"`       // Display name
-	AvatarURL        *string    `json:"avatar_url"`         // Profile picture URL
-	AccessToken      string     `json:"-"`                  // Encrypted OAuth access token
-	RefreshToken     *string    `json:"-"`                  // Encrypted OAuth refresh token
-	TokenExpiresAt   time.Time  `json:"token_expires_at"`   // Token expiration
-	LastMessageAt    *time.Time `json:"last_message_at"`    // Last message timestamp
-	MessageCount1Min int        `json:"message_count_1min"` // Messages in last 1 minute
-	MessageCount1Hour int       `json:"message_count_1hour"` // Messages in last 1 hour
-	RateLimitReset1Min *time.Time `json:"rate_limit_reset_1min"` // 1-minute counter reset
+	ID                  uuid.UUID  `json:"id"`
+	Platform            string     `json:"platform"`               // 'twitch', 'youtube', 'kick', 'tiktok'
+	PlatformUserID      string     `json:"platform_user_id"`       // Platform-specific user ID
+	Username            string     `json:"username"`               // Platform username
+	DisplayName         string     `json:"display_name"`           // Display name
+	AvatarURL           *string    `json:"avatar_url"`             // Profile picture URL
+	AccessToken         string     `json:"-"`                      // Encrypted OAuth access token
+	RefreshToken        *string    `json:"-"`                      // Encrypted OAuth refresh token
+	TokenExpiresAt      time.Time  `json:"token_expires_at"`       // Token expiration
+	LastMessageAt       *time.Time `json:"last_message_at"`        // Last message timestamp
+	MessageCount1Min    int        `json:"message_count_1min"`     // Messages in last 1 minute
+	MessageCount1Hour   int        `json:"message_count_1hour"`    // Messages in last 1 hour
+	RateLimitReset1Min  *time.Time `json:"rate_limit_reset_1min"`  // 1-minute counter reset
 	RateLimitReset1Hour *time.Time `json:"rate_limit_reset_1hour"` // 1-hour counter reset
-	IsPremium        bool       `json:"is_premium"`         // Whether viewer has premium access
-	ViewerID         *uuid.UUID `json:"viewer_id"`          // Linked viewer identity ID
-	IsBanned         bool       `json:"is_banned"`          // Whether viewer is banned
-	BannedAt         *time.Time `json:"banned_at"`          // When viewer was banned
-	BannedReason     *string    `json:"banned_reason"`      // Reason for ban
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
+	IsPremium           bool       `json:"is_premium"`             // Whether viewer has premium access
+	PremiumExpiresAt    *time.Time `json:"premium_expires_at"`     // ADR-0027: time-limited admin premium deadline (NULL = permanent)
+	ViewerID            *uuid.UUID `json:"viewer_id"`              // Linked viewer identity ID
+	IsBanned            bool       `json:"is_banned"`              // Whether viewer is banned
+	BannedAt            *time.Time `json:"banned_at"`              // When viewer was banned
+	BannedReason        *string    `json:"banned_reason"`          // Reason for ban
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
 }
 
 // ViewerMessageLog represents a message sent by a viewer through All-Chat
 type ViewerMessageLog struct {
-	ID               uuid.UUID  `json:"id"`
-	ViewerSessionID  uuid.UUID  `json:"viewer_session_id"`
-	StreamerUserID   uuid.UUID  `json:"streamer_user_id"`
-	OverlayID        *uuid.UUID `json:"overlay_id"`       // May be null
-	Platform         string     `json:"platform"`         // Platform message was sent to
-	ChannelID        string     `json:"channel_id"`       // Target channel ID
-	ChannelName      string     `json:"channel_name"`     // Target channel name
-	MessageText      string     `json:"message_text"`     // Message content
-	SentAt           time.Time  `json:"sent_at"`          // When message was sent
-	Success          bool       `json:"success"`          // Whether send was successful
-	ErrorMessage     *string    `json:"error_message"`    // Error details if failed
-	CreatedAt        time.Time  `json:"created_at"`
+	ID              uuid.UUID  `json:"id"`
+	ViewerSessionID uuid.UUID  `json:"viewer_session_id"`
+	StreamerUserID  uuid.UUID  `json:"streamer_user_id"`
+	OverlayID       *uuid.UUID `json:"overlay_id"`    // May be null
+	Platform        string     `json:"platform"`      // Platform message was sent to
+	ChannelID       string     `json:"channel_id"`    // Target channel ID
+	ChannelName     string     `json:"channel_name"`  // Target channel name
+	MessageText     string     `json:"message_text"`  // Message content
+	SentAt          time.Time  `json:"sent_at"`       // When message was sent
+	Success         bool       `json:"success"`       // Whether send was successful
+	ErrorMessage    *string    `json:"error_message"` // Error details if failed
+	CreatedAt       time.Time  `json:"created_at"`
 }
 
 // ViewerAuthResponse is returned after successful viewer OAuth
 type ViewerAuthResponse struct {
-	Token       string        `json:"token"`        // JWT token for viewer session
-	ExpiresIn   int           `json:"expires_in"`   // JWT expiration in seconds
-	ViewerInfo  ViewerInfo    `json:"viewer_info"`  // Viewer information
+	Token      string     `json:"token"`       // JWT token for viewer session
+	ExpiresIn  int        `json:"expires_in"`  // JWT expiration in seconds
+	ViewerInfo ViewerInfo `json:"viewer_info"` // Viewer information
 }
 
 // ViewerInfo contains viewer profile information

--- a/services/auth-service/repository/user_repo_test.go
+++ b/services/auth-service/repository/user_repo_test.go
@@ -90,6 +90,7 @@ func setupTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 			is_admin BOOLEAN NOT NULL DEFAULT FALSE,
 			is_premium BOOLEAN NOT NULL DEFAULT FALSE,
 			is_beta_tester BOOLEAN NOT NULL DEFAULT FALSE,
+			premium_admin_override_expires_at TIMESTAMP,
 			is_banned BOOLEAN NOT NULL DEFAULT FALSE,
 			banned_at TIMESTAMP,
 			banned_reason TEXT,

--- a/services/auth-service/repository/user_repository.go
+++ b/services/auth-service/repository/user_repository.go
@@ -615,7 +615,7 @@ func (r *UserRepository) decryptToken(token string) (string, error) {
 func (r *UserRepository) GetAllUsers(ctx context.Context) ([]*models.User, error) {
 	query := `
 SELECT u.id, u.twitch_id, u.google_id, u.kick_id, u.auth_provider, u.username, u.display_name, u.profile_image_url,
-       u.is_admin, u.is_premium, u.is_beta_tester,
+       u.is_admin, u.is_premium, u.is_beta_tester, u.premium_admin_override_expires_at,
        (u.is_banned OR bpi.platform_id IS NOT NULL) AS is_banned,
        COALESCE(u.banned_at, bpi.banned_at) AS banned_at,
        COALESCE(u.banned_reason, bpi.reason) AS banned_reason,
@@ -651,7 +651,8 @@ ORDER BY u.created_at DESC
 		err := rows.Scan(
 			&user.ID, &user.TwitchID, &user.GoogleID, &user.KickID, &user.AuthProvider,
 			&user.Username, &user.DisplayName, &profileImageURL,
-			&user.IsAdmin, &user.IsPremium, &user.IsBetaTester, &user.IsBanned, &user.BannedAt, &user.BannedReason, &user.BannedBy,
+			&user.IsAdmin, &user.IsPremium, &user.IsBetaTester, &user.PremiumExpiresAt,
+			&user.IsBanned, &user.BannedAt, &user.BannedReason, &user.BannedBy,
 			&user.CreatedAt, &user.UpdatedAt,
 		)
 		if err != nil {

--- a/services/auth-service/repository/viewer_repository.go
+++ b/services/auth-service/repository/viewer_repository.go
@@ -324,6 +324,7 @@ func (r *ViewerRepository) ListAll(ctx context.Context, limit, offset int) ([]mo
 		       vs.last_message_at, vs.message_count_1min, vs.message_count_1hour,
 		       vs.rate_limit_reset_1min, vs.rate_limit_reset_1hour,
 		       COALESCE(v.is_premium, false) AS is_premium,
+		       v.premium_admin_override_expires_at,
 		       vs.viewer_id,
 		       vs.is_banned, vs.banned_at, vs.banned_reason,
 		       vs.created_at, vs.updated_at
@@ -358,6 +359,7 @@ func (r *ViewerRepository) ListAll(ctx context.Context, limit, offset int) ([]mo
 			&session.RateLimitReset1Min,
 			&session.RateLimitReset1Hour,
 			&session.IsPremium,
+			&session.PremiumExpiresAt,
 			&session.ViewerID,
 			&session.IsBanned,
 			&session.BannedAt,
@@ -427,7 +429,12 @@ func (r *ViewerRepository) UnbanViewer(ctx context.Context, sessionID uuid.UUID)
 // clears the override (NULL) so premium then follows any active viewer subscription
 // or linked-streamer inheritance. A hard viewer-premium ban (override FALSE) is
 // reserved for a future explicit admin action.
-func (r *ViewerRepository) SetViewerPremium(ctx context.Context, sessionID uuid.UUID, isPremium bool) error {
+//
+// ttl makes the grant time-limited (ADR-0027): non-nil grants viewer premium only
+// until NOW()+ttl, after which RecomputeViewer (and the payment-service sweep) treat
+// the override as absent. ttl is only meaningful when granting; a nil ttl (or any
+// revoke) clears the expiry. The deadline is computed from the database clock.
+func (r *ViewerRepository) SetViewerPremium(ctx context.Context, sessionID uuid.UUID, isPremium bool, ttl *time.Duration) error {
 	var viewerID uuid.UUID
 	err := r.db.QueryRow(ctx,
 		`SELECT viewer_id FROM viewer_sessions WHERE id = $1 AND viewer_id IS NOT NULL`, sessionID).Scan(&viewerID)
@@ -443,8 +450,19 @@ func (r *ViewerRepository) SetViewerPremium(ctx context.Context, sessionID uuid.
 		v := true
 		override = &v
 	}
-	if _, err := r.db.Exec(ctx,
-		`UPDATE viewers SET premium_admin_override = $2 WHERE id = $1`, viewerID, override); err != nil {
+	var ttlSeconds *float64
+	if isPremium && ttl != nil {
+		s := ttl.Seconds()
+		ttlSeconds = &s
+	}
+	if _, err := r.db.Exec(ctx, `
+		UPDATE viewers
+		SET premium_admin_override = $2,
+		    premium_admin_override_expires_at = CASE
+		        WHEN $3::double precision IS NULL THEN NULL
+		        ELSE NOW() + make_interval(secs => $3::double precision)
+		    END
+		WHERE id = $1`, viewerID, override, ttlSeconds); err != nil {
 		return fmt.Errorf("failed to update viewer premium override: %w", err)
 	}
 

--- a/services/payment-service/README.md
+++ b/services/payment-service/README.md
@@ -57,6 +57,18 @@ via `viewer_sessions.user_id`, so the message-processor `ViewerBadgeEnricher` an
 viewer JWT readers stay unchanged. `auth-service` (admin override, viewer↔streamer
 link) and `payment-service` (viewer subscription) both call `RecomputeViewer`.
 
+### Time-limited admin overrides + the expiry sweep (ADR-0027)
+
+An admin premium grant (user or viewer) may carry an optional `premium_admin_override_expires_at`
+deadline — a comp/trial that reverts on its own. `Recompute`/`RecomputeViewer` treat an
+override past its expiry as absent (premium falls through to the subscription), evaluated
+against the DB clock, so `is_premium` is correct on any recompute. Because the column is
+materialized, a grant that lapses with **no** other write would otherwise stay stale, so
+payment-service also runs the single-replica **`OverrideExpirySweeper`** (`reconcile/override_expiry.go`,
+`PAYMENT_OVERRIDE_SWEEP_INTERVAL`): each pass clears due overrides and recomputes, with a
+guarded atomic clear that never clobbers a concurrent re-grant. The admin endpoints compute
+the deadline server-side as `NOW() + duration_seconds`.
+
 ## Endpoints
 
 | Method | Path | Auth | Purpose |
@@ -107,6 +119,8 @@ keep no separate grace timer.
 | `PAYMENT_RECONCILE_INTERVAL` | no | `6h` | reconcile cadence |
 | `PATREON_TOKEN_REFRESH_BUFFER` | no | `24h` | refresh tokens expiring within this window |
 | `PAYMENT_RECONCILE_BATCH_SIZE` | no | `500` | connections re-queried per pass |
+| `PAYMENT_OVERRIDE_SWEEP_INTERVAL` | no | `5m` | admin override-expiry sweep cadence (ADR-0027) |
+| `PAYMENT_OVERRIDE_SWEEP_BATCH_SIZE` | no | `500` | expired overrides cleared per subject-kind per pass |
 | `JWT_SECRET_V1` | yes | – | validates user JWTs |
 | `TOKEN_ENCRYPTION_KEY_V1` | yes | – | encrypts stored Patreon tokens |
 | `DATABASE_*`, `REDIS_*`, `FRONTEND_URL` | – | localhost | standard |

--- a/services/payment-service/cmd/main.go
+++ b/services/payment-service/cmd/main.go
@@ -178,6 +178,22 @@ func main() {
 		}
 	}()
 
+	// Time-limited admin premium overrides (ADR-0027): a fast, cheap sweep that
+	// clears lapsed grants and recomputes is_premium. Runs on the same single-replica
+	// lifecycle as the Patreon reconcile job, on its own (shorter) interval since a
+	// day-scale comp should not linger a full reconcile cycle past its deadline.
+	overrideSweeper := reconcile.NewOverrideExpirySweeper(
+		db, recomputer,
+		getDuration("PAYMENT_OVERRIDE_SWEEP_INTERVAL", 5*time.Minute),
+		getInt("PAYMENT_OVERRIDE_SWEEP_BATCH_SIZE", 500),
+		log,
+	)
+	go func() {
+		if err := overrideSweeper.Start(reconcileCtx); err != nil && err != context.Canceled {
+			log.Error("Override-expiry sweeper stopped with error", zap.Error(err))
+		}
+	}()
+
 	// HTTP server.
 	httpRequests := promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "http_requests_total", Help: "Total HTTP requests",

--- a/services/payment-service/integrationtest/override_expiry_test.go
+++ b/services/payment-service/integrationtest/override_expiry_test.go
@@ -1,0 +1,204 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package integrationtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/caesar/all-chat/services/payment-service/reconcile"
+	"github.com/caesar/all-chat/shared/premium"
+)
+
+// TestRecomputeHonorsOverrideExpiry validates the ADR-0027 expiry semantics against
+// the real recompute SQL: a future-dated override is honored, an expired one is
+// ignored (premium falls through to the subscription), and a permanent (NULL-expiry)
+// override behaves exactly as before.
+func TestRecomputeHonorsOverrideExpiry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Docker")
+	}
+	pool, cleanup := setupDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	rc := premium.NewRecomputer(pool, zap.NewNop())
+
+	// (a) Force-grant with a FUTURE expiry, no subscription -> premium (still active).
+	future := insertUser(t, pool, "exp-future")
+	setUserOverride(t, pool, future, true, "NOW() + INTERVAL '1 hour'")
+	got, err := rc.Recompute(ctx, future)
+	require.NoError(t, err)
+	assert.True(t, got, "an unexpired time-limited grant is premium")
+	assert.True(t, dbPremium(t, pool, future))
+
+	// (b) Force-grant with a PAST expiry, no subscription -> not premium (lapsed).
+	past := insertUser(t, pool, "exp-past")
+	setUserOverride(t, pool, past, true, "NOW() - INTERVAL '1 hour'")
+	got, err = rc.Recompute(ctx, past)
+	require.NoError(t, err)
+	assert.False(t, got, "an expired grant falls through to the (absent) subscription")
+	assert.False(t, dbPremium(t, pool, past))
+
+	// (c) Force-grant with a PAST expiry but an ACTIVE subscription -> premium via sub.
+	pastSub := insertUser(t, pool, "exp-past-sub")
+	setUserOverride(t, pool, pastSub, true, "NOW() - INTERVAL '1 hour'")
+	_, err = pool.Exec(ctx,
+		"INSERT INTO premium_subscriptions (user_id, provider, provider_user_id, status, cents) VALUES ($1,'patreon',$2,'active',500)",
+		pastSub, "pu-"+pastSub)
+	require.NoError(t, err)
+	got, err = rc.Recompute(ctx, pastSub)
+	require.NoError(t, err)
+	assert.True(t, got, "an expired override defers to an active subscription")
+
+	// (d) Permanent force-grant (NULL expiry), no subscription -> premium (unchanged).
+	perm := insertUser(t, pool, "exp-perm")
+	setUserOverride(t, pool, perm, true, "NULL")
+	got, err = rc.Recompute(ctx, perm)
+	require.NoError(t, err)
+	assert.True(t, got, "a permanent grant (no expiry) is premium")
+}
+
+// TestExpireUserOverrideIfDue validates the atomic guarded clear: a lapsed override is
+// cleared and is_premium recomputed, while a still-valid (future) override is left
+// untouched — the guard that prevents clobbering a fresh re-grant.
+func TestExpireUserOverrideIfDue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Docker")
+	}
+	pool, cleanup := setupDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	rc := premium.NewRecomputer(pool, zap.NewNop())
+
+	// A lapsed grant whose materialized is_premium is still stale-TRUE (no other write
+	// since it expired) — exactly what the sweep must converge.
+	lapsed := insertUser(t, pool, "due-lapsed")
+	setStaleExpiredUser(t, pool, lapsed)
+	assert.True(t, dbPremium(t, pool, lapsed), "precondition: stale premium before sweep")
+
+	didExpire, err := rc.ExpireUserOverrideIfDue(ctx, lapsed)
+	require.NoError(t, err)
+	assert.True(t, didExpire, "a due override should be expired")
+	assert.False(t, dbPremium(t, pool, lapsed), "is_premium recomputed to false after expiry")
+	ov, exp := dbUserOverride(t, pool, lapsed)
+	assert.Nil(t, ov, "override cleared")
+	assert.Nil(t, exp, "expiry cleared")
+
+	// A future-dated (valid) grant must NOT be touched.
+	valid := insertUser(t, pool, "due-valid")
+	setUserOverride(t, pool, valid, true, "NOW() + INTERVAL '1 hour'")
+	_, err = rc.Recompute(ctx, valid)
+	require.NoError(t, err)
+
+	didExpire, err = rc.ExpireUserOverrideIfDue(ctx, valid)
+	require.NoError(t, err)
+	assert.False(t, didExpire, "a still-valid grant is not expired")
+	assert.True(t, dbPremium(t, pool, valid), "valid grant stays premium")
+	ov, _ = dbUserOverride(t, pool, valid)
+	require.NotNil(t, ov)
+	assert.True(t, *ov, "valid override preserved")
+}
+
+// TestOverrideExpirySweeper is the end-to-end backstop check: the sweeper flips every
+// lapsed user and viewer grant to not-premium and clears its columns, while leaving a
+// still-valid grant alone.
+func TestOverrideExpirySweeper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Docker")
+	}
+	pool, cleanup := setupDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Two lapsed subjects (stale-premium) and one still-valid streamer grant.
+	lapsedUser := insertUser(t, pool, "sweep-user")
+	setStaleExpiredUser(t, pool, lapsedUser)
+
+	lapsedViewer := insertViewer(t, pool)
+	setStaleExpiredViewer(t, pool, lapsedViewer)
+
+	validUser := insertUser(t, pool, "sweep-valid")
+	setUserOverride(t, pool, validUser, true, "NOW() + INTERVAL '2 hours'")
+	_, err := premium.NewRecomputer(pool, zap.NewNop()).Recompute(ctx, validUser)
+	require.NoError(t, err)
+
+	sweeper := reconcile.NewOverrideExpirySweeper(pool, premium.NewRecomputer(pool, zap.NewNop()), time.Minute, 500, zap.NewNop())
+	require.NoError(t, sweeper.SweepOnce(ctx))
+
+	// Lapsed subjects converged to not-premium with cleared columns.
+	assert.False(t, dbPremium(t, pool, lapsedUser), "lapsed streamer grant swept to not-premium")
+	ov, exp := dbUserOverride(t, pool, lapsedUser)
+	assert.Nil(t, ov)
+	assert.Nil(t, exp)
+	assert.False(t, dbViewerPremium(t, pool, lapsedViewer), "lapsed viewer grant swept to not-premium")
+
+	// Still-valid grant untouched.
+	assert.True(t, dbPremium(t, pool, validUser), "valid grant survives the sweep")
+	ov, _ = dbUserOverride(t, pool, validUser)
+	require.NotNil(t, ov)
+	assert.True(t, *ov)
+
+	// Idempotent: a second pass expires nothing new and changes nothing.
+	require.NoError(t, sweeper.SweepOnce(ctx))
+	assert.True(t, dbPremium(t, pool, validUser))
+}
+
+// --- helpers ---
+
+// setUserOverride sets users.premium_admin_override and its expiry (a raw SQL
+// expression like "NOW() + INTERVAL '1 hour'" or "NULL") without recomputing.
+func setUserOverride(t *testing.T, pool *pgxpool.Pool, userID string, override bool, expiryExpr string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		"UPDATE users SET premium_admin_override = $2, premium_admin_override_expires_at = "+expiryExpr+" WHERE id = $1",
+		userID, override)
+	require.NoError(t, err)
+}
+
+// setStaleExpiredUser puts a user in the post-expiry stale state the sweep must fix:
+// is_premium still TRUE, override TRUE, expiry in the past.
+func setStaleExpiredUser(t *testing.T, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`UPDATE users SET is_premium = TRUE, premium_admin_override = TRUE,
+		 premium_admin_override_expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1`, userID)
+	require.NoError(t, err)
+}
+
+// setStaleExpiredViewer is the viewer counterpart of setStaleExpiredUser.
+func setStaleExpiredViewer(t *testing.T, pool *pgxpool.Pool, viewerID string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`UPDATE viewers SET is_premium = TRUE, premium_admin_override = TRUE,
+		 premium_admin_override_expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1`, viewerID)
+	require.NoError(t, err)
+}
+
+func dbUserOverride(t *testing.T, pool *pgxpool.Pool, userID string) (*bool, *time.Time) {
+	t.Helper()
+	var ov *bool
+	var exp *time.Time
+	require.NoError(t, pool.QueryRow(context.Background(),
+		"SELECT premium_admin_override, premium_admin_override_expires_at FROM users WHERE id = $1", userID).Scan(&ov, &exp))
+	return ov, exp
+}

--- a/services/payment-service/reconcile/override_expiry.go
+++ b/services/payment-service/reconcile/override_expiry.go
@@ -1,0 +1,197 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/caesar/all-chat/shared/premium"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+)
+
+// OverrideExpirySweeper is the backstop that expires time-limited admin premium
+// overrides (ADR-0027). Recompute already treats a lapsed override as absent on any
+// recompute, so is_premium is correct the moment anything else touches the subject;
+// this sweep exists for the subject that has NO other write after its grant lapses —
+// it clears the due override columns (so the row stops matching) and recomputes the
+// materialized is_premium down to what the subscription alone warrants.
+//
+// It lives in payment-service because that service is the single-replica entitlement
+// authority (like the Patreon reconcile Manager). Each per-subject write is atomic and
+// guarded (see premium.ExpireUserOverrideIfDue), so it is in fact safe under
+// concurrency — but running one replica keeps the periodic scan from being redundant.
+type OverrideExpirySweeper struct {
+	db         *pgxpool.Pool
+	recomputer *premium.Recomputer
+	interval   time.Duration
+	batchSize  int
+	logger     *zap.Logger
+
+	mu        sync.Mutex
+	isRunning bool
+}
+
+// NewOverrideExpirySweeper builds a sweeper. batchSize caps how many due subjects of
+// each kind are processed per pass; a due subject not reached this pass is picked up
+// on the next one.
+func NewOverrideExpirySweeper(db *pgxpool.Pool, recomputer *premium.Recomputer, interval time.Duration, batchSize int, logger *zap.Logger) *OverrideExpirySweeper {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+	return &OverrideExpirySweeper{
+		db:         db,
+		recomputer: recomputer,
+		interval:   interval,
+		batchSize:  batchSize,
+		logger:     logger,
+	}
+}
+
+// Start runs the sweep until ctx is cancelled, processing immediately on startup and
+// then every interval.
+func (s *OverrideExpirySweeper) Start(ctx context.Context) error {
+	s.logger.Info("Starting premium override-expiry sweeper",
+		zap.Duration("interval", s.interval),
+		zap.Int("batch_size", s.batchSize))
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	if err := s.SweepOnce(ctx); err != nil {
+		s.logger.Error("Initial override-expiry sweep failed", zap.Error(err))
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("Premium override-expiry sweeper stopping")
+			return ctx.Err()
+		case <-ticker.C:
+			if err := s.SweepOnce(ctx); err != nil {
+				s.logger.Error("Override-expiry sweep failed", zap.Error(err))
+			}
+		}
+	}
+}
+
+// SweepOnce expires every due user and viewer override (up to batchSize each) and
+// recomputes their is_premium. Safe to call directly (tests do). Overlapping passes
+// are skipped rather than stacked.
+func (s *OverrideExpirySweeper) SweepOnce(ctx context.Context) error {
+	s.mu.Lock()
+	if s.isRunning {
+		s.mu.Unlock()
+		s.logger.Warn("Override-expiry sweep already in progress, skipping")
+		return nil
+	}
+	s.isRunning = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.isRunning = false
+		s.mu.Unlock()
+	}()
+
+	users, uErr := s.sweepUsers(ctx)
+	viewers, vErr := s.sweepViewers(ctx)
+
+	s.logger.Info("Override-expiry sweep complete",
+		zap.Int("users_expired", users),
+		zap.Int("viewers_expired", viewers))
+
+	if uErr != nil {
+		return uErr
+	}
+	return vErr
+}
+
+// sweepUsers clears due user overrides and returns how many were expired.
+func (s *OverrideExpirySweeper) sweepUsers(ctx context.Context) (int, error) {
+	ids, err := s.dueIDs(ctx, "users")
+	if err != nil {
+		return 0, fmt.Errorf("failed to list due user overrides: %w", err)
+	}
+	expired := 0
+	for _, id := range ids {
+		didExpire, err := s.recomputer.ExpireUserOverrideIfDue(ctx, id)
+		if err != nil {
+			s.logger.Error("Failed to expire user override", zap.String("user_id", id), zap.Error(err))
+			continue
+		}
+		if didExpire {
+			expired++
+		}
+	}
+	return expired, nil
+}
+
+// sweepViewers clears due viewer overrides and returns how many were expired.
+func (s *OverrideExpirySweeper) sweepViewers(ctx context.Context) (int, error) {
+	ids, err := s.dueIDs(ctx, "viewers")
+	if err != nil {
+		return 0, fmt.Errorf("failed to list due viewer overrides: %w", err)
+	}
+	expired := 0
+	for _, id := range ids {
+		didExpire, err := s.recomputer.ExpireViewerOverrideIfDue(ctx, id)
+		if err != nil {
+			s.logger.Error("Failed to expire viewer override", zap.String("viewer_id", id), zap.Error(err))
+			continue
+		}
+		if didExpire {
+			expired++
+		}
+	}
+	return expired, nil
+}
+
+// dueIDs returns the ids of rows in the given table (users or viewers) whose
+// time-limited admin override has lapsed. The partial index on
+// premium_admin_override_expires_at (migration 067) serves this predicate. The table
+// name is a fixed internal constant, never user input.
+func (s *OverrideExpirySweeper) dueIDs(ctx context.Context, table string) ([]string, error) {
+	query := fmt.Sprintf(`
+		SELECT id FROM %s
+		WHERE premium_admin_override IS NOT NULL
+		  AND premium_admin_override_expires_at IS NOT NULL
+		  AND premium_admin_override_expires_at <= NOW()
+		ORDER BY premium_admin_override_expires_at
+		LIMIT $1`, table)
+
+	rows, err := s.db.Query(ctx, query, s.batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/services/share-service/handlers/admin.go
+++ b/services/share-service/handlers/admin.go
@@ -20,15 +20,21 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
+// maxPremiumGrantSeconds caps a time-limited admin premium grant (ADR-0027) at
+// ~10 years — long enough for any legitimate comp while rejecting absurd/overflowing
+// durations. A grant with no duration is permanent and unaffected by this cap.
+const maxPremiumGrantSeconds int64 = 10 * 365 * 24 * 60 * 60
+
 // userEntitlementWriter is the narrow repository surface the admin handler needs.
 // Satisfied by *repository.PremiumRepository in production and a mock in tests.
 type userEntitlementWriter interface {
-	UpdateUserPremium(ctx context.Context, userID string, isPremium bool) error
+	UpdateUserPremium(ctx context.Context, userID string, isPremium bool, ttl *time.Duration) error
 	SetUserBetaTester(ctx context.Context, userID string, isBetaTester bool) error
 }
 
@@ -45,7 +51,9 @@ func NewAdminHandler(premiumRepo userEntitlementWriter, logger *zap.Logger) *Adm
 }
 
 // SetUserPremium handles POST /api/v1/admin/users/:id/premium
-// Body: {"is_premium": true}
+// Body: {"is_premium": true, "duration_seconds": 604800}  // duration optional
+// A positive duration_seconds makes the grant time-limited (ADR-0027); omit it (or
+// send null) for a permanent grant. duration_seconds is ignored when revoking.
 // User decision: Dedicated endpoint for clarity (not generic PATCH)
 func (h *AdminHandler) SetUserPremium(c *gin.Context) {
 	adminUserID := c.GetString("user_id") // From JWTAuth middleware
@@ -59,7 +67,8 @@ func (h *AdminHandler) SetUserPremium(c *gin.Context) {
 	}
 
 	var req struct {
-		IsPremium bool `json:"is_premium"`
+		IsPremium       bool   `json:"is_premium"`
+		DurationSeconds *int64 `json:"duration_seconds"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -69,8 +78,24 @@ func (h *AdminHandler) SetUserPremium(c *gin.Context) {
 		return
 	}
 
+	// Validate the optional time limit. Only meaningful when granting; on a revoke it
+	// is ignored (the repo clears any prior expiry regardless).
+	var ttl *time.Duration
+	if req.DurationSeconds != nil {
+		if *req.DurationSeconds <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration_seconds must be positive"})
+			return
+		}
+		if *req.DurationSeconds > maxPremiumGrantSeconds {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "duration_seconds exceeds maximum"})
+			return
+		}
+		d := time.Duration(*req.DurationSeconds) * time.Second
+		ttl = &d
+	}
+
 	// Update premium status
-	err := h.premiumRepo.UpdateUserPremium(c.Request.Context(), targetUserID, req.IsPremium)
+	err := h.premiumRepo.UpdateUserPremium(c.Request.Context(), targetUserID, req.IsPremium, ttl)
 	if err != nil {
 		h.logger.Error("Failed to update premium status",
 			zap.String("admin_id", adminUserID),
@@ -94,13 +119,18 @@ func (h *AdminHandler) SetUserPremium(c *gin.Context) {
 	h.logger.Info("Premium status updated by admin",
 		zap.String("admin_id", adminUserID),
 		zap.String("target_id", targetUserID),
-		zap.Bool("is_premium", req.IsPremium))
+		zap.Bool("is_premium", req.IsPremium),
+		zap.Bool("time_limited", ttl != nil))
 
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"message":    "premium status updated",
 		"user_id":    targetUserID,
 		"is_premium": req.IsPremium,
-	})
+	}
+	if ttl != nil && req.IsPremium {
+		resp["duration_seconds"] = int64(ttl.Seconds())
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // SetUserBetaTester handles POST /api/v1/admin/beta-tester/users/:id

--- a/services/share-service/handlers/admin_test.go
+++ b/services/share-service/handlers/admin_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -33,6 +34,8 @@ import (
 type mockEntitlementWriter struct {
 	premiumUserID string
 	premiumValue  bool
+	premiumTTL    *time.Duration
+	premiumCalled bool
 	premiumErr    error
 
 	betaUserID string
@@ -40,9 +43,11 @@ type mockEntitlementWriter struct {
 	betaErr    error
 }
 
-func (m *mockEntitlementWriter) UpdateUserPremium(_ context.Context, userID string, isPremium bool) error {
+func (m *mockEntitlementWriter) UpdateUserPremium(_ context.Context, userID string, isPremium bool, ttl *time.Duration) error {
 	m.premiumUserID = userID
 	m.premiumValue = isPremium
+	m.premiumTTL = ttl
+	m.premiumCalled = true
 	return m.premiumErr
 }
 
@@ -112,10 +117,9 @@ func TestSetUserBetaTester_InternalError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-// TestSetUserPremium_NotFound locks in the prefix-match fix: the repo returns
-// "user not found: <id>", which must map to 404 (previously fell through to 500).
-func TestSetUserPremium_NotFound(t *testing.T) {
-	repo := &mockEntitlementWriter{premiumErr: errors.New("user not found: u-42")}
+// premiumRouter wires SetUserPremium behind the production param shape
+// (/admin/premium/users/:id), injecting an admin user_id like JWTAuth would.
+func premiumRouter(repo userEntitlementWriter) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h := NewAdminHandler(repo, zap.NewNop())
@@ -123,7 +127,55 @@ func TestSetUserPremium_NotFound(t *testing.T) {
 		c.Set("user_id", "admin-1")
 		c.Next()
 	}, h.SetUserPremium)
+	return r
+}
 
-	w := postJSON(r, "/admin/premium/users/u-42", `{"is_premium":true}`)
+// TestSetUserPremium_NotFound locks in the prefix-match fix: the repo returns
+// "user not found: <id>", which must map to 404 (previously fell through to 500).
+func TestSetUserPremium_NotFound(t *testing.T) {
+	repo := &mockEntitlementWriter{premiumErr: errors.New("user not found: u-42")}
+	w := postJSON(premiumRouter(repo), "/admin/premium/users/u-42", `{"is_premium":true}`)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestSetUserPremium_PermanentGrant: no duration_seconds => permanent grant (nil ttl).
+func TestSetUserPremium_PermanentGrant(t *testing.T) {
+	repo := &mockEntitlementWriter{}
+	w := postJSON(premiumRouter(repo), "/admin/premium/users/u-42", `{"is_premium":true}`)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "u-42", repo.premiumUserID)
+	assert.True(t, repo.premiumValue)
+	assert.Nil(t, repo.premiumTTL, "a grant with no duration must pass a nil ttl (permanent)")
+}
+
+// TestSetUserPremium_TimeLimitedGrant: a positive duration_seconds becomes the ttl.
+func TestSetUserPremium_TimeLimitedGrant(t *testing.T) {
+	repo := &mockEntitlementWriter{}
+	w := postJSON(premiumRouter(repo), "/admin/premium/users/u-42", `{"is_premium":true,"duration_seconds":604800}`)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, repo.premiumValue)
+	if assert.NotNil(t, repo.premiumTTL, "a positive duration must be passed as a ttl") {
+		assert.Equal(t, 7*24*time.Hour, *repo.premiumTTL)
+	}
+}
+
+// TestSetUserPremium_RejectsNonPositiveDuration: zero/negative durations are 400.
+func TestSetUserPremium_RejectsNonPositiveDuration(t *testing.T) {
+	for _, body := range []string{`{"is_premium":true,"duration_seconds":0}`, `{"is_premium":true,"duration_seconds":-5}`} {
+		repo := &mockEntitlementWriter{}
+		w := postJSON(premiumRouter(repo), "/admin/premium/users/u-42", body)
+		assert.Equal(t, http.StatusBadRequest, w.Code, body)
+		assert.False(t, repo.premiumCalled, "repo must not be called for an invalid duration: %s", body)
+	}
+}
+
+// TestSetUserPremium_RejectsOverCapDuration: durations beyond the ~10y cap are 400.
+func TestSetUserPremium_RejectsOverCapDuration(t *testing.T) {
+	repo := &mockEntitlementWriter{}
+	// 11 years in seconds, well over the 10y cap.
+	w := postJSON(premiumRouter(repo), "/admin/premium/users/u-42", `{"is_premium":true,"duration_seconds":346896000}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.False(t, repo.premiumCalled, "repo must not be called for an over-cap duration")
 }

--- a/services/share-service/repository/premium_repo.go
+++ b/services/share-service/repository/premium_repo.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/caesar/all-chat/shared/premium"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -40,16 +41,36 @@ func NewPremiumRepository(db *pgxpool.Pool, recomputer *premium.Recomputer, logg
 // force-grant (override TRUE) that survives Patreon subscription lapses; revoking
 // clears the override (NULL) so premium then follows any active subscription. A hard
 // premium-ban (override FALSE) is reserved for a future explicit admin action.
-func (r *PremiumRepository) UpdateUserPremium(ctx context.Context, userID string, isPremium bool) error {
+//
+// ttl makes the grant time-limited (ADR-0027): non-nil grants premium only until
+// NOW()+ttl, after which Recompute (and the payment-service sweep) treat the override
+// as absent. ttl is only meaningful when granting; a nil ttl (or any revoke) clears
+// the expiry, leaving a permanent grant / clean slate. The expiry is computed from
+// the database clock (NOW()) so the grant lasts exactly ttl regardless of app clock.
+func (r *PremiumRepository) UpdateUserPremium(ctx context.Context, userID string, isPremium bool, ttl *time.Duration) error {
 	var override *bool
 	if isPremium {
 		v := true
 		override = &v
 	}
 
-	result, err := r.db.Exec(ctx,
-		"UPDATE users SET premium_admin_override = $1 WHERE id = $2",
-		override, userID)
+	// Seconds for the expiry, computed server-side as NOW() + make_interval(secs => $2).
+	// nil => no expiry (permanent grant, or a revoke that clears any prior expiry).
+	var ttlSeconds *float64
+	if isPremium && ttl != nil {
+		s := ttl.Seconds()
+		ttlSeconds = &s
+	}
+
+	result, err := r.db.Exec(ctx, `
+		UPDATE users
+		SET premium_admin_override = $1,
+		    premium_admin_override_expires_at = CASE
+		        WHEN $2::double precision IS NULL THEN NULL
+		        ELSE NOW() + make_interval(secs => $2::double precision)
+		    END
+		WHERE id = $3`,
+		override, ttlSeconds, userID)
 	if err != nil {
 		r.logger.Error("Failed to update premium override",
 			zap.String("user_id", userID),
@@ -71,7 +92,8 @@ func (r *PremiumRepository) UpdateUserPremium(ctx context.Context, userID string
 
 	r.logger.Info("Premium override updated",
 		zap.String("user_id", userID),
-		zap.Bool("is_premium", isPremium))
+		zap.Bool("is_premium", isPremium),
+		zap.Bool("time_limited", ttlSeconds != nil))
 
 	return nil
 }

--- a/shared/premium/recompute.go
+++ b/shared/premium/recompute.go
@@ -27,6 +27,14 @@
 //
 // Both columns are MATERIALIZED and recomputed by the writer after any input
 // change (share-service / payment-service / auth-service).
+//
+// The admin override may carry an OPTIONAL expiry (ADR-0027): a time-limited comp.
+// Once past its expiry the override is treated as absent (premium falls through to
+// the subscription half). The expiry is compared against the database clock (NOW())
+// inside the read SQL, so Effective stays a pure, time-free boolean and there is a
+// single clock. The materialized column converges on any recompute; the
+// payment-service expiry sweep (see ExpireUserOverrideIfDue / ExpireViewerOverrideIfDue)
+// is the backstop that clears a lapsed grant when nothing else triggers a recompute.
 package premium
 
 import (
@@ -45,8 +53,11 @@ import (
 //   - adminOverride == FALSE -> not premium (force-deny, reserved)
 //   - adminOverride == NULL  -> follow the subscription (hasActiveSub)
 //
-// The SQL in Recompute is a faithful transcription of this function; keep them
-// in sync (the integration tests assert they agree).
+// The caller supplies the *effective* override: the recompute read SQL first maps an
+// expired time-limited override (ADR-0027) to NULL before calling Effective, so an
+// expired grant is indistinguishable here from "no admin opinion". Effective itself
+// stays time-free (its truth table is exhaustively unit-tested); only the subscription
+// half's own grace is Patreon's (ADR-0018).
 func Effective(adminOverride *bool, hasActiveSub bool) bool {
 	if adminOverride != nil {
 		return *adminOverride
@@ -65,9 +76,9 @@ func NewRecomputer(db *pgxpool.Pool, logger *zap.Logger) *Recomputer {
 	return &Recomputer{db: db, logger: logger}
 }
 
-// Recompute derives users.is_premium for userID from premium_admin_override, the
-// user's premium_subscriptions, and the beta-tester flag, writes it, and returns
-// the new value.
+// Recompute derives users.is_premium for userID from premium_admin_override (with
+// its optional expiry), the user's premium_subscriptions, and the beta-tester flag,
+// writes it, and returns the new value.
 //
 // The "premium half" (the non-override input to Effective) is the OR of an active
 // subscription and is_beta_tester (ADR-0020): a beta-tester is premium, the same
@@ -76,11 +87,11 @@ func NewRecomputer(db *pgxpool.Pool, logger *zap.Logger) *Recomputer {
 // force-deny (override FALSE) still wins over both.
 //
 // It is convergent and idempotent: the value is a pure function (Effective) of
-// the user's current rows, so calling it any number of times in any order — after
-// a webhook, a reconcile pass, or an admin write (premium override OR beta-tester)
-// — yields the same result. The read and write run in one transaction with
-// SELECT ... FOR UPDATE so concurrent recomputes for the same user are serialized
-// (no lost-update race).
+// the user's current rows and the database clock, so calling it any number of times
+// in any order — after a webhook, a reconcile pass, an admin write (premium override
+// OR beta-tester), or an override lapsing — yields the correct result. The read and
+// write run in one transaction with SELECT ... FOR UPDATE so concurrent recomputes
+// for the same user are serialized (no lost-update race).
 func (r *Recomputer) Recompute(ctx context.Context, userID string) (bool, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
@@ -88,11 +99,32 @@ func (r *Recomputer) Recompute(ctx context.Context, userID string) (bool, error)
 	}
 	defer func() { _ = tx.Rollback(ctx) }() // no-op once committed
 
+	effective, err := r.recomputeUserTx(ctx, tx, userID)
+	if err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("failed to commit premium recompute: %w", err)
+	}
+	return effective, nil
+}
+
+// recomputeUserTx reads the user's premium inputs (mapping an expired override to
+// NULL via the DB clock), applies Effective, and writes users.is_premium — all
+// inside tx. The caller owns the transaction lifecycle (begin/commit). The row is
+// locked FOR UPDATE so concurrent recomputes serialize.
+func (r *Recomputer) recomputeUserTx(ctx context.Context, tx pgx.Tx, userID string) (bool, error) {
 	var adminOverride *bool
 	var hasActiveSub bool
 	var isBetaTester bool
-	err = tx.QueryRow(ctx, `
-		SELECT u.premium_admin_override,
+	err := tx.QueryRow(ctx, `
+		SELECT CASE
+		           WHEN u.premium_admin_override_expires_at IS NOT NULL
+		            AND u.premium_admin_override_expires_at <= NOW()
+		           THEN NULL
+		           ELSE u.premium_admin_override
+		       END,
 		       EXISTS (
 		           SELECT 1 FROM premium_subscriptions s
 		           WHERE s.user_id = u.id AND s.status = 'active'
@@ -115,19 +147,60 @@ func (r *Recomputer) Recompute(ctx context.Context, userID string) (bool, error)
 		return false, fmt.Errorf("failed to write is_premium: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return false, fmt.Errorf("failed to commit premium recompute: %w", err)
-	}
-
 	if r.logger != nil {
 		r.logger.Debug("Recomputed premium",
 			zap.String("user_id", userID),
-			zap.Boolp("admin_override", adminOverride),
+			zap.Boolp("effective_admin_override", adminOverride),
 			zap.Bool("has_active_sub", hasActiveSub),
 			zap.Bool("is_beta_tester", isBetaTester),
 			zap.Bool("is_premium", effective))
 	}
 	return effective, nil
+}
+
+// ExpireUserOverrideIfDue clears a time-limited admin override that has passed its
+// expiry and recomputes users.is_premium, atomically (ADR-0027). It is the write the
+// payment-service sweep performs per due user.
+//
+// Returns (true, nil) when an expired override was cleared and premium recomputed;
+// (false, nil) when the user has no override, no expiry, or an expiry still in the
+// future — the guarded UPDATE's WHERE clause matches only a genuinely-lapsed grant,
+// so a concurrent admin re-grant (fresh future expiry, or permanent) is never
+// clobbered. The clear and the recompute share one transaction, so a crash can never
+// strand a cleared-but-not-recomputed row (which would leave is_premium stale).
+func (r *Recomputer) ExpireUserOverrideIfDue(ctx context.Context, userID string) (bool, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to begin override-expiry tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op once committed
+
+	ct, err := tx.Exec(ctx, `
+		UPDATE users
+		SET premium_admin_override = NULL,
+		    premium_admin_override_expires_at = NULL
+		WHERE id = $1
+		  AND premium_admin_override IS NOT NULL
+		  AND premium_admin_override_expires_at IS NOT NULL
+		  AND premium_admin_override_expires_at <= NOW()`, userID)
+	if err != nil {
+		return false, fmt.Errorf("failed to clear expired user override: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return false, nil // not due, or concurrently re-granted / already swept
+	}
+
+	if _, err := r.recomputeUserTx(ctx, tx, userID); err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("failed to commit user override expiry: %w", err)
+	}
+	if r.logger != nil {
+		r.logger.Info("Expired time-limited admin premium override", zap.String("user_id", userID))
+	}
+	return true, nil
 }
 
 // RecomputeViewer derives viewers.is_premium for viewerID and writes it (ADR-0019).
@@ -140,9 +213,10 @@ func (r *Recomputer) Recompute(ctx context.Context, userID string) (bool, error)
 //     ViewerBadgeEnricher and viewer JWT already grant to a streamer's own viewer
 //     identity.
 //
-// viewers.premium_admin_override (tri-state) overrides both, exactly like the user
-// side. The result is a pure function of current rows, so a viewer webhook, a
-// reconcile pass, an admin write, or LinkViewerToUser converge regardless of order
+// viewers.premium_admin_override (tri-state, with its optional ADR-0027 expiry)
+// overrides both, exactly like the user side. The result is a pure function of
+// current rows and the database clock, so a viewer webhook, a reconcile pass, an
+// admin write, an override lapsing, or LinkViewerToUser converge regardless of order
 // or concurrency. The read + write run in one transaction with SELECT ... FOR UPDATE
 // on the viewers row, serializing concurrent recomputes for the same viewer.
 //
@@ -156,10 +230,30 @@ func (r *Recomputer) RecomputeViewer(ctx context.Context, viewerID string) (bool
 	}
 	defer func() { _ = tx.Rollback(ctx) }() // no-op once committed
 
+	effective, err := r.recomputeViewerTx(ctx, tx, viewerID)
+	if err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("failed to commit viewer premium recompute: %w", err)
+	}
+	return effective, nil
+}
+
+// recomputeViewerTx reads the viewer's premium inputs (mapping an expired override to
+// NULL via the DB clock), applies Effective, and writes viewers.is_premium — all
+// inside tx. The caller owns the transaction lifecycle.
+func (r *Recomputer) recomputeViewerTx(ctx context.Context, tx pgx.Tx, viewerID string) (bool, error) {
 	var adminOverride *bool
 	var hasPremiumInput bool
-	err = tx.QueryRow(ctx, `
-		SELECT v.premium_admin_override,
+	err := tx.QueryRow(ctx, `
+		SELECT CASE
+		           WHEN v.premium_admin_override_expires_at IS NOT NULL
+		            AND v.premium_admin_override_expires_at <= NOW()
+		           THEN NULL
+		           ELSE v.premium_admin_override
+		       END,
 		       EXISTS (
 		           SELECT 1 FROM premium_subscriptions s
 		           WHERE s.viewer_id = v.id AND s.product = 'viewer' AND s.status = 'active'
@@ -186,16 +280,51 @@ func (r *Recomputer) RecomputeViewer(ctx context.Context, viewerID string) (bool
 		return false, fmt.Errorf("failed to write viewers.is_premium: %w", err)
 	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return false, fmt.Errorf("failed to commit viewer premium recompute: %w", err)
-	}
-
 	if r.logger != nil {
 		r.logger.Debug("Recomputed viewer premium",
 			zap.String("viewer_id", viewerID),
-			zap.Boolp("admin_override", adminOverride),
+			zap.Boolp("effective_admin_override", adminOverride),
 			zap.Bool("has_premium_input", hasPremiumInput),
 			zap.Bool("is_premium", effective))
 	}
 	return effective, nil
+}
+
+// ExpireViewerOverrideIfDue is the viewer counterpart of ExpireUserOverrideIfDue
+// (ADR-0027): it clears a lapsed time-limited viewer override and recomputes
+// viewers.is_premium atomically, with the same guarded UPDATE (never clobbers a
+// concurrent re-grant) and the same crash-safety.
+func (r *Recomputer) ExpireViewerOverrideIfDue(ctx context.Context, viewerID string) (bool, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to begin viewer override-expiry tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() // no-op once committed
+
+	ct, err := tx.Exec(ctx, `
+		UPDATE viewers
+		SET premium_admin_override = NULL,
+		    premium_admin_override_expires_at = NULL
+		WHERE id = $1
+		  AND premium_admin_override IS NOT NULL
+		  AND premium_admin_override_expires_at IS NOT NULL
+		  AND premium_admin_override_expires_at <= NOW()`, viewerID)
+	if err != nil {
+		return false, fmt.Errorf("failed to clear expired viewer override: %w", err)
+	}
+	if ct.RowsAffected() == 0 {
+		return false, nil // not due, or concurrently re-granted / already swept
+	}
+
+	if _, err := r.recomputeViewerTx(ctx, tx, viewerID); err != nil {
+		return false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("failed to commit viewer override expiry: %w", err)
+	}
+	if r.logger != nil {
+		r.logger.Info("Expired time-limited admin viewer premium override", zap.String("viewer_id", viewerID))
+	}
+	return true, nil
 }


### PR DESCRIPTION
## What

Admins can grant premium **for a limited amount of time** to a **user** (streamer, `users.is_premium`) and/or a **viewer** (`viewers.is_premium`). The grant reverts on its own with no second admin action. Permanent grants remain the default.

## How (ADR-0027)

- The admin override gains an optional `premium_admin_override_expires_at` (migration `067`, idempotent/re-run-safe).
- `Recompute` / `RecomputeViewer` treat an **expired** override as absent (premium falls through to the subscription), evaluated in SQL against the **DB clock** — so `Effective(override, active)` stays an unchanged, time-free boolean and every reader is untouched. Only the override half gains time; the subscription half still honors Patreon's grace.
- Because `is_premium` is materialized, payment-service (single replica) runs a new `OverrideExpirySweeper` (`PAYMENT_OVERRIDE_SWEEP_INTERVAL`, default 5m) that clears lapsed grants via a **guarded atomic clear + recompute** that never clobbers a concurrent re-grant.
- The admin endpoints accept optional `duration_seconds` (validated positive, ≤10y); the deadline is computed server-side as `NOW() + duration`, so a grant lasts exactly the chosen duration regardless of browser clock.
- Frontend: shared `PremiumDurationChooser` (presets 1d/7d/30d/90d + custom days, or Permanent) in both admin grant dialogs; the expiry is shown on active grants.

## Tests

- Testcontainers e2e (real Postgres + full migrations): recompute expiry truth table, `ExpireIfDue` guard, and the sweep flipping `is_premium` false + clearing columns end-to-end. Existing payment integration suite + migration re-run guard still pass.
- Handler unit tests (duration parse/validate/reject) and a frontend `customDaysToSeconds` unit test. Full frontend unit project (529 tests) green.

## Deploy notes

- Migration `067` applies on pod start (auth-service runs the migration set); it writes no values, so re-runs can't shorten a live grant.
- `PAYMENT_OVERRIDE_SWEEP_INTERVAL` is optional (defaults to 5m); no configmap change required.

See `docs/adr/0027-time-limited-admin-premium-overrides.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)