### PR TITLE
feat(a11y): CI accessibility gate — axe smoke, jsx-a11y ratchet, token contrast lock

### DIFF
--- a/.github/workflows/frontend-a11y.yml
+++ b/.github/workflows/frontend-a11y.yml
@@ -1,0 +1,100 @@
+name: Frontend A11y Gate
+
+# The accessibility gate for the WCAG 2.2 AA initiative. Deliberately SEPARATE
+# from frontend-quality.yml (dispatch-only/dead because of pre-existing lint
+# debt): this workflow contains ONLY a11y checks so it stays green
+# independently of that debt and can gate PRs immediately.
+#
+# Ratchets (may only shrink, never grow):
+#   - frontend/eslint.a11y.suppressions.json  (jsx-a11y strict baseline)
+#   - frontend/tests/e2e/a11y-baseline.json   (axe smoke baseline)
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-a11y.yml'
+
+jobs:
+  a11y-static:
+    name: A11y lint + token contrast
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: A11y ESLint (jsx-a11y strict, suppression-ratcheted)
+        run: >
+          npx eslint -c eslint.a11y.config.mjs
+          --suppressions-location eslint.a11y.suppressions.json
+          'src/**/*.tsx'
+
+      - name: Design-token contrast lock
+        run: npx vitest --project unit --run src/app/__tests__/token-contrast.test.ts
+
+  a11y-storybook:
+    name: Storybook axe (components + pages)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium (vitest browser provider)
+        run: npx playwright install --with-deps chromium
+
+      - name: Storybook a11y tests (axe violations = error)
+        run: npx vitest --project storybook --run
+
+  a11y-smoke:
+    name: Axe page smoke (Playwright)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Axe smoke over app pages
+        run: npx playwright test a11y --project=chromium
+
+      - name: Upload axe reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: axe-reports
+          path: frontend/playwright-report/
+          retention-days: 14

--- a/frontend/eslint.a11y.config.mjs
+++ b/frontend/eslint.a11y.config.mjs
@@ -1,0 +1,103 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Accessibility-only ESLint config — the a11y CI gate (WCAG 2.2 AA initiative).
+ *
+ * Deliberately standalone and MINIMAL: jsx-a11y strict + the design system's
+ * focus-visible rule, nothing else. It must stay green independently of the
+ * main lint debt (react-hooks errors, plugin/ESLint-version breakage in
+ * eslint.config.mjs), so never add non-a11y plugins here.
+ *
+ * Run (glob = all .tsx under src, as in .github/workflows/frontend-a11y.yml):
+ *   npx eslint -c eslint.a11y.config.mjs --suppressions-location eslint.a11y.suppressions.json src
+ * Ratchet:  pre-existing violations live in eslint.a11y.suppressions.json
+ *           (ESLint bulk suppressions). New violations FAIL immediately.
+ *           Fixing violations leaves stale suppressions — prune them by
+ *           adding --prune-suppressions to the command above.
+ *           The suppressions file must only ever shrink.
+ */
+
+import { defineConfig, globalIgnores } from 'eslint/config'
+import tsParser from '@typescript-eslint/parser'
+import { createRequire } from 'node:module'
+import { dirname } from 'node:path'
+
+// eslint-plugin-jsx-a11y has no ESLint-10-compatible release yet (peers stop
+// at ^9), so it cannot be a direct devDependency while the repo is on ESLint
+// 10. eslint-config-next (core-web-vitals) bundles it by design — resolve
+// that copy. TODO: switch to a direct devDependency import once upstream
+// publishes ESLint 10 peers (https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
+const require = createRequire(import.meta.url)
+const jsxA11y = require(
+  require.resolve('eslint-plugin-jsx-a11y', {
+    // Start resolution from inside eslint-config-next so its nested copy is
+    // found (its package.json subpath is not exported, so resolve the main
+    // entry and walk from there).
+    paths: [dirname(require.resolve('eslint-config-next'))],
+  })
+)
+
+export default defineConfig([
+  {
+    files: ['src/**/*.{jsx,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    linterOptions: {
+      // Ignore ALL inline eslint comments: (a) disable-comments for rules this
+      // minimal config doesn't load would error as unknown rules, and (b) the
+      // a11y gate must not be silenceable inline — the suppressions file is
+      // the only (shrink-only) escape hatch.
+      noInlineConfig: true,
+      reportUnusedDisableDirectives: 'off',
+    },
+    plugins: {
+      'jsx-a11y': jsxA11y,
+    },
+    rules: {
+      ...jsxA11y.flatConfigs.strict.rules,
+      // Design-system rule (mirrors eslint.config.mjs Rule 3): bare focus:
+      // suppresses keyboard focus indication — always use focus-visible:.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXAttribute[name.name="className"] Literal[value=/(?<![\\w-])focus:/]',
+          message:
+            'Use focus-visible: instead of focus: for keyboard navigation accessibility. See DESIGN_SYSTEM.md.',
+        },
+      ],
+    },
+  },
+
+  globalIgnores([
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+    'node_modules/**',
+    'storybook-static/**',
+    // Storybook stories are exercised by the Storybook axe gate instead.
+    'src/stories/**',
+  ]),
+])

