### PR TITLE
feat(frontend): onboarding plumbing (user field, API client, analytics, Discord constant)

### DIFF
--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -46,6 +46,7 @@ import { PlatformBadge } from '@/components/ui/badge'
 import { SpotlightCard } from '@/components/SpotlightCard'
 import { PLATFORM_COLORS } from '@/lib/platform-colors'
 import { toastManager } from '@/lib/toast'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 import { LayoutGrid, Zap, Palette, Puzzle, Code2, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { trackEvent } from '@/lib/analytics'
@@ -565,7 +566,7 @@ export default function HomeClient() {
           </a>
           <span aria-hidden="true">&bull;</span>
           <a
-            href="https://discord.gg/xCGBSuz39P"
+            href={DISCORD_INVITE_URL}
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => trackEvent('outbound_click', { dest: 'discord' })}

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { AppNav } from '@/components/AppNav'
 import { Code, Pre } from '@/components/docs/prose'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 
 export const metadata = {
   title: 'Documentation',
@@ -463,7 +464,7 @@ export default function DocsPage() {
                 </a>
                 . Already have a theme from another tool, or want help writing one? Ask in our{' '}
                 <a
-                  href="https://discord.gg/xCGBSuz39P"
+                  href={DISCORD_INVITE_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-twitch hover:underline"

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -39,6 +39,7 @@ import ImpersonationBanner from '@/components/ImpersonationBanner'
 import { ToastProvider } from '@/components/ui/toast'
 import { Toaster as HotToaster } from 'react-hot-toast'
 import { cn } from '@/lib/utils'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 
 const barlow = Barlow({
   subsets: ['latin'],
@@ -113,7 +114,7 @@ const organizationLd = {
   name: 'All-Chat',
   url: 'https://allch.at',
   logo: 'https://allch.at/icon.svg',
-  sameAs: ['https://github.com/caesarakalaeii/all-chat', 'https://discord.gg/xCGBSuz39P'],
+  sameAs: ['https://github.com/caesarakalaeii/all-chat', DISCORD_INVITE_URL],
 }
 
 const webSiteLd = {

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -51,6 +51,7 @@ import { sharesApi } from '@/lib/api/shares'
 import { getGuilds, getGuildChannels, updateSourceConfig } from '@/lib/api/discord'
 import type { DiscordGuild, ChannelCategory } from '@/lib/api/discord'
 import { ApiError } from '@/lib/api/client'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 import { engagementApi } from '@/lib/api/engagement'
 import type { EarnConfig } from '@/lib/types/engagement'
 import type { Overlay, ChatSource, DiscordSourceConfig, FilterSettings, DisplaySettings } from '@/lib/types/overlay'
@@ -2588,7 +2589,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                 <p className="mb-5 text-sm text-text-sub">
                   Questions? Join our{' '}
                   <a
-                    href="https://discord.gg/xCGBSuz39P"
+                    href={DISCORD_INVITE_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="font-medium text-twitch hover:underline"

--- a/frontend/src/components/BetaWarning.tsx
+++ b/frontend/src/components/BetaWarning.tsx
@@ -28,6 +28,7 @@
 'use client'
 
 import { Dialog } from '@/components/ui/dialog'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 
 interface BetaWarningProps {
   platform: 'youtube' | 'tiktok'
@@ -88,7 +89,7 @@ export function BetaWarning({ platform, onCancel, onContinue }: BetaWarningProps
         </p>
 
         <a
-          href="https://discord.gg/xCGBSuz39P"
+          href={DISCORD_INVITE_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="mt-2 inline-flex items-center gap-2 text-sm text-blue-400 underline underline-offset-4 hover:text-blue-300"

--- a/frontend/src/components/ThemeSwitcher.tsx
+++ b/frontend/src/components/ThemeSwitcher.tsx
@@ -42,6 +42,7 @@ import { SAMPLE_PREVIEW_MESSAGES } from '@/lib/theme-marketplace/constants'
 import type { Theme } from '@/lib/theme-marketplace/types'
 import { Palette } from 'lucide-react'
 import { trackEvent } from '@/lib/analytics'
+import { DISCORD_INVITE_URL } from '@/lib/constants'
 
 /**
  * The curated showcase — four visually distinct looks that read well at a glance:
@@ -218,7 +219,7 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
       <p className="mt-1.5 text-center text-sm text-text-sub">
         Coming from another tool?{' '}
         <a
-          href="https://discord.gg/xCGBSuz39P"
+          href={DISCORD_INVITE_URL}
           target="_blank"
           rel="noopener noreferrer"
           onClick={() => trackEvent('outbound_click', { dest: 'discord_theme_help' })}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -41,6 +41,15 @@ export type AnalyticsEvent =
   | 'source_add_failed'
   | 'moderation_enabled'
   | 'obs_url_copied'
+  // First-run setup guide (onboarding) funnel. `step` payloads use the
+  // OnboardingStepId enum values, never IDs or user data.
+  | 'onboarding_started'
+  | 'onboarding_step_viewed'
+  | 'onboarding_step_completed'
+  | 'onboarding_step_skipped'
+  | 'onboarding_dismissed'
+  | 'onboarding_finished'
+  | 'onboarding_discord_clicked'
   // Feature adoption
   | 'theme_previewed'
   | 'theme_applied'

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -78,4 +78,12 @@ export const authApi = {
   async deleteAccount(): Promise<void> {
     await apiClient.delete('/api/v1/auth/me')
   },
+
+  /**
+   * Set (true = finished/dismissed) or clear (false = restart from Settings)
+   * the first-run setup guide state. Rejected with 403 while impersonating.
+   */
+  async updateOnboarding(completed: boolean): Promise<{ onboarding_completed_at: string | null }> {
+    return apiClient.patch('/api/v1/auth/me/onboarding', { completed })
+  },
 }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -24,3 +24,11 @@
  * of truth for every "Subscribe on Patreon" link in the app.
  */
 export const PATREON_JOIN_URL = 'https://www.patreon.com/16269405/join'
+
+/**
+ * Canonical Discord community invite.
+ *
+ * Single source of truth for every "Join our Discord" link (landing footer,
+ * docs, upsell modals, onboarding setup guide, JSON-LD sameAs).
+ */
+export const DISCORD_INVITE_URL = 'https://discord.gg/xCGBSuz39P'

--- a/frontend/src/lib/types/auth.ts
+++ b/frontend/src/lib/types/auth.ts
@@ -41,6 +41,8 @@ export interface User {
   impersonated_by?: string
   created_at: string
   updated_at: string
+  // null = user has not finished/dismissed the first-run setup guide.
+  onboarding_completed_at?: string | null
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## What

Frontend groundwork for the first-run **setup guide** (retention initiative). No user-visible behavior change; the checklist UI lands in a follow-up PR.

- `User.onboarding_completed_at?: string | null` — matches the new `/auth/me` field from #560 (null = setup guide is shown).
- `authApi.updateOnboarding(completed)` → `PATCH /api/v1/auth/me/onboarding` via the existing `apiClient.patch`.
- `AnalyticsEvent` union extended with the onboarding funnel: `onboarding_started`, `onboarding_step_viewed`, `onboarding_step_completed`, `onboarding_step_skipped`, `onboarding_dismissed`, `onboarding_finished`, `onboarding_discord_clicked` (payloads stay enum/bool per the file's no-PII contract).
- `DISCORD_INVITE_URL` promoted to `@/lib/constants` (next to `PATREON_JOIN_URL`) and all six hardcoded `discord.gg/xCGBSuz39P` literals replaced (layout JSON-LD sameAs, landing footer, docs page, editor premium modal, BetaWarning, ThemeSwitcher).

## Testing

- `npm run type-check` clean (after clearing a stale `.next` cache whose generated route types were already broken on main).
- `npm test --project unit`: 57 files, 553 passed.
- Prettier warnings on 3 touched files are pre-existing on main (whole-file); not reformatting them here.

Pairs with #560 (backend). Either PR is safe to merge first — the frontend field is optional and the endpoint is unused until the setup-guide PR.