### PR TITLE
feat(admin): show how long each overlay has been connected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 
 # Test artifacts
 test/contract/schema/capture
+test/contract/schema/contract
+test/contract/dual-listener/dual-listener
 
 # Output of the go coverage tool
 *.out
@@ -39,6 +41,9 @@ services/*/twitch-listener
 services/*/youtube-listener
 services/*/message-processor
 services/*/main
+# Compiled command binaries (go build output in cmd/ subdirs)
+services/auth-service/cmd/key-rotator/key-rotator
+services/youtube-listener/cmd/token_backfill/token_backfill
 
 # Environment variables
 .env

--- a/frontend/src/app/admin/overlays/page.tsx
+++ b/frontend/src/app/admin/overlays/page.tsx
@@ -26,6 +26,11 @@ import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlatformBadge } from '@/components/ui/badge'
 import type { Platform } from '@/lib/platform-colors'
+import { formatConnectedFor } from '@/lib/utils'
+
+// Connections open longer than this are highlighted so admins can spot overlays
+// that are likely open but no longer live ("dead but open").
+const LONG_OPEN_MS = 12 * 60 * 60 * 1000
 
 interface Overlay {
   id: string
@@ -34,6 +39,13 @@ interface Overlay {
   created_at: string
   updated_at: string
   sources_count?: number
+}
+
+// Shape of GET /api/v1/admin/overlays/active: overlays with a live WebSocket
+// connection, each with when that connection began (null while unavailable).
+interface ActiveOverlay {
+  overlay_id: string
+  connected_since?: string | null
 }
 
 interface OverlaySource {
@@ -50,6 +62,8 @@ export default function OverlaysPage() {
   const [selectedOverlay, setSelectedOverlay] = useState<Overlay | null>(null)
   const [sources, setSources] = useState<OverlaySource[]>([])
   const [activeOverlayIds, setActiveOverlayIds] = useState<Set<string>>(new Set())
+  // overlay id -> connection start timestamp (RFC3339), for "connected for X".
+  const [connectedSince, setConnectedSince] = useState<Map<string, string>>(new Map())
   const [loading, setLoading] = useState(true)
   const [sourcesLoading, setSourcesLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -102,8 +116,15 @@ export default function OverlaysPage() {
           credentials: 'same-origin',
         })
         if (response.ok) {
-          const ids: string[] = await response.json()
-          setActiveOverlayIds(new Set(ids))
+          const active: ActiveOverlay[] = await response.json()
+          setActiveOverlayIds(new Set(active.map((o) => o.overlay_id)))
+          setConnectedSince(
+            new Map(
+              active
+                .filter((o) => o.connected_since)
+                .map((o) => [o.overlay_id, o.connected_since as string])
+            )
+          )
         }
       } catch (err) {
         console.error('Failed to load active overlays:', err)
@@ -157,6 +178,13 @@ export default function OverlaysPage() {
     }
   }, [selectedOverlay])
 
+  // Connection start (epoch ms) for sorting; unknown timestamps sort last.
+  const connectedStartMs = (id: string): number => {
+    const since = connectedSince.get(id)
+    const parsed = since ? Date.parse(since) : Number.NaN
+    return Number.isNaN(parsed) ? Number.POSITIVE_INFINITY : parsed
+  }
+
   // Filter overlays by search term and connected status
   const connectedCount = overlays.filter((o) => activeOverlayIds.has(o.id)).length
   const filteredOverlays = overlays.filter((o) => {
@@ -169,6 +197,19 @@ export default function OverlaysPage() {
       o.user_id.toLowerCase().includes(term)
     )
   })
+
+  // When narrowed to connected overlays, surface the longest-open first so the
+  // likely "dead but open" overlays rise to the top.
+  const orderedOverlays = showConnectedOnly
+    ? [...filteredOverlays].sort((a, b) => connectedStartMs(a.id) - connectedStartMs(b.id))
+    : filteredOverlays
+
+  // Connection status for the detail panel of the selected overlay.
+  const selectedConnected = selectedOverlay ? activeOverlayIds.has(selectedOverlay.id) : false
+  const selectedSince = selectedOverlay ? connectedSince.get(selectedOverlay.id) : undefined
+  const selectedConnectedFor = formatConnectedFor(selectedSince)
+  const selectedLongOpen =
+    selectedConnected && !!selectedSince && Date.now() - Date.parse(selectedSince) >= LONG_OPEN_MS
 
   if (error) {
     return (
@@ -230,7 +271,13 @@ export default function OverlaysPage() {
                 </div>
               </div>
               <ul className="max-h-[70vh] divide-y divide-border overflow-y-auto">
-                {filteredOverlays.map((overlay) => (
+                {orderedOverlays.map((overlay) => {
+                  const isConnected = activeOverlayIds.has(overlay.id)
+                  const since = connectedSince.get(overlay.id)
+                  const connectedFor = formatConnectedFor(since)
+                  const isLongOpen =
+                    isConnected && !!since && Date.now() - Date.parse(since) >= LONG_OPEN_MS
+                  return (
                   <li
                     key={overlay.id}
                     className={clsx(
@@ -242,8 +289,18 @@ export default function OverlaysPage() {
                     <div className="flex items-center justify-between">
                       <div className="flex-1">
                         <div className="flex items-center">
-                          {activeOverlayIds.has(overlay.id) && (
-                            <span className="mr-1.5 inline-block h-2 w-2 shrink-0 rounded-full bg-kick" title="Connected" />
+                          {isConnected && (
+                            <span
+                              className={clsx(
+                                'mr-1.5 inline-block h-2 w-2 shrink-0 rounded-full',
+                                isLongOpen ? 'bg-amber-400' : 'bg-kick'
+                              )}
+                              title={
+                                since
+                                  ? `Connected since ${new Date(since).toLocaleString()}`
+                                  : 'Connected'
+                              }
+                            />
                           )}
                           <p className="text-sm font-medium text-text">{overlay.name}</p>
                           <span className="ml-2 inline-flex items-center rounded bg-badge-bg px-2 py-0.5 text-xs font-medium text-text-sub">
@@ -253,6 +310,19 @@ export default function OverlaysPage() {
                         <p className="mt-1 font-mono text-xs text-text-sub">ID: {overlay.id}</p>
                         <p className="mt-1 text-xs text-text-dim">
                           Created {new Date(overlay.created_at).toLocaleDateString()}
+                          {isConnected && (
+                            <>
+                              {' · '}
+                              <span
+                                className={clsx(
+                                  'font-medium',
+                                  isLongOpen ? 'text-amber-400' : 'text-kick'
+                                )}
+                              >
+                                {connectedFor ? `Connected ${connectedFor}` : 'Connected'}
+                              </span>
+                            </>
+                          )}
                         </p>
                       </div>
                       <div className="flex items-center space-x-2">
@@ -292,7 +362,8 @@ export default function OverlaysPage() {
                       </div>
                     </div>
                   </li>
-                ))}
+                  )
+                })}
               </ul>
             </Card>
           )}
@@ -324,6 +395,38 @@ export default function OverlaysPage() {
                       <dd className="mt-1 font-mono text-xs break-all text-text">
                         {selectedOverlay.user_id}
                       </dd>
+                    </div>
+                    <div>
+                      <dt className="text-sm font-medium text-text-sub">Connection</dt>
+                      <dd className="mt-1 text-sm">
+                        {selectedConnected ? (
+                          <span className="inline-flex items-center gap-1.5">
+                            <span
+                              className={clsx(
+                                'inline-block h-2 w-2 shrink-0 rounded-full',
+                                selectedLongOpen ? 'bg-amber-400' : 'bg-kick'
+                              )}
+                            />
+                            <span
+                              className={clsx(
+                                'font-medium',
+                                selectedLongOpen ? 'text-amber-400' : 'text-kick'
+                              )}
+                            >
+                              {selectedConnectedFor
+                                ? `Connected ${selectedConnectedFor}`
+                                : 'Connected'}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-text-dim">Not connected</span>
+                        )}
+                      </dd>
+                      {selectedConnected && selectedSince && (
+                        <dd className="mt-1 text-xs text-text-dim">
+                          Since {new Date(selectedSince).toLocaleString()}
+                        </dd>
+                      )}
                     </div>
                   </dl>
                 </div>

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { formatCompactDuration, formatConnectedFor } from '@/lib/utils'
+
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+
+describe('formatCompactDuration', () => {
+  it('renders sub-minute durations as "just now"', () => {
+    expect(formatCompactDuration(0)).toBe('just now')
+    expect(formatCompactDuration(59_000)).toBe('just now')
+  })
+
+  it('renders minute-only durations', () => {
+    expect(formatCompactDuration(MIN)).toBe('1m')
+    expect(formatCompactDuration(8 * MIN)).toBe('8m')
+    expect(formatCompactDuration(59 * MIN)).toBe('59m')
+  })
+
+  it('renders hours with minutes, dropping zero minutes', () => {
+    expect(formatCompactDuration(HOUR)).toBe('1h')
+    expect(formatCompactDuration(5 * HOUR + 12 * MIN)).toBe('5h 12m')
+    expect(formatCompactDuration(3 * HOUR)).toBe('3h')
+  })
+
+  it('renders days with hours, dropping zero hours', () => {
+    expect(formatCompactDuration(DAY)).toBe('1d')
+    expect(formatCompactDuration(3 * DAY + 4 * HOUR)).toBe('3d 4h')
+    expect(formatCompactDuration(2 * DAY + 30 * MIN)).toBe('2d') // minutes hidden at day scale
+  })
+
+  it('treats negative and non-finite input as zero', () => {
+    expect(formatCompactDuration(-5000)).toBe('just now')
+    expect(formatCompactDuration(Number.NaN)).toBe('just now')
+    expect(formatCompactDuration(Number.POSITIVE_INFINITY)).toBe('just now')
+  })
+})
+
+describe('formatConnectedFor', () => {
+  const now = Date.parse('2026-07-13T12:00:00Z')
+
+  it('returns null for missing input', () => {
+    expect(formatConnectedFor(null, now)).toBeNull()
+    expect(formatConnectedFor(undefined, now)).toBeNull()
+    expect(formatConnectedFor('', now)).toBeNull()
+  })
+
+  it('returns null for unparseable timestamps', () => {
+    expect(formatConnectedFor('not-a-date', now)).toBeNull()
+  })
+
+  it('formats a valid RFC3339 start relative to now', () => {
+    expect(formatConnectedFor('2026-07-13T08:48:00Z', now)).toBe('3h 12m')
+    expect(formatConnectedFor('2026-07-10T12:00:00Z', now)).toBe('3d')
+  })
+
+  it('clamps a future start to "just now"', () => {
+    expect(formatConnectedFor('2026-07-13T12:05:00Z', now)).toBe('just now')
+  })
+})

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -22,3 +22,37 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Formats an elapsed duration (in milliseconds) as a compact "how long"
+ * string suitable for dense admin tables: "3d 4h", "5h 12m", "8m", "just now".
+ * Shows the two most significant non-zero units and never renders seconds
+ * beyond the sub-minute "just now" case. Negative inputs are treated as zero.
+ */
+export function formatCompactDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 60_000) return 'just now'
+
+  const totalMinutes = Math.floor(ms / 60_000)
+  const days = Math.floor(totalMinutes / 1440)
+  const hours = Math.floor((totalMinutes % 1440) / 60)
+  const minutes = totalMinutes % 60
+
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+  return `${minutes}m`
+}
+
+/**
+ * Formats "connected for X" from an ISO/RFC3339 start timestamp relative to
+ * `now` (defaults to Date.now()). Returns null for missing or unparseable
+ * input so callers can omit the label entirely.
+ */
+export function formatConnectedFor(
+  startedAt: string | null | undefined,
+  now: number = Date.now()
+): string | null {
+  if (!startedAt) return null
+  const started = Date.parse(startedAt)
+  if (Number.isNaN(started)) return null
+  return formatCompactDuration(now - started)
+}

--- a/services/api-gateway/handlers/stats.go
+++ b/services/api-gateway/handlers/stats.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/caesar/all-chat/services/api-gateway/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 )
@@ -63,12 +64,28 @@ func (h *StatsHandler) GetPlatformStats(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-// GetActiveOverlays returns the IDs of overlays with active WebSocket connections.
+// ActiveOverlay describes an overlay with a live WebSocket connection.
+type ActiveOverlay struct {
+	OverlayID string `json:"overlay_id"`
+	// ConnectedSince is when the current connection session began (RFC3339),
+	// used to show admins how long an overlay has been open. Nil when no session
+	// timestamp is available (e.g. the connection is in its post-disconnect
+	// linger window and the session has already ended).
+	ConnectedSince *time.Time `json:"connected_since,omitempty"`
+}
+
+// GetActiveOverlays returns the overlays with active WebSocket connections,
+// each annotated with when its connection began so admins can spot overlays
+// that are open but whose streamer is no longer live ("dead but open").
 // GET /api/v1/admin/overlays/active — requires admin auth.
 func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 	ctx := c.Request.Context()
 
+	// SCAN guarantees full coverage but not uniqueness (a key can repeat across
+	// batches during rehashing), so de-duplicate to avoid duplicate rows and
+	// redundant lookups.
 	var activeIDs []string
+	seen := make(map[string]struct{})
 	var cursor uint64
 	for {
 		keys, next, err := h.redis.Scan(ctx, cursor, "overlay:connected:*", 100).Result()
@@ -79,9 +96,14 @@ func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 		for _, key := range keys {
 			// key format: "overlay:connected:{id}"
 			id := key[len("overlay:connected:"):]
-			if id != "" {
-				activeIDs = append(activeIDs, id)
+			if id == "" {
+				continue
 			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			activeIDs = append(activeIDs, id)
 		}
 		cursor = next
 		if cursor == 0 {
@@ -89,8 +111,37 @@ func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 		}
 	}
 
-	if activeIDs == nil {
-		activeIDs = []string{}
+	overlays := make([]ActiveOverlay, 0, len(activeIDs))
+	if len(activeIDs) == 0 {
+		c.JSON(http.StatusOK, overlays)
+		return
 	}
-	c.JSON(http.StatusOK, activeIDs)
+
+	// Fetch each overlay's session start time in one round trip. started_at
+	// lives in the session:active:{id} hash written on connect (kept alive by
+	// the connection heartbeat), so no DB access is needed here.
+	pipe := h.redis.Pipeline()
+	startedCmds := make([]*redis.StringCmd, len(activeIDs))
+	for i, id := range activeIDs {
+		startedCmds[i] = pipe.HGet(ctx, sessions.SessionKeyPrefix+id, "started_at")
+	}
+	// Exec reports redis.Nil when a session hash is simply missing (an expected
+	// state, handled per-command below); any other error is a real Redis failure
+	// and should surface as 500 rather than silently dropping every timestamp.
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load overlay sessions"})
+		return
+	}
+
+	for i, id := range activeIDs {
+		overlay := ActiveOverlay{OverlayID: id}
+		if startedStr, err := startedCmds[i].Result(); err == nil && startedStr != "" {
+			if started, perr := time.Parse(time.RFC3339, startedStr); perr == nil {
+				overlay.ConnectedSince = &started
+			}
+		}
+		overlays = append(overlays, overlay)
+	}
+
+	c.JSON(http.StatusOK, overlays)
 }

--- a/services/api-gateway/handlers/stats_test.go
+++ b/services/api-gateway/handlers/stats_test.go
@@ -50,9 +50,11 @@ func TestGetActiveOverlays_Empty(t *testing.T) {
 	handler.GetActiveOverlays(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var ids []string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ids))
-	assert.Empty(t, ids)
+	// Explicitly a JSON array, never null, so the frontend can iterate safely.
+	assert.Equal(t, "[]", w.Body.String())
+	var overlays []ActiveOverlay
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &overlays))
+	assert.Empty(t, overlays)
 }
 
 func TestGetActiveOverlays_ReturnsConnectedIDs(t *testing.T) {
@@ -73,8 +75,59 @@ func TestGetActiveOverlays_ReturnsConnectedIDs(t *testing.T) {
 	handler.GetActiveOverlays(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var ids []string
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ids))
-	assert.Len(t, ids, 2)
+	var overlays []ActiveOverlay
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &overlays))
+	assert.Len(t, overlays, 2)
+
+	ids := make([]string, len(overlays))
+	for i, o := range overlays {
+		ids[i] = o.OverlayID
+	}
 	assert.ElementsMatch(t, []string{"abc-123", "def-456"}, ids)
+
+	// No session hashes exist, so connected_since is omitted for every overlay.
+	for _, o := range overlays {
+		assert.Nil(t, o.ConnectedSince, "overlay %s should have no connected_since without a session", o.OverlayID)
+	}
+}
+
+func TestGetActiveOverlays_IncludesConnectedSince(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client, mr := setupStatsTestRedis(t)
+	handler := NewStatsHandler(client)
+
+	// Overlay with a session hash carrying a start time.
+	startedAt := time.Now().UTC().Add(-90 * time.Minute).Truncate(time.Second)
+	mr.Set("overlay:connected:with-session", "1")
+	mr.SetTTL("overlay:connected:with-session", 10*time.Minute)
+	mr.HSet("session:active:with-session", "started_at", startedAt.Format(time.RFC3339))
+
+	// Overlay connected but without a session (e.g. post-disconnect linger).
+	mr.Set("overlay:connected:no-session", "1")
+	mr.SetTTL("overlay:connected:no-session", 5*time.Minute)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/admin/overlays/active", nil)
+
+	handler.GetActiveOverlays(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var overlays []ActiveOverlay
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &overlays))
+	require.Len(t, overlays, 2)
+
+	byID := make(map[string]ActiveOverlay, len(overlays))
+	for _, o := range overlays {
+		byID[o.OverlayID] = o
+	}
+
+	withSession, ok := byID["with-session"]
+	require.True(t, ok)
+	require.NotNil(t, withSession.ConnectedSince)
+	assert.WithinDuration(t, startedAt, withSession.ConnectedSince.UTC(), time.Second)
+
+	noSession, ok := byID["no-session"]
+	require.True(t, ok)
+	assert.Nil(t, noSession.ConnectedSince)
 }

--- a/services/api-gateway/sessions/manager.go
+++ b/services/api-gateway/sessions/manager.go
@@ -226,6 +226,29 @@ func (sm *SessionManager) CancelGracePeriod(ctx context.Context, overlayID strin
 	return nil
 }
 
+// RefreshTTLs extends the active session Redis TTL for a batch of still-connected
+// overlays in a single round trip. The session hash is otherwise only given a TTL
+// on create and on grace-period transitions, so a continuously-connected overlay
+// (e.g. a 24/7 OBS tab) would lose its hash after SessionTTL even while still
+// connected — taking started_at (the "connected since" signal) with it. Called
+// from the connection heartbeat. A no-op for keys that do not exist (Expire
+// returns false without error).
+func (sm *SessionManager) RefreshTTLs(ctx context.Context, overlayIDs []string) {
+	if len(overlayIDs) == 0 {
+		return
+	}
+	pipe := sm.redis.Pipeline()
+	for _, overlayID := range overlayIDs {
+		pipe.Expire(ctx, SessionKeyPrefix+overlayID, SessionTTL)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		sm.logger.Warn("Failed to refresh session TTLs",
+			zap.Int("count", len(overlayIDs)),
+			zap.Error(err),
+		)
+	}
+}
+
 // EndSession transitions to COMPLETED and archives to database
 func (sm *SessionManager) EndSession(ctx context.Context, overlayID string) error {
 	key := SessionKeyPrefix + overlayID

--- a/services/api-gateway/sessions/manager_test.go
+++ b/services/api-gateway/sessions/manager_test.go
@@ -17,8 +17,13 @@
 package sessions
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
 )
 
 func TestParseSessionTime(t *testing.T) {
@@ -127,4 +132,29 @@ func TestValidateStartedAt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRefreshTTLs(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	sm := NewSessionManager(client, nil, zap.NewNop(), time.Minute)
+	ctx := context.Background()
+
+	// An existing session with a short TTL should be extended to SessionTTL.
+	mr.HSet(SessionKeyPrefix+"live", "started_at", time.Now().UTC().Format(time.RFC3339))
+	mr.SetTTL(SessionKeyPrefix+"live", time.Minute)
+
+	// A missing overlay must be a safe no-op (EXPIRE on a missing key returns
+	// false without error and must not create the key).
+	sm.RefreshTTLs(ctx, []string{"live", "missing"})
+
+	if ttl := mr.TTL(SessionKeyPrefix + "live"); ttl != SessionTTL {
+		t.Fatalf("expected TTL %v after refresh, got %v", SessionTTL, ttl)
+	}
+	if mr.Exists(SessionKeyPrefix + "missing") {
+		t.Fatalf("missing overlay key should not have been created")
+	}
+
+	// Empty input is a no-op and must not panic or error.
+	sm.RefreshTTLs(ctx, nil)
 }

--- a/services/api-gateway/websocket/manager.go
+++ b/services/api-gateway/websocket/manager.go
@@ -602,6 +602,12 @@ func (m *Manager) refreshConnectionTTLs() {
 		return
 	}
 
+	// Keep each connected overlay's stream session hash alive so its started_at
+	// (surfaced to admins as "connected since") survives a long-lived connection
+	// instead of expiring after SessionTTL. Batched into a single round trip
+	// rather than one EXPIRE per overlay alongside the SetEx below.
+	m.sessionManager.RefreshTTLs(ctx, overlayIDs)
+
 	// Refresh TTL for each connected overlay
 	refreshed := 0
 	for _, overlayID := range overlayIDs {


### PR DESCRIPTION
## Why

We shipped the passive overlay param today, and right now ~9 people have a connected overlay while a good number aren't live. Admins had no way to tell a freshly-connected overlay from a forgotten-open one. This surfaces **how long each overlay has been connected** so we can spot "dead but open" overlays (an OBS/browser tab left open after the streamer went offline).

## What

On **/admin/overlays**, each connected overlay now shows a **"Connected for X"** duration (inline in the list and in the detail panel):
- Connections open **≥ 12h** render in **amber** (dot + label) as an eyeball cue.
- The **"Connected (N)"** filter now sorts **longest-open first**, floating likely-dead tabs to the top.

## How

Reuses the existing `session:active:{id}.started_at` timestamp, so **no migration and no new tracking**.

- **api-gateway** (`handlers/stats.go`): `GET /api/v1/admin/overlays/active` now returns `[{overlay_id, connected_since}]` instead of a bare ID array. `connected_since` is read from the session hash in one pipelined round trip. SCAN results are de-duplicated, and a real Redis failure surfaces as 500 (consistent with the SCAN path) rather than a silent 200 with blank durations.
- **sessions** (`sessions/manager.go`): new `RefreshTTLs` refreshes the session-hash TTL on the connection heartbeat, so a long-lived connection keeps its `started_at` instead of losing it at the 24h TTL (the exact long-open case this feature is for).
- **frontend** (`admin/overlays/page.tsx`, `lib/utils.ts`): render + highlight + sort, with compact duration formatting (`3d 4h` / `5h 12m` / `just now`).

## Notes / limitations

- The duration is **connection age, not liveness** — the amber "≥12h" cue correlates with dead-but-open but also with a legit multi-day continuous stream. The label itself is neutral.
- **Passive overlays (`?passive=true`) are intentionally invisible here** — they assert no demand, so they never enter the `overlay:connected:*` set. A follow-up could add a `session:active:*` scan to surface demand-free connections labeled "passive".

## Testing

- api-gateway Go suite green (`go vet` clean); new tests cover the enriched endpoint (`connected_since` present/absent), SCAN dedupe, and the TTL refresh.
- Frontend formatter unit tests green (9/9); `tsc --noEmit` clean for changed files.
- Ran an adversarial multi-agent review; 7 findings, all verified low/nit — the 3 touching this code (discarded pipeline error, doubled heartbeat round trips, non-unique SCAN) are fixed.