--- a/frontend/eslint.a11y.suppressions.json
+++ b/frontend/eslint.a11y.suppressions.json
@@ -1,0 +1,120 @@
+{
+  "src/app/admin/overlays/page.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1
+    },
+    "jsx-a11y/no-noninteractive-element-interactions": {
+      "count": 1
+    }
+  },
+  "src/app/admin/sources/page.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 3
+    }
+  },
+  "src/app/admin/users/page.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1
+    },
+    "jsx-a11y/label-has-associated-control": {
+      "count": 1
+    },
+    "jsx-a11y/no-noninteractive-element-interactions": {
+      "count": 1
+    }
+  },
+  "src/app/admin/viewers/page.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 1
+    }
+  },
+  "src/app/dashboard/shares/components/AcceptModal.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 3
+    }
+  },
+  "src/app/overlays/[id]/credits/page.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 9
+    }
+  },
+  "src/app/overlays/[id]/events/page.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 1
+    }
+  },
+  "src/app/overlays/[id]/page.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 4
+    },
+    "jsx-a11y/label-has-associated-control": {
+      "count": 11
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 4
+    }
+  },
+  "src/app/settings/viewer/page.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 1
+    }
+  },
+  "src/app/upgrade/page.tsx": {
+    "jsx-a11y/anchor-has-content": {
+      "count": 1
+    }
+  },
+  "src/components/ResizableSplit.tsx": {
+    "jsx-a11y/no-noninteractive-element-interactions": {
+      "count": 1
+    },
+    "jsx-a11y/no-noninteractive-tabindex": {
+      "count": 1
+    }
+  },
+  "src/components/SplitView.tsx": {
+    "jsx-a11y/no-noninteractive-element-interactions": {
+      "count": 1
+    },
+    "jsx-a11y/no-noninteractive-tabindex": {
+      "count": 1
+    }
+  },
+  "src/components/ThemeSwitcher.tsx": {
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    }
+  },
+  "src/components/admin/BanModal.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 2
+    },
+    "jsx-a11y/label-has-associated-control": {
+      "count": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 2
+    }
+  },
+  "src/components/appearance/FontFamilyCombobox.tsx": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
+  "src/components/appearance/TypographyGroup.tsx": {
+    "jsx-a11y/label-has-associated-control": {
+      "count": 7
+    },
+    "no-restricted-syntax": {
+      "count": 4
+    }
+  },
+  "src/components/theme-marketplace/ThemeMarketplaceModal.tsx": {
+    "jsx-a11y/click-events-have-key-events": {
+      "count": 1
+    },
+    "jsx-a11y/no-static-element-interactions": {
+      "count": 1
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "zustand": "^5.0.14"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@chromatic-com/storybook": "^5.2.1",
         "@next/bundle-analyzer": "^16.2.10",
         "@playwright/test": "^1.61.1",
@@ -133,6 +134,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -6126,9 +6140,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2513,9 +2513,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2531,9 +2528,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2551,9 +2545,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2569,9 +2560,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3479,9 +3467,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3499,9 +3484,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3519,9 +3501,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3539,9 +3518,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3559,9 +3535,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3579,9 +3552,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4204,9 +4174,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4224,9 +4191,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4244,9 +4208,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4264,9 +4225,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8477,6 +8435,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14171,6 +14130,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "showDetails": true
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@chromatic-com/storybook": "^5.2.1",
     "@next/bundle-analyzer": "^16.2.10",
     "@playwright/test": "^1.61.1",

--- a/frontend/src/app/__tests__/token-contrast.test.ts
+++ b/frontend/src/app/__tests__/token-contrast.test.ts
@@ -1,0 +1,217 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Design-token contrast lock (WCAG 2.2 AA initiative, a11y CI gate).
+ *
+ * Parses the `@theme` block in globals.css and asserts the contrast pairs the
+ * design system promises, so a token tweak can never silently ship an
+ * inaccessible text color. This locks TOKEN-level guarantees; in-situ
+ * page-level contrast (arbitrary utility combinations, alpha overlays) is
+ * covered by the axe checks in the Storybook a11y project and
+ * tests/e2e/a11y.spec.ts.
+ *
+ * Scope note: overlay chat THEMES (broadcast art rendered in OBS) are a
+ * product surface with a deliberate lower floor — see
+ * tests/e2e/theme-contrast.spec.ts. They are NOT covered here.
+ *
+ * oklch → sRGB uses the OKLab reference math (Björn Ottosson), the same
+ * conversion browsers implement. Sanity-locked below against #020204, the
+ * rendered bg the design-system comments base their AA claims on.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// --- minimal color math (no deps) -------------------------------------------
+
+type LinearRGB = [number, number, number]
+
+function oklchToLinearSrgb(L: number, C: number, Hdeg: number): LinearRGB {
+  const h = (Hdeg * Math.PI) / 180
+  const a = C * Math.cos(h)
+  const b = C * Math.sin(h)
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b
+  const l = l_ ** 3
+  const m = m_ ** 3
+  const s = s_ ** 3
+  const rgb: LinearRGB = [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ]
+  return rgb.map((c) => Math.min(1, Math.max(0, c))) as LinearRGB
+}
+
+function hexToLinearSrgb(hex: string): LinearRGB {
+  const v = hex.replace('#', '')
+  const chan = (i: number) => parseInt(v.slice(i, i + 2), 16) / 255
+  const linearize = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4)
+  return [linearize(chan(0)), linearize(chan(2)), linearize(chan(4))]
+}
+
+function toHex(rgb: LinearRGB): string {
+  const encode = (c: number) => (c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055)
+  return (
+    '#' +
+    rgb
+      .map((c) =>
+        Math.round(encode(c) * 255)
+          .toString(16)
+          .padStart(2, '0')
+      )
+      .join('')
+  )
+}
+
+function luminance([r, g, b]: LinearRGB): number {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+function contrast(a: LinearRGB, b: LinearRGB): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+// --- @theme token parser ------------------------------------------------------
+
+/**
+ * Resolves `--color-*` tokens from the @theme block. Handles the forms the
+ * token system actually uses: hex, absolute oklch(L C H), and var() aliases.
+ * Alpha/relative forms (border, badge-bg, nav-bg) are intentionally skipped:
+ * they are decorative-by-design and meaningless without a composite backdrop.
+ */
+function parseThemeTokens(css: string): Map<string, LinearRGB> {
+  const themeStart = css.indexOf('@theme {')
+  if (themeStart === -1) throw new Error('globals.css: @theme block not found')
+  let depth = 0
+  let end = themeStart
+  for (let i = css.indexOf('{', themeStart); i < css.length; i++) {
+    if (css[i] === '{') depth++
+    if (css[i] === '}') depth--
+    if (depth === 0) {
+      end = i
+      break
+    }
+  }
+  const block = css.slice(themeStart, end)
+
+  const raw = new Map<string, string>()
+  for (const m of block.matchAll(/(--color-[\w-]+)\s*:\s*([^;]+);/g)) {
+    raw.set(m[1], m[2].trim())
+  }
+
+  const resolved = new Map<string, LinearRGB>()
+  const resolve = (name: string, seen: Set<string> = new Set()): LinearRGB | null => {
+    if (resolved.has(name)) return resolved.get(name) ?? null
+    if (seen.has(name)) throw new Error(`circular var() reference at ${name}`)
+    seen.add(name)
+    const value = raw.get(name)
+    if (!value) return null
+
+    const varRef = value.match(/^var\((--color-[\w-]+)\)$/)
+    if (varRef) {
+      const target = resolve(varRef[1], seen)
+      if (target) resolved.set(name, target)
+      return target
+    }
+    const hex = value.match(/^#([0-9a-fA-F]{6})$/)
+    if (hex) {
+      const rgb = hexToLinearSrgb(value)
+      resolved.set(name, rgb)
+      return rgb
+    }
+    const oklch = value.match(/^oklch\(([\d.]+)\s+([\d.]+)\s+([\d.]+)\)$/)
+    if (oklch) {
+      const rgb = oklchToLinearSrgb(Number(oklch[1]), Number(oklch[2]), Number(oklch[3]))
+      resolved.set(name, rgb)
+      return rgb
+    }
+    // Alpha/relative/color-mix forms: skipped by design (see docblock).
+    return null
+  }
+  for (const name of raw.keys()) resolve(name)
+  return resolved
+}
+
+const css = readFileSync(join(__dirname, '..', 'globals.css'), 'utf-8')
+const tokens = parseThemeTokens(css)
+
+function token(name: string): LinearRGB {
+  const rgb = tokens.get(name)
+  if (!rgb) throw new Error(`token ${name} missing or unresolvable — did the @theme block change?`)
+  return rgb
+}
+
+// --- assertions ---------------------------------------------------------------
+
+const AA_TEXT = 4.5
+const AA_UI = 3.0
+
+const BACKDROPS = ['--color-bg', '--color-surface', '--color-surface-2'] as const
+const TEXT_TOKENS = ['--color-text', '--color-text-sub', '--color-text-dim'] as const
+const PLATFORMS = [
+  '--color-twitch',
+  '--color-youtube',
+  '--color-kick',
+  '--color-tiktok',
+  '--color-discord',
+] as const
+
+describe('design token contrast (WCAG 2.2 AA)', () => {
+  it('oklch conversion matches the rendered bg the design system documents', () => {
+    // The platform-color comment claims AA "on dark backgrounds (#020204)" —
+    // the browser-rendered value of --color-bg. If this fails, the conversion
+    // math drifted and every other assertion here is meaningless.
+    expect(toHex(token('--color-bg'))).toBe('#020204')
+  })
+
+  for (const text of TEXT_TOKENS) {
+    for (const backdrop of BACKDROPS) {
+      it(`${text} on ${backdrop} ≥ ${AA_TEXT}:1`, () => {
+        expect(contrast(token(text), token(backdrop))).toBeGreaterThanOrEqual(AA_TEXT)
+      })
+    }
+  }
+
+  it('--color-text-dim stays a tier below --color-text-sub', () => {
+    // Visual hierarchy contract from the token comments: dim < sub < text.
+    const bg = token('--color-bg')
+    expect(contrast(token('--color-text-dim'), bg)).toBeLessThan(
+      contrast(token('--color-text-sub'), bg)
+    )
+  })
+
+  for (const platform of PLATFORMS) {
+    it(`${platform} as UI component color on --color-bg ≥ ${AA_UI}:1`, () => {
+      expect(contrast(token(platform), token('--color-bg'))).toBeGreaterThanOrEqual(AA_UI)
+    })
+  }
+
+  // The token block claims text-level AA for these four ("Twitch: lightened
+  // ... for 4.5:1", "Others already pass"). Discord is deliberately absent:
+  // it sits at ~4.5:1 exactly and is only used as a badge/brand color.
+  for (const platform of PLATFORMS.filter((p) => p !== '--color-discord')) {
+    it(`${platform} as text on --color-bg ≥ ${AA_TEXT}:1`, () => {
+      expect(contrast(token(platform), token('--color-bg'))).toBeGreaterThanOrEqual(AA_TEXT)
+    })
+  }
+})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -29,12 +29,15 @@
   --color-discord: #5865f2;
 
   /* Neutral scale — oklch with constant chroma ~0.007, hue 270 */
-  --color-neutral-950: oklch(0.09 0.007 270); /* #07070a — bg */
-  --color-neutral-900: oklch(0.11 0.009 270); /* #0d0d12 — surface */
+  --color-neutral-950: oklch(0.09 0.007 270); /* #020204 — bg */
+  --color-neutral-900: oklch(0.11 0.009 270); /* #040407 — surface */
   --color-neutral-800: oklch(0.14 0.008 270); /* surface-2 */
   --color-neutral-700: oklch(0.22 0.007 270); /* elevated border */
   --color-neutral-600: oklch(0.35 0.007 270); /* muted text */
-  --color-neutral-400: oklch(0.58 0.007 270); /* secondary text */
+  /* Raised 0.58 → 0.60 (WCAG initiative): secondary text now ≥5.0:1 on every
+     surface tier, keeping a visible tier above --color-text-dim (~4.7:1).
+     Locked by src/app/__tests__/token-contrast.test.ts. */
+  --color-neutral-400: oklch(0.6 0.007 270); /* secondary text */
   --color-neutral-200: oklch(0.78 0.005 270); /* tertiary text */
   --color-neutral-100: oklch(0.91 0.003 270); /* primary text */
 
@@ -49,9 +52,11 @@
   --color-text: var(--color-neutral-100);
   --color-text-sub: var(--color-neutral-400);
   /* Tertiary text. Decoupled from neutral-600 (oklch 0.35 ≈ 1.8:1 on bg — failed
-     WCAG) and raised to ~4.4:1 so footnotes/captions/timestamps stay legible while
-     remaining a tier below --color-text-sub (~4.8:1). */
-  --color-text-dim: oklch(0.56 0.008 270);
+     WCAG) and raised 0.56 → 0.575 (WCAG initiative) so footnotes/captions/
+     timestamps clear 4.5:1 on bg, surface, AND surface-2 (it is used as small
+     text and placeholders on all three), while remaining a tier below
+     --color-text-sub. Locked by src/app/__tests__/token-contrast.test.ts. */
+  --color-text-dim: oklch(0.575 0.008 270);
 
   /* --------------------------------------------------
      TIER 3: COMPONENT TOKENS (specific-use)

--- a/frontend/tests/e2e/a11y-baseline.json
+++ b/frontend/tests/e2e/a11y-baseline.json
@@ -1,0 +1,10 @@
+{
+  "__doc": "Known pre-existing axe violation rule IDs per page, recorded when the a11y gate was introduced (2026-07-17, union of repeated runs). NEW rule IDs fail CI immediately. Entries may only ever be REMOVED (in the PR that fixes them — the spec logs prunable entries). Never add to this file. Fix mapping: target-size → Batch 9 sweep (WCAG 2.5.8); link-in-text-block → Batch 7 landing/docs/upgrade pass (1.4.1); color-contrast (badge text on platform colors, muted text) → Batches 5/7; aria-required-attr in the editor → Batch 2 primitives.",
+  "landing": ["color-contrast", "target-size"],
+  "docs": ["link-in-text-block"],
+  "upgrade": ["color-contrast", "link-in-text-block"],
+  "dashboard-populated": ["color-contrast"],
+  "dashboard-empty": ["color-contrast"],
+  "settings": ["color-contrast"],
+  "overlay-editor": ["aria-required-attr", "color-contrast"]
+}

--- a/frontend/tests/e2e/a11y-helpers.ts
+++ b/frontend/tests/e2e/a11y-helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Shared axe-core scan helper for the a11y smoke suite (WCAG 2.2 AA gate).
+ *
+ * Product rule, codified once here so it never becomes a blanket disable:
+ * overlay chat THEMES are streamer-chosen broadcast art rendered inside OBS.
+ * They are NOT app UI and are exempt from app-UI contrast rules (they have
+ * their own deliberate floor in theme-contrast.spec.ts). Viewer-defined
+ * chatter name colors must never be contrast-gated. Everything else IS app
+ * UI and gets the full WCAG 2.2 AA ruleset.
+ *
+ * Ratchet: tests/e2e/a11y-baseline.json holds the rule IDs that were already
+ * violated when the gate was introduced, keyed by page. NEW rule IDs fail
+ * immediately. When a batch fixes a rule, remove it from the baseline in the
+ * same PR — the stale-entry report below names removable entries. The
+ * baseline must only ever shrink.
+ */
+
+import { expect, type Page, type TestInfo } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import baselineJson from './a11y-baseline.json'
+
+// The JSON carries a __doc string key (JSON has no comments); widen past it.
+const baseline = baselineJson as unknown as Record<string, string[]>
+
+/** Selectors rendering themed chat content (broadcast art, not app UI). */
+const THEMED_CHAT_SELECTORS = ['.overlay-view', '[data-theme-preview]', '.theme-preview']
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa']
+
+export async function expectNoNewA11yViolations(
+  page: Page,
+  pageKey: string,
+  testInfo: TestInfo
+): Promise<void> {
+  // Freeze CSS animations/transitions before scanning: axe's color-contrast
+  // check cannot resolve backgrounds mid-animation (fade-ins), which made
+  // results depend on scan timing. Frozen pages give deterministic results.
+  // Injected via evaluate, NOT page.addStyleTag: addStyleTag waits on load
+  // events and rejects when an unrelated page error fires meanwhile (e.g. the
+  // editor's Monaco CDN script being CSP-blocked in dev).
+  await page.evaluate(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '*, *::before, *::after { animation: none !important; transition: none !important; }'
+    document.head.appendChild(style)
+  })
+  // Let async-hydrating widgets (comboboxes, editors, fetch-gated sections)
+  // reach their final DOM so the scan sees the same page every run.
+  await page.waitForLoadState('networkidle')
+
+  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS)
+  for (const selector of THEMED_CHAT_SELECTORS) {
+    builder = builder.exclude(selector)
+  }
+  const results = await builder.analyze()
+
+  const known = new Set(baseline[pageKey] ?? [])
+  const found = new Map(results.violations.map((v) => [v.id, v]))
+
+  const fresh = results.violations.filter((v) => !known.has(v.id))
+  const stale = [...known].filter((id) => !found.has(id))
+
+  // Attach the full report for debugging regardless of outcome.
+  await testInfo.attach(`axe-${pageKey}`, {
+    body: JSON.stringify(results.violations, null, 2),
+    contentType: 'application/json',
+  })
+
+  if (stale.length > 0) {
+    // Not a failure (fixes land in their own batches), but must not linger:
+    // prune these ids from a11y-baseline.json in the PR that fixed them.
+    console.warn(
+      `[a11y] ${pageKey}: baseline entries no longer violated — prune from a11y-baseline.json: ${stale.join(', ')}`
+    )
+  }
+
+  expect(
+    fresh.map((v) => ({
+      id: v.id,
+      impact: v.impact,
+      help: v.help,
+      nodes: v.nodes.slice(0, 5).map((n) => n.target.join(' ')),
+    })),
+    `NEW a11y violations on ${pageKey} (not in a11y-baseline.json — fix them, do not extend the baseline)`
+  ).toEqual([])
+}

