### PR TITLE
feat(admin): show active-user counts (24h/7d/30d) on dashboard

### DIFF
--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -21,7 +21,7 @@
 
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { Users, LayoutGrid, Radio, Eye, Ban } from 'lucide-react'
+import { Users, LayoutGrid, Radio, Eye, Ban, Activity } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -31,6 +31,11 @@ interface AdminStats {
   banned_users: number
   active_overlays: number
   total_sources: { [platform: string]: number }
+  // Active users = distinct non-banned users with an overlay connected within
+  // the window (overlays.last_connected_at). DAU / WAU / MAU.
+  active_users_24h: number
+  active_users_7d: number
+  active_users_30d: number
 }
 
 function StatCard({
@@ -111,6 +116,32 @@ export default function AdminDashboard() {
           icon={LayoutGrid}
         />
         <StatCard label="Total Sources" value={loading ? undefined : totalSources} icon={Radio} />
+      </div>
+
+      {/* Active users */}
+      <div className="mb-2 flex items-center gap-2">
+        <Activity className="size-5 text-text-sub" aria-hidden="true" />
+        <h2 className="text-lg font-semibold text-text">Active users</h2>
+      </div>
+      <p className="mb-4 text-sm text-text-sub">
+        Distinct users with at least one overlay connected in the window (excludes banned users).
+      </p>
+      <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Last 24 hours"
+          value={loading ? undefined : stats?.active_users_24h}
+          icon={Activity}
+        />
+        <StatCard
+          label="Last 7 days"
+          value={loading ? undefined : stats?.active_users_7d}
+          icon={Activity}
+        />
+        <StatCard
+          label="Last 30 days"
+          value={loading ? undefined : stats?.active_users_30d}
+          icon={Activity}
+        />
       </div>
 
       {/* Navigation cards */}

--- a/services/api-gateway/websocket/manager_source_heartbeat_test.go
+++ b/services/api-gateway/websocket/manager_source_heartbeat_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/api-gateway/sessions"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -119,6 +120,11 @@ func TestRefreshConnectionTTLs_HeartbeatsConnectedOverlaySources(t *testing.T) {
 		pools:            map[string]*Pool{"o1": NewPool("o1", zap.NewNop()), "o2": NewPool("o2", zap.NewNop())},
 		noDemandOverlays: map[string]bool{},
 		connectionTTL:    10 * time.Minute,
+		// refreshConnectionTTLs calls sessionManager.RefreshTTLs; wire a real one
+		// (backed by the test miniredis) so the heartbeat exercises the actual
+		// session-TTL refresh instead of dereferencing a nil manager. RefreshTTLs
+		// only touches redis, so a nil DB pool is fine here.
+		sessionManager: sessions.NewSessionManager(client, nil, zap.NewNop(), 0),
 	}
 
 	m.refreshConnectionTTLs()
@@ -149,6 +155,7 @@ func TestRefreshConnectionTTLs_SkipsDemandFreeOverlays(t *testing.T) {
 		pools:            map[string]*Pool{"live": NewPool("live", zap.NewNop()), "participant": NewPool("participant", zap.NewNop())},
 		noDemandOverlays: map[string]bool{"participant": true},
 		connectionTTL:    10 * time.Minute,
+		sessionManager:   sessions.NewSessionManager(client, nil, zap.NewNop(), 0),
 	}
 
 	m.refreshConnectionTTLs()

--- a/services/auth-service/handlers/admin.go
+++ b/services/auth-service/handlers/admin.go
@@ -425,6 +425,15 @@ func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
 		BannedUsers    int            `json:"banned_users"`
 		ActiveOverlays int            `json:"active_overlays"`
 		TotalSources   map[string]int `json:"total_sources"`
+		// Active users: distinct non-banned owners of an overlay whose WebSocket
+		// connection was seen within the window. overlays.last_connected_at is
+		// heartbeat-refreshed (~2min) while an overlay is live, so it is the
+		// truest signal of real product usage. Logins are not separately tracked
+		// (users.updated_at is polluted by the daily automated token refresh),
+		// which is why overlay connections define activity here.
+		ActiveUsers24h int `json:"active_users_24h"`
+		ActiveUsers7d  int `json:"active_users_7d"`
+		ActiveUsers30d int `json:"active_users_30d"`
 	}
 
 	var stats AdminStats
@@ -463,6 +472,23 @@ func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
 				stats.TotalSources[platform] = count
 			}
 		}
