### PR TITLE
feat(message-processor): detect empty chat text per platform (decoder-break signal)

### DIFF
--- a/services/message-processor/cmd/main.go
+++ b/services/message-processor/cmd/main.go
@@ -332,6 +332,11 @@ func main() {
 			} else {
 				sendAllGroup = reg
 			}
+
+			// Chat-content health (once per raw chat message): track empty-text
+			// ratio per platform so a broken decoder — messages still flowing but
+			// their text silently gone — trips an alert without a user report.
+			processorMetrics.RecordChatText("message-processor", rawMsg.Platform, strings.TrimSpace(rawMsg.Text) == "")
 		}
 
 		// Process message for each overlay.

--- a/shared/metrics/processor.go
+++ b/shared/metrics/processor.go
@@ -29,6 +29,15 @@ type ProcessorMetrics struct {
 	ProcessingDuration     *prometheus.HistogramVec
 	StageDuration          *prometheus.HistogramVec
 
+	// Chat content health: total chat messages vs. those arriving with empty
+	// text. A sudden spike in the empty ratio for a platform is the signature of
+	// a decoder/library break (e.g. an unofficial listener whose upstream schema
+	// drifted) where messages still flow but their text silently vanishes —
+	// invisible to liveness/error/lag alerts. Events (gift/follow/like) are
+	// excluded; only real chat messages are counted.
+	ChatMessages      *prometheus.CounterVec
+	ChatMessagesEmpty *prometheus.CounterVec
+
 	// Emote Enrichment
 	EmoteLookups           *prometheus.CounterVec
 	EmoteCacheEntries      *prometheus.GaugeVec
@@ -86,6 +95,20 @@ func NewProcessorMetrics() *ProcessorMetrics {
 				Buckets: []float64{0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1},
 			},
 			[]string{"service", "platform", "stage"},
+		),
+		ChatMessages: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "processor_chat_messages_total",
+				Help: "Chat messages (excluding events) consumed, by platform. Denominator for the empty-text ratio.",
+			},
+			[]string{"service", "platform"},
+		),
+		ChatMessagesEmpty: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "processor_chat_messages_empty_total",
+				Help: "Chat messages that arrived with empty/whitespace-only text, by platform. A high ratio signals a broken decoder.",
+			},
+			[]string{"service", "platform"},
 		),
 		EmoteLookups: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -195,6 +218,17 @@ func (m *ProcessorMetrics) RecordMessageConsumed(service, platform, consumerGrou
 // RecordMessageProcessed records a message processed through a pipeline stage
 func (m *ProcessorMetrics) RecordMessageProcessed(service, platform, stage, result string) {
 	m.MessagesProcessed.WithLabelValues(service, platform, stage, result).Inc()
+}
+
+// RecordChatText records a chat message's text presence, once per raw message.
+// Call only for real chat messages (not gift/follow/like events, which carry
+// synthetic text). When empty is true the message arrived with no visible text —
+// a per-platform spike in the empty ratio flags a broken/stale decoder.
+func (m *ProcessorMetrics) RecordChatText(service, platform string, empty bool) {
+	m.ChatMessages.WithLabelValues(service, platform).Inc()
+	if empty {
+		m.ChatMessagesEmpty.WithLabelValues(service, platform).Inc()
+	}
 }
 
 // RecordEmoteLookup records an emote provider lookup


### PR DESCRIPTION
## Why

Follow-up to the TikTok proto-drift outage (#539). That bug was invisible to every existing alert: the listener stayed connected and kept publishing, so liveness, error-rate, and lag all looked green — only the message **text** was empty. We only found it via a user report.

## What

Adds two per-platform counters in `shared/metrics/processor.go`, recorded **once per raw chat message** in the message-processor normalize path (events like gift/follow/like excluded, since they carry synthetic text):

- `processor_chat_messages_total{platform}` — denominator
- `processor_chat_messages_empty_total{platform}` — empty/whitespace-only subset

A spike in the empty ratio for a platform is the signature of a broken/stale decoder — messages flowing but text silently gone. This is the metric the companion **critical alert** in caesar-deployment (`AllChatPlatformMessagesEmpty`) evaluates.

Because it's at the message-processor (the one chokepoint that sees every platform uniformly), it covers TikTok, Kick, and any future unofficial integration with one instrumentation point.

## Verification

- `go build ./...`, `go vet`, full `go test ./...` all pass
- Recorded in the existing "once per raw message" chat-only block, so fan-out to N overlays does not inflate the count

## Deploy order

Merge this first so the metrics exist before the caesar-deployment alert goes live. (If the alert lands first it's harmless — `0/0` yields no data, so it simply won't fire until the metrics appear.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)