### PR TITLE
fix: Twitch token refresh starvation + demand-passive YouTube overlay

### DIFF
--- a/docs/features/passive-overlay-irl.md
+++ b/docs/features/passive-overlay-irl.md
@@ -1,0 +1,91 @@
+# Passive Overlay Mode (24/7 OBS / IRL Streams)
+
+## Overview
+
+A **passive overlay** renders chat exactly like a normal overlay but does **not**
+ask the backend to start capturing chat. It exists for streamers who keep an OBS
+instance connected around the clock — most commonly IRL streamers running a 24/7
+OBS server for disconnect protection.
+
+Add `?passive=true` to your overlay browser-source URL:
+
+```
+https://allch.at/overlay/<overlay-id>?passive=true
+```
+
+You then start chat capture **on demand** from your chat monitor when you actually
+go live (see [Going live](#going-live) below).
+
+## Why it exists
+
+For YouTube, All-Chat discovers your live stream by polling. To avoid hammering
+YouTube for a channel that is offline, discovery **gives up after 1 hour** of not
+finding a live stream and parks the channel until it is re-triggered.
+
+A normal overlay asserts "demand" for the whole time it is connected. If your OBS
+overlay is connected 24/7, that demand is always on — so when you are offline,
+discovery runs, hits the 1-hour limit, and parks. By the time you go live, the
+overlay is parked and chat does not appear until you re-trigger discovery.
+
+A **passive** overlay never asserts that demand, so:
+
+- A 24/7 OBS instance can stay connected indefinitely without ever starting the
+  discovery clock while you are offline.
+- Nothing gets parked, so there is nothing to "un-stick" later.
+- You decide exactly when capture starts, right when you go live.
+
+> Passive mode only changes whether the overlay **drives capture**. It still
+> receives and renders every chat message once capture is running. Twitch, Kick,
+> and TikTok are unaffected by the YouTube discovery timeout, but passive mode is
+> safe to use for any overlay.
+
+## Going live
+
+1. Keep your 24/7 OBS browser source on the **passive** URL
+   (`…?passive=true`). Leave it running.
+2. When you go live, open your overlay's **chat monitor** (the `View` / monitor
+   page for the overlay).
+3. If chat is not already flowing, use **Rediscover** on the monitor to trigger
+   discovery. Capture starts within about a minute.
+4. Keep the chat monitor open while you stream — that is what keeps capture
+   running for the session. When you close it, capture winds down a few minutes
+   later (which is the behaviour you want when the stream ends).
+
+> A plain browser-source refresh does **not** re-trigger a parked YouTube
+> channel — use the monitor's **Rediscover** button.
+
+## Reading the platform indicator
+
+The small per-platform status dots on the overlay/monitor now distinguish the
+parked state:
+
+| Indicator | Meaning |
+|-----------|---------|
+| Green | Connected — chat is flowing |
+| Yellow (`reconnecting`) | Searching for the stream / retrying |
+| **Indigo (`paused`)** | Discovery gave up after 1h and is parked — use the chat monitor's **Rediscover** to retry |
+| Red (`error`) | A real error (e.g. auth required) |
+| Dim (`offline`) | Not live |
+
+The **indigo "paused"** state is not an error: nothing is broken, it just means
+capture is idle and waiting for you to trigger it.
+
+## Quick reference
+
+| You want… | Use |
+|-----------|-----|
+| A 24/7 OBS overlay that never parks while offline | `…/overlay/<id>?passive=true` |
+| A normal overlay that captures whenever connected | `…/overlay/<id>` (no flag) |
+| To start capture for a passive overlay | Chat monitor → **Rediscover** |
+
+## How it works (technical)
+
+`?passive=true` makes the overlay's WebSocket connect **without asserting overlay
+demand** — the API gateway attaches it via the no-demand path (the same mechanism
+used for anonymous participate tabs), skipping source auto-activation while still
+delivering chat frames. With no demand asserted, `source-manager` never tells the
+YouTube listener to poll, so the 1-hour discovery give-up is never reached.
+
+Triggering **Rediscover** from the monitor publishes a control message that forces
+a fresh discovery for the channel; the monitor's own (non-passive) connection then
+sustains demand for the live session.

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -106,10 +106,16 @@ const toc = [
   ['what-is-all-chat', 'What is All-Chat'],
   ['getting-started', 'Get your overlay live'],
   ['24-7-irl', '24/7 & IRL streams'],
+  ['monitor', 'The chat monitor'],
+  ['moderation', 'Moderate your chat'],
+  ['engagement', 'Polls, predictions & points'],
+  ['events-credits', 'Events & credit roll'],
+  ['sharing', 'Share an overlay'],
   ['themes', 'Pick a theme'],
   ['customize', 'Make it your own'],
   ['custom-css', 'Go further with CSS'],
   ['fonts', 'Custom fonts'],
+  ['premium', 'Premium'],
 ]
 
 export default function DocsPage() {
@@ -124,7 +130,8 @@ export default function DocsPage() {
             </p>
             <h1 className="text-3xl font-bold text-text">Streamer guide</h1>
             <p className="text-sm text-text-dim">
-              Get your overlay into OBS, choose a look, and make it your own.
+              Set it up in OBS, run polls, predictions and moderation from the chat monitor, and make
+              it your own.
             </p>
             <p className="text-sm text-text-sub">
               Building a bot, alert box, or analytics tool?{' '}
@@ -224,6 +231,109 @@ export default function DocsPage() {
                 the monitor&apos;s <strong>Rediscover</strong> button. While a channel is parked, its
                 platform dot shows an <strong>indigo &ldquo;paused&rdquo;</strong> state (waiting for
                 you to trigger it), not a red error.
+              </p>
+            </section>
+
+            {/* Chat monitor */}
+            <section id="monitor">
+              <h2>The chat monitor</h2>
+              <p>
+                Open <strong>Monitor View</strong> from the overlay editor for a live control room,
+                separate from the OBS overlay. It shows every message in one panel with an activity
+                feed beside it, and it&apos;s where you send messages and moderate.
+              </p>
+              <ul>
+                <li>
+                  <strong>Send messages</strong> as yourself to Twitch, YouTube or Kick straight from
+                  the monitor (TikTok and Discord have no send API).
+                </li>
+                <li>
+                  <strong>Re-discover YouTube</strong> forces a fresh look for your live stream — use
+                  it if YouTube chat stops after a crash or restart, or to start capture for a{' '}
+                  <a href="#24-7-irl">passive 24/7 overlay</a> when you go live.
+                </li>
+                <li>
+                  <strong>Display</strong> settings toggle what you see (avatars, badges, pronouns,
+                  timestamps, platform icons, moderation controls). These are your personal monitor
+                  preferences and don&apos;t change the OBS overlay.
+                </li>
+              </ul>
+            </section>
+
+            {/* Moderation */}
+            <section id="moderation">
+              <h2>Moderate your chat</h2>
+              <p>
+                With <strong>Moderation controls</strong> on in the monitor, hover a message to{' '}
+                <strong>Delete</strong> it, or open a chatter to <strong>Timeout</strong>,{' '}
+                <strong>Ban</strong> or <strong>Unban</strong> them — applied on the source platform.
+                What&apos;s available depends on the platform (Twitch does delete, timeout and ban;
+                YouTube is ban-only; TikTok has no moderation API).
+              </p>
+              <p>
+                The first time, use <strong>Enable moderation &amp; chat sending</strong> to grant the
+                extra permissions (for Discord you re-invite the bot). Moderating from your overlay is
+                a <a href="#premium">Premium</a> feature.
+              </p>
+            </section>
+
+            {/* Engagement */}
+            <section id="engagement">
+              <h2>Polls, predictions &amp; points</h2>
+              <p>
+                All-Chat has its own <strong>polls</strong>, <strong>predictions</strong> and{' '}
+                <strong>viewer points</strong> that work across every connected platform, not just
+                Twitch.
+              </p>
+              <ul>
+                <li>
+                  Turn them on in the editor&apos;s <strong>Engagement</strong> section:{' '}
+                  <strong>Enable viewer points</strong>, set your <strong>Points name</strong>, and
+                  choose how points are earned (per bit, per sub, per gifted sub, and so on).
+                </li>
+                <li>
+                  Run rounds live from the monitor&apos;s <strong>Engagement</strong> panel:{' '}
+                  <strong>Start poll</strong> / <strong>Close poll</strong>, and{' '}
+                  <strong>Start prediction</strong> / <strong>Lock wagers</strong> / pay out or{' '}
+                  <strong>Cancel &amp; refund</strong>.
+                </li>
+                <li>
+                  Viewers join from chat (e.g. <Code>!vote 2</Code>, <Code>!predict 1 500</Code>) or on
+                  the <strong>Viewer participation page</strong>.
+                </li>
+                <li>
+                  Add the <strong>OBS poll widget</strong> and <strong>OBS prediction widget</strong>{' '}
+                  as their own browser sources so results show on stream — copy their URLs from the
+                  Engagement section.
+                </li>
+              </ul>
+            </section>
+
+            {/* Events & credit roll */}
+            <section id="events-credits">
+              <h2>Events &amp; credit roll</h2>
+              <p>
+                Your overlay shows <strong>events</strong> too — subs, resubs, gift subs, bits/cheers,
+                raids, Super Chats, memberships and follows. Use <strong>Event Settings</strong> in the
+                editor to choose exactly which events appear, per platform.
+              </p>
+              <p>
+                For the end of a stream, open <strong>Credits</strong> to set up a{' '}
+                <strong>Credit Roll</strong> — a scrolling thank-you of your top subscribers, gifters,
+                cheerers, raiders and new followers. It&apos;s its own browser source (
+                <strong>Copy Credits OBS URL</strong>).
+              </p>
+            </section>
+
+            {/* Share an overlay */}
+            <section id="sharing">
+              <h2>Share an overlay</h2>
+              <p>
+                <strong>Share Overlay</strong> lets another streamer pull your overlay&apos;s chat into
+                theirs — handy for collabs and raids. Send a request to their Twitch username; once
+                they accept, your overlay appears in their editor under <strong>Shared Overlays</strong>{' '}
+                to add as a source, and either of you can revoke it later. Sharing is a{' '}
+                <a href="#premium">Premium</a> feature.
               </p>
             </section>
 
@@ -384,6 +494,35 @@ export default function DocsPage() {
                 Requesting a family that isn&apos;t on the list simply won&apos;t load — pick another
                 or leave the default.
               </p>
+            </section>
+
+            {/* Premium */}
+            <section id="premium">
+              <h2>Premium</h2>
+              <p>
+                All-Chat is free and open source. A Premium subscription — via Patreon, connected in{' '}
+                <strong>Settings → Premium</strong> — unlocks:
+              </p>
+              <ul>
+                <li>
+                  <strong>Moderate from your overlay</strong> — delete, timeout and ban from the chat
+                  monitor.
+                </li>
+                <li>
+                  <strong>ElevenLabs text-to-speech</strong> — premium TTS voices (basic browser TTS is
+                  free).
+                </li>
+                <li>
+                  <strong>YouTube stream selection</strong> — choose which stream to follow on
+                  multi-stream channels (the free default follows the first one found).
+                </li>
+                <li>
+                  <strong>Shared chat</strong> — share your overlay with other streamers.
+                </li>
+                <li>
+                  <strong>Viewer flairs</strong> — animated gradient name colors.
+                </li>
+              </ul>
             </section>
           </div>
 

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -105,6 +105,7 @@ function DevCallout({ children }: { children: ReactNode }) {
 const toc = [
   ['what-is-all-chat', 'What is All-Chat'],
   ['getting-started', 'Get your overlay live'],
+  ['24-7-irl', '24/7 & IRL streams'],
   ['themes', 'Pick a theme'],
   ['customize', 'Make it your own'],
   ['custom-css', 'Go further with CSS'],
@@ -184,6 +185,46 @@ export default function DocsPage() {
                   winds down when nothing is connected, so you never pay for idle listeners.
                 </li>
               </ol>
+            </section>
+
+            {/* 24/7 & IRL streams */}
+            <section id="24-7-irl">
+              <h2>24/7 &amp; IRL streams</h2>
+              <p>
+                Running an OBS instance around the clock — a common setup for IRL streamers who want
+                disconnect protection — needs one extra step so YouTube chat behaves. Add{' '}
+                <Code>?passive=true</Code> to your overlay&apos;s browser-source URL:
+              </p>
+              <Pre>{`https://allch.at/overlay/<overlay-id>?passive=true`}</Pre>
+              <p>
+                A <strong>passive</strong> overlay renders chat exactly like a normal one, but it does
+                not ask All-Chat to start capturing on its own. That matters because YouTube discovery
+                gives up after an hour of not finding a live stream (so it never hammers YouTube for an
+                offline channel). A normal 24/7 overlay would trip that timeout while you are offline
+                and sit parked by the time you go live — a passive overlay never starts that clock, so
+                nothing gets stuck.
+              </p>
+              <h3>When you go live</h3>
+              <ol className="list-decimal space-y-2 pl-6 text-text-sub">
+                <li>Leave your 24/7 OBS browser source on the passive URL.</li>
+                <li>
+                  Open your overlay&apos;s <strong>chat monitor</strong> (the monitor / view page).
+                </li>
+                <li>
+                  If chat is not already flowing, hit <strong>Rediscover</strong> on the monitor —
+                  capture starts within about a minute.
+                </li>
+                <li>
+                  Keep the chat monitor open while you stream; that keeps capture running for the
+                  session, and it winds down a few minutes after you close it.
+                </li>
+              </ol>
+              <p>
+                A plain browser-source refresh does <em>not</em> restart a parked YouTube channel — use
+                the monitor&apos;s <strong>Rediscover</strong> button. While a channel is parked, its
+                platform dot shows an <strong>indigo &ldquo;paused&rdquo;</strong> state (waiting for
+                you to trigger it), not a red error.
+              </p>
             </section>
 
             {/* Themes */}

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -271,10 +271,19 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
     })
   }, [])
 
+  // Render-only "disconnect-protection" mode (?passive=true): a 24/7 OBS instance
+  // stays connected for rendering but does NOT assert overlay demand, so it never
+  // starts YouTube discovery (and the 1h give-up) while the streamer is offline.
+  // Discovery is triggered on demand from the chat monitor when they go live.
+  const [passive] = useState(
+    () => typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('passive') === 'true'
+  )
+
   const { config, sources, activeChannels, channelStatuses } = useOverlayStream(id, {
     onChat,
     onMessageUpdate,
     onDeletion,
+    passive,
   })
 
   // Interpret the public config into display state + sound/TTS hydration. Runs

--- a/frontend/src/components/PlatformStatusIndicators.tsx
+++ b/frontend/src/components/PlatformStatusIndicators.tsx
@@ -187,6 +187,14 @@ export default function PlatformStatusIndicators({
             tooltipText = status.error_message
               ? `${platformLabel} - ${source.channelName} - ${status.error_message}`
               : `${platformLabel} - ${source.channelName} - Error`
+          } else if (status.status === 'paused') {
+            // Discovery gave up after the 1h cap and is parked awaiting a manual
+            // re-trigger (chat monitor → Rediscover). Distinct from a red error:
+            // nothing is broken, an action is needed.
+            statusClass = 'bg-indigo-500/20 opacity-100 border border-indigo-500/40'
+            tooltipText = status.error_message
+              ? `${platformLabel} - ${source.channelName} - ${status.error_message}`
+              : `${platformLabel} - ${source.channelName} - Discovery paused (use chat monitor to retry)`
           } else if (status.status === 'offline') {
             // Check if offline is due to auth error
             const isAuthError =

--- a/frontend/src/hooks/useOverlayStream.ts
+++ b/frontend/src/hooks/useOverlayStream.ts
@@ -65,6 +65,14 @@ export interface UseOverlayStreamOptions {
    * A late-hydrated token rebinds the socket once.
    */
   token?: string
+  /**
+   * Render-only ("disconnect-protection") mode: appends `&passive=true` so the
+   * gateway attaches the socket WITHOUT asserting overlay demand. A 24/7 OBS
+   * instance can stay connected without keeping YouTube discovery running (and
+   * getting parked after the 1h give-up); the streamer triggers discovery from
+   * their chat monitor when they go live. Chat still renders normally.
+   */
+  passive?: boolean
   /** Enriched, deduped regular chat message (no event, or a non-deletion event). */
   onChat?: (message: ChatMessage) => void
   /** Enriched TikTok like-aggregate update (no dedup — may repeat by aggregation_id). */
@@ -199,6 +207,9 @@ export function useOverlayStream(
     const params: string[] = []
     if (lastSeenTimestampRef.current > 0) {
       params.push(`since=${lastSeenTimestampRef.current}`)
+    }
+    if (options.passive) {
+      params.push('passive=true')
     }
     if (params.length > 0) {
       wsUrl += `?${params.join('&')}`
@@ -394,7 +405,7 @@ export function useOverlayStream(
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `sources` captured at bind time by design; reconnect bookkeeping lives in refs
-  }, [id, forceReconnect, options.token])
+  }, [id, forceReconnect, options.token, options.passive])
 
   // Recover instantly when the environment signals the network is usable again:
   // the OS reports connectivity (`online`) or the streamer refocuses a

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -137,7 +137,7 @@ export interface PlatformStatus {
   platform: 'youtube' | 'twitch' | 'kick' | 'tiktok' | 'discord';
   channel_id: string;
   channel_name?: string;
-  status: 'connected' | 'reconnecting' | 'offline' | 'quota_exceeded' | 'error';
+  status: 'connected' | 'reconnecting' | 'offline' | 'quota_exceeded' | 'error' | 'paused';
   next_retry_at?: string; // ISO 8601 timestamp
   error_message?: string;
 }

--- a/frontend/src/lib/utils/overlayStreamCore.ts
+++ b/frontend/src/lib/utils/overlayStreamCore.ts
@@ -184,7 +184,11 @@ export function platformStatusReducer(
       activeChannels = new Set(activeChannels)
       activeChannels.add(channelId)
     }
-  } else if (statusData.status === 'offline' || statusData.status === 'error') {
+  } else if (
+    statusData.status === 'offline' ||
+    statusData.status === 'error' ||
+    statusData.status === 'paused'
+  ) {
     if (activeChannels.has(channelId)) {
       activeChannels = new Set(activeChannels)
       activeChannels.delete(channelId)

--- a/services/api-gateway/handlers/websocket.go
+++ b/services/api-gateway/handlers/websocket.go
@@ -191,6 +191,19 @@ func (h *WebSocketHandler) HandleOverlayConnection(c *gin.Context) {
 	// poll/prediction updates. Enforced per-connection at broadcast time (#5).
 	engagementOnly := c.Query("engagementOnly") == "true"
 
+	// passive marks a render-only overlay (e.g. a 24/7 disconnect-protection OBS
+	// instance for IRL streams) that must display chat but must NOT assert demand or
+	// activate sources — otherwise an always-connected overlay keeps YouTube discovery
+	// running while the streamer is offline and gets parked after the 1h give-up. The
+	// streamer instead triggers discovery on demand from their chat monitor when going
+	// live. Unlike engagementOnly, a passive socket STILL receives chat frames.
+	passive := c.Query("passive") == "true"
+
+	// A socket attaches without the overlay:connected demand signal (and skips source
+	// auto-activation) when it is an anonymous participate tab OR an explicitly passive
+	// render-only overlay.
+	skipDemand := skipSourceActivation || passive
+
 	// Resolve JWT from Sec-WebSocket-Protocol subprotocol first, then fall
 	// back to ?token= query param (backward compat during client rollout).
 	// The subprotocol path keeps the token out of access logs (audit H5).
@@ -284,9 +297,10 @@ func (h *WebSocketHandler) HandleOverlayConnection(c *gin.Context) {
 	// must not drive source activation / YouTube quota (P2-3). NOT skipped for the
 	// streamer's OBS poll/prediction display widgets, which must activate so Twitch-native
 	// rounds are mirrored.
-	if skipSourceActivation {
-		h.logger.Debug("viewer participate WS connection; skipping source auto-activation",
+	if skipDemand {
+		h.logger.Debug("no-demand WS connection (participate tab or passive overlay); skipping source auto-activation",
 			zap.String("overlay_id", overlayID),
+			zap.Bool("passive", passive),
 		)
 	} else if activatedCount, err := h.repo.ActivateSourcesForOverlay(ctx, overlayID); err != nil {
 		h.logger.Error("Failed to activate sources for overlay",
@@ -315,10 +329,10 @@ func (h *WebSocketHandler) HandleOverlayConnection(c *gin.Context) {
 
 	// Add connection to manager.
 	// Use background context here too since connection lives beyond HTTP request.
-	// viewerParticipant/engagement-only sockets attach WITHOUT the overlay:connected
-	// demand signal so anonymous participate tabs can't sustain demand-based upstream
-	// capture with no owner in the loop (P2-3).
-	if skipSourceActivation {
+	// viewerParticipant/engagement-only tabs and passive render-only overlays attach
+	// WITHOUT the overlay:connected demand signal so they can't sustain demand-based
+	// upstream capture with no owner going live (P2-3, and the 24/7 IRL OBS case).
+	if skipDemand {
 		h.wsManager.AddConnectionNoDemand(context.Background(), wsConn)
 	} else {
 		h.wsManager.AddConnection(context.Background(), wsConn)

--- a/services/token-refresh-service/cmd/main.go
+++ b/services/token-refresh-service/cmd/main.go
@@ -158,8 +158,16 @@ func main() {
 	tokenRepo := repository.NewTokenRepository(db, encryptor, log)
 
 	refreshInterval := getDuration("TOKEN_REFRESH_INTERVAL", 5*time.Minute)
-	expiryBuffer := getDuration("TOKEN_REFRESH_BUFFER", 10*time.Minute)
-	batchSize := getInt("TOKEN_REFRESH_BATCH_SIZE", 100)
+	// Refresh well before expiry: a small buffer (was 10m) left almost no slack, so
+	// a token skipped for even a couple of batches during a synchronized herd lapsed.
+	// 30m is safely below the shortest access-token lifetime (~1h for Google/YouTube)
+	// yet gives multi-batch slack for the ~4h Twitch tokens. Prioritisation of active
+	// chat-scoped streamers (see QueryGetExpiringUserTokens) is the primary anti-starvation fix.
+	expiryBuffer := getDuration("TOKEN_REFRESH_BUFFER", 30*time.Minute)
+	// Cap on tokens pulled per type per batch (wired into the queries' LIMIT). Raised
+	// from 100 so an hourly herd of expiring tokens fits in one pass instead of being
+	// truncated and starving whatever sorts last.
+	batchSize := getInt("TOKEN_REFRESH_BATCH_SIZE", 250)
 	retryAttempts := getInt("TOKEN_REFRESH_RETRY_ATTEMPTS", 3)
 
 	refreshManager := refresher.NewManager(

--- a/services/token-refresh-service/refresher/manager.go
+++ b/services/token-refresh-service/refresher/manager.go
@@ -37,10 +37,10 @@ import (
 // TokenRepo is the repository interface used by the Manager. Defining it here
 // keeps the refresher package testable without a real database.
 type TokenRepo interface {
-	GetExpiringUserTokens(ctx context.Context, expiresWithin time.Duration) ([]*repository.ExpiringToken, error)
-	GetExpiringViewerTokens(ctx context.Context, expiresWithin time.Duration) ([]*repository.ExpiringToken, error)
-	GetExpiringYouTubeTokens(ctx context.Context, expiresWithin time.Duration) ([]*repository.ExpiringToken, error)
-	GetExpiringTwitchLinkTokens(ctx context.Context, expiresWithin time.Duration) ([]*repository.ExpiringToken, error)
+	GetExpiringUserTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
+	GetExpiringViewerTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
+	GetExpiringYouTubeTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
+	GetExpiringTwitchLinkTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
 
 	UpdateUserTokens(ctx context.Context, userID string, token *oauth2Lib.Token) error
 	UpdateViewerTokens(ctx context.Context, sessionID string, token *oauth2Lib.Token) error
@@ -196,22 +196,22 @@ func (m *Manager) ProcessBatch(ctx context.Context) error {
 	m.logger.Info("Processing token refresh batch")
 
 	// Query expiring tokens from all sources
-	userTokens, err := m.repo.GetExpiringUserTokens(ctx, m.expiryBuffer)
+	userTokens, err := m.repo.GetExpiringUserTokens(ctx, m.expiryBuffer, m.batchSize)
 	if err != nil {
 		return fmt.Errorf("failed to get expiring user tokens: %w", err)
 	}
 
-	viewerTokens, err := m.repo.GetExpiringViewerTokens(ctx, m.expiryBuffer)
+	viewerTokens, err := m.repo.GetExpiringViewerTokens(ctx, m.expiryBuffer, m.batchSize)
 	if err != nil {
 		return fmt.Errorf("failed to get expiring viewer tokens: %w", err)
 	}
 
-	youtubeTokens, err := m.repo.GetExpiringYouTubeTokens(ctx, m.expiryBuffer)
+	youtubeTokens, err := m.repo.GetExpiringYouTubeTokens(ctx, m.expiryBuffer, m.batchSize)
 	if err != nil {
 		return fmt.Errorf("failed to get expiring YouTube tokens: %w", err)
 	}
 
-	twitchLinkTokens, err := m.repo.GetExpiringTwitchLinkTokens(ctx, m.expiryBuffer)
+	twitchLinkTokens, err := m.repo.GetExpiringTwitchLinkTokens(ctx, m.expiryBuffer, m.batchSize)
 	if err != nil {
 		return fmt.Errorf("failed to get expiring linked Twitch tokens: %w", err)
 	}

--- a/services/token-refresh-service/refresher/manager_test.go
+++ b/services/token-refresh-service/refresher/manager_test.go
@@ -92,13 +92,13 @@ type updatedTwitchLinkCall struct {
 	twitchLogin string
 }
 
-func (r *fakeRepo) GetExpiringUserTokens(_ context.Context, _ time.Duration) ([]*repository.ExpiringToken, error) {
+func (r *fakeRepo) GetExpiringUserTokens(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
 	return nil, nil
 }
-func (r *fakeRepo) GetExpiringViewerTokens(_ context.Context, _ time.Duration) ([]*repository.ExpiringToken, error) {
+func (r *fakeRepo) GetExpiringViewerTokens(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
 	return nil, nil
 }
-func (r *fakeRepo) GetExpiringYouTubeTokens(_ context.Context, _ time.Duration) ([]*repository.ExpiringToken, error) {
+func (r *fakeRepo) GetExpiringYouTubeTokens(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
 	return nil, nil
 }
 func (r *fakeRepo) UpdateUserTokens(_ context.Context, _ string, _ *oauth2.Token) error {
@@ -132,7 +132,7 @@ func (r *fakeRepo) MarkYouTubeTokenPermanentlyFailed(_ context.Context, userID, 
 	r.markedYT = append(r.markedYT, markedYTCall{userID: userID, channelID: channelID, suppressDuration: d})
 	return nil
 }
-func (r *fakeRepo) GetExpiringTwitchLinkTokens(_ context.Context, _ time.Duration) ([]*repository.ExpiringToken, error) {
+func (r *fakeRepo) GetExpiringTwitchLinkTokens(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
 	return nil, nil
 }
 func (r *fakeRepo) UpdateTwitchLinkTokens(_ context.Context, userID, twitchLogin string, _ *oauth2.Token) error {

--- a/services/token-refresh-service/repository/token_repository.go
+++ b/services/token-refresh-service/repository/token_repository.go
@@ -47,8 +47,12 @@ const QueryGetExpiringUserTokens = `
 	  AND refresh_token IS NOT NULL
 	  AND refresh_token != ''
 	  AND is_banned = false
-	ORDER BY token_expires_at ASC
-	LIMIT 100
+	-- Prioritise active EventSub streamers (tokens carrying the live chat scope) so a
+	-- synchronized herd of dormant/expiring tokens can never starve a live channel's
+	-- token out of the LIMITed batch and let it lapse mid-stream.
+	ORDER BY (COALESCE(granted_scopes, '{}'::text[]) @> ARRAY['user:read:chat']::text[]) DESC,
+	         token_expires_at ASC
+	LIMIT $2
 `
 
 // QueryGetExpiringViewerTokens is exported for test assertions.
@@ -63,7 +67,7 @@ const QueryGetExpiringViewerTokens = `
 	  AND refresh_token IS NOT NULL
 	  AND refresh_token != ''
 	ORDER BY token_expires_at ASC
-	LIMIT 100
+	LIMIT $2
 `
 
 // QueryGetExpiringYouTubeTokens is exported for test assertions.
@@ -77,7 +81,7 @@ const QueryGetExpiringYouTubeTokens = `
 	  AND refresh_token IS NOT NULL
 	  AND refresh_token != ''
 	ORDER BY expiry ASC
-	LIMIT 100
+	LIMIT $2
 `
 
 // QueryGetExpiringTwitchLinkTokens selects expiring linked Twitch credentials
@@ -94,7 +98,7 @@ const QueryGetExpiringTwitchLinkTokens = `
 	  AND refresh_token IS NOT NULL
 	  AND refresh_token != ''
 	ORDER BY token_expires_at ASC
-	LIMIT 100
+	LIMIT $2
 `
 
 // ExpiringToken represents a token that needs to be refreshed
@@ -134,9 +138,9 @@ func NewTokenRepository(db *pgxpool.Pool, cipher *encryption.MultiKeyEncryptor, 
 // Also recovers already-expired tokens within the last 48 hours to handle transient
 // failures. Tokens older than 48 hours are excluded — they are considered permanently
 // failed and should have been suppressed by MarkUserTokenPermanentlyFailed.
-func (r *TokenRepository) GetExpiringUserTokens(ctx context.Context, expiresWithin time.Duration) ([]*ExpiringToken, error) {
+func (r *TokenRepository) GetExpiringUserTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*ExpiringToken, error) {
 	expiryThreshold := time.Now().Add(expiresWithin)
-	rows, err := r.db.Query(ctx, QueryGetExpiringUserTokens, expiryThreshold)
+	rows, err := r.db.Query(ctx, QueryGetExpiringUserTokens, expiryThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query expiring user tokens: %w", err)
 	}
@@ -194,9 +198,9 @@ func (r *TokenRepository) GetExpiringUserTokens(ctx context.Context, expiresWith
 // GetExpiringViewerTokens returns viewer session tokens expiring within the specified duration.
 // Only recovers tokens that expired within the last 48 hours. Older expired tokens are
 // assumed to have been permanently failed and suppressed via MarkViewerTokenPermanentlyFailed.
-func (r *TokenRepository) GetExpiringViewerTokens(ctx context.Context, expiresWithin time.Duration) ([]*ExpiringToken, error) {
+func (r *TokenRepository) GetExpiringViewerTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*ExpiringToken, error) {
 	expiryThreshold := time.Now().Add(expiresWithin)
-	rows, err := r.db.Query(ctx, QueryGetExpiringViewerTokens, expiryThreshold)
+	rows, err := r.db.Query(ctx, QueryGetExpiringViewerTokens, expiryThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query expiring viewer tokens: %w", err)
 	}
@@ -259,9 +263,9 @@ func (r *TokenRepository) GetExpiringViewerTokens(ctx context.Context, expiresWi
 // GetExpiringYouTubeTokens returns YouTube channel tokens expiring within the specified duration.
 // Only recovers tokens that expired within the last 48 hours. Older expired tokens are
 // assumed to have been permanently failed and suppressed via MarkYouTubeTokenPermanentlyFailed.
-func (r *TokenRepository) GetExpiringYouTubeTokens(ctx context.Context, expiresWithin time.Duration) ([]*ExpiringToken, error) {
+func (r *TokenRepository) GetExpiringYouTubeTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*ExpiringToken, error) {
 	expiryThreshold := time.Now().Add(expiresWithin)
-	rows, err := r.db.Query(ctx, QueryGetExpiringYouTubeTokens, expiryThreshold)
+	rows, err := r.db.Query(ctx, QueryGetExpiringYouTubeTokens, expiryThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query expiring YouTube tokens: %w", err)
 	}
@@ -514,9 +518,9 @@ func (r *TokenRepository) MarkYouTubeTokenPermanentlyFailed(ctx context.Context,
 // twitch_oauth_tokens) expiring within the specified duration. These rows
 // carry the EventSub chat grant of accounts whose login provider is not
 // Twitch; letting them lapse silently demotes the channel to the IRC listener.
-func (r *TokenRepository) GetExpiringTwitchLinkTokens(ctx context.Context, expiresWithin time.Duration) ([]*ExpiringToken, error) {
+func (r *TokenRepository) GetExpiringTwitchLinkTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*ExpiringToken, error) {
 	expiryThreshold := time.Now().Add(expiresWithin)
-	rows, err := r.db.Query(ctx, QueryGetExpiringTwitchLinkTokens, expiryThreshold)
+	rows, err := r.db.Query(ctx, QueryGetExpiringTwitchLinkTokens, expiryThreshold, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query expiring linked Twitch tokens: %w", err)
 	}

--- a/services/token-refresh-service/repository/token_repository_test.go
+++ b/services/token-refresh-service/repository/token_repository_test.go
@@ -58,6 +58,37 @@ func TestGetExpiringYouTubeTokens_QueryHasBoundedRecoveryWindow(t *testing.T) {
 	assertBoundedRecoveryWindow(t, "GetExpiringYouTubeTokens", q)
 }
 
+// TestGetExpiringUserTokens_PrioritisesActiveChatScope guards the anti-starvation
+// fix: active EventSub streamers (tokens carrying user:read:chat) must sort ahead of
+// dormant tokens so a synchronized herd of expiring tokens cannot push a live
+// channel's token out of the LIMITed batch and let it lapse mid-stream.
+func TestGetExpiringUserTokens_PrioritisesActiveChatScope(t *testing.T) {
+	q := repository.QueryGetExpiringUserTokens
+	if !contains(q, "user:read:chat") {
+		t.Errorf("GetExpiringUserTokens: query no longer prioritises active chat-scoped streamers — expected an ORDER BY keyed on user:read:chat")
+	}
+}
+
+// TestExpiringQueries_LimitIsParameterised guards that the per-type per-batch cap is
+// wired to the configurable batch size ($N) rather than hardcoded to 100, which
+// previously truncated the hourly herd and starved whatever sorted last.
+func TestExpiringQueries_LimitIsParameterised(t *testing.T) {
+	queries := map[string]string{
+		"GetExpiringUserTokens":       repository.QueryGetExpiringUserTokens,
+		"GetExpiringViewerTokens":     repository.QueryGetExpiringViewerTokens,
+		"GetExpiringYouTubeTokens":    repository.QueryGetExpiringYouTubeTokens,
+		"GetExpiringTwitchLinkTokens": repository.QueryGetExpiringTwitchLinkTokens,
+	}
+	for name, q := range queries {
+		if contains(q, "LIMIT 100") {
+			t.Errorf("%s: query still hardcodes LIMIT 100 — wire it to the configurable batch size", name)
+		}
+		if !contains(q, "LIMIT $") {
+			t.Errorf("%s: query LIMIT is not parameterised ($N) — expected a bind-parameter limit", name)
+		}
+	}
+}
+
 // TestMarkUserTokenPermanentlyFailed_ExistsOnRepository verifies that the repository
 // exposes the MarkUserTokenPermanentlyFailed method. Compilation of this file is the
 // assertion — if the method does not exist the package will not compile.

--- a/services/youtube-listener-innertube/status/publisher.go
+++ b/services/youtube-listener-innertube/status/publisher.go
@@ -32,7 +32,7 @@ type Message struct {
 	Platform     string     `json:"platform"`
 	ChannelID    string     `json:"channel_id"`
 	ChannelName  string     `json:"channel_name,omitempty"`
-	Status       string     `json:"status"` // "connected", "reconnecting", "offline", "error"
+	Status       string     `json:"status"` // "connected", "reconnecting", "offline", "error", "paused"
 	NextRetryAt  *time.Time `json:"next_retry_at,omitempty"`
 	ErrorMessage string     `json:"error_message,omitempty"`
 }

--- a/services/youtube-listener-innertube/streams/manager.go
+++ b/services/youtube-listener-innertube/streams/manager.go
@@ -553,12 +553,15 @@ func (m *Manager) giveUpDiscovery(state *DiscoveryState) {
 
 	ctx := context.Background()
 
-	// Surface an error on the platform indicator.
+	// Surface a distinct "paused" state (not a generic error): discovery is
+	// intentionally parked until re-triggered, so the indicator must read as "action
+	// needed" rather than "broken". Point the streamer at the chat monitor's
+	// Rediscover — a plain overlay refresh does NOT clear the give-up marker.
 	m.statusPublisher.Publish(ctx, status.Message{
 		Platform:     "youtube",
 		ChannelID:    state.ChannelID,
-		Status:       "error",
-		ErrorMessage: "No live stream found after 1h — refresh your overlay to retry",
+		Status:       "paused",
+		ErrorMessage: "No live stream found after 1h — discovery paused; hit Rediscover in your chat monitor when you go live",
 	})
 
 	// Mark gave-up first, then drop the in-progress reservation, so there is no


### PR DESCRIPTION
## Two production fixes, root-caused from prod logs (Loki/Grafana) + the live DB.

### 1. `fix(token-refresh)` — Twitch tokens lapsing despite the refresher being healthy
A synchronized nightly herd of expiring tokens saturated the refresher's `ORDER BY token_expires_at ASC LIMIT 100` batch, and with only a 10-minute lead-time buffer an active streamer's token could be deprioritized behind dormant tokens and **sit expired for hours in prime time** (observed live: a live channel's `user` token expired 18:32→21:55 UTC). While expired, the EventSub listener skips the channel and Twitch chat drops.

- **Priority ordering**: `GetExpiringUserTokens` now sorts active EventSub streamers (`user:read:chat`) ahead of dormant tokens.
- **Lead-time buffer**: `TOKEN_REFRESH_BUFFER` default `10m → 30m` (still below the ~1h minimum access-token lifetime; gives multi-batch slack for ~4h Twitch tokens).
- **Batch cap**: wired the previously-dead `batchSize` config into the queries' `LIMIT` and raised the default `100 → 250`.
- Guard tests for the priority ordering and parameterized `LIMIT`.

Note: this was **not** a dual-login problem — verified against the DB (72 accounts hold both a streamer + viewer Twitch token for the same account; 60/72 have both healthy; suppression rate matches the general population).

### 2. `feat(overlay)` — demand-passive overlay URL for 24/7 OBS + transparent give-up indicator
An IRL streamer running a 24/7 OBS instance (disconnect protection) keeps the overlay continuously connected, which sustains YouTube discovery demand; the channel is then parked after the intentional 1h give-up and never auto-recovers (no demand transition to clear the marker).

- **`?passive=true` overlay URL**: the gateway attaches such sockets without the `overlay:connected` demand signal (reusing the existing `AddConnectionNoDemand` path) and skips source auto-activation, while still delivering chat frames. A 24/7 overlay uses the passive URL; discovery is triggered from the chat monitor (Rediscover) when the streamer goes live.
- **Transparent indicator**: discovery give-up now publishes a distinct `paused` status (rendered as an "action-needed" indigo state pointing at the chat monitor) instead of a generic red error with misleading "refresh your overlay" copy.

### Verification
- `go build` / `go vet` / package tests green for `token-refresh-service`, `api-gateway`, `youtube-listener-innertube`.
- Frontend: 52 tests pass; `tsc` clean on changed files.
- Issue 1's exact parameterized query validated live against prod PostgreSQL (active chat-scoped streamers sort first).

### To confirm post-deploy
The chat monitor (`/view`) must assert demand while open so a monitor-triggered Rediscover keeps polling for the live session (couldn't be exercised end-to-end without a running stack).

No DB migration. No new service. Config defaults changed in code (env-overridable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