+	}
+
+	// Active users (rolling windows): distinct owners of a recently-connected
+	// overlay, excluding banned users. Computed in one round trip via FILTER;
+	// the outer 30d bound keeps the scan to the window that feeds every bucket.
+	err = h.db.QueryRow(c.Request.Context(), `
+		SELECT
+			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '24 hours'),
+			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '7 days'),
+			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '30 days')
+		FROM overlays o
+		JOIN users u ON u.id = o.user_id
+		WHERE u.is_banned = false
+		  AND o.last_connected_at >= NOW() - INTERVAL '30 days'
+	`).Scan(&stats.ActiveUsers24h, &stats.ActiveUsers7d, &stats.ActiveUsers30d)
+	if err != nil {
+		h.logger.Error("Failed to count active users", zap.Error(err))
 	}
 
 	c.JSON(http.StatusOK, stats)

--- a/services/auth-service/handlers/admin_stats_test.go
+++ b/services/auth-service/handlers/admin_stats_test.go
@@ -1,0 +1,198 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.uber.org/zap"
+)
+
+// setupStatsTestDB starts a PostgreSQL container with the minimal schema that
+// GetDashboardStats reads: users (for totals + is_banned), overlays (for
+// active-overlay and active-user counts) and overlay_chat_sources (for the
+// per-platform breakdown).
+func setupStatsTestDB(t *testing.T) (*pgxpool.Pool, func()) {
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:16-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "testuser",
+			"POSTGRES_PASSWORD": "testpass",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to start container: %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		t.Fatalf("Failed to get container port: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, "postgres://testuser:testpass@"+host+":"+port.Port()+"/testdb?sslmode=disable")
+	if err != nil {
+		t.Fatalf("Failed to create connection pool: %v", err)
+	}
+
+	schema := `
+		CREATE TABLE IF NOT EXISTS users (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			is_banned BOOLEAN NOT NULL DEFAULT FALSE
+		);
+		CREATE TABLE IF NOT EXISTS overlays (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			is_active BOOLEAN NOT NULL DEFAULT TRUE,
+			last_connected_at TIMESTAMP NOT NULL DEFAULT NOW()
+		);
+		CREATE TABLE IF NOT EXISTS overlay_chat_sources (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			overlay_id UUID NOT NULL REFERENCES overlays(id) ON DELETE CASCADE,
+			platform VARCHAR(50) NOT NULL
+		);
+	`
+	if _, err := pool.Exec(ctx, schema); err != nil {
+		t.Fatalf("Failed to create schema: %v", err)
+	}
+
+	return pool, func() {
+		pool.Close()
+		container.Terminate(ctx)
+	}
+}
+
+// insertUser creates a user and returns its id.
+func insertUser(t *testing.T, pool *pgxpool.Pool, banned bool) string {
+	t.Helper()
+	var id string
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (is_banned) VALUES ($1) RETURNING id`, banned).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+// insertOverlay creates an overlay for userID whose last_connected_at is `ago`
+// before now.
+func insertOverlay(t *testing.T, pool *pgxpool.Pool, userID string, ago time.Duration) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO overlays (user_id, last_connected_at) VALUES ($1, NOW() - $2::interval)`,
+		userID, ago.String())
+	if err != nil {
+		t.Fatalf("insert overlay: %v", err)
+	}
+}
+
+// TestGetDashboardStats_ActiveUsers verifies the rolling-window active-user
+// counts: an active user is a distinct non-banned owner of an overlay whose
+// last_connected_at falls inside the 24h / 7d / 30d window.
+func TestGetDashboardStats_ActiveUsers(t *testing.T) {
+	pool, cleanup := setupStatsTestDB(t)
+	defer cleanup()
+
+	// u1: connected 1h ago         -> 24h, 7d, 30d
+	u1 := insertUser(t, pool, false)
+	insertOverlay(t, pool, u1, time.Hour)
+
+	// u2: connected 3 days ago     -> 7d, 30d
+	u2 := insertUser(t, pool, false)
+	insertOverlay(t, pool, u2, 3*24*time.Hour)
+
+	// u3: connected 20 days ago    -> 30d only
+	u3 := insertUser(t, pool, false)
+	insertOverlay(t, pool, u3, 20*24*time.Hour)
+
+	// u4: connected 60 days ago    -> none
+	u4 := insertUser(t, pool, false)
+	insertOverlay(t, pool, u4, 60*24*time.Hour)
+
+	// u5: banned, connected 1h ago -> excluded from every window
+	u5 := insertUser(t, pool, true)
+	insertOverlay(t, pool, u5, time.Hour)
+
+	// u6: two overlays both recent -> counted once (DISTINCT user)
+	u6 := insertUser(t, pool, false)
+	insertOverlay(t, pool, u6, 2*time.Hour)
+	insertOverlay(t, pool, u6, 5*time.Hour)
+
+	handler := &AdminHandler{db: pool, logger: zap.NewNop()}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/stats", nil)
+
+	handler.GetDashboardStats(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var stats struct {
+		TotalUsers     int `json:"total_users"`
+		BannedUsers    int `json:"banned_users"`
+		ActiveUsers24h int `json:"active_users_24h"`
+		ActiveUsers7d  int `json:"active_users_7d"`
+		ActiveUsers30d int `json:"active_users_30d"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
+	}
+
+	if stats.TotalUsers != 6 {
+		t.Errorf("total_users = %d, want 6", stats.TotalUsers)
+	}
+	if stats.BannedUsers != 1 {
+		t.Errorf("banned_users = %d, want 1", stats.BannedUsers)
+	}
+	if stats.ActiveUsers24h != 2 { // u1, u6
+		t.Errorf("active_users_24h = %d, want 2", stats.ActiveUsers24h)
+	}
+	if stats.ActiveUsers7d != 3 { // u1, u2, u6
+		t.Errorf("active_users_7d = %d, want 3", stats.ActiveUsers7d)
+	}
+	if stats.ActiveUsers30d != 4 { // u1, u2, u3, u6
+		t.Errorf("active_users_30d = %d, want 4", stats.ActiveUsers30d)
+	}
+}


### PR DESCRIPTION
## What

Adds **active-user counts** to the admin dashboard so we can see how many users are actually using the platform, as rolling windows: **DAU (24h) / WAU (7d) / MAU (30d)**.

## Metric definition

An **active user** = a distinct, non-banned user who owns at least one overlay that connected within the window.

- Signal: `overlays.last_connected_at` (migration 052), heartbeat-refreshed (~2 min) while an overlay holds a live WebSocket — the truest signal of real product usage (the streamer's overlay is actually running).
- **Logins were rejected as a signal:** the `users` table has no login timestamp, and `updated_at` is bumped by the daily automated token refresh, so it can't distinguish a real login from a background refresh.
- Banned users are excluded (a ban deactivates overlays but does not reset `last_connected_at`).

## Changes

- **auth-service** `GetDashboardStats` (`/api/v1/admin/stats`): adds `active_users_24h/7d/30d`, computed in one round trip via `COUNT(DISTINCT user_id) FILTER (...)` joined to `users` (`is_banned = false`), scan bounded to 30d. No new endpoint, no cross-service Redis coupling.
- **frontend** admin dashboard: new "Active users" section with three stat cards + a one-line explanation.
- **test:** testcontainer-backed coverage for window boundaries, banned-user exclusion, and DISTINCT-user dedup.

## Deploy

Merging rebuilds `allchat-auth-service:main` + `allchat-frontend:main`; Keel (`policy: force`) auto-rolls out both.

## Note

`last_connected_at` defaults to `NOW()` on overlay creation, so a just-created overlay counts as active for up to 24h even if never opened in OBS (arguably still "active in the product"). Strict "actually connected" semantics would need a nullable-default migration.