--- a/frontend/tests/e2e/a11y.spec.ts
+++ b/frontend/tests/e2e/a11y.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A11y smoke suite — axe-core over the main app pages (WCAG 2.2 AA gate).
+ *
+ * Auth is cookie/`/auth/me`-based, so authenticated pages are driven with
+ * NETWORK-ROUTE mocks (page.route on /api/v1/*), not the legacy
+ * localStorage['auth-store'] mock used by older specs — that store is no
+ * longer read for auth decisions.
+ *
+ * Each test asserts a page-specific anchor is visible BEFORE scanning, so a
+ * broken mock fails loudly instead of silently scanning an error page.
+ *
+ * Coverage gaps (deliberate, not silent): /dashboard/shares, /admin/*, and
+ * /overlay/[id]/participate need heavier fixtures (share tokens, admin stats,
+ * viewer session + websocket) and join the suite with the admin pass
+ * (roadmap Batch 8) and the cross-cutting sweep (Batch 9). Modal-open states
+ * follow with the modal consolidation batch.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { expectNoNewA11yViolations } from './a11y-helpers'
+
+const USER = {
+  id: '11111111-1111-1111-1111-111111111111',
+  username: 'a11y_smoke',
+  display_name: 'A11y Smoke',
+  auth_provider: 'twitch',
+  is_admin: false,
+  is_premium: false,
+  is_beta_tester: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  // Completed, so the (upcoming) first-run setup guide never overlays the
+  // pages this suite scans.
+  onboarding_completed_at: '2026-01-02T00:00:00Z',
+}
+
+const OVERLAY = {
+  id: '22222222-2222-2222-2222-222222222222',
+  user_id: USER.id,
+  name: 'A11y Test Overlay',
+  description: '',
+  is_active: true,
+  is_public_for_viewers: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+const SOURCES = [
+  {
+    id: 'source-1',
+    overlay_id: OVERLAY.id,
+    platform: 'twitch',
+    channel_id: '123',
+    channel_name: 'somechannel',
+    is_active: true,
+  },
+]
+
+const CONFIG = {
+  id: 'config-1',
+  overlay_id: OVERLAY.id,
+  display_settings: {},
+  filter_settings: {},
+  visual_settings: {},
+  enable_7tv: true,
+  enable_bttv: false,
+  enable_ffz: false,
+  theme_id: null,
+  custom_css: '',
+}
+
+/**
+ * Register mocks for an authenticated session. Registration order matters:
+ * Playwright matches routes LAST-registered-first, so the JSON-404 catch-all
+ * goes first and specific endpoints override it. The catch-all keeps unknown
+ * API calls from hanging the page or hitting a real backend.
+ */
+async function mockAuthedApi(page: Page, overrides: Record<string, unknown> = {}) {
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 404, contentType: 'application/json', body: '{}' })
+  )
+  const json = (body: unknown) => ({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+  await page.route('**/api/v1/auth/me', (route) => route.fulfill(json(USER)))
+  await page.route('**/api/v1/auth/guilds', (route) => route.fulfill(json([])))
+  await page.route('**/api/v1/payment/status', (route) =>
+    route.fulfill(json({ connected: false, is_premium: false }))
+  )
+  for (const [pattern, body] of Object.entries(overrides)) {
+    await page.route(pattern, (route) => route.fulfill(json(body)))
+  }
+}
+
+test.describe('a11y smoke (axe, WCAG 2.2 AA)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Must be set BEFORE navigation: the landing theme carousel reads
+    // prefers-reduced-motion at mount (ThemeSwitcher) and otherwise keeps
+    // auto-advancing via JS, changing the DOM between scans. CSS animations
+    // are additionally frozen inside the scan helper.
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    // Monaco (editor CSS panel) loads from cdn.jsdelivr.net, which the dev
+    // CSP rejects — the async failure surfaces at random points and flakes
+    // the scan. Block it outright; the Monaco surface is audited separately
+    // (roadmap Batch 6).
+    await page.route('https://cdn.jsdelivr.net/**', (route) => route.abort())
+  })
+
+  test('landing page', async ({ page }, testInfo) => {
+    await page.goto('/')
+    await expect(page.getByRole('main')).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'landing', testInfo)
+  })
+
+  test('docs page', async ({ page }, testInfo) => {
+    await page.goto('/docs')
+    // No <main> landmark on this page yet (itself a Batch 7 finding) — anchor
+    // on the h1 instead.
+    await expect(page.getByRole('heading', { name: 'Streamer guide' })).toBeVisible({
+      timeout: 20_000,
+    })
+    await expectNoNewA11yViolations(page, 'docs', testInfo)
+  })
+
+  test('upgrade page', async ({ page }, testInfo) => {
+    await mockAuthedApi(page)
+    await page.goto('/upgrade')
+    await expect(page.getByRole('main')).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'upgrade', testInfo)
+  })
+
+  test('dashboard with overlays', async ({ page }, testInfo) => {
+    await mockAuthedApi(page, {
+      '**/api/v1/overlays': [OVERLAY],
+      [`**/api/v1/overlays/${OVERLAY.id}/sources`]: SOURCES,
+    })
+    await page.goto('/dashboard')
+    await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'dashboard-populated', testInfo)
+  })
+
+  test('dashboard empty state', async ({ page }, testInfo) => {
+    await mockAuthedApi(page, { '**/api/v1/overlays': [] })
+    await page.goto('/dashboard')
+    await expect(page.getByText('No overlays yet')).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'dashboard-empty', testInfo)
+  })
+
+  test('settings page', async ({ page }, testInfo) => {
+    await mockAuthedApi(page)
+    await page.goto('/settings')
+    await expect(page.getByText(USER.username)).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'settings', testInfo)
+  })
+
+  test('overlay editor', async ({ page }, testInfo) => {
+    await mockAuthedApi(page, {
+      [`**/api/v1/overlays/${OVERLAY.id}`]: OVERLAY,
+      [`**/api/v1/overlays/${OVERLAY.id}/sources`]: SOURCES,
+      [`**/api/v1/overlays/${OVERLAY.id}/config`]: CONFIG,
+    })
+    await page.goto(`/overlays/${OVERLAY.id}`)
+    await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
+    await expectNoNewA11yViolations(page, 'overlay-editor', testInfo)
+  })
+})


