### PR TITLE
fix(youtube-innertube): default stream selection to most_viewers (#473)

### DIFF
--- a/services/youtube-listener-innertube/innertube/discovery.go
+++ b/services/youtube-listener-innertube/innertube/discovery.go
@@ -146,11 +146,15 @@ func (d *Discovery) browseLiveCandidates(ctx context.Context, channelID string) 
 // DiscoverLiveStream discovers the live video ID for a given channel ID.
 // Uses the InnerTube Browse API to list recent streams, then applies the
 // given selection strategy to choose among multiple concurrent streams.
-// strategy defaults to "first_found" if empty. matchTerm is only used
-// with "title_match" strategy.
+// strategy defaults to "most_viewers" if empty (issue #473): the old
+// "first_found" default grabbed candidates[0] in browse order, which on
+// multi-stream channels is often a low-engagement simulcast (e.g. a
+// 1-viewer vertical stream) with little or no chat, leaving the overlay
+// "connected but empty". The main stream is the most-watched one.
+// matchTerm is only used with "title_match" strategy.
 func (d *Discovery) DiscoverLiveStream(ctx context.Context, channelID, strategy, matchTerm string) (string, error) {
 	if strategy == "" {
-		strategy = StrategyFirstFound
+		strategy = StrategyMostViewers
 	}
 
 	d.logger.Info("discovering live stream",
@@ -236,17 +240,8 @@ func SelectStream(candidates []LiveStreamCandidate, strategy, matchTerm string) 
 	}
 
 	switch strategy {
-	case StrategyFirstFound, "":
+	case StrategyFirstFound:
 		return candidates[0], nil
-
-	case StrategyMostViewers:
-		best := candidates[0]
-		for _, c := range candidates[1:] {
-			if c.ViewerCount > best.ViewerCount {
-				best = c
-			}
-		}
-		return best, nil
 
 	case StrategyFewestViewers:
 		best := candidates[0]
@@ -271,8 +266,19 @@ func SelectStream(candidates []LiveStreamCandidate, strategy, matchTerm string) 
 		// No title match found — fall back to first
 		return candidates[0], nil
 
+	case StrategyMostViewers, "":
+		fallthrough
 	default:
-		return candidates[0], nil
+		// most_viewers is the default for empty/unknown strategies (issue #473):
+		// on multi-stream channels first_found grabbed candidates[0] in browse
+		// order, often a low-engagement simulcast with little/no chat.
+		best := candidates[0]
+		for _, c := range candidates[1:] {
+			if c.ViewerCount > best.ViewerCount {
+				best = c
+			}
+		}
+		return best, nil
 	}
 }
 

--- a/services/youtube-listener-innertube/innertube/discovery_test.go
+++ b/services/youtube-listener-innertube/innertube/discovery_test.go
@@ -265,13 +265,16 @@ func TestSelectStream(t *testing.T) {
 		}
 	})
 
-	t.Run("empty strategy defaults to first_found", func(t *testing.T) {
+	t.Run("empty strategy defaults to most_viewers", func(t *testing.T) {
+		// #473: the default flipped from first_found to most_viewers so
+		// multi-stream channels land on the main (most-watched) stream
+		// rather than candidates[0] (often a low/no-chat simulcast).
 		result, err := SelectStream(candidates, "", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if result.VideoID != "vid1" {
-			t.Errorf("expected vid1, got %s", result.VideoID)
+		if result.VideoID != "vid2" {
+			t.Errorf("expected vid2 (most_viewers default), got %s", result.VideoID)
 		}
 	})
 
@@ -366,13 +369,13 @@ func TestSelectStream(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown strategy falls back to first", func(t *testing.T) {
+	t.Run("unknown strategy falls back to most_viewers default", func(t *testing.T) {
 		result, err := SelectStream(candidates, "unknown_strategy", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if result.VideoID != "vid1" {
-			t.Errorf("expected vid1, got %s", result.VideoID)
+		if result.VideoID != "vid2" {
+			t.Errorf("expected vid2 (most_viewers default, #473), got %s", result.VideoID)
 		}
 	})
 


### PR DESCRIPTION
Closes #473.

## Re-triage (against the DEPLOYED `youtube-listener-innertube`)
The issue's original writeup + its 3 "affected files" target `services/youtube-listener`, which is **not in production** — prod runs only `youtube-listener-innertube`. Re-triaged against the deployed service.

## Root cause (confirmed in prod Loki)
Default stream-selection strategy `first_found` returns `candidates[0]` in InnerTube browse "streams"-tab order. On **multi-stream channels** that's frequently the wrong stream. Live proof — channel `UCnBuBR7c7aTGRJ7LPxuWX4Q`, logged twice on different pods:
```
"discovered live stream" candidates:2 strategy:"first_found"
  → video leEASCbp0Vw  "🔴 LIVE [Vertical]: PUBG…"  viewer_count:1
```
It grabbed the **1-viewer vertical simulcast** (little/no chat) instead of the main horizontal stream → overlay shows "connected but empty", and re-discovery re-picks the same wrong stream. Selection can't validate an active chat because the InnerTube player API is IP-blocked on datacenter egress (returns LOGIN_REQUIRED), so it reads only the LIVE badge from browse.

## Fix
Flip the **default** (empty/unknown) strategy from `first_found` → `most_viewers` in `innertube/discovery.go` (`DiscoverLiveStream` + `SelectStream`). The main stream is essentially always the most-watched one.
- **Single-stream channels: unaffected** (one candidate → returned regardless).
- Explicit `first_found` still works for anyone who sets it.
- The full per-source strategy config + premium gate remains future work (partly in the stale `feature/youtube-stream-selection-strategy` branch).

## Tests
`go build`/`vet` clean; updated `TestSelectStream` (empty + unknown now expect the most-viewed candidate); full `innertube` package green.