### PR TITLE
fix(frontend): allow Umami analytics host in CSP script-src

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -61,8 +61,10 @@ const nextConfig = {
       "img-src 'self' data: https: static-cdn.jtvnw.net yt3.ggpht.com cdn.7tv.app cdn.betterttv.net cdn.frankerfacez.com files.kick.com ui-avatars.com cdn.discordapp.com",
       // embed.twitch.tv hosts the Twitch Embed SDK used by the credits/clips
       // overlay route (audit #3); without it the SDK script is CSP-blocked and
-      // clips never play.
-      "script-src 'self' 'unsafe-inline' https://embed.twitch.tv",
+      // clips never play. analytics.allch.at hosts the self-hosted Umami tracker
+      // (components/Analytics.tsx); without it the tracker script is CSP-blocked
+      // and no page views or custom events are recorded.
+      "script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at",
       "style-src 'self' 'unsafe-inline'",
       "connect-src 'self' wss: ws: https:",
       "font-src 'self' data:",


### PR DESCRIPTION
## Problem

Umami analytics volume collapsed from ~300 events/day to ~1/day starting **2026-06-25**, despite active site usage. Data wasn't lost in transit — the tracker script was never loading.

## Root cause

The M10 security-hardening CSP (#478) set:

```
script-src 'self' 'unsafe-inline' https://embed.twitch.tv
```

The self-hosted Umami tracker loads from `https://analytics.allch.at/script.js` (`Analytics.tsx`), which was **not** in the allowlist. Browsers blocked the script entirely, so neither automatic page views nor custom `trackEvent` calls ever fired. (`connect-src` already permits `https:`, so the send-beacon was never the issue — the script simply never loaded.)

The event cliff lines up exactly with the #478 rollout.

## Fix

Add `https://analytics.allch.at` to `script-src` (shared `cspBase`, so it covers both the catch-all and `/overlay/*` route blocks). Verified there is no second CSP layer at the ingress.

## Notes

- Historical data from 2026-06-25 → 2026-07-06 is permanently gone (events never reached the server); new traffic records correctly after deploy.