### PR DESCRIPTION
## What

**Batch 0 of the WCAG 2.2 AA initiative** (approved plan, retention project): an enforceable a11y gate that stays green **independently of the pre-existing lint debt** (the 39 react-hooks errors keeping `frontend-quality.yml` dispatch-only), plus the full violation inventory that scopes the follow-up batches.

### New required-check candidate: `.github/workflows/frontend-a11y.yml` (on: pull_request)
| Job | What it runs |
|---|---|
| a11y-static | jsx-a11y **strict** ESLint (a11y-only config) + design-token contrast vitest |
| a11y-storybook | The existing-but-never-CI'd Storybook axe project (`a11y: test:'error'`) — **verified green locally: 45 tests** |
| a11y-smoke | New Playwright axe scan (wcag2a→wcag22aa) over landing, docs, upgrade, dashboard ×2, settings, overlay editor |

### Two shrink-only ratchets (never grow, prune in the PR that fixes)
- `eslint.a11y.suppressions.json` — 67 pre-existing errors in 17 files (dominant: `label-has-associated-control` ×38 → forms batch; `click-events-have-key-events` ×9; 5 bare `focus:`)
- `tests/e2e/a11y-baseline.json` — pre-existing axe rule ids per page (`target-size`, `link-in-text-block`, `color-contrast`, `aria-required-attr`); **new rule ids fail CI**

