### PR TITLE
fix(frontend): stop 7TV/BTTV/FFZ emote first-letter flash (#447)

### DIFF
--- a/frontend/src/lib/renderMessage.tsx
+++ b/frontend/src/lib/renderMessage.tsx
@@ -95,7 +95,7 @@ export function renderMessageContent(message: ChatMessage): React.ReactNode {
         <Image
           key={emote.key}
           src={emote.url}
-          alt={emote.code}
+          alt=""
           title={`${emote.code} (${emote.provider})`}
           width={28}
           height={28}


### PR DESCRIPTION
Fixes the remaining half of #447.

## Problem
Next.js `<Image>` renders the `alt` text while the image is still loading. With `alt={emote.code}`, an emote briefly flashed its code (the first letter/label) before the emote image appeared — the "first letter flash" reported in #447.

## Fix
One line in `frontend/src/lib/renderMessage.tsx`: `alt={emote.code}` → `alt=""`. The emote name is already exposed via the `title` attribute for hover, and emotes are decorative in the overlay render path, so an empty alt removes the flash without losing information.

## Context
The harder reliability half of #447 (backend stale-while-revalidate + client-side pre-caching, which stopped emotes falling back to plain text for up to a minute) already shipped in #448. This closes out the literal flash that #448 deliberately left.

Closes #447