### PR TITLE
fix(tiktok): show per-viewer avatars instead of one shared placeholder

### DIFF
--- a/frontend/src/components/UserAvatar.tsx
+++ b/frontend/src/components/UserAvatar.tsx
@@ -19,6 +19,8 @@
  */
 
 
+import { useState } from 'react'
+
 export interface UserAvatarProps {
   avatarUrl?: string
   frameUrl?: string
@@ -32,15 +34,24 @@ export function UserAvatar({ avatarUrl, frameUrl, flairUrl, size, displayName }:
   const flairSize = Math.round(size * 0.4)
   const initials = displayName ? displayName.charAt(0).toUpperCase() : '?'
 
+  // Fall back to initials when the avatar image can't be displayed (e.g. a
+  // dead/placeholder TikTok CDN URL). Tracking the failed URL — rather than a
+  // plain boolean — resets the fallback automatically when the component is
+  // reused for a different avatar.
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+  const showImage = Boolean(avatarUrl) && failedUrl !== avatarUrl
+
   return (
     <div className="relative" style={{ width: size, height: size, overflow: 'visible' }}>
       {/* Base avatar */}
-      {avatarUrl ? (
+      {showImage ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
           src={avatarUrl}
           alt={displayName ?? 'Avatar'}
           className="w-full h-full rounded-full object-cover"
+          referrerPolicy="no-referrer"
+          onError={() => setFailedUrl(avatarUrl ?? null)}
         />
       ) : (
         <div

--- a/frontend/src/components/__tests__/UserAvatar.test.tsx
+++ b/frontend/src/components/__tests__/UserAvatar.test.tsx
@@ -31,7 +31,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { UserAvatar } from '../UserAvatar'
 
 describe('UserAvatar', () => {
@@ -93,6 +93,30 @@ describe('UserAvatar', () => {
       <UserAvatar size={40} displayName="Alice" />
     )
     expect(getByText('A')).toBeDefined()
+  })
+
+  it('falls back to initials when the avatar image fails to load', () => {
+    const { container } = render(
+      <UserAvatar size={40} avatarUrl="https://example.com/broken.png" displayName="Alice" />
+    )
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+
+    // Simulate the browser failing to load the image (dead/placeholder URL).
+    fireEvent.error(img!)
+
+    // The <img> is replaced by the initial-letter fallback.
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.textContent).toContain('A')
+  })
+
+  it('sets referrerPolicy=no-referrer so cross-origin CDN avatars can load', () => {
+    const { container } = render(
+      <UserAvatar size={40} avatarUrl="https://p16-sign.tiktokcdn.com/avatar.jpeg" displayName="Bob" />
+    )
+    const img = container.querySelector('img')
+    expect(img).not.toBeNull()
+    expect(img!.getAttribute('referrerpolicy')).toBe('no-referrer')
   })
 
   it('renders ? fallback when avatarUrl and displayName both absent', () => {

--- a/services/tiktok-listener/src/avatar.test.ts
+++ b/services/tiktok-listener/src/avatar.test.ts
@@ -1,0 +1,98 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { pickAvatarUrl, tiktokAvatarUrl } from './avatar.js';
+
+// Representative TikTok avatar url shapes (paths shortened, tokens elided).
+const SHRINK = 'https://p16-sign.tiktokcdn-us.com/tos/avt/72x72/user-a.jpeg?shrink=1';
+const WEBP_100 = 'https://p16-sign-va.tiktokcdn.com/tos/100x100/avt/user-a.webp?x-expires=1';
+const JPEG_100 = 'https://p16-sign-va.tiktokcdn.com/tos/100x100/avt/user-a.jpeg?x-expires=1';
+const JPEG_300 = 'https://p16-sign-va.tiktokcdn.com/tos/300x300/avt/user-a.jpeg?x-expires=1';
+
+describe('pickAvatarUrl', () => {
+  it('returns empty string for missing image / urlList / empty list', () => {
+    expect(pickAvatarUrl(undefined)).toBe('');
+    expect(pickAvatarUrl({})).toBe('');
+    expect(pickAvatarUrl({ urlList: [] })).toBe('');
+  });
+
+  it('prefers a 100x100 webp over other formats', () => {
+    expect(pickAvatarUrl({ urlList: [SHRINK, JPEG_300, JPEG_100, WEBP_100] })).toBe(WEBP_100);
+  });
+
+  it('prefers a 100x100 jpeg when no 100x100 webp exists', () => {
+    expect(pickAvatarUrl({ urlList: [SHRINK, JPEG_300, JPEG_100] })).toBe(JPEG_100);
+  });
+
+  it('avoids the shrink placeholder when a real URL exists', () => {
+    expect(pickAvatarUrl({ urlList: [SHRINK, JPEG_300] })).toBe(JPEG_300);
+  });
+
+  it('returns empty (not the shared placeholder) when every URL is a shrink placeholder', () => {
+    // Returning '' lets tiktokAvatarUrl fall through to a larger model / the
+    // initial, instead of emitting the account-shared placeholder.
+    expect(pickAvatarUrl({ urlList: ['a-shrink-1', 'b-shrink-2'] })).toBe('');
+  });
+
+  it('ignores empty / non-string entries', () => {
+    // Empty strings must never be chosen (they would suppress the initial fallback).
+    expect(pickAvatarUrl({ urlList: ['', JPEG_300] })).toBe(JPEG_300);
+    expect(pickAvatarUrl({ urlList: ['', ''] })).toBe('');
+  });
+});
+
+describe('tiktokAvatarUrl', () => {
+  it('returns empty string when the user or all image models are absent', () => {
+    expect(tiktokAvatarUrl(undefined)).toBe('');
+    expect(tiktokAvatarUrl({})).toBe('');
+    expect(tiktokAvatarUrl({ avatarThumb: { urlList: [] } })).toBe('');
+  });
+
+  it('reads the thumb image model when present', () => {
+    expect(tiktokAvatarUrl({ avatarThumb: { urlList: [WEBP_100] } })).toBe(WEBP_100);
+  });
+
+  it('falls through to medium then large when smaller models are empty', () => {
+    expect(
+      tiktokAvatarUrl({ avatarThumb: { urlList: [] }, avatarMedium: { urlList: [JPEG_100] } })
+    ).toBe(JPEG_100);
+    expect(
+      tiktokAvatarUrl({
+        avatarThumb: {},
+        avatarMedium: { urlList: [] },
+        avatarLarge: { urlList: [JPEG_300] },
+      })
+    ).toBe(JPEG_300);
+  });
+
+  it('falls through when the thumb model carries only shrink placeholders', () => {
+    expect(
+      tiktokAvatarUrl({
+        avatarThumb: { urlList: ['x-shrink-1', 'y-shrink-2'] },
+        avatarMedium: { urlList: [JPEG_100] },
+      })
+    ).toBe(JPEG_100);
+  });
+
+  it('gives distinct URLs for distinct users (regression: all-identical avatars)', () => {
+    const userA = { avatarThumb: { urlList: [SHRINK, 'https://cdn/tos/100x100/avt/A.webp'] } };
+    const userB = { avatarThumb: { urlList: [SHRINK, 'https://cdn/tos/100x100/avt/B.webp'] } };
+    expect(tiktokAvatarUrl(userA)).not.toBe(tiktokAvatarUrl(userB));
+  });
+});

--- a/services/tiktok-listener/src/avatar.ts
+++ b/services/tiktok-listener/src/avatar.ts
@@ -1,0 +1,85 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * TikTok profile-picture URL selection.
+ *
+ * The v3 `User` proto carries a viewer's avatar as up to three image models
+ * (`avatarThumb`, `avatarMedium`, `avatarLarge`), each exposing a `urlList` of
+ * several CDN URLs for the *same* picture in different formats and sizes —
+ * including a low-resolution "shrink" placeholder that TikTok reuses across
+ * many accounts.
+ *
+ * Blindly taking `avatarThumb.urlList[0]` (as this service briefly did after
+ * the 2.4.0 upgrade) is unreliable: that first entry is frequently the generic
+ * shrink placeholder, so every viewer collapsed to the *same* avatar instead of
+ * their own. This mirrors the connector library's own `getPreferredPictureFormat`
+ * heuristic — prefer a real 100x100 WebP/JPEG, avoid the shrink placeholder, and
+ * fall back to the raw first entry only as a last resort.
+ */
+
+/** Minimal structural view of a TikTok avatar image model. */
+export interface AvatarImageModel {
+  urlList?: string[];
+}
+
+/** Minimal structural view of the avatar-bearing fields of a TikTok user. */
+export interface AvatarUser {
+  avatarThumb?: AvatarImageModel;
+  avatarMedium?: AvatarImageModel;
+  avatarLarge?: AvatarImageModel;
+}
+
+/**
+ * Picks the most broadly loadable profile-picture URL from a single avatar
+ * image model, or an empty string when the model carries no usable URL.
+ */
+export function pickAvatarUrl(image: AvatarImageModel | undefined): string {
+  const urls = image?.urlList?.filter(
+    (url): url is string => typeof url === 'string' && url.length > 0
+  );
+  if (!urls || urls.length === 0) {
+    return '';
+  }
+
+  return (
+    urls.find((url) => url.includes('100x100') && url.includes('.webp')) ||
+    urls.find((url) => url.includes('100x100') && url.includes('.jpeg')) ||
+    urls.find((url) => !url.includes('shrink')) ||
+    // Every remaining URL is a "shrink" placeholder (shared across accounts).
+    // Return '' rather than the placeholder so the caller falls through to the
+    // next image model, and ultimately to the viewer's initial — never the
+    // shared image that caused this regression in the first place.
+    ''
+  );
+}
+
+/**
+ * Reads a viewer's profile-picture URL from the v3 avatar image models,
+ * falling through thumb → medium → large so a viewer still gets a real,
+ * per-user avatar when the smallest model is absent or only carries the
+ * shared shrink placeholder. Returns an empty string when none is available,
+ * which the overlay renders as the viewer's initial.
+ */
+export function tiktokAvatarUrl(user: AvatarUser | undefined): string {
+  return (
+    pickAvatarUrl(user?.avatarThumb) ||
+    pickAvatarUrl(user?.avatarMedium) ||
+    pickAvatarUrl(user?.avatarLarge)
+  );
+}

--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -58,6 +58,7 @@ import { LeadershipCoordinator } from './coordination/leadership.js';
 
 // Import demand subscriber (Phase 5)
 import { DemandSubscriber, DemandSource } from './demand/subscriber.js';
+import { tiktokAvatarUrl } from './avatar.js';
 
 // Environment variables
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
@@ -181,7 +182,12 @@ interface TikTokUser {
   id?: string; // numeric user id (was `userId`)
   nickname?: string; // display name
   displayId?: string; // @handle (was `uniqueId`)
-  avatarThumb?: TikTokImageModel; // profile picture (was `profilePictureUrl`)
+  // Profile picture image models, smallest → largest (was `profilePictureUrl`).
+  // TikTok populates these inconsistently per message, so avatar selection
+  // falls through thumb → medium → large; see tiktokAvatarUrl in ./avatar.
+  avatarThumb?: TikTokImageModel;
+  avatarMedium?: TikTokImageModel;
+  avatarLarge?: TikTokImageModel;
 }
 
 // Per-message relationship flags relative to the broadcasting anchor.
@@ -232,11 +238,6 @@ interface TikTokSocialData {
 // Reads the TikTok @handle, falling back to the numeric id then a placeholder.
 function tiktokUserHandle(user: TikTokUser | undefined): string {
   return user?.displayId || user?.id || 'unknown';
-}
-
-// Reads the profile picture URL from the v3 avatar image model.
-function tiktokAvatarUrl(user: TikTokUser | undefined): string {
-  return user?.avatarThumb?.urlList?.[0] || '';
 }
 
 // Like aggregation window for tracking likes over 30-second periods


### PR DESCRIPTION
## Problem

On overlays, **every TikTok viewer showed the exact same profile picture**, and the username-initial fallback (shown when a picture can't be displayed) stopped appearing. Reported to start with the last TikTok change — PR #539, which upgraded `tiktok-live-connector` 2.1.0 → 2.4.0 to restore chat text.

## Root cause

That upgrade remapped the avatar from the old format-selected `profilePictureUrl` to the raw first URL:

```
- profile_picture_url: data.user?.profilePictureUrl
+ profile_picture_url: data.user?.avatarThumb?.urlList?.[0]
```

TikTok returns several CDN URLs per avatar; `urlList[0]` is frequently the low-res **`"shrink"` placeholder that is shared across accounts**. The message-processor `AvatarEnricher` then fetches those bytes server-side and caches them behind the per-user avatar proxy — so the proxy serves an **identical image for every viewer**. And `UserAvatar` had **no `onError`**, so the shared placeholder rendered for everyone instead of falling back to the initial.

The connector library's own extractor (`getPreferredPictureFormat`) deliberately avoids `[0]` — it prefers a `100x100` webp/jpeg and skips `"shrink"`.

## Fix

- **`services/tiktok-listener/src/avatar.ts`** (new, unit-tested): `tiktokAvatarUrl` selects a real per-user picture — prefer `100x100` webp → jpeg → any non-`shrink` URL, and fall through `avatarThumb → avatarMedium → avatarLarge`; returns `''` when only the shared placeholder exists, so the overlay shows the initial. Mirrors the library's heuristic.
- **`frontend/src/components/UserAvatar.tsx`**: `onError` → initial-letter fallback (tracked per-URL so it resets on reuse), plus `referrerPolicy="no-referrer"`.

## Verification

- tiktok-listener: `tsc` clean, **48/48** tests (incl. new `avatar.test.ts`).
- frontend: **12/12** `UserAvatar` tests (incl. new `onError` fallback + `referrerPolicy` cases).
- Adversarial multi-lens review (correctness / regression / root-cause) — no code defects survived verification.

## ⚠️ Required post-rollout step

The `AvatarEnricher` caches image bytes per user in `avatar:img:tiktok:*` (24h TTL) and short-circuits on key existence without re-fetching. After the **new tiktok-listener is live**, flush the stale keys so corrected avatars appear immediately instead of after TTL expiry:

```
redis-cli --scan --pattern 'avatar:img:tiktok:*' | xargs -r redis-cli del
```

(Order matters — flush *after* the corrected listener rolls out, otherwise the enricher re-caches placeholders.)