### Determinism hardening (what it took to get 8+ consecutive green runs)
- CSS animations frozen before scanning (axe can't resolve backgrounds mid-fade-in → timing-dependent results) — injected via `evaluate`, not `addStyleTag`, which rejects on unrelated page errors (the editor's CSP-blocked Monaco CDN loader)
- `reducedMotion: 'reduce'` emulated pre-navigation so the landing theme carousel stops mutating the DOM between scans
- network-idle settle + cold-compile anchor timeouts; every page asserts a content anchor **before** scanning so broken mocks fail loudly
- Auth mocked via **network routes** (`/auth/me` etc.) — not the stale `localStorage['auth-store']` pattern in older specs

### A real fix the token lock caught immediately
`--color-text-dim` measured **4.28:1** on `surface-2`, where it's used as placeholders/small text in 50 files → raised to `oklch(0.575)`, with `--color-neutral-400` → `oklch(0.6)` to preserve the sub/dim hierarchy. Stale hex comments corrected (bg actually renders `#020204`). The vitest lock (inline OKLab math, sanity-pinned to `#020204`) prevents regression.

### Notes
- `eslint-plugin-jsx-a11y` has **no ESLint-10-compatible release** (peers stop at ^9) — resolved via `createRequire` from the copy eslint-config-next bundles; TODO comment tracks switching to a direct dep.
- Deliberate smoke coverage gaps (documented in the spec): `/dashboard/shares`, `/admin/*`, `/overlay/[id]/participate`, and modal-open states join with roadmap Batches 3/8/9.
- Suggest making the three jobs **required checks** once this merges.

## Testing
- Axe smoke: 8+ consecutive green runs locally (plus cold-server run via Playwright-managed `npm run dev`)
- Canary test: a synthetic violation fails the ESLint gate; suppressed baseline passes
- `npm run type-check` clean, token test 20/20, unit suite 573 passed, Storybook axe 45/45