### PR TITLE
feat(a11y): primitive gap-fill — switch, field, popover, alert-dialog, visually-hidden (Batch 2)

### DIFF
--- a/frontend/src/components/appearance/ColorPickerControl.tsx
+++ b/frontend/src/components/appearance/ColorPickerControl.tsx
@@ -18,9 +18,17 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+/**
+ * Color control for the appearance panels. The swatch opens a ui/popover
+ * (focus management, Escape, outside-press handled by the primitive — this
+ * replaces the old hand-rolled fixed-position flyout with its own mousedown
+ * listener) containing the visual picker plus a hex text input, so the color
+ * is settable without dragging (WCAG 2.5.7) and by exact value.
+ */
 
-import React, { useEffect, useRef, useState } from 'react'
-import { HexColorPicker } from 'react-colorful'
+import React from 'react'
+import { HexColorPicker, HexColorInput } from 'react-colorful'
+import { Popover } from '@/components/ui/popover'
 
 export interface ColorPickerControlProps {
   label: string
@@ -39,59 +47,32 @@ export function ColorPickerControl({
   opacity,
   onOpacityChange,
 }: ColorPickerControlProps): React.ReactElement {
-  const [open, setOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<HTMLButtonElement>(null)
-  const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 })
-
-  useEffect(() => {
-    if (!open) return
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [open])
-
-  useEffect(() => {
-    if (!open || !buttonRef.current) return
-    const rect = buttonRef.current.getBoundingClientRect()
-    setPopoverPos({ top: rect.bottom + 4, left: rect.left })
-  }, [open])
-
   const opacityValue =
-    showOpacity && opacity !== undefined
-      ? Math.round(parseFloat(opacity) * 100)
-      : 100
+    showOpacity && opacity !== undefined ? Math.round(parseFloat(opacity) * 100) : 100
 
   return (
-    <div className="flex items-center gap-2" ref={containerRef}>
+    <div className="flex items-center gap-2">
       <span className="w-28 shrink-0 text-sm text-text-sub">{label}</span>
 
-      <div className="relative">
-        {/* Color swatch button */}
-        <button
-          ref={buttonRef}
-          type="button"
+      <Popover.Root>
+        <Popover.Trigger
           data-testid="color-swatch"
-          className="h-7 w-10 rounded border border-border"
+          className="h-7 w-10 rounded border border-border focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
           style={{ backgroundColor: value }}
-          onClick={() => setOpen((prev) => !prev)}
           aria-label={`Pick color for ${label}`}
         />
-
-        {/* Popover with color picker */}
-        {open && (
-          <div
-            className="fixed z-[200] rounded border border-border bg-surface p-2 shadow-lg"
-            style={{ top: popoverPos.top, left: popoverPos.left }}
-          >
-            <HexColorPicker color={value} onChange={onChange} />
-          </div>
-        )}
-      </div>
+        <Popover.Content className="space-y-2">
+          <Popover.Title className="sr-only">{`Color for ${label}`}</Popover.Title>
+          <HexColorPicker color={value} onChange={onChange} />
+          <HexColorInput
+            color={value}
+            onChange={onChange}
+            prefixed
+            aria-label={`Hex value for ${label}`}
+            className="w-full rounded border border-border bg-bg px-2 py-1.5 font-mono text-sm text-text focus-visible:ring-1 focus-visible:ring-border focus-visible:outline-none"
+          />
+        </Popover.Content>
+      </Popover.Root>
 
       {/* Opacity slider — only when showOpacity is true and callbacks are provided */}
       {showOpacity && opacity !== undefined && onOpacityChange && (

--- a/frontend/src/components/appearance/FontFamilyCombobox.tsx
+++ b/frontend/src/components/appearance/FontFamilyCombobox.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import React, { useState } from 'react'
 import { Combobox } from '@base-ui/react/combobox'
 import { Check } from 'lucide-react'
@@ -59,12 +58,15 @@ export interface FontFamilyComboboxProps {
   value: string | null
   onChange: (value: string | null) => void
   placeholder?: string
+  /** Accessible name for the text input — the placeholder is only a hint. */
+  'aria-label'?: string
 }
 
 export function FontFamilyCombobox({
   value,
   onChange,
   placeholder = 'Select font…',
+  'aria-label': ariaLabel = 'Font family',
 }: FontFamilyComboboxProps): React.ReactElement {
   const [inputValue, setInputValue] = useState<string>('')
 
@@ -87,8 +89,9 @@ export function FontFamilyCombobox({
     >
       <div className="relative">
         <Combobox.Input
-          className="w-full rounded border border-border bg-bg px-2 py-1.5 text-sm text-text placeholder:text-text-dim focus:outline-none focus:ring-1 focus:ring-border"
+          className="w-full rounded border border-border bg-bg px-2 py-1.5 text-sm text-text placeholder:text-text-dim focus-visible:ring-1 focus-visible:ring-border focus-visible:outline-none"
           placeholder={placeholder}
+          aria-label={ariaLabel}
         />
         <Combobox.Trigger
           className="absolute inset-y-0 right-0 flex items-center px-2 text-text-dim"
@@ -100,53 +103,53 @@ export function FontFamilyCombobox({
         </Combobox.Trigger>
       </div>
       <Combobox.Portal>
-      <Combobox.Positioner className="z-[200]">
-        <Combobox.Popup className="max-h-60 overflow-y-auto rounded border border-border bg-surface py-1 shadow-lg">
-          {!hasResults && (
-            <Combobox.Empty className="px-3 py-2 text-sm text-text-dim">
-              No fonts found
-            </Combobox.Empty>
-          )}
-          {filteredSystem.length > 0 && (
-            <Combobox.Group>
-              <Combobox.GroupLabel className="px-3 py-1 text-xs font-semibold text-text-dim uppercase tracking-wide">
-                System Fonts
-              </Combobox.GroupLabel>
-              {filteredSystem.map((font) => (
-                <Combobox.Item
-                  key={font.value}
-                  value={font.value}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-text hover:bg-subtle data-[highlighted]:bg-subtle"
-                >
-                  <Combobox.ItemIndicator className="w-4">
-                    <Check className="h-3 w-3" />
-                  </Combobox.ItemIndicator>
-                  <span style={{ fontFamily: font.value }}>{font.label}</span>
-                </Combobox.Item>
-              ))}
-            </Combobox.Group>
-          )}
-          {filteredGoogle.length > 0 && (
-            <Combobox.Group>
-              <Combobox.GroupLabel className="px-3 py-1 text-xs font-semibold text-text-dim uppercase tracking-wide">
-                Google Fonts
-              </Combobox.GroupLabel>
-              {filteredGoogle.map((font) => (
-                <Combobox.Item
-                  key={font.value}
-                  value={font.value}
-                  className="flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-text hover:bg-subtle data-[highlighted]:bg-subtle"
-                >
-                  <Combobox.ItemIndicator className="w-4">
-                    <Check className="h-3 w-3" />
-                  </Combobox.ItemIndicator>
-                  <span style={{ fontFamily: font.value }}>{font.label}</span>
-                </Combobox.Item>
-              ))}
-            </Combobox.Group>
-          )}
-        </Combobox.Popup>
-      </Combobox.Positioner>
+        <Combobox.Positioner className="z-[200]">
+          <Combobox.Popup className="max-h-60 overflow-y-auto rounded border border-border bg-surface py-1 shadow-lg">
+            {!hasResults && (
+              <Combobox.Empty className="px-3 py-2 text-sm text-text-dim">
+                No fonts found
+              </Combobox.Empty>
+            )}
+            {filteredSystem.length > 0 && (
+              <Combobox.Group>
+                <Combobox.GroupLabel className="px-3 py-1 text-xs font-semibold tracking-wide text-text-dim uppercase">
+                  System Fonts
+                </Combobox.GroupLabel>
+                {filteredSystem.map((font) => (
+                  <Combobox.Item
+                    key={font.value}
+                    value={font.value}
+                    className="hover:bg-subtle data-[highlighted]:bg-subtle flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-text"
+                  >
+                    <Combobox.ItemIndicator className="w-4">
+                      <Check className="h-3 w-3" />
+                    </Combobox.ItemIndicator>
+                    <span style={{ fontFamily: font.value }}>{font.label}</span>
+                  </Combobox.Item>
+                ))}
+              </Combobox.Group>
+            )}
+            {filteredGoogle.length > 0 && (
+              <Combobox.Group>
+                <Combobox.GroupLabel className="px-3 py-1 text-xs font-semibold tracking-wide text-text-dim uppercase">
+                  Google Fonts
+                </Combobox.GroupLabel>
+                {filteredGoogle.map((font) => (
+                  <Combobox.Item
+                    key={font.value}
+                    value={font.value}
+                    className="hover:bg-subtle data-[highlighted]:bg-subtle flex cursor-pointer items-center gap-2 px-3 py-1.5 text-sm text-text"
+                  >
+                    <Combobox.ItemIndicator className="w-4">
+                      <Check className="h-3 w-3" />
+                    </Combobox.ItemIndicator>
+                    <span style={{ fontFamily: font.value }}>{font.label}</span>
+                  </Combobox.Item>
+                ))}
+              </Combobox.Group>
+            )}
+          </Combobox.Popup>
+        </Combobox.Positioner>
       </Combobox.Portal>
     </Combobox.Root>
   )

--- a/frontend/src/components/appearance/SliderControl.tsx
+++ b/frontend/src/components/appearance/SliderControl.tsx
@@ -18,8 +18,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-import React from 'react'
+import React, { useId } from 'react'
 
 export interface SliderControlProps {
   label: string
@@ -31,11 +30,25 @@ export interface SliderControlProps {
   onChange: (v: number) => void
 }
 
-export function SliderControl({ label, value, min, max, step, unit, onChange }: SliderControlProps): React.ReactElement {
+export function SliderControl({
+  label,
+  value,
+  min,
+  max,
+  step,
+  unit,
+  onChange,
+}: SliderControlProps): React.ReactElement {
+  // Explicit label/control association so the range input has an accessible
+  // name; the native range element keeps 2.1.1/2.5.7 handled by the browser.
+  const id = useId()
   return (
     <div className="flex items-center gap-2">
-      <span className="w-28 shrink-0 text-sm text-text-sub">{label}</span>
+      <label htmlFor={id} className="w-28 shrink-0 text-sm text-text-sub">
+        {label}
+      </label>
       <input
+        id={id}
         type="range"
         min={min}
         max={max}
@@ -44,8 +57,12 @@ export function SliderControl({ label, value, min, max, step, unit, onChange }: 
         onChange={(e) => onChange(parseFloat(e.target.value))}
         className="flex-1 accent-current"
       />
-      <span className="w-12 shrink-0 text-right text-sm text-text-dim tabular-nums">
-        {value}{unit ?? ''}
+      <span
+        aria-hidden="true"
+        className="w-12 shrink-0 text-right text-sm text-text-dim tabular-nums"
+      >
+        {value}
+        {unit ?? ''}
       </span>
     </div>
   )

--- a/frontend/src/components/appearance/ToggleSwitch.tsx
+++ b/frontend/src/components/appearance/ToggleSwitch.tsx
@@ -18,8 +18,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+/**
+ * Labeled toggle row for the appearance panels. Built on ui/switch inside a
+ * Field so the visible label IS the switch's accessible name (the previous
+ * hand-rolled version rendered the label as an unassociated sibling span —
+ * screen readers announced an unnamed switch). Clicking the label toggles.
+ */
 
 import React from 'react'
+import { Field } from '@/components/ui/field'
+import { Switch } from '@/components/ui/switch'
 
 export interface ToggleSwitchProps {
   label: string
@@ -29,23 +37,11 @@ export interface ToggleSwitchProps {
 
 export function ToggleSwitch({ label, checked, onChange }: ToggleSwitchProps): React.ReactElement {
   return (
-    <div className="flex items-center justify-between">
-      <span className="text-sm text-text-sub">{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-200 ${
-          checked ? 'bg-twitch' : 'bg-surface-alt'
-        }`}
-      >
-        <span
-          className={`inline-block h-4 w-4 translate-y-0.5 rounded-full bg-white shadow transition duration-200 ease-in-out ${
-            checked ? 'translate-x-4' : 'translate-x-0.5'
-          }`}
-        />
-      </button>
-    </div>
+    <Field.Root className="flex-row items-center justify-between gap-2">
+      <Field.Label className="text-sm font-normal text-text-sub">{label}</Field.Label>
+      <Switch.Root checked={checked} onCheckedChange={onChange}>
+        <Switch.Thumb />
+      </Switch.Root>
+    </Field.Root>
   )
 }

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Accessible alert dialog (Base UI AlertDialog) for destructive/irreversible
+ * confirmations: ban, delete, revoke, disconnect. Unlike ui/dialog it renders
+ * role="alertdialog", is NOT dismissed by clicking outside, and has no corner
+ * close button — the user must make an explicit choice. Put the cancel/least-
+ * destructive action first in DOM order so it receives initial focus.
+ */
+
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const alertDialogContentVariants = cva(
+  'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-full rounded-xl border border-border bg-surface p-6 shadow-xl text-text',
+  {
+    variants: {
+      size: {
+        sm: 'max-w-sm',
+        default: 'max-w-md',
+        lg: 'max-w-lg',
+      },
+    },
+    defaultVariants: { size: 'default' },
+  }
+)
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      className={cn('text-lg font-semibold text-text', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      className={cn('mt-2 text-sm text-text-sub', className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Popup> &
+  VariantProps<typeof alertDialogContentVariants>) {
+  return (
+    <AlertDialogPrimitive.Portal>
+      <AlertDialogPrimitive.Backdrop className="fixed inset-0 z-40 bg-black/60 backdrop-blur-[8px]" />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(alertDialogContentVariants({ size, className }))}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Popup>
+    </AlertDialogPrimitive.Portal>
+  )
+}
+
+export const AlertDialog = {
+  Root: AlertDialogPrimitive.Root,
+  Trigger: AlertDialogPrimitive.Trigger,
+  Close: AlertDialogPrimitive.Close,
+  Title: AlertDialogTitle,
+  Description: AlertDialogDescription,
+  Content: AlertDialogContent,
+}
+
+export { alertDialogContentVariants }

--- a/frontend/src/components/ui/field.tsx
+++ b/frontend/src/components/ui/field.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Accessible form-field primitive (Base UI Field).
+ *
+ * The workhorse of the WCAG form-labeling batches: `Field.Root` wires
+ * label ↔ control ↔ description ↔ error associations (htmlFor,
+ * aria-describedby, aria-invalid) automatically — no manual id plumbing.
+ *
+ *   <Field.Root>
+ *     <Field.Label>Channel name</Field.Label>
+ *     <Field.Control render={<Input />} />   // or any control, e.g. Switch
+ *     <Field.Description>Shown under your messages.</Field.Description>
+ *     <Field.Error />                        // renders on validation failure
+ *   </Field.Root>
+ */
+
+import { Field as FieldPrimitive } from '@base-ui/react/field'
+import { cn } from '@/lib/utils'
+
+function FieldRoot({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof FieldPrimitive.Root>) {
+  return (
+    <FieldPrimitive.Root
+      data-slot="field"
+      className={cn('flex flex-col gap-1', className)}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof FieldPrimitive.Label>) {
+  return (
+    <FieldPrimitive.Label
+      data-slot="field-label"
+      className={cn('text-sm font-medium text-text', className)}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof FieldPrimitive.Description>) {
+  return (
+    <FieldPrimitive.Description
+      data-slot="field-description"
+      className={cn('text-sm text-text-sub', className)}
+      {...props}
+    />
+  )
+}
+
+function FieldError({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof FieldPrimitive.Error>) {
+  return (
+    <FieldPrimitive.Error
+      data-slot="field-error"
+      className={cn('text-sm text-red-400', className)}
+      {...props}
+    />
+  )
+}
+
+export const Field = {
+  Root: FieldRoot,
+  Label: FieldLabel,
+  Control: FieldPrimitive.Control,
+  Description: FieldDescription,
+  Error: FieldError,
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Accessible popover primitive (Base UI Popover): focus management, Escape,
+ * outside-press dismissal and anchor positioning for free. Use for anchored
+ * pickers/panels (color swatch pickers, small config flyouts) — for
+ * confirmation flows use ui/dialog or ui/alert-dialog instead.
+ */
+
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover'
+import { cn } from '@/lib/utils'
+
+function PopoverContent({
+  className,
+  sideOffset = 8,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Popup> & {
+  sideOffset?: number
+}) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner sideOffset={sideOffset} className="z-50">
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            'rounded-lg border border-border-md bg-surface-2 p-3 text-text shadow-xl',
+            'focus-visible:outline-none',
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </PopoverPrimitive.Popup>
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Title>) {
+  return (
+    <PopoverPrimitive.Title
+      className={cn('text-sm font-semibold text-text', className)}
+      {...props}
+    />
+  )
+}
+
+export const Popover = {
+  Root: PopoverPrimitive.Root,
+  Trigger: PopoverPrimitive.Trigger,
+  Close: PopoverPrimitive.Close,
+  Title: PopoverTitle,
+  Content: PopoverContent,
+}

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Accessible switch primitive (Base UI Switch).
+ *
+ * The root is 24px tall — the WCAG 2.5.8 minimum target size. Always give a
+ * switch an accessible name: render it inside a `Field.Root` with a
+ * `Field.Label` (auto-associated), or pass `aria-label` / `aria-labelledby`.
+ */
+
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch'
+import { cn } from '@/lib/utils'
+
+function SwitchRoot({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'inline-flex h-6 w-10 shrink-0 items-center rounded-full p-0.5 transition-colors duration-200',
+        'bg-surface-2 data-[checked]:bg-twitch',
+        'focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SwitchThumb({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Thumb>) {
+  return (
+    <SwitchPrimitive.Thumb
+      data-slot="switch-thumb"
+      className={cn(
+        'block h-5 w-5 rounded-full bg-white shadow transition-transform duration-200 ease-in-out',
+        'data-[checked]:translate-x-4',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export const Switch = {
+  Root: SwitchRoot,
+  Thumb: SwitchThumb,
+}

--- a/frontend/src/components/ui/visually-hidden.tsx
+++ b/frontend/src/components/ui/visually-hidden.tsx
@@ -1,0 +1,30 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Screen-reader-only text. Use for labels/status that must be announced but
+ * not shown: spinner "Loading…" text, icon-button context, live-region
+ * updates. Prefer this component over a bare `sr-only` span — it's greppable
+ * and signals intent in JSX.
+ */
+
+import { cn } from '@/lib/utils'
+
+export function VisuallyHidden({ className, ...props }: React.ComponentPropsWithoutRef<'span'>) {
+  return <span data-slot="visually-hidden" className={cn('sr-only', className)} {...props} />
+}

--- a/frontend/src/stories/AlertDialog.stories.tsx
+++ b/frontend/src/stories/AlertDialog.stories.tsx
@@ -1,0 +1,56 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import React from 'react'
+import { AlertDialog } from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+function AlertDialogDemo() {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <AlertDialog.Root open={open} onOpenChange={setOpen}>
+      <AlertDialog.Trigger render={<Button variant="destructive">Delete overlay</Button>} />
+      <AlertDialog.Content>
+        <AlertDialog.Title>Delete this overlay?</AlertDialog.Title>
+        <AlertDialog.Description>
+          This removes the overlay and all its chat sources. This cannot be undone.
+        </AlertDialog.Description>
+        <div className="mt-4 flex justify-end gap-2">
+          {/* Cancel first in DOM order = initial focus on the safe action */}
+          <AlertDialog.Close render={<Button variant="ghost">Cancel</Button>} />
+          <Button variant="destructive" onClick={() => setOpen(false)}>
+            Delete
+          </Button>
+        </div>
+      </AlertDialog.Content>
+    </AlertDialog.Root>
+  )
+}
+
+const meta = {
+  title: 'UI/AlertDialog',
+  component: AlertDialogDemo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AlertDialogDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/stories/Field.stories.tsx
+++ b/frontend/src/stories/Field.stories.tsx
@@ -1,0 +1,44 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import React from 'react'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+
+function FieldDemo() {
+  return (
+    <Field.Root className="w-72">
+      <Field.Label>Channel name</Field.Label>
+      <Field.Control render={<Input placeholder="e.g. caesarlp" />} />
+      <Field.Description>The channel whose chat appears on the overlay.</Field.Description>
+    </Field.Root>
+  )
+}
+
+const meta = {
+  title: 'UI/Field',
+  component: FieldDemo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof FieldDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/frontend/src/stories/Popover.stories.tsx
+++ b/frontend/src/stories/Popover.stories.tsx
@@ -1,0 +1,59 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import React from 'react'
+import { Popover } from '@/components/ui/popover'
+import { Button } from '@/components/ui/button'
+import { ColorPickerControl } from '@/components/appearance/ColorPickerControl'
+
+function PopoverDemo() {
+  return (
+    <Popover.Root>
+      <Popover.Trigger render={<Button variant="outline">Open popover</Button>} />
+      <Popover.Content className="w-64">
+        <Popover.Title>Quick settings</Popover.Title>
+        <p className="mt-1 text-sm text-text-sub">
+          Anchored panel with focus management and Escape-to-close.
+        </p>
+      </Popover.Content>
+    </Popover.Root>
+  )
+}
+
+function ColorPickerDemo() {
+  const [color, setColor] = React.useState('#a37bff')
+  return (
+    <div className="w-80">
+      <ColorPickerControl label="Username color" value={color} onChange={setColor} />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'UI/Popover',
+  component: PopoverDemo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PopoverDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const ColorPicker: Story = { render: () => <ColorPickerDemo /> }

--- a/frontend/src/stories/Switch.stories.tsx
+++ b/frontend/src/stories/Switch.stories.tsx
@@ -1,0 +1,69 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import React from 'react'
+import { Switch } from '@/components/ui/switch'
+import { Field } from '@/components/ui/field'
+import { ToggleSwitch } from '@/components/appearance/ToggleSwitch'
+
+// The axe gate (a11y test: 'error') verifies every rendered switch has an
+// accessible name — the exact defect the old hand-rolled ToggleSwitch had.
+function SwitchDemo() {
+  const [checked, setChecked] = React.useState(false)
+  return (
+    <Field.Root className="w-64 flex-row items-center justify-between">
+      <Field.Label>Enable notifications</Field.Label>
+      <Switch.Root checked={checked} onCheckedChange={setChecked}>
+        <Switch.Thumb />
+      </Switch.Root>
+    </Field.Root>
+  )
+}
+
+function ToggleSwitchDemo() {
+  const [checked, setChecked] = React.useState(true)
+  return (
+    <div className="w-64">
+      <ToggleSwitch label="Show timestamps" checked={checked} onChange={setChecked} />
+    </div>
+  )
+}
+
+const meta = {
+  title: 'UI/Switch',
+  component: SwitchDemo,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SwitchDemo>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+export const AppearanceToggleRow: Story = { render: () => <ToggleSwitchDemo /> }
+export const Disabled: Story = {
+  render: () => (
+    <Field.Root className="w-64 flex-row items-center justify-between">
+      <Field.Label>Locked setting</Field.Label>
+      <Switch.Root disabled checked={false}>
+        <Switch.Thumb />
+      </Switch.Root>
+    </Field.Root>
+  ),
+}


### PR DESCRIPTION
## What

**Batch 2 of the WCAG 2.2 AA initiative**, and the hard prerequisite for the onboarding setup-guide UI (PR-C consumes these primitives instead of inventing its own).

### New `ui/` primitives (Base UI 1.6.0, styled in the `ui/dialog` house pattern; note the earlier plan's "installed 1.5.0" concern was stale — installed = pinned = 1.6.0)

| Primitive | Why |
|---|---|
| `ui/switch` | 24px-tall root (2.5.8 minimum target size) |
| `ui/field` | Auto-wired label ↔ control ↔ description ↔ error associations — the workhorse for the upcoming form-labeling batches |
| `ui/popover` | Anchored panels with focus management / Escape / outside-press |
| `ui/alert-dialog` | `role=alertdialog` for destructive confirms: no outside-press dismissal, cancel-first initial focus |
| `ui/visually-hidden` | Greppable sr-only span for SR-only labels/status |

Each has an **axe-gated story** (Storybook `a11y: test:'error'`).

### Reworked feature components — props APIs unchanged, callers untouched

- **`appearance/ToggleSwitch`** — rebuilt on ui/switch + ui/field. The old hand-rolled version rendered `role=switch` with **no accessible name** (label was an unassociated sibling span) and violated the repo's own template-literal-className lint rule. The new axe story is the regression guard.
- **`appearance/ColorPickerControl`** — swatch opens a ui/popover with the visual picker **plus a `HexColorInput`**: color settable without dragging (2.5.7) and by exact value. Deletes the hand-rolled fixed-position flyout and its document `mousedown` listener.
- **`appearance/SliderControl`** — explicit `label htmlFor` via `useId` (was an unassociated span).
- **`appearance/FontFamilyCombobox`** — input gains an accessible name (was placeholder-only) + its bare `focus:` utilities become `focus-visible:` (the latent violation the a11y lint in #562 flagged).

## Testing
- `npm run type-check` clean
- Unit suite 553 passed (appearance-group tests exercise the reworked components through their real usage)
- Storybook axe project **52/52** (45 pre-existing + 7 new)

## Notes
- After #562 merges, the ToggleSwitch/FontFamilyCombobox entries in `eslint.a11y.suppressions.json` become prunable — I'll prune in a follow-up once both are on main.
- Editor `aria-required-attr` axe-baseline entry may also become prunable (suspected source was the unnamed switch) — will verify against the smoke suite post-merge.