### PR TITLE
feat(auth): first-run onboarding state (users.onboarding_completed_at)

### DIFF
--- a/migrations/077_user_onboarding.sql
+++ b/migrations/077_user_onboarding.sql
@@ -1,0 +1,33 @@
+-- Migration: 077_user_onboarding
+-- Description: Add users.onboarding_completed_at for the first-run setup guide.
+--
+-- NULL means the user has not finished (or dismissed) the first-run onboarding
+-- and the frontend shows the setup guide; a timestamp means finished/dismissed.
+-- Restarting onboarding from Settings sets the column back to NULL.
+--
+-- The migration runner (scripts/run-migrations.sh) re-runs EVERY migration on
+-- every pod start, so the one-time backfill is guarded by the column-existence
+-- check: it only runs in the same transaction that first adds the column.
+-- Re-runs are a complete no-op and never touch user state (see
+-- services/auth-service/repository/migrations_rerun_test.go).
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'users' AND column_name = 'onboarding_completed_at'
+    ) THEN
+        ALTER TABLE users ADD COLUMN onboarding_completed_at TIMESTAMP NULL;
+
+        -- Backfill: users who already own an overlay have de-facto onboarded.
+        -- Existing zero-overlay users (the signed-up-then-dropped-out cohort
+        -- this feature targets) keep NULL and get the setup guide on their
+        -- next visit.
+        UPDATE users u
+        SET onboarding_completed_at = NOW()
+        WHERE EXISTS (SELECT 1 FROM overlays o WHERE o.user_id = u.id);
+    END IF;
+END $$;
+
+COMMENT ON COLUMN users.onboarding_completed_at IS
+    'When the user finished or dismissed the first-run setup guide; NULL = guide is shown';

