### PR TITLE
fix(frontend): serve font proxy under /font-proxy (fixes 404 MIME error on themed fonts)

### DIFF
--- a/frontend/public/legal/privacy.html
+++ b/frontend/public/legal/privacy.html
@@ -137,7 +137,7 @@
       <p>
         Typography assets originally distributed by Google Fonts are <strong>self-hosted on our
         infrastructure</strong>. Interface fonts are bundled at build time; overlay-selectable
-        fonts are served through a server-side proxy at <code>/api/fonts/*</code>. Your browser
+        fonts are served through a server-side proxy at <code>/font-proxy/*</code>. Your browser
         only connects to the All-Chat origin; <strong>no IP address, user agent, or request
         metadata is transmitted to Google</strong> when fonts are loaded (LG M&uuml;nchen I,
         20 January 2022, Az. 3 O 17493/20).

--- a/frontend/public/obs-badge.html
+++ b/frontend/public/obs-badge.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>all-chat — Powered By Badge</title>
-<!-- Fonts are proxied through /api/fonts/css so viewer IPs never reach Google
+<!-- Fonts are proxied through /font-proxy/css so viewer IPs never reach Google
      (DSGVO / "Google Fonts Urteil" LG München 2022-01-20, Az. 3 O 17493/20). -->
-<link href="/api/fonts/css?family=Barlow%3Awght%40400%3B600%3B700%3B800" rel="stylesheet">
+<link href="/font-proxy/css?family=Barlow%3Awght%40400%3B600%3B700%3B800" rel="stylesheet">
 <style>
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/frontend/src/app/font-proxy/css/route.ts
+++ b/frontend/src/app/font-proxy/css/route.ts
@@ -99,10 +99,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   // Rewrite every https://fonts.gstatic.com/... URL to our file proxy so the
   // browser never connects to Google directly.
-  const rewritten = css.replace(
-    /https:\/\/fonts\.gstatic\.com\//g,
-    '/api/fonts/file/',
-  )
+  const rewritten = css.replace(/https:\/\/fonts\.gstatic\.com\//g, '/font-proxy/file/')
 
   return new NextResponse(rewritten, {
     status: 200,

--- a/frontend/src/app/font-proxy/file/[...path]/route.ts
+++ b/frontend/src/app/font-proxy/file/[...path]/route.ts
@@ -22,12 +22,7 @@ import { NextResponse } from 'next/server'
 // the proxy narrow — it cannot be abused to fetch arbitrary gstatic content.
 const ALLOWED_PREFIX = 's/'
 
-const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set([
-  'woff2',
-  'woff',
-  'ttf',
-  'otf',
-])
+const ALLOWED_EXTENSIONS: ReadonlySet<string> = new Set(['woff2', 'woff', 'ttf', 'otf'])
 
 const CONTENT_TYPES: Record<string, string> = {
   woff2: 'font/woff2',

--- a/frontend/src/app/legal/privacy/page.tsx
+++ b/frontend/src/app/legal/privacy/page.tsx
@@ -33,9 +33,9 @@ export default function PrivacyPolicyPage() {
       <div className="space-y-4">
         <div className="rounded-xl border border-twitch/20 bg-twitch/5 p-5 text-text-sub">
           <strong className="text-text">TL;DR:</strong> All-Chat only collects the information we
-          need to authenticate with your streaming platforms and render chat in your overlays. Tokens
-          are encrypted, chat messages are automatically deleted after one hour, and we never sell
-          your data. We use cookieless, self-hosted analytics (no tracking cookies; see
+          need to authenticate with your streaming platforms and render chat in your overlays.
+          Tokens are encrypted, chat messages are automatically deleted after one hour, and we never
+          sell your data. We use cookieless, self-hosted analytics (no tracking cookies; see
           Section&nbsp;5.6).
         </div>
         <div className="rounded-xl border border-tiktok/20 bg-tiktok/5 p-5 text-text-sub">
@@ -137,10 +137,7 @@ export default function PrivacyPolicyPage() {
             If you choose to link multiple platform accounts as a viewer (e.g.&nbsp;Twitch +
             YouTube), we create a unified viewer profile that associates your platform identities.
             This is{' '}
-            <strong className="text-text">
-              opt-in only and requires your explicit action
-            </strong>
-            .
+            <strong className="text-text">opt-in only and requires your explicit action</strong>.
           </p>
           <p className="text-sm text-text-dim">
             Legal basis: Art.&nbsp;6(1)(a) DSGVO &ndash; your consent. You can unlink platforms at
@@ -189,7 +186,10 @@ export default function PrivacyPolicyPage() {
         <h3 className="text-lg font-semibold text-text">4.2 Safeguards</h3>
         <ul className={listClasses}>
           <li>OAuth tokens encrypted with AES-GCM before touching the database</li>
-          <li>HTTPS at the ingress layer for all external traffic; internal services isolated via Kubernetes network policies</li>
+          <li>
+            HTTPS at the ingress layer for all external traffic; internal services isolated via
+            Kubernetes network policies
+          </li>
           <li>Role-scoped infrastructure access and audit logging</li>
           <li>Regular dependency upgrades and security patching</li>
           <li>Security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)</li>
@@ -202,9 +202,7 @@ export default function PrivacyPolicyPage() {
 
       {/* --- Third Parties --- */}
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-text">
-          5. Data Sharing &amp; Third Parties
-        </h2>
+        <h2 className="text-2xl font-semibold text-text">5. Data Sharing &amp; Third Parties</h2>
 
         <h3 className="text-lg font-semibold text-text">5.1 Streaming Platform APIs</h3>
         <p>We connect to the following services to deliver the core product:</p>
