### PR TITLE
feat(a11y): global foundations — skip link, reduced motion, carousel pause (Batch 1)

### DIFF
--- a/frontend/eslint.a11y.suppressions.json
+++ b/frontend/eslint.a11y.suppressions.json
@@ -96,11 +96,6 @@
       "count": 2
     }
   },
-  "src/components/appearance/FontFamilyCombobox.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "src/components/appearance/TypographyGroup.tsx": {
     "jsx-a11y/label-has-associated-control": {
       "count": 7

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -173,7 +173,7 @@ export default function HomeClient() {
   }
 
   return (
-    <main className="min-h-screen scroll-smooth">
+    <main id="main-content" tabIndex={-1} className="min-h-screen scroll-smooth">
       <HomeHeader />
 
       {/* ------------------------------------------------------------------ */}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -28,7 +28,7 @@ function AdminLayoutContent({ children }: { children: ReactNode }) {
       <AdminSidebar />
       {/* Offset for the fixed desktop sidebar; full width below the lg breakpoint. */}
       <div className="lg:pl-60">
-        <main>{children}</main>
+        <main id="main-content" tabIndex={-1}>{children}</main>
       </div>
     </div>
   )

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import { useEffect, useState } from 'react'
 import { overlaysApi } from '@/lib/api/overlays'
 import { useRouter } from 'next/navigation'
@@ -216,7 +215,7 @@ function DashboardContent() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         <div className="mb-4 space-y-4">
           <MaintenanceBanner />
           <EventSubMigrationBanner sourcesByOverlay={sourcesByOverlay} />

--- a/frontend/src/app/dev/theme-contrast/page.tsx
+++ b/frontend/src/app/dev/theme-contrast/page.tsx
@@ -41,7 +41,7 @@ export default function ThemeContrastHarness() {
   const themes = getBundledThemes()
 
   return (
-    <main className="mx-auto max-w-2xl space-y-8 p-6">
+    <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl space-y-8 p-6">
       <header>
         <h1 className="text-xl font-bold text-text">Theme contrast harness</h1>
         <p className="text-sm text-text-sub">

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -123,7 +123,7 @@ export default function DocsPage() {
   return (
     <div className="min-h-screen bg-bg transition-colors duration-300">
       <AppNav />
-      <div className="mx-auto max-w-4xl px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-4xl px-4 py-12">
         <div className="rounded-xl border border-border bg-surface p-8 transition-colors duration-300 md:p-12">
           <div className="mb-8 space-y-2">
             <p className="text-xs font-semibold tracking-[0.2em] text-twitch uppercase">
@@ -131,8 +131,8 @@ export default function DocsPage() {
             </p>
             <h1 className="text-3xl font-bold text-text">Streamer guide</h1>
             <p className="text-sm text-text-dim">
-              Set it up in OBS, run polls, predictions and moderation from the chat monitor, and make
-              it your own.
+              Set it up in OBS, run polls, predictions and moderation from the chat monitor, and
+              make it your own.
             </p>
             <p className="text-sm text-text-sub">
               Building a bot, alert box, or analytics tool?{' '}
@@ -181,8 +181,8 @@ export default function DocsPage() {
                 </li>
                 <li>
                   In the dashboard, create an <strong>overlay</strong> and connect the platforms you
-                  stream on. Each connected platform becomes a <em>chat source</em> on that overlay —
-                  mix and match as many as you like.
+                  stream on. Each connected platform becomes a <em>chat source</em> on that overlay
+                  — mix and match as many as you like.
                 </li>
                 <li>
                   Copy the overlay&apos;s browser-source URL and add it to OBS as a{' '}
@@ -205,12 +205,12 @@ export default function DocsPage() {
               </p>
               <Pre>{`https://allch.at/overlay/<overlay-id>?passive=true`}</Pre>
               <p>
-                A <strong>passive</strong> overlay renders chat exactly like a normal one, but it does
-                not ask All-Chat to start capturing on its own. That matters because YouTube discovery
-                gives up after an hour of not finding a live stream (so it never hammers YouTube for an
-                offline channel). A normal 24/7 overlay would trip that timeout while you are offline
-                and sit parked by the time you go live — a passive overlay never starts that clock, so
-                nothing gets stuck.
+                A <strong>passive</strong> overlay renders chat exactly like a normal one, but it
+                does not ask All-Chat to start capturing on its own. That matters because YouTube
+                discovery gives up after an hour of not finding a live stream (so it never hammers
+                YouTube for an offline channel). A normal 24/7 overlay would trip that timeout while
+                you are offline and sit parked by the time you go live — a passive overlay never
+                starts that clock, so nothing gets stuck.
               </p>
               <h3>When you go live</h3>
               <ol className="list-decimal space-y-2 pl-6 text-text-sub">
@@ -228,10 +228,10 @@ export default function DocsPage() {
                 </li>
               </ol>
               <p>
-                A plain browser-source refresh does <em>not</em> restart a parked YouTube channel — use
-                the monitor&apos;s <strong>Rediscover</strong> button. While a channel is parked, its
-                platform dot shows an <strong>indigo &ldquo;paused&rdquo;</strong> state (waiting for
-                you to trigger it), not a red error.
+                A plain browser-source refresh does <em>not</em> restart a parked YouTube channel —
+                use the monitor&apos;s <strong>Rediscover</strong> button. While a channel is
+                parked, its platform dot shows an <strong>indigo &ldquo;paused&rdquo;</strong> state
+                (waiting for you to trigger it), not a red error.
               </p>
             </section>
 
@@ -245,12 +245,12 @@ export default function DocsPage() {
               </p>
               <ul>
                 <li>
-                  <strong>Send messages</strong> as yourself to Twitch, YouTube or Kick straight from
-                  the monitor (TikTok and Discord have no send API).
+                  <strong>Send messages</strong> as yourself to Twitch, YouTube or Kick straight
+                  from the monitor (TikTok and Discord have no send API).
                 </li>
                 <li>
-                  <strong>Re-discover YouTube</strong> forces a fresh look for your live stream — use
-                  it if YouTube chat stops after a crash or restart, or to start capture for a{' '}
+                  <strong>Re-discover YouTube</strong> forces a fresh look for your live stream —
+                  use it if YouTube chat stops after a crash or restart, or to start capture for a{' '}
                   <a href="#24-7-irl">passive 24/7 overlay</a> when you go live.
                 </li>
                 <li>
@@ -267,14 +267,14 @@ export default function DocsPage() {
               <p>
                 With <strong>Moderation controls</strong> on in the monitor, hover a message to{' '}
                 <strong>Delete</strong> it, or open a chatter to <strong>Timeout</strong>,{' '}
-                <strong>Ban</strong> or <strong>Unban</strong> them — applied on the source platform.
-                What&apos;s available depends on the platform (Twitch does delete, timeout and ban;
-                YouTube is ban-only; TikTok has no moderation API).
+                <strong>Ban</strong> or <strong>Unban</strong> them — applied on the source
+                platform. What&apos;s available depends on the platform (Twitch does delete, timeout
+                and ban; YouTube is ban-only; TikTok has no moderation API).
               </p>
               <p>
-                The first time, use <strong>Enable moderation &amp; chat sending</strong> to grant the
-                extra permissions (for Discord you re-invite the bot). Moderating from your overlay is
-                a <a href="#premium">Premium</a> feature.
+                The first time, use <strong>Enable moderation &amp; chat sending</strong> to grant
+                the extra permissions (for Discord you re-invite the bot). Moderating from your
+                overlay is a <a href="#premium">Premium</a> feature.
               </p>
             </section>
 
@@ -299,13 +299,13 @@ export default function DocsPage() {
                   <strong>Cancel &amp; refund</strong>.
                 </li>
                 <li>
-                  Viewers join from chat (e.g. <Code>!vote 2</Code>, <Code>!predict 1 500</Code>) or on
-                  the <strong>Viewer participation page</strong>.
+                  Viewers join from chat (e.g. <Code>!vote 2</Code>, <Code>!predict 1 500</Code>) or
+                  on the <strong>Viewer participation page</strong>.
                 </li>
                 <li>
-                  Add the <strong>OBS poll widget</strong> and <strong>OBS prediction widget</strong>{' '}
-                  as their own browser sources so results show on stream — copy their URLs from the
-                  Engagement section.
+                  Add the <strong>OBS poll widget</strong> and{' '}
+                  <strong>OBS prediction widget</strong> as their own browser sources so results
+                  show on stream — copy their URLs from the Engagement section.
                 </li>
               </ul>
             </section>
@@ -314,14 +314,15 @@ export default function DocsPage() {
             <section id="events-credits">
               <h2>Events &amp; credit roll</h2>
               <p>
-                Your overlay shows <strong>events</strong> too — subs, resubs, gift subs, bits/cheers,
-                raids, Super Chats, memberships and follows. Use <strong>Event Settings</strong> in the
-                editor to choose exactly which events appear, per platform.
+                Your overlay shows <strong>events</strong> too — subs, resubs, gift subs,
+                bits/cheers, raids, Super Chats, memberships and follows. Use{' '}
+                <strong>Event Settings</strong> in the editor to choose exactly which events appear,
+                per platform.
               </p>
               <p>
                 For the end of a stream, open <strong>Credits</strong> to set up a{' '}
-                <strong>Credit Roll</strong> — a scrolling thank-you of your top subscribers, gifters,
-                cheerers, raiders and new followers. It&apos;s its own browser source (
+                <strong>Credit Roll</strong> — a scrolling thank-you of your top subscribers,
+                gifters, cheerers, raiders and new followers. It&apos;s its own browser source (
                 <strong>Copy Credits OBS URL</strong>).
               </p>
             </section>
@@ -330,11 +331,11 @@ export default function DocsPage() {
             <section id="sharing">
               <h2>Share an overlay</h2>
               <p>
-                <strong>Share Overlay</strong> lets another streamer pull your overlay&apos;s chat into
-                theirs — handy for collabs and raids. Send a request to their Twitch username; once
-                they accept, your overlay appears in their editor under <strong>Shared Overlays</strong>{' '}
-                to add as a source, and either of you can revoke it later. Sharing is a{' '}
-                <a href="#premium">Premium</a> feature.
+                <strong>Share Overlay</strong> lets another streamer pull your overlay&apos;s chat
+                into theirs — handy for collabs and raids. Send a request to their Twitch username;
+                once they accept, your overlay appears in their editor under{' '}
+                <strong>Shared Overlays</strong> to add as a source, and either of you can revoke it
+                later. Sharing is a <a href="#premium">Premium</a> feature.
               </p>
             </section>
 
@@ -344,8 +345,7 @@ export default function DocsPage() {
               <p>
                 All-Chat ships with <strong>16 built-in themes</strong> — from Modern Dark and
                 Minimal to Trading Card, Comic Speech, Sticky Notes, Vaporwave, Cyberpunk and more.
-                Applying
-                one takes a click and needs <strong>no CSS at all</strong>.
+                Applying one takes a click and needs <strong>no CSS at all</strong>.
               </p>
               <ol className="list-decimal space-y-2 pl-6 text-text-sub">
                 <li>Open your overlay in the dashboard to edit it.</li>
@@ -356,8 +356,8 @@ export default function DocsPage() {
                 <li>Save. Your OBS browser source picks up the new look on its next refresh.</li>
               </ol>
               <p>
-                You can also preview every theme live on the{' '}
-                <Link href="/">home page</Link> before you sign in.
+                You can also preview every theme live on the <Link href="/">home page</Link> before
+                you sign in.
               </p>
             </section>
 
@@ -398,7 +398,10 @@ export default function DocsPage() {
                   It loads <em>after</em> the theme, so you can start from a built-in theme and
                   override just the parts you want.
                 </li>
-                <li>There&apos;s a live preview right next to the editor, so you see changes as you type.</li>
+                <li>
+                  There&apos;s a live preview right next to the editor, so you see changes as you
+                  type.
+                </li>
               </ul>
 
               <h3>Quick wins: style variables</h3>
@@ -410,16 +413,52 @@ export default function DocsPage() {
                 rows={[
                   { name: '--chat-font-size', default: '1rem', effect: 'Message text size.' },
                   { name: '--chat-font-family', default: 'inherit', effect: 'Message text font.' },
-                  { name: '--chat-message-color', default: '#ffffff', effect: 'Message text color.' },
-                  { name: '--chat-message-gap', default: '0.75rem', effect: 'Vertical space between messages.' },
-                  { name: '--chat-bubble-border-radius', default: '0.5rem', effect: 'Roundness of the message bubble.' },
-                  { name: '--chat-bubble-padding', default: '0.75rem', effect: 'Padding inside each message.' },
-                  { name: '--chat-avatar-size', default: '2.5rem', effect: 'Avatar width and height.' },
-                  { name: '--chat-username-font-size', default: '0.875rem', effect: 'Username size.' },
+                  {
+                    name: '--chat-message-color',
+                    default: '#ffffff',
+                    effect: 'Message text color.',
+                  },
+                  {
+                    name: '--chat-message-gap',
+                    default: '0.75rem',
+                    effect: 'Vertical space between messages.',
+                  },
+                  {
+                    name: '--chat-bubble-border-radius',
+                    default: '0.5rem',
+                    effect: 'Roundness of the message bubble.',
+                  },
+                  {
+                    name: '--chat-bubble-padding',
+                    default: '0.75rem',
+                    effect: 'Padding inside each message.',
+                  },
+                  {
+                    name: '--chat-avatar-size',
+                    default: '2.5rem',
+                    effect: 'Avatar width and height.',
+                  },
+                  {
+                    name: '--chat-username-font-size',
+                    default: '0.875rem',
+                    effect: 'Username size.',
+                  },
                   { name: '--chat-emote-scale', default: '1', effect: 'Emote size multiplier.' },
-                  { name: '--chat-show-avatars', default: 'block', effect: 'Set to none to hide avatars.' },
-                  { name: '--chat-show-badges', default: 'flex', effect: 'Set to none to hide badges.' },
-                  { name: '--chat-show-timestamps', default: 'block', effect: 'Set to none to hide timestamps.' },
+                  {
+                    name: '--chat-show-avatars',
+                    default: 'block',
+                    effect: 'Set to none to hide avatars.',
+                  },
+                  {
+                    name: '--chat-show-badges',
+                    default: 'flex',
+                    effect: 'Set to none to hide badges.',
+                  },
+                  {
+                    name: '--chat-show-timestamps',
+                    default: 'block',
+                    effect: 'Set to none to hide timestamps.',
+                  },
                 ]}
               />
               <Pre lang="css">{`:root {
@@ -435,13 +474,33 @@ export default function DocsPage() {
               </p>
               <HookTable
                 rows={[
-                  { selector: '.overlay-live-body', kind: 'class', targets: 'The whole message list container.' },
+                  {
+                    selector: '.overlay-live-body',
+                    kind: 'class',
+                    targets: 'The whole message list container.',
+                  },
                   { selector: '.chat-message', kind: 'class', targets: 'One chat message bubble.' },
                   { selector: '.chat-username', kind: 'class', targets: 'The author name.' },
-                  { selector: '.platform-badge', kind: 'class', targets: 'The platform tag/icon next to the name.' },
-                  { selector: '.event-message', kind: 'class', targets: 'A sub / raid / super chat / gift alert.' },
-                  { selector: '[data-platform="twitch"]', kind: 'attribute', targets: 'Messages from a platform (twitch, youtube, kick, tiktok, discord).' },
-                  { selector: '[data-username="…"]', kind: 'attribute', targets: 'Messages from a specific user.' },
+                  {
+                    selector: '.platform-badge',
+                    kind: 'class',
+                    targets: 'The platform tag/icon next to the name.',
+                  },
+                  {
+                    selector: '.event-message',
+                    kind: 'class',
+                    targets: 'A sub / raid / super chat / gift alert.',
+                  },
+                  {
+                    selector: '[data-platform="twitch"]',
+                    kind: 'attribute',
+                    targets: 'Messages from a platform (twitch, youtube, kick, tiktok, discord).',
+                  },
+                  {
+                    selector: '[data-username="…"]',
+                    kind: 'attribute',
+                    targets: 'Messages from a specific user.',
+                  },
                 ]}
               />
               <p>Example — give each platform its own accent stripe:</p>
@@ -480,8 +539,9 @@ export default function DocsPage() {
               <h2>Custom fonts</h2>
               <p>
                 You can pull in a Google Font with a normal <Code>@import</Code>, then use it
-                anywhere in your CSS. To protect your viewers&apos; privacy, fonts are served through
-                All-Chat rather than directly from Google, so only these families are available:
+                anywhere in your CSS. To protect your viewers&apos; privacy, fonts are served
+                through All-Chat rather than directly from Google, so only these families are
+                available:
               </p>
               <p className="text-sm text-text-sub">
                 Barlow, Barlow Condensed, Bebas Neue, Exo 2, Inter, Monoton, Montserrat, Nunito,
@@ -492,8 +552,8 @@ export default function DocsPage() {
 
 :root { --chat-font-family: 'Press Start 2P', monospace; }`}</Pre>
               <p>
-                Requesting a family that isn&apos;t on the list simply won&apos;t load — pick another
-                or leave the default.
+                Requesting a family that isn&apos;t on the list simply won&apos;t load — pick
+                another or leave the default.
               </p>
             </section>
 
@@ -506,12 +566,12 @@ export default function DocsPage() {
               </p>
               <ul>
                 <li>
-                  <strong>Moderate from your overlay</strong> — delete, timeout and ban from the chat
-                  monitor.
+                  <strong>Moderate from your overlay</strong> — delete, timeout and ban from the
+                  chat monitor.
                 </li>
                 <li>
-                  <strong>ElevenLabs text-to-speech</strong> — premium TTS voices (basic browser TTS is
-                  free).
+                  <strong>ElevenLabs text-to-speech</strong> — premium TTS voices (basic browser TTS
+                  is free).
                 </li>
                 <li>
                   <strong>YouTube stream selection</strong> — choose which stream to follow on
@@ -543,7 +603,7 @@ export default function DocsPage() {
             </div>
           </div>
         </div>
-      </div>
+      </main>
     </div>
   )
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,6 +123,9 @@
     color: var(--color-text);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Keep keyboard-focused / anchor-jumped elements clear of the sticky
+       navs (AppNav h-60px, HomeHeader) — WCAG 2.4.11 Focus Not Obscured. */
+    scroll-padding-top: 5rem;
   }
   body {
     background-color: var(--color-bg);
@@ -197,6 +200,26 @@
   }
   to {
     opacity: 1;
+  }
+}
+
+/* ============================================================
+   REDUCED MOTION — global gate (WCAG 2.3.3 / supports 2.2.2)
+   Document scope, after the layered styles, so it wins everywhere in the app
+   chrome: decorative animation (logo ring-spin, fade-ins, slide-up, spinners)
+   collapses to its end state and transitions become instant. JS-driven motion
+   is gated separately via hooks/useReducedMotion. Overlay marketplace THEMES
+   (broadcast art rendered in OBS) ship their own reduced-motion blocks and
+   are not app chrome.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -128,6 +128,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={cn(barlow.variable, dmMono.variable)}>
       <body>
+        {/* Skip link (WCAG 2.4.1): first focusable element on every page;
+            visually hidden until keyboard-focused. Pages opt in by giving
+            their <main> id="main-content" tabIndex={-1}. */}
+        <a
+          href="#main-content"
+          className="sr-only z-[100] rounded-md border border-border-md bg-surface-2 px-4 py-2 text-sm font-medium text-text focus-visible:not-sr-only focus-visible:fixed focus-visible:top-4 focus-visible:left-4 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+        >
+          Skip to main content
+        </a>
         <JsonLd data={organizationLd} />
         <JsonLd data={webSiteLd} />
         <Analytics />

--- a/frontend/src/app/overlay/[id]/participate/page.tsx
+++ b/frontend/src/app/overlay/[id]/participate/page.tsx
@@ -297,12 +297,12 @@ export default function ParticipatePage({ params }: { params: Promise<{ id: stri
   )
 
   if (authed === null) {
-    return <main className="mx-auto max-w-md p-6 text-center text-text-sub">Loading…</main>
+    return <main id="main-content" tabIndex={-1} className="mx-auto max-w-md p-6 text-center text-text-sub">Loading…</main>
   }
 
   if (!authed) {
     return (
-      <main className="mx-auto max-w-md space-y-4 p-6 text-center">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-md space-y-4 p-6 text-center">
         <h1 className="text-xl font-bold">Join the fun</h1>
         <p className="text-text-sub">Log in with your platform account to vote and wager.</p>
         <div className="flex flex-col gap-2">
@@ -336,7 +336,7 @@ export default function ParticipatePage({ params }: { params: Promise<{ id: stri
   const pointsName = engagement?.points_name ?? 'Points'
 
   return (
-    <main className="mx-auto max-w-md space-y-6 p-4">
+    <main id="main-content" tabIndex={-1} className="mx-auto max-w-md space-y-6 p-4">
       <header className="flex items-center justify-between">
         <h1 className="text-lg font-bold">Participate</h1>
         <span

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -645,7 +645,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
   )
 
   return (
-    <main className="min-h-screen bg-transparent">
+    <main id="main-content" tabIndex={-1} className="min-h-screen bg-transparent">
       {useCustomCss && scopedPreviewCss && (
         <style
           key={scopedPreviewCss}

--- a/frontend/src/app/overlays/new/page.tsx
+++ b/frontend/src/app/overlays/new/page.tsx
@@ -67,7 +67,7 @@ function NewOverlayContent() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-lg px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-lg px-4 py-12">
         <Card className="p-8">
           <h1 className="mb-2 text-2xl font-bold text-text">Create Overlay</h1>
           <p className="mb-8 text-sm text-text-sub">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import Link from 'next/link'
 import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -104,7 +103,7 @@ function SettingsContent() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-2xl space-y-6 px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl space-y-6 px-4 py-12">
         <h1 className="text-2xl font-bold text-text">Settings</h1>
 
         {/* Profile section */}
@@ -214,10 +213,7 @@ function SettingsContent() {
                   >
                     <Dialog.Trigger
                       render={
-                        <Button
-                          variant="destructive"
-                          onClick={() => setDisconnectTarget(guild)}
-                        >
+                        <Button variant="destructive" onClick={() => setDisconnectTarget(guild)}>
                           Disconnect
                         </Button>
                       }

--- a/frontend/src/app/settings/premium/page.tsx
+++ b/frontend/src/app/settings/premium/page.tsx
@@ -119,7 +119,7 @@ function PremiumContent() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-2xl space-y-6 px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl space-y-6 px-4 py-12">
         <div className="space-y-1">
           <Link
             href="/settings"

--- a/frontend/src/app/settings/viewer/page.tsx
+++ b/frontend/src/app/settings/viewer/page.tsx
@@ -115,7 +115,7 @@ function UnauthenticatedState() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="max-w-2xl mx-auto px-4 py-12 space-y-6">
+      <main id="main-content" tabIndex={-1} className="max-w-2xl mx-auto px-4 py-12 space-y-6">
         <h1 className="text-2xl font-bold text-text">Viewer Identity</h1>
         <p className="text-text-sub text-sm">
           Customize how your name appears across all overlays
@@ -867,7 +867,7 @@ function ViewerSettingsContent({ claims }: { claims: ViewerJWTClaims }) {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="max-w-2xl mx-auto px-4 py-12 space-y-6">
+      <main id="main-content" tabIndex={-1} className="max-w-2xl mx-auto px-4 py-12 space-y-6">
         {/* Header */}
         <div>
           <h1 className="text-2xl font-bold text-text">Viewer Identity</h1>

--- a/frontend/src/app/settings/viewer/premium/page.tsx
+++ b/frontend/src/app/settings/viewer/premium/page.tsx
@@ -114,7 +114,7 @@ function ViewerPremiumContent() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-2xl space-y-6 px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl space-y-6 px-4 py-12">
         <div className="space-y-1">
           <Link
             href="/settings/viewer"
@@ -215,7 +215,7 @@ function ViewerPremiumUnauthenticated() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-2xl space-y-6 px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-2xl space-y-6 px-4 py-12">
         <h1 className="text-2xl font-bold text-text">Viewer Premium</h1>
         <Card className="p-6">
           <h2 className="mb-2 text-lg font-semibold text-text">Sign in to manage viewer premium</h2>

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -72,7 +72,7 @@ export default function UpgradePage() {
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
-      <main className="mx-auto max-w-3xl space-y-10 px-4 py-12">
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-3xl space-y-10 px-4 py-12">
         {/* Hero */}
         <header className="space-y-4 text-center">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-3 py-1 text-xs font-medium text-text-sub">

--- a/frontend/src/components/ThemeSwitcher.tsx
+++ b/frontend/src/components/ThemeSwitcher.tsx
@@ -40,9 +40,10 @@ import ThemePreview from '@/components/theme-marketplace/ThemePreview'
 import { getBundledTheme, getBundledThemes } from '@/lib/theme-marketplace/bundled-themes'
 import { SAMPLE_PREVIEW_MESSAGES } from '@/lib/theme-marketplace/constants'
 import type { Theme } from '@/lib/theme-marketplace/types'
-import { Palette } from 'lucide-react'
+import { Palette, Pause, Play } from 'lucide-react'
 import { trackEvent } from '@/lib/analytics'
 import { DISCORD_INVITE_URL } from '@/lib/constants'
+import { useReducedMotion } from '@/hooks/useReducedMotion'
 
 /**
  * The curated showcase — four visually distinct looks that read well at a glance:
@@ -84,18 +85,22 @@ interface ThemeSwitcherProps {
 export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
   const [active, setActive] = useState(0)
   const [paused, setPaused] = useState(false)
+  // Explicit pause via the visible control (WCAG 2.2.2 Pause, Stop, Hide) —
+  // unlike hover/focus pause, this persists until the visitor resumes.
+  const [userPaused, setUserPaused] = useState(false)
   const [frameH, setFrameH] = useState<number>()
   const slideRef = useRef<HTMLDivElement>(null)
+  const reducedMotion = useReducedMotion()
 
-  // Auto-advance, paused while the visitor is hovering/focusing the widget and
-  // disabled entirely under prefers-reduced-motion.
+  // Auto-advance, paused while the visitor is hovering/focusing the widget or
+  // has hit the pause control, and disabled entirely under
+  // prefers-reduced-motion (live, not just at mount).
   useEffect(() => {
-    if (paused) return
-    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return
+    if (paused || userPaused || reducedMotion) return
     if (RESOLVED.length < 2) return
     const id = setInterval(() => setActive((a) => (a + 1) % RESOLVED.length), ROTATE_MS)
     return () => clearInterval(id)
-  }, [paused])
+  }, [paused, userPaused, reducedMotion])
 
   // Drive the frame height from the active slide's real content so every theme
   // shows at its true size — no scrollbar and no dead padding. A ResizeObserver
@@ -169,6 +174,23 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
             role="group"
             aria-label="Choose a theme"
           >
+            {/* Under reduced motion the rotation is off entirely, so the
+                pause control would be inert — hide it. */}
+            {RESOLVED.length > 1 && !reducedMotion && (
+              <button
+                type="button"
+                onClick={() => setUserPaused((p) => !p)}
+                aria-label={userPaused ? 'Resume theme rotation' : 'Pause theme rotation'}
+                aria-pressed={userPaused}
+                className="flex h-6 w-6 items-center justify-center rounded-full text-text-sub hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
+              >
+                {userPaused ? (
+                  <Play className="h-3.5 w-3.5" aria-hidden="true" />
+                ) : (
+                  <Pause className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+              </button>
+            )}
             {RESOLVED.map((t, i) => {
               const isActive = i === active
               return (

--- a/frontend/src/hooks/useReducedMotion.ts
+++ b/frontend/src/hooks/useReducedMotion.ts
@@ -1,0 +1,43 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function subscribe(onChange: () => void): () => void {
+  const mql = window.matchMedia(QUERY)
+  mql.addEventListener('change', onChange)
+  return () => mql.removeEventListener('change', onChange)
+}
+
+/**
+ * Whether the visitor prefers reduced motion, kept live across OS setting
+ * changes. SSR renders as `false` (motion-on) and corrects on hydration;
+ * pure-CSS animations are additionally gated globally in globals.css — use
+ * this hook for JS-driven animation (intervals, rAF, imperative scrolling).
+ */
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(QUERY).matches,
+    () => false
+  )
+}


### PR DESCRIPTION
## What

**Batch 1 of the WCAG 2.2 AA initiative** (follows #562's gate): the app-wide foundations.

- **Skip link (2.4.1)** — first focusable element in the root layout, visually hidden until keyboard focus. Every page `<main>` (13 files) gets `id="main-content" tabIndex={-1}` so activation moves *real* focus, not just scroll. `/docs` had no `<main>` landmark at all — it does now.
- **Reduced motion (2.3.3, supports 2.2.2)** — global `prefers-reduced-motion` block in `globals.css` collapses all app-chrome animation (logo ring-spin, fade-ins, slide-up, spinners) and transitions. Overlay marketplace **themes are untouched** (broadcast art with their own per-theme blocks). New `hooks/useReducedMotion` (`useSyncExternalStore` over `matchMedia`, live across OS setting changes) for JS-driven motion; `ThemeSwitcher` refactored onto it — its old check was mount-only.
- **Carousel pause control (2.2.2)** — the landing theme carousel auto-advances every 4.2s; hover/focus-pause alone doesn't satisfy Pause-Stop-Hide. Added a visible, persistent pause/play toggle: 24×24px (2.5.8 minimum), `aria-pressed`, hidden under reduced motion (rotation is off entirely there).
- **Focus not obscured (2.4.11)** — `html { scroll-padding-top: 5rem }` keeps keyboard-focused / anchor-jumped content clear of the sticky navs (AppNav is 60px).

## Verified in the running app (keyboard drive via Playwright)

- Tab from load → skip link appears top-left → Enter → `document.activeElement` is `MAIN#main-content` ✓
- Pause button renders at exactly 24×24 with correct label/state ✓
- `npm run type-check` clean; unit suite 553 passed (×3 runs)

## Notes

- Textually independent of #561 (both touch `docs/page.tsx`/`layout.tsx` in different regions) and of #562 (different `globals.css` regions).
- Once #562's axe smoke merges alongside this, the docs test's anchor can switch to `getByRole('main')`.