--- a/migrations/077_user_onboarding_down.sql
+++ b/migrations/077_user_onboarding_down.sql
@@ -1,0 +1,3 @@
+-- Rollback: 077_user_onboarding
+
+ALTER TABLE users DROP COLUMN IF EXISTS onboarding_completed_at;

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -628,7 +628,8 @@ func main() {
 	{
 		// Auth service - protected routes
 		protectedAPI.GET("/auth/me", proxyHandler.ForwardRequest)
-		protectedAPI.GET("/auth/me/data-export", proxyHandler.ForwardRequest) // DSGVO Art. 20 data portability
+		protectedAPI.GET("/auth/me/data-export", proxyHandler.ForwardRequest)  // DSGVO Art. 20 data portability
+		protectedAPI.PATCH("/auth/me/onboarding", proxyHandler.ForwardRequest) // first-run setup guide state
 		protectedAPI.POST("/auth/logout", localmiddleware.AuthCookieForward(), proxyHandler.ForwardRequest)
 		protectedAPI.POST("/auth/stop-impersonation", localmiddleware.AuthCookieForward(), proxyHandler.ForwardRequest)
 		protectedAPI.DELETE("/auth/me", localmiddleware.AuthCookieForward(), proxyHandler.ForwardRequest)

--- a/services/auth-service/README.md
+++ b/services/auth-service/README.md
@@ -217,6 +217,21 @@ Authorization: Bearer <jwt-token>
 → Returns: { "success": true }
 ```
 
+### User Profile
+
+```bash
+# Current user (includes onboarding_completed_at; null = first-run setup guide is shown)
+GET /api/v1/auth/me
+Authorization: Bearer <jwt-token>
+
+# Finish/dismiss the first-run setup guide (true) or re-arm it from Settings (false).
+# Rejected with 403 during admin impersonation.
+PATCH /api/v1/auth/me/onboarding
+Authorization: Bearer <jwt-token>
+Body: { "completed": true }
+→ Returns: { "onboarding_completed_at": "2026-07-17T12:00:00Z" }
+```
+
 ### Health Checks
 
 ```bash

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -380,6 +380,7 @@ func main() {
 	{
 		protected.GET("/me", legacyAuthHandler.HandleGetMe)
 		protected.GET("/me/data-export", legacyAuthHandler.HandleDataExport)
+		protected.PATCH("/me/onboarding", legacyAuthHandler.HandleUpdateOnboarding)
 		protected.POST("/logout", legacyAuthHandler.HandleLogout)
 		protected.POST("/stop-impersonation", legacyAuthHandler.HandleStopImpersonation)
 		protected.DELETE("/me", legacyAuthHandler.HandleDeleteAccount)

--- a/services/auth-service/handlers/onboarding.go
+++ b/services/auth-service/handlers/onboarding.go
@@ -1,0 +1,74 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// updateOnboardingRequest is the PATCH /me/onboarding body. Completed is a
+// pointer so a missing field is rejected instead of defaulting to false
+// (which would silently re-arm the setup guide).
+type updateOnboardingRequest struct {
+	Completed *bool `json:"completed" binding:"required"`
+}
+
+// HandleUpdateOnboarding sets or clears users.onboarding_completed_at for the
+// authenticated user. completed=true is sent when the user finishes or
+// dismisses the first-run setup guide; completed=false re-arms it (the
+// "restart onboarding" action in Settings).
+//
+// Impersonation sessions are rejected: an admin browsing as a user must not
+// silently mutate that user's onboarding state.
+func (h *AuthHandler) HandleUpdateOnboarding(c *gin.Context) {
+	userID, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	if ib, ok := c.Get("impersonated_by"); ok {
+		if ibStr, ok := ib.(string); ok && ibStr != "" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Onboarding state cannot be changed while impersonating"})
+			return
+		}
+	}
+
+	var req updateOnboardingRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Body must be {\"completed\": true|false}"})
+		return
+	}
+
+	completedAt, err := h.userRepo.SetOnboardingCompleted(c.Request.Context(), userID.(string), *req.Completed)
+	if err != nil {
+		if errors.Is(err, repository.ErrUserNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
+			return
+		}
+		h.logger.Error("Failed to update onboarding state", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update onboarding state"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"onboarding_completed_at": completedAt})
+}

--- a/services/auth-service/handlers/onboarding_test.go
+++ b/services/auth-service/handlers/onboarding_test.go
@@ -1,0 +1,101 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// onboardingTestRouter wires HandleUpdateOnboarding behind a stub middleware
+// that injects the given context values (standing in for JWTAuthWithRevocation).
+// The guard paths under test (401/403/400) never reach the repository, so a
+// zero repo is fine; the success path is covered by
+// repository.TestUserRepository_SetOnboardingCompleted.
+func onboardingTestRouter(ctxValues map[string]string) *gin.Engine {
+	router := setupTestRouter()
+	h := &AuthHandler{logger: zap.NewNop()}
+	router.PATCH("/me/onboarding", func(c *gin.Context) {
+		for k, v := range ctxValues {
+			c.Set(k, v)
+		}
+		h.HandleUpdateOnboarding(c)
+	})
+	return router
+}
+
+func TestHandleUpdateOnboarding_Unauthenticated(t *testing.T) {
+	router := onboardingTestRouter(nil) // no user_id in context
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/me/onboarding", strings.NewReader(`{"completed":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestHandleUpdateOnboarding_ImpersonationForbidden(t *testing.T) {
+	router := onboardingTestRouter(map[string]string{
+		"user_id":         "11111111-1111-1111-1111-111111111111",
+		"impersonated_by": "22222222-2222-2222-2222-222222222222",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/me/onboarding", strings.NewReader(`{"completed":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestHandleUpdateOnboarding_InvalidBody(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty body", ``},
+		{"missing completed", `{}`},
+		{"wrong type", `{"completed":"yes"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := onboardingTestRouter(map[string]string{
+				"user_id": "11111111-1111-1111-1111-111111111111",
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPatch, "/me/onboarding", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}

--- a/services/auth-service/handlers/platform_auth_v2_link_test.go
+++ b/services/auth-service/handlers/platform_auth_v2_link_test.go
@@ -200,7 +200,8 @@ func setupLinkTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 			token_expires_at TIMESTAMP NOT NULL,
 			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
 			created_at TIMESTAMP DEFAULT NOW(),
-			updated_at TIMESTAMP DEFAULT NOW()
+			updated_at TIMESTAMP DEFAULT NOW(),
+			onboarding_completed_at TIMESTAMP NULL
 		);
 		CREATE TABLE IF NOT EXISTS kick_oauth_tokens (
 			id SERIAL PRIMARY KEY,

--- a/services/auth-service/models/user.go
+++ b/services/auth-service/models/user.go
@@ -42,6 +42,9 @@ type User struct {
 	GrantedScopes    []string   `json:"-"` // OAuth scopes granted at consent (TEXT[] in DB); gates EventSub chat reading
 	CreatedAt        time.Time  `json:"created_at"`
 	UpdatedAt        time.Time  `json:"updated_at"`
+	// NULL = first-run setup guide is shown; deliberately no omitempty so the
+	// frontend receives an explicit null for users who have not onboarded.
+	OnboardingCompletedAt *time.Time `json:"onboarding_completed_at"`
 }
 
 // TwitchUserInfo represents Twitch user data from OAuth

--- a/services/auth-service/repository/migrations_rerun_test.go
+++ b/services/auth-service/repository/migrations_rerun_test.go
@@ -64,6 +64,18 @@ func TestMigrationsSurviveRerun(t *testing.T) {
 		t.Fatalf("failed to insert canary user: %v", err)
 	}
 
+	// Give the canary an overlay. The 077 onboarding backfill marks
+	// overlay-owning users as onboarded, but ONLY in the run that first adds
+	// the column — a re-run (= every pod restart) must not re-fire it and
+	// silently "complete" onboarding for users who restarted it from Settings.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO overlays (user_id, name)
+		SELECT id, 'canary overlay' FROM users WHERE username = 'rerun_canary'
+	`)
+	if err != nil {
+		t.Fatalf("failed to insert canary overlay: %v", err)
+	}
+
 	// Second pass = pod restart.
 	runMigrations(t, pool, migrations)
 
@@ -88,6 +100,20 @@ func TestMigrationsSurviveRerun(t *testing.T) {
 	}
 	if !hasChat {
 		t.Errorf("re-running migrations destroyed granted_scopes: %v", scopes)
+	}
+
+	// 077 backfill must not re-fire: the canary owns an overlay but was
+	// created AFTER the column-add run, so its onboarding state must still be
+	// NULL after the re-run.
+	var onboardingCompleted *time.Time
+	err = pool.QueryRow(ctx, `
+		SELECT onboarding_completed_at FROM users WHERE username = 'rerun_canary'
+	`).Scan(&onboardingCompleted)
+	if err != nil {
+		t.Fatalf("failed to read canary onboarding state: %v", err)
+	}
+	if onboardingCompleted != nil {
+		t.Errorf("re-running migrations re-fired the 077 onboarding backfill (onboarding_completed_at = %v); a deploy would silently complete onboarding for users who restarted it", onboardingCompleted)
 	}
 }
 

--- a/services/auth-service/repository/user_repo_test.go
+++ b/services/auth-service/repository/user_repo_test.go
@@ -101,6 +101,7 @@ func setupTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
 			created_at TIMESTAMP DEFAULT NOW(),
 			updated_at TIMESTAMP DEFAULT NOW(),
+			onboarding_completed_at TIMESTAMP NULL,
 			CONSTRAINT check_auth_ids CHECK (
 				(auth_provider = 'twitch' AND twitch_id IS NOT NULL) OR
 				(auth_provider = 'youtube' AND google_id IS NOT NULL) OR
@@ -670,5 +671,76 @@ func TestUserRepository_UpdateTokens(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestUserRepository_SetOnboardingCompleted covers the full lifecycle of
+// users.onboarding_completed_at: fresh users read NULL through scanUser,
+// completing sets a timestamp, restarting (Settings) clears it back to NULL.
+func TestUserRepository_SetOnboardingCompleted(t *testing.T) {
+	pool, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := newTestUserRepository(t, pool)
+	ctx := context.Background()
+
+	twitchID := "555000111"
+	testUser := &models.User{
+		TwitchID:       &twitchID,
+		AuthProvider:   "twitch",
+		Username:       "onboarding_user",
+		DisplayName:    "Onboarding User",
+		AccessToken:    "access",
+		RefreshToken:   "refresh",
+		TokenExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	if err := repo.Create(ctx, testUser); err != nil {
+		t.Fatalf("Failed to create test user: %v", err)
+	}
+
+	// Fresh user: scanUser must surface an explicit NULL.
+	got, err := repo.GetByID(ctx, testUser.ID)
+	if err != nil {
+		t.Fatalf("GetByID() failed: %v", err)
+	}
+	if got.OnboardingCompletedAt != nil {
+		t.Errorf("fresh user OnboardingCompletedAt = %v, want nil", got.OnboardingCompletedAt)
+	}
+
+	// Complete onboarding.
+	completedAt, err := repo.SetOnboardingCompleted(ctx, testUser.ID, true)
+	if err != nil {
+		t.Fatalf("SetOnboardingCompleted(true) failed: %v", err)
+	}
+	if completedAt == nil {
+		t.Fatal("SetOnboardingCompleted(true) returned nil timestamp")
+	}
+	got, err = repo.GetByID(ctx, testUser.ID)
+	if err != nil {
+		t.Fatalf("GetByID() after complete failed: %v", err)
+	}
+	if got.OnboardingCompletedAt == nil {
+		t.Error("OnboardingCompletedAt still nil after completing")
+	}
+
+	// Restart from Settings: clears back to NULL.
+	completedAt, err = repo.SetOnboardingCompleted(ctx, testUser.ID, false)
+	if err != nil {
+		t.Fatalf("SetOnboardingCompleted(false) failed: %v", err)
+	}
+	if completedAt != nil {
+		t.Errorf("SetOnboardingCompleted(false) returned %v, want nil", completedAt)
+	}
+	got, err = repo.GetByID(ctx, testUser.ID)
+	if err != nil {
+		t.Fatalf("GetByID() after restart failed: %v", err)
+	}
+	if got.OnboardingCompletedAt != nil {
+		t.Errorf("OnboardingCompletedAt = %v after restart, want nil", got.OnboardingCompletedAt)
+	}
+
+	// Unknown user surfaces ErrUserNotFound.
+	if _, err := repo.SetOnboardingCompleted(ctx, "550e8400-e29b-41d4-a716-446655440000", true); err != ErrUserNotFound {
+		t.Errorf("SetOnboardingCompleted(unknown) error = %v, want ErrUserNotFound", err)
 	}
 }

--- a/services/auth-service/repository/user_repository.go
+++ b/services/auth-service/repository/user_repository.go
@@ -100,7 +100,7 @@ func (r *UserRepository) GetByTwitchID(ctx context.Context, twitchID string) (*m
 	query := `
 SELECT id, twitch_id, google_id, kick_id, auth_provider, username, display_name, profile_image_url,
            is_admin, is_premium, is_beta_tester, is_banned, banned_at, banned_reason, banned_by,
-           access_token, refresh_token, token_expires_at, created_at, updated_at
+           access_token, refresh_token, token_expires_at, created_at, updated_at, onboarding_completed_at
 FROM users
 WHERE twitch_id = $1
 `
@@ -121,7 +121,7 @@ func (r *UserRepository) GetByGoogleID(ctx context.Context, googleID string) (*m
 	query := `
 SELECT id, twitch_id, google_id, kick_id, auth_provider, username, display_name, profile_image_url,
            is_admin, is_premium, is_beta_tester, is_banned, banned_at, banned_reason, banned_by,
-           access_token, refresh_token, token_expires_at, created_at, updated_at
+           access_token, refresh_token, token_expires_at, created_at, updated_at, onboarding_completed_at
 FROM users
 WHERE google_id = $1
 `
@@ -149,7 +149,7 @@ func (r *UserRepository) GetByID(ctx context.Context, id string) (*models.User, 
 	query := `
 SELECT id, twitch_id, google_id, kick_id, auth_provider, username, display_name, profile_image_url,
            is_admin, is_premium, is_beta_tester, is_banned, banned_at, banned_reason, banned_by,
-           access_token, refresh_token, token_expires_at, created_at, updated_at
+           access_token, refresh_token, token_expires_at, created_at, updated_at, onboarding_completed_at
 FROM users
 WHERE id = $1
 `
@@ -170,7 +170,7 @@ func (r *UserRepository) GetByUsername(ctx context.Context, username string) (*m
 	query := `
 SELECT id, twitch_id, google_id, kick_id, auth_provider, username, display_name, profile_image_url,
            is_admin, is_premium, is_beta_tester, is_banned, banned_at, banned_reason, banned_by,
-           access_token, refresh_token, token_expires_at, created_at, updated_at
+           access_token, refresh_token, token_expires_at, created_at, updated_at, onboarding_completed_at
 FROM users
 WHERE LOWER(username) = LOWER($1)
 `
@@ -310,7 +310,7 @@ func (r *UserRepository) GetByKickID(ctx context.Context, kickID string) (*model
 	query := `
 SELECT id, twitch_id, google_id, kick_id, auth_provider, username, display_name, profile_image_url,
            is_admin, is_premium, is_beta_tester, is_banned, banned_at, banned_reason, banned_by,
-           access_token, refresh_token, token_expires_at, created_at, updated_at
+           access_token, refresh_token, token_expires_at, created_at, updated_at, onboarding_completed_at
 FROM users
 WHERE kick_id = $1
 `
@@ -559,6 +559,27 @@ func (r *UserRepository) GetPlatformGrantedScopes(ctx context.Context, userID, p
 	return out, nil
 }
 
+// SetOnboardingCompleted marks the first-run setup guide as finished/dismissed
+// (completed=true → NOW()) or re-arms it (completed=false → NULL, used by the
+// "restart onboarding" action in Settings). Returns the new column value.
+func (r *UserRepository) SetOnboardingCompleted(ctx context.Context, userID string, completed bool) (*time.Time, error) {
+	var completedAt *time.Time
+	err := r.db.QueryRow(ctx, `
+		UPDATE users
+		SET onboarding_completed_at = CASE WHEN $2 THEN NOW() ELSE NULL END,
+		    updated_at = NOW()
+		WHERE id = $1
+		RETURNING onboarding_completed_at
+	`, userID, completed).Scan(&completedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("failed to set onboarding completion: %w", err)
+	}
+	return completedAt, nil
+}
+
 func (r *UserRepository) scanUser(row pgx.Row) (*models.User, error) {
 	user := &models.User{}
 	var encryptedAccessToken, encryptedRefreshToken string
@@ -570,7 +591,7 @@ func (r *UserRepository) scanUser(row pgx.Row) (*models.User, error) {
 		&user.ID, &user.TwitchID, &user.GoogleID, &user.KickID, &user.AuthProvider, &user.Username, &user.DisplayName,
 		&profileImageURL, &user.IsAdmin, &user.IsPremium, &user.IsBetaTester, &user.IsBanned, &user.BannedAt, &user.BannedReason, &user.BannedBy,
 		&encryptedAccessToken, &encryptedRefreshToken,
-		&user.TokenExpiresAt, &user.CreatedAt, &user.UpdatedAt,
+		&user.TokenExpiresAt, &user.CreatedAt, &user.UpdatedAt, &user.OnboardingCompletedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -680,7 +701,7 @@ SELECT u.id, u.twitch_id, u.google_id, u.kick_id, u.auth_provider, u.username, u
        COALESCE(u.banned_at, bpi.banned_at) AS banned_at,
        COALESCE(u.banned_reason, bpi.reason) AS banned_reason,
        COALESCE(u.banned_by, bpi.banned_by) AS banned_by,
-       u.access_token, u.refresh_token, u.token_expires_at, u.created_at, u.updated_at
+       u.access_token, u.refresh_token, u.token_expires_at, u.created_at, u.updated_at, u.onboarding_completed_at
 FROM users u
 LEFT JOIN LATERAL (
   SELECT bpi.platform_id, bpi.banned_at, bpi.reason, bpi.banned_by


### PR DESCRIPTION
## What

Backend half of the first-run **setup guide** (retention initiative: too many users sign up and drop out before getting chat into OBS). This PR is deliberately invisible to users and independently revertable; the frontend checklist lands separately.

- **Migration 077**: `users.onboarding_completed_at TIMESTAMP NULL` + one-time backfill marking overlay-owning users as onboarded. Existing **zero-overlay** users keep NULL and will see the setup guide on their next visit — intentional re-engagement of the drop-out cohort. The backfill sits inside a column-existence `DO` block so the re-run-all migration runner never re-fires it; `TestMigrationsSurviveRerun` now asserts exactly that.
- **auth-service**: `OnboardingCompletedAt` on `models.User` (explicit `null` in `/auth/me`, no omitempty); column appended to **all six** scanUser-fed SELECTs + `scanUser` atomically; new `SetOnboardingCompleted` repo method; new `PATCH /me/onboarding` handler — `{"completed": true}` finishes/dismisses, `{"completed": false}` re-arms (Settings restart), `*bool` binding rejects a missing field, **403 during admin impersonation**.
- **api-gateway**: `PATCH /api/v1/auth/me/onboarding` proxied inside the existing `protectedAPI` group (CookieToBearer/JWT/OriginCheck inherited group-wide).
- README: documented the new endpoint.

## Testing

- `TestUserRepository_SetOnboardingCompleted` (testcontainers): NULL for fresh users through scanUser, set → timestamp, clear → NULL, unknown user → ErrUserNotFound.
- `TestMigrationsSurviveRerun` extended: canary user gains an overlay between runs; re-run must NOT re-fire the backfill.
- `TestHandleUpdateOnboarding_*`: 401 / 403 (impersonation) / 400 (missing field, wrong type).
- Full `go test ./...` green in auth-service and api-gateway (with local Redis + Docker for the container-backed suites).

## Notes for review

- **Backfill semantics decision**: existing zero-overlay users get re-onboarded on purpose. To exempt them instead, drop the `WHERE EXISTS` clause to backfill everyone.
- `migrations/init/` intentionally untouched (stale, unused by the prod runner).