@@ -226,23 +224,25 @@ export default function PrivacyPolicyPage() {
           <strong className="text-text">self-hosted on our infrastructure</strong>. The fonts used
           by the All-Chat interface are bundled at build time via Next.js, and fonts selectable for
           overlay customization are served through a server-side proxy at{' '}
-          <code className="rounded bg-surface-2 px-1 py-0.5 text-xs">/api/fonts/*</code>. Your
-          browser only connects to the All-Chat origin; <strong className="text-text">no IP
-          address, user agent, or request metadata is transmitted to Google</strong> when fonts
-          are loaded. This aligns with the Landgericht M&uuml;nchen I ruling on Google Fonts (20
-          January 2022, Az. 3 O 17493/20).
+          <code className="rounded bg-surface-2 px-1 py-0.5 text-xs">/font-proxy/*</code>. Your
+          browser only connects to the All-Chat origin;{' '}
+          <strong className="text-text">
+            no IP address, user agent, or request metadata is transmitted to Google
+          </strong>{' '}
+          when fonts are loaded. This aligns with the Landgericht M&uuml;nchen I ruling on Google
+          Fonts (20 January 2022, Az. 3 O 17493/20).
         </p>
         <p className="text-sm text-text-dim">
-          Legal basis: Art.&nbsp;6(1)(f) DSGVO &ndash; legitimate interest in delivering the
-          visual appearance of the overlay. The font files themselves are licensed under the SIL
-          Open Font License 1.1 or Apache 2.0.
+          Legal basis: Art.&nbsp;6(1)(f) DSGVO &ndash; legitimate interest in delivering the visual
+          appearance of the overlay. The font files themselves are licensed under the SIL Open Font
+          License 1.1 or Apache 2.0.
         </p>
 
         <h3 className="text-lg font-semibold text-text">5.3 Third-Party Frontend Resources</h3>
         <p>
           Overlay and dashboard pages may load the following external resources. Each request
-          transmits your <strong className="text-text">IP address</strong> and browser user agent
-          to the respective provider:
+          transmits your <strong className="text-text">IP address</strong> and browser user agent to
+          the respective provider:
         </p>
         <ul className={listClasses}>
           <li>
@@ -255,9 +255,9 @@ export default function PrivacyPolicyPage() {
           </li>
         </ul>
         <p className="text-sm text-text-dim">
-          Legal basis: Art.&nbsp;6(1)(f) DSGVO &ndash; legitimate interest in providing a
-          functional and visually complete overlay experience. You can avoid loading these by not
-          opening the theme marketplace and by providing a custom avatar URL.
+          Legal basis: Art.&nbsp;6(1)(f) DSGVO &ndash; legitimate interest in providing a functional
+          and visually complete overlay experience. You can avoid loading these by not opening the
+          theme marketplace and by providing a custom avatar URL.
         </p>
 
         <h3 className="text-lg font-semibold text-text">5.4 YouTube-Specific Notice</h3>
@@ -312,15 +312,14 @@ export default function PrivacyPolicyPage() {
         <p className="text-sm text-text-dim">
           Your <strong className="text-text">IP address is not stored</strong>: it is used only
           momentarily to derive the country and to generate a daily, salted hash for counting unique
-          visits, after which it is discarded. We do{' '}
-          <strong className="text-text">not</strong> track public overlay views (the pages OBS loads
-          as a browser source). You can block the analytics script with any browser content blocker
-          without affecting the site.
+          visits, after which it is discarded. We do <strong className="text-text">not</strong>{' '}
+          track public overlay views (the pages OBS loads as a browser source). You can block the
+          analytics script with any browser content blocker without affecting the site.
         </p>
         <p className="text-sm text-text-dim">
-          Because the tracker stores no information on, and reads none from, your device, it does not
-          require consent under &sect;&nbsp;25 TTDSG; the processing of the resulting data rests on
-          Art.&nbsp;6(1)(f) DSGVO &ndash; our legitimate interest in measuring and improving the
+          Because the tracker stores no information on, and reads none from, your device, it does
+          not require consent under &sect;&nbsp;25 TTDSG; the processing of the resulting data rests
+          on Art.&nbsp;6(1)(f) DSGVO &ndash; our legitimate interest in measuring and improving the
           service.
         </p>
       </section>
@@ -338,8 +337,8 @@ export default function PrivacyPolicyPage() {
             platform, when they expire (cleaned up after 7 days), or when you delete your account
           </li>
           <li>
-            <strong className="text-text">Chat messages sent through All-Chat:</strong> automatically
-            deleted after 1 hour
+            <strong className="text-text">Chat messages sent through All-Chat:</strong>{' '}
+            automatically deleted after 1 hour
           </li>
           <li>
             <strong className="text-text">Chat messages displayed in overlays:</strong> streamed
@@ -454,11 +453,10 @@ export default function PrivacyPolicyPage() {
         <h2 className="text-2xl font-semibold text-text">10. International Data Transfers</h2>
         <p>
           When you use streaming platform integrations, data is transferred to servers operated by
-          Twitch (Amazon, US), Google/YouTube (US), TikTok (various), and Kick (AU). These
-          transfers are necessary to perform the service you requested (Art.&nbsp;49(1)(b) DSGVO).
-          The GitHub API (theme marketplace) may also involve transfers to the US. Fonts are
-          self-hosted on our infrastructure and therefore do not involve any third-country
-          transfer when loaded.
+          Twitch (Amazon, US), Google/YouTube (US), TikTok (various), and Kick (AU). These transfers
+          are necessary to perform the service you requested (Art.&nbsp;49(1)(b) DSGVO). The GitHub
+          API (theme marketplace) may also involve transfers to the US. Fonts are self-hosted on our
+          infrastructure and therefore do not involve any third-country transfer when loaded.
         </p>
       </section>
 
@@ -477,8 +475,8 @@ export default function PrivacyPolicyPage() {
         <ul className={listClasses}>
           <li>All source code is publicly auditable under AGPL-3.0</li>
           <li>
-            No hidden tracking &mdash; our analytics are cookieless and documented (Section&nbsp;5.6),
-            and the whole stack is verifiable on GitHub
+            No hidden tracking &mdash; our analytics are cookieless and documented
+            (Section&nbsp;5.6), and the whole stack is verifiable on GitHub
           </li>
           <li>Privacy practices are open to community scrutiny</li>
         </ul>
@@ -535,8 +533,8 @@ export default function PrivacyPolicyPage() {
 
         <h3 className="text-lg font-semibold text-text">Discord</h3>
         <p>
-          When you connect a Discord server, we store the guild ID and name. Chat relay uses
-          webhook URLs you configure. We do not access server member lists or DMs.
+          When you connect a Discord server, we store the guild ID and name. Chat relay uses webhook
+          URLs you configure. We do not access server member lists or DMs.
         </p>
       </section>
 

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -61,7 +61,7 @@ import { createTTSPlayer } from '@/lib/utils/ttsPlayer'
 import type { TTSPlayer, TTSSettings } from '@/lib/utils/ttsPlayer'
 
 // ---- Font loader ----------------------------------------------------------
-// Fonts are proxied through /api/fonts/css so end-user IPs never reach Google
+// Fonts are proxied through /font-proxy/css so end-user IPs never reach Google
 // (DSGVO / "Google Fonts Urteil" LG München 2022-01-20, Az. 3 O 17493/20).
 
 const GOOGLE_FONT_NAMES = new Set([
@@ -85,7 +85,7 @@ function ensureGoogleFontLoaded(fontFamily: string): void {
   link.id = 'gfont-' + slug
   link.rel = 'stylesheet'
   const family = encodeURIComponent(`${fontFamily}:wght@400;600;700`)
-  link.href = `/api/fonts/css?family=${family}`
+  link.href = `/font-proxy/css?family=${family}`
   document.head.appendChild(link)
 }
 

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -169,7 +169,7 @@ const PlatformIcon = ({ platform }: { platform: string }) => {
 }
 
 // ---- Font loader ----------------------------------------------------------
-// Fonts are proxied through /api/fonts/css so end-user IPs never reach Google
+// Fonts are proxied through /font-proxy/css so end-user IPs never reach Google
 // (DSGVO / "Google Fonts Urteil" LG München 2022-01-20, Az. 3 O 17493/20).
 
 const GOOGLE_FONT_NAMES = new Set([
@@ -193,7 +193,7 @@ function ensureGoogleFontLoaded(fontFamily: string): void {
   link.id = 'gfont-' + slug
   link.rel = 'stylesheet'
   const family = encodeURIComponent(`${fontFamily}:wght@400;600;700`)
-  link.href = `/api/fonts/css?family=${family}`
+  link.href = `/font-proxy/css?family=${family}`
   document.head.appendChild(link)
 }
 
@@ -361,9 +361,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
           rate: s.tts_rate ?? prev.rate,
           pitch: s.tts_pitch ?? prev.pitch,
           filter_mode: (s.tts_filter_mode ?? prev.filter_mode) as
-            | 'all'
-            | 'sample'
-            | 'priority_only',
+            'all' | 'sample' | 'priority_only',
           sample_rate: s.tts_sample_rate ?? prev.sample_rate,
           max_queue: s.tts_max_queue ?? prev.max_queue,
           messages_per_minute: s.tts_messages_per_minute ?? prev.messages_per_minute,

--- a/frontend/src/components/theme-marketplace/ThemePreview.tsx
+++ b/frontend/src/components/theme-marketplace/ThemePreview.tsx
@@ -102,7 +102,7 @@ export default function ThemePreview({
   const uniqueId = `theme-preview-${themeId}`
 
   // Scope CSS when it changes. Route Google-Fonts @imports through the same-origin
-  // /api/fonts/css proxy first (like the real overlay/embed render paths do) — the
+  // /font-proxy/css proxy first (like the real overlay/embed render paths do) — the
   // site CSP blocks direct fonts.googleapis.com loads, so without this the preview
   // silently falls back to a system font. The proxy also keeps viewer IPs off Google
   // (DSGVO). See lib/theme-marketplace/font-proxy.ts.

--- a/frontend/src/lib/theme-marketplace/font-proxy.ts
+++ b/frontend/src/lib/theme-marketplace/font-proxy.ts
@@ -18,15 +18,19 @@
 
 /**
  * rewriteThemeFontImports rewrites Google Fonts `@import url('https://fonts.googleapis.com/css2?...')`
- * stylesheet references in bundled-theme CSS to the same-origin `/api/fonts/css`
+ * stylesheet references in bundled-theme CSS to the same-origin `/font-proxy/css`
  * proxy (audit #11).
+ *
+ * The proxy lives under `/font-proxy/*` (NOT `/api/*`): the ingress routes
+ * `/api/*` to the api-gateway and next.config rewrites `/api/*` there too, so a
+ * proxy under `/api/fonts` was shadowed and 404'd in production.
  *
  * Why: the overlay CSP (`style-src 'self' 'unsafe-inline'`) blocks a direct
  * `@import` from fonts.googleapis.com, so themed overlays silently fell back to
  * the system font. Whitelisting Google in the CSP is NOT acceptable — the proxy
  * exists specifically so viewer IPs never hit Google directly (DSGVO / "Google
  * Fonts" ruling). The proxy validates each font family against an allowlist and
- * additionally rewrites the gstatic font binaries to `/api/fonts/file`, so after
+ * additionally rewrites the gstatic font binaries to `/font-proxy/file`, so after
  * this rewrite no overlay viewer ever connects to a Google host.
  *
  * Only the css2 stylesheet URL is rewritten; the query string (family axes +
@@ -34,8 +38,5 @@
  */
 export function rewriteThemeFontImports(css: string): string {
   if (!css) return css
-  return css.replace(
-    /https:\/\/fonts\.googleapis\.com\/css2\?([^'")\s]+)/g,
-    '/api/fonts/css?$1',
-  )
+  return css.replace(/https:\/\/fonts\.googleapis\.com\/css2\?([^'")\s]+)/g, '/font-proxy/css?$1')
 }


### PR DESCRIPTION
The Google-Fonts proxy lived under `/api/fonts/*`, but the ingress (`/api/* -> api-gateway`) and next.config (`/api/* -> api-gateway`) both own the `/api` namespace, so `/api/fonts/css` returned a backend 404 (text/plain + nosniff) → browser `NS_ERROR_CORRUPTED_CONTENT`. Theme webfonts silently fell back to system fonts on the homepage, overlays, embeds, and the OBS badge.

Moved the proxy to `/font-proxy/css` + `/font-proxy/file/[...path]` (matched by the ingress `/ -> frontend` rule, not rewritten by next.config) and updated every reference. Same-origin DSGVO behaviour unchanged.

Verified locally: `/font-proxy/css` → 200 `text/css`; `/font-proxy/file` → 200 `font/woff2`. Lint, type-check, 575 unit tests, and the 17-theme contrast gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)