### PR TITLE
fix(frontend): bump Docker base image to node:26-alpine

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,9 @@
 # Multi-stage build for Next.js application
 
 # Stage 1: Dependencies
-FROM node:22-alpine AS deps
+# node:26-alpine ships npm 11.x, matching the version used to author package-lock.json
+# (lockfileVersion 3); node:22-alpine's npm 10.x rejects that lockfile as out-of-sync.
+FROM node:26-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -11,7 +13,7 @@ COPY frontend/package.json frontend/package-lock.json* ./
 RUN npm ci
 
 # Stage 2: Builder
-FROM node:22-alpine AS builder
+FROM node:26-alpine AS builder
 WORKDIR /app
 
 # Copy dependencies from deps stage
@@ -39,7 +41,7 @@ RUN rm -rf .next
 RUN npm run build
 
 # Stage 3: Runner
-FROM node:22-alpine AS runner
+FROM node:26-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Problem

The latest push to `main` failed the **Build and Push Docker Images** workflow (frontend image). `npm ci` failed with:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: typescript@5.9.3 from lock file
```

The `package-lock.json` is `lockfileVersion 3`, authored by npm 11 (matching the local toolchain, node 26). The Docker build used `node:22-alpine`, which ships **npm 10.x** — npm 10 interprets the npm-11 lockfile as out-of-sync and rejects it. This is the known npm 10↔11 lockfile trap.

## Fix

Bump all three build stages (`deps`, `builder`, `runner`) from `node:22-alpine` to `node:26-alpine`, which ships npm 11.x and matches the version used to author the lockfile.

## Verification

Built the `deps` stage locally against the repo-root context (same as CI); `npm ci` now completes successfully under node:26-alpine (npm 11.17.0).