### PR TITLE
feat(onboarding): first-run setup guide

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -33,6 +33,10 @@ import { PlatformBadge } from '@/components/ui/badge'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { MaintenanceBanner } from '@/components/MaintenanceBanner'
 import { EventSubMigrationBanner } from '@/components/EventSubMigrationBanner'
+import { OnboardingChecklist } from '@/components/onboarding/OnboardingChecklist'
+import { CreateOverlayDialog } from '@/components/onboarding/CreateOverlayDialog'
+import { useOnboardingStore } from '@/lib/stores/onboarding-store'
+import { useAuthStore } from '@/lib/stores/auth-store'
 import type { ChatSource } from '@/lib/types/overlay'
 
 // Extended overlay type that includes sources when available
@@ -155,10 +159,37 @@ function DashboardContent() {
   const router = useRouter()
   const { overlays, loading, fetchOverlays, deleteOverlay } = useOverlayStore()
   const [sourcesByOverlay, setSourcesByOverlay] = useState<Record<string, ChatSource[]>>({})
+  const user = useAuthStore((s) => s.user)
+  const onboardingStatus = useOnboardingStore((s) => s.status)
+  const startOnboarding = useOnboardingStore((s) => s.start)
+  const activeOverlayId = useOnboardingStore((s) => s.activeOverlayId)
+  const setActiveOverlay = useOnboardingStore((s) => s.setActiveOverlay)
+  const [onboardingCreateOpen, setOnboardingCreateOpen] = useState(false)
+  const [overlaysFetched, setOverlaysFetched] = useState(false)
 
   useEffect(() => {
-    fetchOverlays()
+    fetchOverlays().then(() => setOverlaysFetched(true))
   }, [fetchOverlays])
+
+  // First-run setup guide auto-start: only for a signed-in, non-impersonated
+  // user whose server flag is explicitly null AND who has no overlays yet
+  // (the zero-overlay guard protects users created between backend and
+  // frontend deploys). Gated on overlaysFetched, NOT the store's loading
+  // flag — that starts false before the first fetch, which would race the
+  // guard into always seeing zero overlays. Settings restart bypasses this
+  // via start('settings').
+  useEffect(() => {
+    if (!overlaysFetched || !user || user.impersonating) return
+    if (user.onboarding_completed_at !== null) return
+    if (overlays.length > 0) return
+    startOnboarding('auto')
+  }, [overlaysFetched, user, overlays.length, startOnboarding])
+
+  // Steps 2-4 need an overlay to point at; on the dashboard bind them to the
+  // first overlay when the editor hasn't set one.
+  useEffect(() => {
+    if (!activeOverlayId && overlays.length > 0) setActiveOverlay(overlays[0].id)
+  }, [activeOverlayId, overlays, setActiveOverlay])
 
   // Fetch sources for all overlays after the list loads
   useEffect(() => {
@@ -231,7 +262,15 @@ function DashboardContent() {
         {loading ? (
           <OverlayGridSkeleton />
         ) : overlaysWithSources.length === 0 ? (
-          <DashboardEmptyState onCreateClick={() => router.push('/overlays/new')} />
+          <DashboardEmptyState
+            onCreateClick={() =>
+              // During onboarding the empty-state CTA IS step 1 — one path,
+              // not two competing ones.
+              onboardingStatus === 'active'
+                ? setOnboardingCreateOpen(true)
+                : router.push('/overlays/new')
+            }
+          />
         ) : (
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
             {overlaysWithSources.map((overlay) => (
@@ -315,6 +354,9 @@ function DashboardContent() {
           </div>
         )}
       </main>
+
+      <OnboardingChecklist surface="dashboard" overlayCount={overlays.length} />
+      <CreateOverlayDialog open={onboardingCreateOpen} onOpenChange={setOnboardingCreateOpen} />
     </div>
   )
 }

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -52,9 +52,18 @@ import { getGuilds, getGuildChannels, updateSourceConfig } from '@/lib/api/disco
 import type { DiscordGuild, ChannelCategory } from '@/lib/api/discord'
 import { ApiError } from '@/lib/api/client'
 import { DISCORD_INVITE_URL } from '@/lib/constants'
+import { OnboardingChecklist } from '@/components/onboarding/OnboardingChecklist'
+import { ObsHelpContent } from '@/components/onboarding/ObsHelpContent'
+import { deriveSteps, useOnboardingStore } from '@/lib/stores/onboarding-store'
 import { engagementApi } from '@/lib/api/engagement'
 import type { EarnConfig } from '@/lib/types/engagement'
-import type { Overlay, ChatSource, DiscordSourceConfig, FilterSettings, DisplaySettings } from '@/lib/types/overlay'
+import type {
+  Overlay,
+  ChatSource,
+  DiscordSourceConfig,
+  FilterSettings,
+  DisplaySettings,
+} from '@/lib/types/overlay'
 import type { ChatMessage } from '@/lib/types/message'
 import type { AcceptedShare } from '@/lib/types/share'
 import type { VisualSettings } from '@/lib/types/visual-settings'
@@ -93,7 +102,10 @@ const MonacoCSSEditor = dynamic(() => import('@/components/MonacoCSSEditor'), {
 
 // Dynamically import ThemeContent for inline Theme section (SSR unsafe — uses hooks)
 const ThemeContent = dynamic(
-  () => import('@/components/theme-marketplace/ThemeContent').then((m) => ({ default: m.ThemeContent })),
+  () =>
+    import('@/components/theme-marketplace/ThemeContent').then((m) => ({
+      default: m.ThemeContent,
+    })),
   { ssr: false }
 )
 
@@ -426,12 +438,36 @@ function SourceCard({
 // ---- StreamSelectionPanel ---------------------------------------------------
 
 const STREAM_STRATEGIES = [
-  { value: 'first_found', label: 'First found', description: 'Picks the first live stream (default)' },
-  { value: 'most_viewers', label: 'Most viewers', description: 'Picks the stream with the highest viewer count' },
-  { value: 'fewest_viewers', label: 'Fewest viewers', description: 'Picks the stream with the lowest viewer count' },
-  { value: 'title_match', label: 'Title match', description: 'Picks the first stream whose title contains a keyword' },
-  { value: 'title_match_all', label: 'Title match (all)', description: 'Monitors all streams whose title contains a keyword' },
-  { value: 'all', label: 'All streams', description: 'Monitors all concurrent live streams simultaneously' },
+  {
+    value: 'first_found',
+    label: 'First found',
+    description: 'Picks the first live stream (default)',
+  },
+  {
+    value: 'most_viewers',
+    label: 'Most viewers',
+    description: 'Picks the stream with the highest viewer count',
+  },
+  {
+    value: 'fewest_viewers',
+    label: 'Fewest viewers',
+    description: 'Picks the stream with the lowest viewer count',
+  },
+  {
+    value: 'title_match',
+    label: 'Title match',
+    description: 'Picks the first stream whose title contains a keyword',
+  },
+  {
+    value: 'title_match_all',
+    label: 'Title match (all)',
+    description: 'Monitors all streams whose title contains a keyword',
+  },
+  {
+    value: 'all',
+    label: 'All streams',
+    description: 'Monitors all concurrent live streams simultaneously',
+  },
 ] as const
 
 function StreamSelectionPanel({
@@ -519,9 +555,7 @@ function StreamSelectionPanel({
 
         {(strategy === 'title_match' || strategy === 'title_match_all') && (
           <div>
-            <label className="mb-1 block text-xs font-medium text-text-sub">
-              Title keyword
-            </label>
+            <label className="mb-1 block text-xs font-medium text-text-sub">Title keyword</label>
             <Input
               value={matchTerm}
               onChange={(e) => setMatchTerm(e.target.value)}
@@ -541,7 +575,12 @@ function StreamSelectionPanel({
           size="sm"
           variant="outline"
           className="w-full"
-          disabled={!hasChanges || saving || locked || ((strategy === 'title_match' || strategy === 'title_match_all') && !matchTerm.trim())}
+          disabled={
+            !hasChanges ||
+            saving ||
+            locked ||
+            ((strategy === 'title_match' || strategy === 'title_match_all') && !matchTerm.trim())
+          }
           onClick={handleSave}
         >
           {saving ? 'Saving…' : 'Save'}
@@ -564,9 +603,7 @@ function RelayPanel({
 }) {
   const discordConfig = source.config as DiscordSourceConfig
   const [relayEnabled, setRelayEnabled] = useState(discordConfig.relay_enabled ?? false)
-  const [relayChannelId, setRelayChannelId] = useState<string>(
-    discordConfig.relay_channel_id ?? ''
-  )
+  const [relayChannelId, setRelayChannelId] = useState<string>(discordConfig.relay_channel_id ?? '')
   const [channels, setChannels] = useState<ChannelCategory[]>([])
   const [channelsLoading, setChannelsLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -602,7 +639,7 @@ function RelayPanel({
   const isSaveDisabled = saving || (relayEnabled && !relayChannelId)
 
   return (
-    <div className="ml-4 mt-1 rounded-lg border border-border bg-surface-2 p-4 space-y-3">
+    <div className="mt-1 ml-4 space-y-3 rounded-lg border border-border bg-surface-2 p-4">
       {/* Loop filter info — static */}
       <p className="text-xs text-text-sub">
         Loop filter: active — Discord messages are never relayed back to Discord.
@@ -614,7 +651,7 @@ function RelayPanel({
           type="checkbox"
           checked={relayEnabled}
           onChange={(e) => setRelayEnabled(e.target.checked)}
-          className="accent-discord size-4"
+          className="size-4 accent-discord"
         />
         Enable relay
       </label>
@@ -695,7 +732,12 @@ const EARN_NUMBER_FIELDS: ReadonlyArray<{
   { key: 'gift_per_sub', label: 'Per gifted sub', hint: 'awarded to the gifter' },
   // chat_per_minute has no producer in v1 (nothing publishes engagement:chat), so it
   // never accrues — flag it disabled so streamers don't configure a dead dimension (M6).
-  { key: 'chat_per_minute', label: 'Chatting, per minute', hint: 'active chatters', comingSoon: true },
+  {
+    key: 'chat_per_minute',
+    label: 'Chatting, per minute',
+    hint: 'active chatters',
+    comingSoon: true,
+  },
   // watch_per_minute rewards participation-PAGE focus time (heartbeat), not stream-watch time (M6).
   {
     key: 'watch_per_minute',
@@ -813,7 +855,10 @@ function EngagementPanel({ overlayId }: { overlayId: string }) {
     try {
       window.location.href = await engagementApi.getTwitchMirrorConsentUrl(overlayId)
     } catch {
-      toastManager.add({ title: 'Could not start Twitch consent. Please try again.', type: 'error' })
+      toastManager.add({
+        title: 'Could not start Twitch consent. Please try again.',
+        type: 'error',
+      })
     }
   }
 
@@ -835,15 +880,15 @@ function EngagementPanel({ overlayId }: { overlayId: string }) {
           type="checkbox"
           checked={config.enabled}
           onChange={(e) => setConfig({ ...config, enabled: e.target.checked })}
-          className="accent-twitch size-4"
+          className="size-4 accent-twitch"
         />
         Enable viewer points
       </label>
       <p className="text-xs text-text-sub">
         Viewers earn {config.points_name.trim() || 'Points'} by supporting the stream (subs, bits,
-        donations, gifts) and by keeping the participation page open, and wager them on
-        predictions. Run polls and predictions from the Monitor View; viewers join straight from
-        chat (<code>!vote 2</code> or just <code>2</code>, <code>!predict 1 500</code>) or the
+        donations, gifts) and by keeping the participation page open, and wager them on predictions.
+        Run polls and predictions from the Monitor View; viewers join straight from chat (
+        <code>!vote 2</code> or just <code>2</code>, <code>!predict 1 500</code>) or the
         participation page — no install required.
       </p>
 
@@ -853,7 +898,7 @@ function EngagementPanel({ overlayId }: { overlayId: string }) {
             type="checkbox"
             checked={config.announce_on_start}
             onChange={(e) => setConfig({ ...config, announce_on_start: e.target.checked })}
-            className="accent-twitch size-4"
+            className="size-4 accent-twitch"
           />
           Announce new rounds in chat
         </label>
@@ -890,7 +935,10 @@ function EngagementPanel({ overlayId }: { overlayId: string }) {
               value={numbers[f.key]}
               disabled={f.comingSoon}
               onChange={(e) => setNumbers({ ...numbers, [f.key]: e.target.value })}
-              className={cn('w-full rounded-md border border-border bg-bg px-2 py-1 text-xs text-text', f.comingSoon && 'opacity-50')}
+              className={cn(
+                'w-full rounded-md border border-border bg-bg px-2 py-1 text-xs text-text',
+                f.comingSoon && 'opacity-50'
+              )}
             />
             <p className="mt-0.5 text-[11px] text-text-sub">
               {f.hint}
@@ -1174,7 +1222,9 @@ function AddSourceForm({
           <button
             onClick={handleDiscordButtonClick}
             className="flex items-center gap-2.5 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
-            style={{ backgroundColor: '#5865F2', '--tw-ring-color': '#5865F2' } as React.CSSProperties}
+            style={
+              { backgroundColor: '#5865F2', '--tw-ring-color': '#5865F2' } as React.CSSProperties
+            }
           >
             {/* Discord logo mark */}
             <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
@@ -1340,7 +1390,9 @@ function AddSourceForm({
                 }
               } catch (err) {
                 if (adminPlatform === 'youtube') {
-                  setYoutubeResolveError(err instanceof Error ? err.message : 'Failed to resolve YouTube channel')
+                  setYoutubeResolveError(
+                    err instanceof Error ? err.message : 'Failed to resolve YouTube channel'
+                  )
                   setYoutubeResolved(null)
                 }
               } finally {
@@ -1370,7 +1422,11 @@ function AddSourceForm({
                   setYoutubeResolved(null)
                   setYoutubeResolveError(null)
                 }}
-                placeholder={adminPlatform === 'youtube' ? '@handle, channel URL, or UC…' : 'Channel ID or username'}
+                placeholder={
+                  adminPlatform === 'youtube'
+                    ? '@handle, channel URL, or UC…'
+                    : 'Channel ID or username'
+                }
                 className="flex-1 text-xs"
               />
             </div>
@@ -1378,13 +1434,21 @@ function AddSourceForm({
               <div className="flex items-center gap-2 rounded-lg bg-surface px-2 py-1.5 text-xs text-text-sub">
                 {youtubeResolved.thumbnail && (
                   // eslint-disable-next-line @next/next/no-img-element
-                  <img src={youtubeResolved.thumbnail} alt="" className="h-6 w-6 rounded-full object-cover" />
+                  <img
+                    src={youtubeResolved.thumbnail}
+                    alt=""
+                    className="h-6 w-6 rounded-full object-cover"
+                  />
                 )}
-                <span className="font-medium text-text">{youtubeResolved.title ?? youtubeResolved.channel_id}</span>
+                <span className="font-medium text-text">
+                  {youtubeResolved.title ?? youtubeResolved.channel_id}
+                </span>
                 {youtubeResolved.custom_url && (
                   <span className="text-text-sub">{youtubeResolved.custom_url}</span>
                 )}
-                <span className="ml-auto font-mono text-[10px] text-text-sub">{youtubeResolved.channel_id}</span>
+                <span className="ml-auto font-mono text-[10px] text-text-sub">
+                  {youtubeResolved.channel_id}
+                </span>
               </div>
             )}
             {adminPlatform === 'youtube' && youtubeResolveError && (
@@ -1425,6 +1489,21 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   const [acceptedShares, setAcceptedShares] = useState<AcceptedShare[]>([])
   const [revokeTarget, setRevokeTarget] = useState<ChatSource | null>(null)
 
+  // --- First-run setup guide (onboarding) ---
+  const onboardingActive = useOnboardingStore((s) => s.status === 'active')
+  const setActiveOverlay = useOnboardingStore((s) => s.setActiveOverlay)
+  const obsCopiedStep = useOnboardingStore((s) => s.sessionSteps.obsCopied)
+  // Explicit spotlight from a checklist "Show me" click; while unset the
+  // active step's own section is spotlighted.
+  const [spotlightOverride, setSpotlightOverride] = useState<
+    'sources' | 'theme' | 'appearance' | null
+  >(null)
+  const spotlightRefs = {
+    sources: useRef<HTMLDivElement>(null),
+    theme: useRef<HTMLDivElement>(null),
+    appearance: useRef<HTMLDivElement>(null),
+  }
+
   // --- Customization state ---
   const [maxMessages, setMaxMessages] = useState(50)
   const [messageDuration, setMessageDuration] = useState(15)
@@ -1441,10 +1520,10 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   // Descriptor for the currently-saved set, populated by an auto-resolve on
   // config load so the editor shows the human name + emote count instead of
   // an opaque ULID. Cleared whenever the saved ID changes to "".
-  const [seventvSavedDescriptor, setSeventvSavedDescriptor] = useState<
-    | { name?: string; emoteCount?: number }
-    | null
-  >(null)
+  const [seventvSavedDescriptor, setSeventvSavedDescriptor] = useState<{
+    name?: string
+    emoteCount?: number
+  } | null>(null)
   const [seventvResolveState, setSeventvResolveState] = useState<
     | { status: 'idle' }
     | { status: 'resolving' }
@@ -1471,9 +1550,60 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   const [useCustomCss, setUseCustomCss] = useState(false)
   const [themeId, setThemeId] = useState('')
 
+  // Setup-guide wiring: bind steps 2-4 to this overlay, and while the guide
+  // is active spotlight exactly one of the three step sections (forced open,
+  // the other two forced closed — progressive disclosure for first-run
+  // users; the user's own section preferences are untouched, see
+  // CollapsibleSection.forceOpen).
+  useEffect(() => {
+    setActiveOverlay(id)
+  }, [id, setActiveOverlay])
+
+  // Re-arm the guide after HARD navigations: connecting Twitch/YouTube/Kick
+  // is a full-window OAuth redirect back to this page, which resets the
+  // in-memory store. A flag-null, non-impersonated user in the editor is
+  // mid-onboarding by construction (no zero-overlay guard here — they're
+  // editing an overlay), so the guide continues where the derived steps say.
+  const startOnboarding = useOnboardingStore((s) => s.start)
+  useEffect(() => {
+    if (!user || user.impersonating) return
+    if (user.onboarding_completed_at !== null) return
+    startOnboarding('auto')
+  }, [user, startOnboarding])
+
+  const onboardingActiveStep = onboardingActive
+    ? deriveSteps({
+        overlayCount: 1,
+        sourceCount: sources.length,
+        themeId: themeId || null,
+        obsCopied: obsCopiedStep,
+      }).find((s) => s.active)?.id
+    : undefined
+  const spotlight: 'sources' | 'theme' | 'appearance' | null = !onboardingActive
+    ? null
+    : (spotlightOverride ??
+      (onboardingActiveStep === 'connect_source'
+        ? 'sources'
+        : onboardingActiveStep === 'choose_theme'
+          ? 'theme'
+          : null))
+
+  const sectionForce = (section: 'sources' | 'theme' | 'appearance'): boolean | undefined =>
+    onboardingActive ? spotlight === section : undefined
+
+  function handleSpotlightSection(section: 'sources' | 'theme' | 'appearance') {
+    setSpotlightOverride(section)
+    // Let the forced-open render land before scrolling to the section.
+    requestAnimationFrame(() => {
+      spotlightRefs[section].current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }
+
   // --- Visual appearance settings state ---
   const [visualSettings, setVisualSettings] = useState<Partial<VisualSettings>>({})
-  const [iframeVisibilityDefaults, setIframeVisibilityDefaults] = useState<Partial<VisualSettings>>({})
+  const [iframeVisibilityDefaults, setIframeVisibilityDefaults] = useState<Partial<VisualSettings>>(
+    {}
+  )
   const [parsedThemeSettings, setParsedThemeSettings] = useState<Partial<VisualSettings>>({})
   const [showThemeConfirm, setShowThemeConfirm] = useState(false)
   const [pendingTheme, setPendingTheme] = useState<Theme | null>(null)
@@ -1516,7 +1646,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
 
   // --- Discord relay state ---
   const [relayExpandedSourceId, setRelayExpandedSourceId] = useState<string | null>(null)
-  const [streamSelectExpandedSourceId, setStreamSelectExpandedSourceId] = useState<string | null>(null)
+  const [streamSelectExpandedSourceId, setStreamSelectExpandedSourceId] = useState<string | null>(
+    null
+  )
 
   // --- Share overlay state ---
   const [showShareModal, setShowShareModal] = useState(false)
@@ -1585,10 +1717,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   // --- sendCssToIframe: post CSS generated from visualSettings to the iframe ---
   const sendCssToIframe = useCallback((settings: Partial<VisualSettings>) => {
     const css = visualSettingsToCss(settings)
-    iframeRef.current?.contentWindow?.postMessage(
-      { type: 'VISUAL_CSS_UPDATE', css },
-      '*'
-    )
+    iframeRef.current?.contentWindow?.postMessage({ type: 'VISUAL_CSS_UPDATE', css }, '*')
     // Send non-CSS visual settings (platform badge position/style, indicators toggle)
     iframeRef.current?.contentWindow?.postMessage(
       {
@@ -1605,58 +1734,76 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   }, [])
 
   // --- handleVisualSettingsChange: merge patch, update state, send CSS ---
-  const handleVisualSettingsChange = useCallback((patch: Partial<VisualSettings>) => {
-    setVisualSettings((prev) => {
-      const next = { ...prev, ...patch }
-      sendCssToIframe(next)
-      return next
-    })
-  }, [sendCssToIframe])
+  const handleVisualSettingsChange = useCallback(
+    (patch: Partial<VisualSettings>) => {
+      setVisualSettings((prev) => {
+        const next = { ...prev, ...patch }
+        sendCssToIframe(next)
+        return next
+      })
+    },
+    [sendCssToIframe]
+  )
 
   // --- handleFilterSettingsChange: merge patch, update state, send to iframe immediately (D-07 WYSIWYG) ---
-  const handleFilterSettingsChange = useCallback((patch: Partial<FilterSettings>) => {
-    setFilterSettings((prev) => {
-      const next = { ...prev, ...patch }
-      sendFilterSettingsToIframe(next)
-      return next
-    })
-  }, [sendFilterSettingsToIframe])
+  const handleFilterSettingsChange = useCallback(
+    (patch: Partial<FilterSettings>) => {
+      setFilterSettings((prev) => {
+        const next = { ...prev, ...patch }
+        sendFilterSettingsToIframe(next)
+        return next
+      })
+    },
+    [sendFilterSettingsToIframe]
+  )
 
   // --- handleSoundSettingsChange: merge patch, update state, send to iframe (Phase 12) ---
-  const handleSoundSettingsChange = useCallback((patch: Partial<DisplaySettings>) => {
-    setSoundSettings((prev) => {
-      const next = { ...prev, ...patch }
-      sendSoundSettingsToIframe(next)
-      return next
-    })
-  }, [sendSoundSettingsToIframe])
+  const handleSoundSettingsChange = useCallback(
+    (patch: Partial<DisplaySettings>) => {
+      setSoundSettings((prev) => {
+        const next = { ...prev, ...patch }
+        sendSoundSettingsToIframe(next)
+        return next
+      })
+    },
+    [sendSoundSettingsToIframe]
+  )
 
   // --- handleTTSSettingsChange: merge patch, update state, send to embed iframe (Phase 13 D-22) ---
-  const handleTTSSettingsChange = useCallback((patch: Partial<DisplaySettings>) => {
-    setTtsSettings((prev) => {
-      const next = { ...prev, ...patch }
-      sendTtsSettingsToIframe(next)
-      return next
-    })
-  }, [sendTtsSettingsToIframe])
+  const handleTTSSettingsChange = useCallback(
+    (patch: Partial<DisplaySettings>) => {
+      setTtsSettings((prev) => {
+        const next = { ...prev, ...patch }
+        sendTtsSettingsToIframe(next)
+        return next
+      })
+    },
+    [sendTtsSettingsToIframe]
+  )
 
   // Phase 13 Plan 03 — ElevenLabs flow handlers (wired via AppearancePanel -> TTSGroup props)
-  const handleSaveTTSKey = useCallback(async (apiKey: string, voiceId: string): Promise<void> => {
-    await overlaysApi.saveTTSKey(id, apiKey, voiceId)
-    // Refresh metadata so the OBS URL + Test button render.
-    const meta = await overlaysApi.getTTSConfig(id)
-    setHasElevenLabsConfig(meta.has_elevenlabs_config)
-    setObsUrl(meta.obs_url)
-    setElevenLabsVoiceId(meta.voice_id)
-  }, [id])
+  const handleSaveTTSKey = useCallback(
+    async (apiKey: string, voiceId: string): Promise<void> => {
+      await overlaysApi.saveTTSKey(id, apiKey, voiceId)
+      // Refresh metadata so the OBS URL + Test button render.
+      const meta = await overlaysApi.getTTSConfig(id)
+      setHasElevenLabsConfig(meta.has_elevenlabs_config)
+      setObsUrl(meta.obs_url)
+      setElevenLabsVoiceId(meta.voice_id)
+    },
+    [id]
+  )
 
   // Issue #276 — voice-only update path. Persists to PATCH /tts-config/voice
   // and refreshes local state so the picker no longer shows the "Save voice"
   // button (pickedVoiceId === savedVoiceId).
-  const handleSaveTTSVoice = useCallback(async (voiceId: string): Promise<void> => {
-    await overlaysApi.saveTTSVoice(id, voiceId)
-    setElevenLabsVoiceId(voiceId)
-  }, [id])
+  const handleSaveTTSVoice = useCallback(
+    async (voiceId: string): Promise<void> => {
+      await overlaysApi.saveTTSVoice(id, voiceId)
+      setElevenLabsVoiceId(voiceId)
+    },
+    [id]
+  )
 
   const handleRemoveTTSKey = useCallback(async (): Promise<void> => {
     await overlaysApi.removeTTSKey(id)
@@ -1697,15 +1844,12 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     async (apiKey: string): Promise<ElevenLabsVoice[]> => {
       return overlaysApi.previewTTSVoices(id, apiKey)
     },
-    [id],
+    [id]
   )
 
   // --- sendCustomCssToIframe: post the full theme CSS to the embed preview ---
   const sendCustomCssToIframe = useCallback((css: string) => {
-    iframeRef.current?.contentWindow?.postMessage(
-      { type: 'CUSTOM_CSS_UPDATE', css },
-      '*'
-    )
+    iframeRef.current?.contentWindow?.postMessage({ type: 'CUSTOM_CSS_UPDATE', css }, '*')
   }, [])
 
   // --- applyThemeImmediately: reference the theme by id + apply its parsed
@@ -1763,33 +1907,41 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     }
     window.addEventListener('message', handleEmbedReady)
     return () => window.removeEventListener('message', handleEmbedReady)
-  }, [sendCssToIframe, sendFilterSettingsToIframe, sendSoundSettingsToIframe, sendTtsSettingsToIframe])
+  }, [
+    sendCssToIframe,
+    sendFilterSettingsToIframe,
+    sendSoundSettingsToIframe,
+    sendTtsSettingsToIframe,
+  ])
 
   // --- handleIframeReady: store iframe ref, send initial CSS, and query visibility defaults ---
-  const handleIframeReady = useCallback((iframe: HTMLIFrameElement) => {
-    iframeRef.current = iframe
-    sendCssToIframe(visualSettingsRef.current)
-    const doc = iframe.contentDocument ?? iframe.contentWindow?.document
-    if (doc) {
-      const style = getComputedStyle(doc.documentElement)
-      const visFields: Array<[keyof VisualSettings, string]> = [
-        ['showAvatars', '--chat-show-avatars'],
-        ['showBadges', '--chat-show-badges'],
-        ['showTimestamps', '--chat-show-timestamps'],
-        ['showPlatformBadge', '--chat-show-platform-badge'],
-        ['showEmotes', '--chat-show-emotes'],
-        ['showUsername', '--chat-show-username'],
-      ]
-      const defaults: Partial<VisualSettings> = {}
-      for (const [field, cssVar] of visFields) {
-        const v = style.getPropertyValue(cssVar).trim()
-        if (v) {
-          ;(defaults as Record<string, string>)[field] = v
+  const handleIframeReady = useCallback(
+    (iframe: HTMLIFrameElement) => {
+      iframeRef.current = iframe
+      sendCssToIframe(visualSettingsRef.current)
+      const doc = iframe.contentDocument ?? iframe.contentWindow?.document
+      if (doc) {
+        const style = getComputedStyle(doc.documentElement)
+        const visFields: Array<[keyof VisualSettings, string]> = [
+          ['showAvatars', '--chat-show-avatars'],
+          ['showBadges', '--chat-show-badges'],
+          ['showTimestamps', '--chat-show-timestamps'],
+          ['showPlatformBadge', '--chat-show-platform-badge'],
+          ['showEmotes', '--chat-show-emotes'],
+          ['showUsername', '--chat-show-username'],
+        ]
+        const defaults: Partial<VisualSettings> = {}
+        for (const [field, cssVar] of visFields) {
+          const v = style.getPropertyValue(cssVar).trim()
+          if (v) {
+            ;(defaults as Record<string, string>)[field] = v
+          }
         }
+        setIframeVisibilityDefaults(defaults)
       }
-      setIframeVisibilityDefaults(defaults)
-    }
-  }, [sendCssToIframe])
+    },
+    [sendCssToIframe]
+  )
 
   // Load overlay, sources, accepted shares and config
   // Note: `router` is intentionally excluded from deps — it is only used for
@@ -1889,9 +2041,14 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           // Migrate platform badge settings from display_settings to visual_settings
           const platformBadgeDefaults: Partial<VisualSettings> = {}
           if (typeof display.show_platform_badge === 'boolean') {
-            platformBadgeDefaults.showPlatformBadge = display.show_platform_badge ? 'inline' : 'none'
+            platformBadgeDefaults.showPlatformBadge = display.show_platform_badge
+              ? 'inline'
+              : 'none'
           }
-          if (display.platform_badge_position === 'before' || display.platform_badge_position === 'after') {
+          if (
+            display.platform_badge_position === 'before' ||
+            display.platform_badge_position === 'after'
+          ) {
             platformBadgeDefaults.platformBadgePosition = display.platform_badge_position
           }
           if (display.platform_badge_style === 'text' || display.platform_badge_style === 'icon') {
@@ -1920,11 +2077,16 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           if (config.display_settings) {
             const d = config.display_settings
             const loaded: Partial<DisplaySettings> = {}
-            if (typeof d.notification_sound_enabled === 'boolean') loaded.notification_sound_enabled = d.notification_sound_enabled
-            if (typeof d.notification_sound_preset === 'string') loaded.notification_sound_preset = d.notification_sound_preset
-            if (typeof d.notification_sound_volume === 'number') loaded.notification_sound_volume = d.notification_sound_volume
-            if (typeof d.notification_sound_cooldown === 'number') loaded.notification_sound_cooldown = d.notification_sound_cooldown
-            if (typeof d.notification_sound_url === 'string') loaded.notification_sound_url = d.notification_sound_url
+            if (typeof d.notification_sound_enabled === 'boolean')
+              loaded.notification_sound_enabled = d.notification_sound_enabled
+            if (typeof d.notification_sound_preset === 'string')
+              loaded.notification_sound_preset = d.notification_sound_preset
+            if (typeof d.notification_sound_volume === 'number')
+              loaded.notification_sound_volume = d.notification_sound_volume
+            if (typeof d.notification_sound_cooldown === 'number')
+              loaded.notification_sound_cooldown = d.notification_sound_cooldown
+            if (typeof d.notification_sound_url === 'string')
+              loaded.notification_sound_url = d.notification_sound_url
             setSoundSettings(loaded)
           }
 
@@ -1933,29 +2095,43 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
             const d = config.display_settings
             const tts: Partial<DisplaySettings> = {}
             if (typeof d.tts_enabled === 'boolean') tts.tts_enabled = d.tts_enabled
-            if (d.tts_provider === 'browser' || d.tts_provider === 'elevenlabs') tts.tts_provider = d.tts_provider
+            if (d.tts_provider === 'browser' || d.tts_provider === 'elevenlabs')
+              tts.tts_provider = d.tts_provider
             if (typeof d.tts_volume === 'number') tts.tts_volume = d.tts_volume
             if (typeof d.tts_voice_uri === 'string') tts.tts_voice_uri = d.tts_voice_uri
             if (typeof d.tts_rate === 'number') tts.tts_rate = d.tts_rate
             if (typeof d.tts_pitch === 'number') tts.tts_pitch = d.tts_pitch
-            if (d.tts_filter_mode === 'all' || d.tts_filter_mode === 'sample' || d.tts_filter_mode === 'priority_only') {
+            if (
+              d.tts_filter_mode === 'all' ||
+              d.tts_filter_mode === 'sample' ||
+              d.tts_filter_mode === 'priority_only'
+            ) {
               tts.tts_filter_mode = d.tts_filter_mode
             }
             if (typeof d.tts_sample_rate === 'number') tts.tts_sample_rate = d.tts_sample_rate
             if (typeof d.tts_max_queue === 'number') tts.tts_max_queue = d.tts_max_queue
-            if (typeof d.tts_messages_per_minute === 'number') tts.tts_messages_per_minute = d.tts_messages_per_minute
-            if (typeof d.tts_user_cooldown_seconds === 'number') tts.tts_user_cooldown_seconds = d.tts_user_cooldown_seconds
-            if (typeof d.tts_staleness_seconds === 'number') tts.tts_staleness_seconds = d.tts_staleness_seconds
-            if (typeof d.tts_priority_events === 'boolean') tts.tts_priority_events = d.tts_priority_events
-            if (typeof d.tts_priority_bits_min === 'number') tts.tts_priority_bits_min = d.tts_priority_bits_min
-            if (typeof d.tts_read_username === 'boolean') tts.tts_read_username = d.tts_read_username
-            if (typeof d.tts_read_platform === 'boolean') tts.tts_read_platform = d.tts_read_platform
-            if (typeof d.tts_max_message_chars === 'number') tts.tts_max_message_chars = d.tts_max_message_chars
-            if (typeof d.tts_skip_emote_only === 'boolean') tts.tts_skip_emote_only = d.tts_skip_emote_only
+            if (typeof d.tts_messages_per_minute === 'number')
+              tts.tts_messages_per_minute = d.tts_messages_per_minute
+            if (typeof d.tts_user_cooldown_seconds === 'number')
+              tts.tts_user_cooldown_seconds = d.tts_user_cooldown_seconds
+            if (typeof d.tts_staleness_seconds === 'number')
+              tts.tts_staleness_seconds = d.tts_staleness_seconds
+            if (typeof d.tts_priority_events === 'boolean')
+              tts.tts_priority_events = d.tts_priority_events
+            if (typeof d.tts_priority_bits_min === 'number')
+              tts.tts_priority_bits_min = d.tts_priority_bits_min
+            if (typeof d.tts_read_username === 'boolean')
+              tts.tts_read_username = d.tts_read_username
+            if (typeof d.tts_read_platform === 'boolean')
+              tts.tts_read_platform = d.tts_read_platform
+            if (typeof d.tts_max_message_chars === 'number')
+              tts.tts_max_message_chars = d.tts_max_message_chars
+            if (typeof d.tts_skip_emote_only === 'boolean')
+              tts.tts_skip_emote_only = d.tts_skip_emote_only
             if (typeof d.tts_skip_links === 'boolean') tts.tts_skip_links = d.tts_skip_links
             if (Array.isArray(d.tts_enabled_platforms)) {
               tts.tts_enabled_platforms = d.tts_enabled_platforms.filter(
-                (p: unknown): p is string => typeof p === 'string',
+                (p: unknown): p is string => typeof p === 'string'
               )
             }
             setTtsSettings(tts)
@@ -2339,7 +2515,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           notification_sound_preset: soundSettings.notification_sound_preset ?? 'chime',
           notification_sound_volume: soundSettings.notification_sound_volume ?? 0.5,
           notification_sound_cooldown: soundSettings.notification_sound_cooldown ?? 500,
-          ...(soundSettings.notification_sound_url ? { notification_sound_url: soundSettings.notification_sound_url } : {}),
+          ...(soundSettings.notification_sound_url
+            ? { notification_sound_url: soundSettings.notification_sound_url }
+            : {}),
           // Phase 13: persist all 20 tts_* fields (ElevenLabs key/voice live in overlay_tts_configs, NOT here)
           ...ttsSettings,
         },
@@ -2452,6 +2630,14 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
       <SplitView overlayId={id} onIframeReady={handleIframeReady}>
         {/* Config panel content */}
         <div className="max-w-none space-y-6 p-6">
+          <OnboardingChecklist
+            surface="editor"
+            variant="inline"
+            overlayCount={1}
+            sourceCount={sources.length}
+            themeId={themeId || null}
+            onSpotlightSection={handleSpotlightSection}
+          />
           {/* 1. Header */}
           <div className="flex items-start justify-between">
             <div>
@@ -2510,6 +2696,24 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
             <Clipboard className="size-4" />
             {copiedObs ? 'Copied!' : 'Copy OBS URL'}
           </Button>
+          <Dialog.Root>
+            <Dialog.Trigger
+              render={
+                <button
+                  type="button"
+                  className="mx-auto block text-xs text-text-sub underline-offset-2 hover:text-text hover:underline"
+                >
+                  How do I add this to OBS?
+                </button>
+              }
+            />
+            <Dialog.Content size="sm">
+              <Dialog.Title>Add the overlay to OBS</Dialog.Title>
+              <div className="mt-3">
+                <ObsHelpContent />
+              </div>
+            </Dialog.Content>
+          </Dialog.Root>
 
           {/* 2b. Share overlay */}
           <Button
@@ -2677,169 +2881,187 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           <div className="relative">
             <div className="divide-y divide-border">
               {/* Theme section — first and open by default */}
-              <CollapsibleSection
-                id="theme"
-                title="Theme"
-                storageKey="editor-panel-sections-v1"
-                defaultOpen={true}
-              >
-                <ThemeContent onApply={handleThemeApply} isAdmin={user?.is_admin === true} />
-                <button
-                  type="button"
-                  className="mt-3 text-xs text-text-sub underline-offset-2 hover:text-text hover:underline"
-                  onClick={handleResetToTheme}
+              <div ref={spotlightRefs.theme}>
+                <CollapsibleSection
+                  id="theme"
+                  title="Theme"
+                  storageKey="editor-panel-sections-v1"
+                  defaultOpen={true}
+                  forceOpen={sectionForce('theme')}
                 >
-                  Reset to theme defaults
-                </button>
-              </CollapsibleSection>
+                  <ThemeContent onApply={handleThemeApply} isAdmin={user?.is_admin === true} />
+                  <button
+                    type="button"
+                    className="mt-3 text-xs text-text-sub underline-offset-2 hover:text-text hover:underline"
+                    onClick={handleResetToTheme}
+                  >
+                    Reset to theme defaults
+                  </button>
+                </CollapsibleSection>
+              </div>
 
               {/* Appearance section */}
-              <CollapsibleSection
-                id="appearance"
-                title="Appearance"
-                storageKey="editor-panel-sections-v1"
-                defaultOpen={false}
-              >
-                <AppearancePanel
-                  visualSettings={visualSettings}
-                  onChange={handleVisualSettingsChange}
-                  visibilityDefaults={iframeVisibilityDefaults}
-                  filterSettings={filterSettings}
-                  onFilterChange={handleFilterSettingsChange}
-                  displaySettings={{ ...soundSettings, ...ttsSettings }}
-                  onSoundChange={handleSoundSettingsChange}
-                  isPremium={user?.is_premium ?? false}
-                  onTTSChange={handleTTSSettingsChange}
-                  overlayId={id}
-                  hasElevenLabsConfig={hasElevenLabsConfig}
-                  obsUrl={obsUrl}
-                  onTTSPreview={() => {
-                    // Browser Web Speech API preview — fires the fixed sample phrase through the
-                    // current rate/pitch/volume/voice_uri. Click again mid-speech cancels.
-                    if (typeof window === 'undefined' || typeof window.speechSynthesis === 'undefined') return
-                    const synth = window.speechSynthesis
-                    if (synth.speaking) {
-                      synth.cancel()
-                      return
-                    }
-                    const u = new SpeechSynthesisUtterance(
-                      'Hello, this is how your chat will sound.',
-                    )
-                    u.volume = ttsSettings.tts_volume ?? 0.8
-                    u.rate = ttsSettings.tts_rate ?? 1.0
-                    u.pitch = ttsSettings.tts_pitch ?? 1.0
-                    const savedUri = ttsSettings.tts_voice_uri
-                    if (savedUri) {
-                      const match = synth.getVoices().find((v) => v.voiceURI === savedUri)
-                      if (match) u.voice = match
-                    }
-                    synth.speak(u)
-                  }}
-                  onTTSPreviewStop={() => {
-                    if (typeof window !== 'undefined' && window.speechSynthesis) {
-                      window.speechSynthesis.cancel()
-                    }
-                  }}
-                  onSaveTTSKey={handleSaveTTSKey}
-                  onSaveTTSVoice={handleSaveTTSVoice}
-                  savedTTSVoiceId={elevenLabsVoiceId}
-                  onTestTTSKey={handleTestTTSKey}
-                  onRotateTTSToken={handleRotateTTSToken}
-                  onRemoveTTSKey={handleRemoveTTSKey}
-                  onFetchTTSVoices={handleFetchTTSVoices}
-                  onPreviewTTSVoices={handlePreviewTTSVoices}
-                />
-              </CollapsibleSection>
+              <div ref={spotlightRefs.appearance}>
+                <CollapsibleSection
+                  id="appearance"
+                  title="Appearance"
+                  storageKey="editor-panel-sections-v1"
+                  defaultOpen={false}
+                  forceOpen={sectionForce('appearance')}
+                >
+                  <AppearancePanel
+                    visualSettings={visualSettings}
+                    onChange={handleVisualSettingsChange}
+                    visibilityDefaults={iframeVisibilityDefaults}
+                    filterSettings={filterSettings}
+                    onFilterChange={handleFilterSettingsChange}
+                    displaySettings={{ ...soundSettings, ...ttsSettings }}
+                    onSoundChange={handleSoundSettingsChange}
+                    isPremium={user?.is_premium ?? false}
+                    onTTSChange={handleTTSSettingsChange}
+                    overlayId={id}
+                    hasElevenLabsConfig={hasElevenLabsConfig}
+                    obsUrl={obsUrl}
+                    onTTSPreview={() => {
+                      // Browser Web Speech API preview — fires the fixed sample phrase through the
+                      // current rate/pitch/volume/voice_uri. Click again mid-speech cancels.
+                      if (
+                        typeof window === 'undefined' ||
+                        typeof window.speechSynthesis === 'undefined'
+                      )
+                        return
+                      const synth = window.speechSynthesis
+                      if (synth.speaking) {
+                        synth.cancel()
+                        return
+                      }
+                      const u = new SpeechSynthesisUtterance(
+                        'Hello, this is how your chat will sound.'
+                      )
+                      u.volume = ttsSettings.tts_volume ?? 0.8
+                      u.rate = ttsSettings.tts_rate ?? 1.0
+                      u.pitch = ttsSettings.tts_pitch ?? 1.0
+                      const savedUri = ttsSettings.tts_voice_uri
+                      if (savedUri) {
+                        const match = synth.getVoices().find((v) => v.voiceURI === savedUri)
+                        if (match) u.voice = match
+                      }
+                      synth.speak(u)
+                    }}
+                    onTTSPreviewStop={() => {
+                      if (typeof window !== 'undefined' && window.speechSynthesis) {
+                        window.speechSynthesis.cancel()
+                      }
+                    }}
+                    onSaveTTSKey={handleSaveTTSKey}
+                    onSaveTTSVoice={handleSaveTTSVoice}
+                    savedTTSVoiceId={elevenLabsVoiceId}
+                    onTestTTSKey={handleTestTTSKey}
+                    onRotateTTSToken={handleRotateTTSToken}
+                    onRemoveTTSKey={handleRemoveTTSKey}
+                    onFetchTTSVoices={handleFetchTTSVoices}
+                    onPreviewTTSVoices={handlePreviewTTSVoices}
+                  />
+                </CollapsibleSection>
+              </div>
 
               {/* Sources section — open by default */}
-              <CollapsibleSection
-                id="sources"
-                title="Sources"
-                storageKey="editor-panel-sections-v1"
-                defaultOpen={true}
-              >
-                {isLoading ? (
-                  <SourceListSkeleton />
-                ) : (
-                  <div className="mb-4 space-y-3">
-                    {sources.map((source) => (
-                      <div key={source.id}>
-                        <SourceCard
-                          source={source}
-                          onRemove={handleRemoveSource}
-                          onRevoke={setRevokeTarget}
-                          onConfigureRelay={(s) =>
-                            setRelayExpandedSourceId((prev) => (prev === s.id ? null : s.id))
-                          }
-                          onConfigureStreamSelect={(s) =>
-                            setStreamSelectExpandedSourceId((prev) => (prev === s.id ? null : s.id))
-                          }
-                          isOwnChannel={
-                            // Prefer the server-computed flag (covers linked/non-Twitch-login
-                            // owners per ADR-0016); fall back to the username heuristic only if
-                            // the field is absent (older API responses).
-                            source.is_own_channel ??
-                            (user?.auth_provider === 'twitch' &&
-                              !!user?.username &&
-                              user.username.toLowerCase() === source.channel_id.toLowerCase())
-                          }
-                          onReconnectChat={handleReconnectTwitchChat}
-                        />
-                        {source.id === relayExpandedSourceId && source.platform === 'discord' && (
-                          <RelayPanel
+              <div ref={spotlightRefs.sources}>
+                <CollapsibleSection
+                  id="sources"
+                  title="Sources"
+                  storageKey="editor-panel-sections-v1"
+                  defaultOpen={true}
+                  forceOpen={sectionForce('sources')}
+                >
+                  {isLoading ? (
+                    <SourceListSkeleton />
+                  ) : (
+                    <div className="mb-4 space-y-3">
+                      {sources.map((source) => (
+                        <div key={source.id}>
+                          <SourceCard
                             source={source}
-                            overlayId={id}
-                            onSaved={handleRelayConfigSaved}
+                            onRemove={handleRemoveSource}
+                            onRevoke={setRevokeTarget}
+                            onConfigureRelay={(s) =>
+                              setRelayExpandedSourceId((prev) => (prev === s.id ? null : s.id))
+                            }
+                            onConfigureStreamSelect={(s) =>
+                              setStreamSelectExpandedSourceId((prev) =>
+                                prev === s.id ? null : s.id
+                              )
+                            }
+                            isOwnChannel={
+                              // Prefer the server-computed flag (covers linked/non-Twitch-login
+                              // owners per ADR-0016); fall back to the username heuristic only if
+                              // the field is absent (older API responses).
+                              source.is_own_channel ??
+                              (user?.auth_provider === 'twitch' &&
+                                !!user?.username &&
+                                user.username.toLowerCase() === source.channel_id.toLowerCase())
+                            }
+                            onReconnectChat={handleReconnectTwitchChat}
                           />
-                        )}
-                        {source.id === streamSelectExpandedSourceId && source.platform === 'youtube' && (
-                          <StreamSelectionPanel
-                            source={source}
-                            overlayId={id}
-                            isPremium={user?.is_premium ?? false}
-                            onSaved={async () => {
-                              const updated = await overlaysApi.getSources(id)
-                              setSources(updated)
-                            }}
-                          />
-                        )}
-                      </div>
-                    ))}
-                    {sources.length === 0 && (
-                      <p className="py-2 text-sm text-text-sub">
-                        No sources added yet. Add a platform below.
-                      </p>
-                    )}
-                  </div>
-                )}
-
-                {/* Accepted shared overlays — add as source */}
-                {acceptedShares.length > 0 && (
-                  <div className="mb-4 border-t border-border pt-4">
-                    <h3 className="mb-3 text-sm font-medium text-text">Shared Overlays</h3>
-                    <div className="space-y-2">
-                      {acceptedShares.map((share) => (
-                        <button
-                          key={share.share_id}
-                          onClick={() => handleAddSharedOverlay(share)}
-                          className="flex w-full items-center justify-between rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text transition-colors hover:bg-surface-2"
-                        >
-                          <span>{share.sender_display_name}&apos;s overlay</span>
-                          <span className="text-xs text-twitch">+ Add</span>
-                        </button>
+                          {source.id === relayExpandedSourceId && source.platform === 'discord' && (
+                            <RelayPanel
+                              source={source}
+                              overlayId={id}
+                              onSaved={handleRelayConfigSaved}
+                            />
+                          )}
+                          {source.id === streamSelectExpandedSourceId &&
+                            source.platform === 'youtube' && (
+                              <StreamSelectionPanel
+                                source={source}
+                                overlayId={id}
+                                isPremium={user?.is_premium ?? false}
+                                onSaved={async () => {
+                                  const updated = await overlaysApi.getSources(id)
+                                  setSources(updated)
+                                }}
+                              />
+                            )}
+                        </div>
                       ))}
+                      {sources.length === 0 && (
+                        <p className="py-2 text-sm text-text-sub">
+                          No sources added yet. Add a platform below.
+                        </p>
+                      )}
                     </div>
-                  </div>
-                )}
+                  )}
 
-                <AddSourceForm
-                  overlayId={id}
-                  onAddTikTok={handleAddTikTokSource}
-                  onAddManual={handleAddManual}
-                  onSourceAdded={() => overlaysApi.getSources(id).then(setSources).catch(console.error)}
-                  isAdmin={user?.is_admin === true}
-                />
-              </CollapsibleSection>
+                  {/* Accepted shared overlays — add as source */}
+                  {acceptedShares.length > 0 && (
+                    <div className="mb-4 border-t border-border pt-4">
+                      <h3 className="mb-3 text-sm font-medium text-text">Shared Overlays</h3>
+                      <div className="space-y-2">
+                        {acceptedShares.map((share) => (
+                          <button
+                            key={share.share_id}
+                            onClick={() => handleAddSharedOverlay(share)}
+                            className="flex w-full items-center justify-between rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text transition-colors hover:bg-surface-2"
+                          >
+                            <span>{share.sender_display_name}&apos;s overlay</span>
+                            <span className="text-xs text-twitch">+ Add</span>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <AddSourceForm
+                    overlayId={id}
+                    onAddTikTok={handleAddTikTokSource}
+                    onAddManual={handleAddManual}
+                    onSourceAdded={() =>
+                      overlaysApi.getSources(id).then(setSources).catch(console.error)
+                    }
+                    isAdmin={user?.is_admin === true}
+                  />
+                </CollapsibleSection>
+              </div>
 
               {/* Behavior section */}
               <CollapsibleSection
@@ -2950,9 +3172,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                   <div>
                     <p className="mb-1 text-xs text-text-sub">7TV Emote Set</p>
                     <p className="mb-2 text-[11px] text-text-sub/70">
-                      Optional. Paste a 7TV emote-set ID, an emote-set URL, or your
-                      7TV profile URL to attach those emotes to this overlay
-                      regardless of which platforms you stream on.
+                      Optional. Paste a 7TV emote-set ID, an emote-set URL, or your 7TV profile URL
+                      to attach those emotes to this overlay regardless of which platforms you
+                      stream on.
                     </p>
                     {/* Saved-state pill: shows what's actually attached right now,
                         with a one-click Remove. Hidden while nothing is saved. */}
@@ -2962,7 +3184,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                           <span className="text-text-sub">Currently active: </span>
                           {seventvSavedDescriptor?.name ? (
                             <>
-                              <span className="font-medium">&quot;{seventvSavedDescriptor.name}&quot;</span>
+                              <span className="font-medium">
+                                &quot;{seventvSavedDescriptor.name}&quot;
+                              </span>
                               {typeof seventvSavedDescriptor.emoteCount === 'number'
                                 ? ` (${seventvSavedDescriptor.emoteCount} emotes)`
                                 : ''}
@@ -3038,7 +3262,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                           try {
                             const result = await overlaysApi.resolveSevenTV(
                               id,
-                              seventvOverrideInput.trim(),
+                              seventvOverrideInput.trim()
                             )
                             setSeventvResolveState({
                               status: 'resolved',
@@ -3066,11 +3290,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                             : ''}
                           {' — click Save Configuration to apply.'}
                         </p>
-                    )}
+                      )}
                     {seventvResolveState.status === 'error' && (
-                      <p className="mt-1 text-[11px] text-red-500">
-                        {seventvResolveState.message}
-                      </p>
+                      <p className="mt-1 text-[11px] text-red-500">{seventvResolveState.message}</p>
                     )}
                   </div>
                 </div>
@@ -3253,13 +3475,13 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                 <div className="space-y-3">
                   <p className="text-xs text-text-sub">
                     Reset your overlay ID to revoke any leaked OBS URLs. A new overlay with the same
-                    configuration will be created and you will be redirected to it. The old overlay and
-                    its URL will be permanently deleted.
+                    configuration will be created and you will be redirected to it. The old overlay
+                    and its URL will be permanently deleted.
                   </p>
                   <Button
                     type="button"
                     variant="outline"
-                    className="w-full border-destructive/50 text-destructive hover:bg-destructive/10"
+                    className="border-destructive/50 text-destructive hover:bg-destructive/10 w-full"
                     onClick={() => setShowResetConfirm(true)}
                     disabled={isResetting}
                   >
@@ -3343,8 +3565,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
         <Dialog.Content size="sm" showCloseButton={false}>
           <Dialog.Title>Reset Overlay ID?</Dialog.Title>
           <Dialog.Description>
-            This will create a new overlay with a fresh ID and permanently delete this one.
-            Any existing OBS URLs will stop working — update your browser source after the reset.
+            This will create a new overlay with a fresh ID and permanently delete this one. Any
+            existing OBS URLs will stop working — update your browser source after the reset.
           </Dialog.Description>
           <div className="mt-4 flex justify-end gap-2">
             <Dialog.Close

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -24,6 +24,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { authApi } from '@/lib/api/auth'
 import { useAuthStore } from '@/lib/stores/auth-store'
+import { useOnboardingStore } from '@/lib/stores/onboarding-store'
 import { AppNav } from '@/components/AppNav'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -43,6 +44,29 @@ function SettingsContent() {
   const [guilds, setGuilds] = useState<DiscordGuild[]>([])
   const [guildsLoading, setGuildsLoading] = useState(true)
   const [disconnectTarget, setDisconnectTarget] = useState<DiscordGuild | null>(null)
+  const [restartingGuide, setRestartingGuide] = useState(false)
+  const initAuth = useAuthStore((state) => state.init)
+  const startOnboarding = useOnboardingStore((state) => state.start)
+
+  // Re-arm the first-run setup guide: clear the server flag, refresh
+  // /auth/me, then start explicitly (bypasses the zero-overlay auto-start
+  // guard so users with existing overlays can re-walk the steps too).
+  async function handleRestartGuide() {
+    setRestartingGuide(true)
+    try {
+      await authApi.updateOnboarding(false)
+      await initAuth()
+      startOnboarding('settings')
+      router.push('/dashboard')
+    } catch {
+      toastManager.add({
+        title: 'Could not restart the setup guide',
+        description: 'Please try again.',
+        type: 'error',
+      })
+      setRestartingGuide(false)
+    }
+  }
 
   async function fetchGuilds() {
     try {
@@ -130,6 +154,24 @@ function SettingsContent() {
               <span className="text-sm text-text-sub">Primary Platform</span>
               <p className="font-medium text-text capitalize">{user.auth_provider ?? 'Unknown'}</p>
             </div>
+          </div>
+        </Card>
+
+        {/* Setup guide section */}
+        <Card className="p-6">
+          <h2 className="mb-4 text-lg font-semibold text-text">Setup guide</h2>
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-sm text-text-sub">
+              Walk through overlay setup again: create an overlay, connect chat, pick a theme, and
+              get the OBS link.
+            </p>
+            <Button
+              variant="outline"
+              disabled={restartingGuide}
+              onClick={() => void handleRestartGuide()}
+            >
+              {restartingGuide ? 'Restarting…' : 'Restart'}
+            </Button>
           </div>
         </Card>
 

--- a/frontend/src/components/appearance/CollapsibleSection.tsx
+++ b/frontend/src/components/appearance/CollapsibleSection.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import React, { useState } from 'react'
 import { Collapsible } from '@base-ui/react/collapsible'
 import { ChevronDown } from 'lucide-react'
@@ -41,6 +40,14 @@ export interface CollapsibleSectionProps {
   children: React.ReactNode
   storageKey?: string
   defaultOpen?: boolean
+  /**
+   * Controlled override used by the onboarding setup guide to spotlight a
+   * section: true forces open, false forces closed; undefined (default)
+   * keeps the normal user-toggled behavior. The forced state is NEVER
+   * written to localStorage, so the user's own open/closed preferences
+   * survive onboarding untouched.
+   */
+  forceOpen?: boolean
 }
 
 export function CollapsibleSection({
@@ -49,6 +56,7 @@ export function CollapsibleSection({
   children,
   storageKey = STORAGE_KEY,
   defaultOpen = false,
+  forceOpen,
 }: CollapsibleSectionProps): React.ReactElement {
   const [open, setOpen] = useState<boolean>(() => {
     const stored = readStoredSections(storageKey)
@@ -56,6 +64,7 @@ export function CollapsibleSection({
   })
 
   function handleOpenChange(nextOpen: boolean): void {
+    if (forceOpen !== undefined) return
     setOpen(nextOpen)
     try {
       const stored = readStoredSections(storageKey)
@@ -67,17 +76,17 @@ export function CollapsibleSection({
   }
 
   return (
-    <Collapsible.Root open={open} onOpenChange={handleOpenChange}>
-      <Collapsible.Trigger className="flex w-full items-center justify-between py-2 text-sm font-medium text-text hover:text-text-sub transition-colors">
+    <Collapsible.Root open={forceOpen ?? open} onOpenChange={handleOpenChange}>
+      <Collapsible.Trigger className="flex w-full items-center justify-between py-2 text-sm font-medium text-text transition-colors hover:text-text-sub">
         <span>{title}</span>
         <ChevronDown
           className="h-4 w-4 text-text-dim transition-transform duration-200 data-[open]:rotate-180"
-          data-open={open ? '' : undefined}
+          data-open={(forceOpen ?? open) ? '' : undefined}
         />
       </Collapsible.Trigger>
       <Collapsible.Panel
         keepMounted
-        className="overflow-hidden max-h-0 data-[open]:max-h-[2000px] transition-all duration-200"
+        className="max-h-0 overflow-hidden transition-all duration-200 data-[open]:max-h-[2000px]"
       >
         <div className="pb-3">{children}</div>
       </Collapsible.Panel>

--- a/frontend/src/components/appearance/__tests__/CollapsibleSection.test.tsx
+++ b/frontend/src/components/appearance/__tests__/CollapsibleSection.test.tsx
@@ -21,16 +21,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import React from 'react'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 
-afterEach(() => { cleanup() })
+afterEach(() => {
+  cleanup()
+})
 
 // Mock localStorage before any imports that might reference it
 const localStorageMock = (() => {
   let store: Record<string, string> = {}
   return {
     getItem: vi.fn((key: string) => store[key] ?? null),
-    setItem: vi.fn((key: string, value: string) => { store[key] = value }),
-    removeItem: vi.fn((key: string) => { delete store[key] }),
-    clear: vi.fn(() => { store = {} }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
   }
 })()
 
@@ -169,5 +177,45 @@ describe('CollapsibleSection', () => {
     const lastCall = calls[calls.length - 1] as [string, string]
     const stored = JSON.parse(lastCall[1]) as Record<string, boolean>
     expect(stored['themes']).toBe(true)
+  })
+})
+
+describe('CollapsibleSection forceOpen (onboarding spotlight)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
+  it('forceOpen=true opens regardless of stored preference', () => {
+    localStorageMock.setItem('appearance-panel-sections-v1', JSON.stringify({ sources: false }))
+    localStorageMock.setItem.mockClear()
+    render(
+      <CollapsibleSection id="sources" title="Sources" forceOpen>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('forceOpen=false closes even when the stored preference is open', () => {
+    localStorageMock.setItem('appearance-panel-sections-v1', JSON.stringify({ sources: true }))
+    localStorageMock.setItem.mockClear()
+    render(
+      <CollapsibleSection id="sources" title="Sources" forceOpen={false}>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('toggling while forced never writes the forced state to localStorage', () => {
+    render(
+      <CollapsibleSection id="sources" title="Sources" forceOpen>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(localStorageMock.setItem).not.toHaveBeenCalled()
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('true')
   })
 })

--- a/frontend/src/components/onboarding/CreateOverlayDialog.tsx
+++ b/frontend/src/components/onboarding/CreateOverlayDialog.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Step 1 of the onboarding setup guide: create the first overlay without
+ * leaving the dashboard, then continue in the editor where the remaining
+ * steps live. The standalone /overlays/new page stays as the regular
+ * (non-onboarding) path.
+ */
+
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { Field } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useOverlayStore } from '@/lib/stores/overlay-store'
+import { useOnboardingStore } from '@/lib/stores/onboarding-store'
+import { trackEvent } from '@/lib/analytics'
+import { toastManager } from '@/lib/toast'
+
+export interface CreateOverlayDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function CreateOverlayDialog({ open, onOpenChange }: CreateOverlayDialogProps) {
+  const router = useRouter()
+  const createOverlay = useOverlayStore((s) => s.createOverlay)
+  const setActiveOverlay = useOnboardingStore((s) => s.setActiveOverlay)
+  const reportStepCompleted = useOnboardingStore((s) => s.reportStepCompleted)
+  const [name, setName] = useState('My Stream')
+  const [submitting, setSubmitting] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed || submitting) return
+    setSubmitting(true)
+    try {
+      const overlay = await createOverlay({ name: trimmed })
+      trackEvent('overlay_created')
+      reportStepCompleted('create_overlay')
+      setActiveOverlay(overlay.id)
+      onOpenChange(false)
+      router.push(`/overlays/${overlay.id}`)
+    } catch {
+      toastManager.add({
+        title: 'Could not create the overlay',
+        description: 'Please try again.',
+      })
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogTitle>Create your overlay</DialogTitle>
+        <DialogDescription>
+          Give it a name — you&apos;ll connect your chat right after.
+        </DialogDescription>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <Field.Root>
+            <Field.Label>Overlay name</Field.Label>
+            <Field.Control
+              render={
+                <Input
+                  value={name}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+                  maxLength={100}
+                />
+              }
+            />
+          </Field.Root>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="gradient" disabled={!name.trim() || submitting}>
+              {submitting ? 'Creating…' : 'Create overlay'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog.Root>
+  )
+}

--- a/frontend/src/components/onboarding/ObsHelpContent.tsx
+++ b/frontend/src/components/onboarding/ObsHelpContent.tsx
@@ -1,0 +1,39 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The canonical "add your overlay to OBS" instructions, shared by the
+ * onboarding setup guide (step 4) and the editor's OBS help dialog so the
+ * copy can never drift between the two.
+ */
+
+export function ObsHelpContent() {
+  return (
+    <ol className="list-decimal space-y-1.5 pl-5 text-sm text-text-sub">
+      <li>
+        In OBS, click <strong className="text-text">+</strong> under Sources and choose{' '}
+        <strong className="text-text">Browser</strong>.
+      </li>
+      <li>Paste the copied overlay link into the URL field.</li>
+      <li>
+        Set the size to your canvas (e.g. 1920×1080) and click OK — chat appears as soon as the
+        overlay connects.
+      </li>
+    </ol>
+  )
+}

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The first-run setup guide (retention initiative): a floating checklist that
+ * walks a new streamer to "chat visible in OBS". It rides on DERIVED state
+ * (see onboarding-store) so it survives the full-window OAuth round-trips of
+ * source connection, and it points INTO the real editor sections rather than
+ * duplicating their UI.
+ *
+ * Mounted on /dashboard and /overlays/[id]. Desktop: bottom-right card.
+ * Mobile: bottom bar that expands. Dismissible with confirm (restartable
+ * from Settings), minimizable, fully keyboard operable.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, ChevronDown, ChevronUp, Clipboard, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog'
+import { VisuallyHidden } from '@/components/ui/visually-hidden'
+import { ObsHelpContent } from './ObsHelpContent'
+import { CreateOverlayDialog } from './CreateOverlayDialog'
+import {
+  deriveSteps,
+  useOnboardingStore,
+  type OnboardingStepId,
+} from '@/lib/stores/onboarding-store'
+import { trackEvent } from '@/lib/analytics'
+import { DISCORD_INVITE_URL, PATREON_JOIN_URL } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+
+const STEP_LABELS: Record<OnboardingStepId, string> = {
+  create_overlay: 'Create your overlay',
+  connect_source: 'Connect a chat source',
+  choose_theme: 'Pick a theme',
+  copy_obs: 'Add it to OBS',
+}
+
+const STEP_INDEX: Record<OnboardingStepId, number> = {
+  create_overlay: 0,
+  connect_source: 1,
+  choose_theme: 2,
+  copy_obs: 3,
+}
+
+export interface OnboardingChecklistProps {
+  /** Where the checklist is mounted; step CTAs differ between the two. */
+  surface: 'dashboard' | 'editor'
+  /**
+   * floating: fixed bottom-right card (dashboard — nothing sits under it).
+   * inline: in-flow block (editor config panel — a floating card would
+   * obscure controls beneath it, WCAG 2.5.8 / axe target-size).
+   */
+  variant?: 'floating' | 'inline'
+  /** Editor only: number of sources on the active overlay. */
+  sourceCount?: number
+  /** Editor only: currently applied theme id (null = none yet). */
+  themeId?: string | null
+  /** Editor only: scroll to + force open an editor section. */
+  onSpotlightSection?: (section: 'sources' | 'theme' | 'appearance') => void
+  /** Dashboard only: overlays count from the overlay store. */
+  overlayCount?: number
+}
+
+export function OnboardingChecklist({
+  surface,
+  variant = 'floating',
+  sourceCount = 0,
+  themeId = null,
+  onSpotlightSection,
+  overlayCount = 0,
+}: OnboardingChecklistProps) {
+  const router = useRouter()
+  const status = useOnboardingStore((s) => s.status)
+  const activeOverlayId = useOnboardingStore((s) => s.activeOverlayId)
+  const sessionSteps = useOnboardingStore((s) => s.sessionSteps)
+  const minimized = useOnboardingStore((s) => s.minimized)
+  const minimize = useOnboardingStore((s) => s.minimize)
+  const markObsCopied = useOnboardingStore((s) => s.markObsCopied)
+  const markExtrasDone = useOnboardingStore((s) => s.markExtrasDone)
+  const reportStepCompleted = useOnboardingStore((s) => s.reportStepCompleted)
+  const dismiss = useOnboardingStore((s) => s.dismiss)
+  const finish = useOnboardingStore((s) => s.finish)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [confirmDismiss, setConfirmDismiss] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const steps = useMemo(
+    () =>
+      deriveSteps({
+        overlayCount: surface === 'editor' ? Math.max(overlayCount, 1) : overlayCount,
+        sourceCount,
+        themeId,
+        obsCopied: sessionSteps.obsCopied,
+      }),
+    [surface, overlayCount, sourceCount, themeId, sessionSteps.obsCopied]
+  )
+
+  const activeStep = steps.find((s) => s.active)
+  const doneCount = steps.filter((s) => s.done).length
+  const coreDone = doneCount === steps.length
+  const showExtras = coreDone && !sessionSteps.extrasDone
+  const showFinale = coreDone && sessionSteps.extrasDone
+
+  // Report derived completions + the active step view (double-fire guarded
+  // in the store / by the step index key).
+  useEffect(() => {
+    if (status !== 'active') return
+    for (const step of steps) {
+      if (step.done && step.id !== 'copy_obs') reportStepCompleted(step.id)
+    }
+  }, [status, steps, reportStepCompleted])
+
+  const [viewedStep, setViewedStep] = useState<OnboardingStepId | null>(null)
+  useEffect(() => {
+    if (status !== 'active' || !activeStep || activeStep.id === viewedStep) return
+    setViewedStep(activeStep.id)
+    trackEvent('onboarding_step_viewed', {
+      step: activeStep.id,
+      index: STEP_INDEX[activeStep.id],
+    })
+  }, [status, activeStep, viewedStep])
+
+  if (status !== 'active') return null
+
+  async function handleCopyObs() {
+    const overlayId = activeOverlayId
+    if (!overlayId) return
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}/overlay/${overlayId}`)
+      trackEvent('obs_url_copied', { surface: 'onboarding' })
+      markObsCopied()
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard unavailable — the editor's own copy button is the fallback.
+    }
+  }
+
+  function stepCta(stepId: OnboardingStepId) {
+    switch (stepId) {
+      case 'create_overlay':
+        return (
+          <Button size="sm" variant="gradient" onClick={() => setCreateOpen(true)}>
+            Create
+          </Button>
+        )
+      case 'connect_source':
+      case 'choose_theme': {
+        const section = stepId === 'connect_source' ? 'sources' : 'theme'
+        if (surface === 'editor' && onSpotlightSection) {
+          return (
+            <Button size="sm" variant="outline" onClick={() => onSpotlightSection(section)}>
+              Show me
+            </Button>
+          )
+        }
+        return (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!activeOverlayId}
+            onClick={() => activeOverlayId && router.push(`/overlays/${activeOverlayId}`)}
+          >
+            Open editor
+          </Button>
+        )
+      }
+      case 'copy_obs':
+        return (
+          <Button size="sm" variant="outline" disabled={!activeOverlayId} onClick={handleCopyObs}>
+            <Clipboard className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+            {copied ? 'Copied!' : 'Copy link'}
+          </Button>
+        )
+    }
+  }
+
+  return (
+    <section
+      aria-label="Setup guide"
+      className={cn(
+        'border border-border-md bg-surface',
+        variant === 'floating'
+          ? 'fixed inset-x-0 bottom-0 z-40 rounded-t-xl shadow-xl sm:inset-x-auto sm:right-4 sm:bottom-4 sm:w-96 sm:rounded-xl'
+          : 'rounded-xl'
+      )}
+    >
+      <header className="flex items-center justify-between gap-2 border-b border-border p-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-text">Setup guide</h2>
+          <p className="text-xs text-text-sub" aria-live="polite">
+            {coreDone ? 'All steps done!' : `${doneCount} of ${steps.length} steps done`}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={() => minimize(!minimized)}
+            aria-expanded={!minimized}
+            aria-label={minimized ? 'Expand setup guide' : 'Minimize setup guide'}
+            className="flex h-6 w-6 items-center justify-center rounded-md text-text-sub hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          >
+            {minimized ? (
+              <ChevronUp className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDismiss(true)}
+            aria-label="Dismiss setup guide"
+            className="flex h-6 w-6 items-center justify-center rounded-md text-text-sub hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+
+      {!minimized && (
+        <div className="space-y-3 p-3">
+          <ol className="space-y-2">
+            {steps.map((step) => (
+              <li key={step.id} className="flex items-center justify-between gap-2">
+                <span className="flex min-w-0 items-center gap-2">
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs',
+                      step.done
+                        ? 'border-kick/60 bg-kick/15 text-kick'
+                        : 'border-border-md text-text-dim'
+                    )}
+                  >
+                    {step.done ? <Check className="h-3 w-3" /> : STEP_INDEX[step.id] + 1}
+                  </span>
+                  <span
+                    className={cn(
+                      'truncate text-sm',
+                      step.done ? 'text-text-dim line-through' : 'text-text'
+                    )}
+                  >
+                    {STEP_LABELS[step.id]}
+                    {step.done && <VisuallyHidden> (done)</VisuallyHidden>}
+                  </span>
+                </span>
+                {step.active && !step.done && stepCta(step.id)}
+              </li>
+            ))}
+          </ol>
+
+          {activeStep?.id === 'copy_obs' && !coreDone && (
+            <div className="rounded-lg border border-border bg-surface-2 p-3">
+              <h3 className="mb-1.5 text-xs font-semibold text-text">In OBS:</h3>
+              <ObsHelpContent />
+            </div>
+          )}
+
+          {showExtras && (
+            <div className="rounded-lg border border-border bg-surface-2 p-3">
+              <h3 className="text-sm font-semibold text-text">Optional: make it yours</h3>
+              <p className="mt-1 text-sm text-text-sub">
+                Have chat read aloud with text-to-speech (free with your browser&apos;s voices), or
+                see what{' '}
+                <a
+                  href={PATREON_JOIN_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-text underline decoration-dotted underline-offset-2 hover:text-twitch"
+                >
+                  Premium
+                </a>{' '}
+                adds.
+              </p>
+              <div className="mt-2 flex gap-2">
+                {surface === 'editor' && onSpotlightSection ? (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      onSpotlightSection('appearance')
+                      markExtrasDone(false)
+                    }}
+                  >
+                    Set up TTS
+                  </Button>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={!activeOverlayId}
+                    onClick={() => {
+                      markExtrasDone(false)
+                      if (activeOverlayId) router.push(`/overlays/${activeOverlayId}`)
+                    }}
+                  >
+                    Set up TTS
+                  </Button>
+                )}
+                <Button size="sm" variant="ghost" onClick={() => markExtrasDone(true)}>
+                  Skip
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {showFinale && (
+            <div className="rounded-lg border border-border bg-surface-2 p-3">
+              <h3 className="text-sm font-semibold text-text">You&apos;re live! 🎉</h3>
+              <p className="mt-1 text-sm text-text-sub">
+                Questions, feedback, or theme requests? Our community is happy to help.
+              </p>
+              <div className="mt-2 flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  render={
+                    <a
+                      href={DISCORD_INVITE_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={() => trackEvent('onboarding_discord_clicked')}
+                    >
+                      Join the Discord
+                    </a>
+                  }
+                />
+                <Button size="sm" variant="gradient" onClick={() => void finish()}>
+                  Finish
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <CreateOverlayDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+      <Dialog.Root open={confirmDismiss} onOpenChange={setConfirmDismiss}>
+        <DialogContent size="sm">
+          <DialogTitle>Hide the setup guide?</DialogTitle>
+          <DialogDescription>
+            You can restart it anytime from Settings → Setup guide.
+          </DialogDescription>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setConfirmDismiss(false)}>
+              Keep it
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setConfirmDismiss(false)
+                void dismiss(activeStep?.id ?? 'extras')
+              }}
+            >
+              Hide guide
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog.Root>
+    </section>
+  )
+}

--- a/frontend/src/lib/stores/__tests__/onboarding-store.test.ts
+++ b/frontend/src/lib/stores/__tests__/onboarding-store.test.ts
@@ -1,0 +1,172 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Node test env has no localStorage — stub the minimal surface the store
+// touches (same approach as the CollapsibleSection tests).
+const localStorageStub = (() => {
+  let data: Record<string, string> = {}
+  return {
+    getItem: (key: string) => data[key] ?? null,
+    setItem: (key: string, value: string) => {
+      data[key] = value
+    },
+    removeItem: (key: string) => {
+      delete data[key]
+    },
+    clear: () => {
+      data = {}
+    },
+  }
+})()
+vi.stubGlobal('localStorage', localStorageStub)
+
+vi.mock('@/lib/api/auth', () => ({
+  authApi: {
+    updateOnboarding: vi
+      .fn()
+      .mockResolvedValue({ onboarding_completed_at: '2026-07-17T00:00:00Z' }),
+  },
+}))
+vi.mock('@/lib/stores/auth-store', () => ({
+  useAuthStore: {
+    getState: () => ({
+      user: { id: 'user-1' },
+      init: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}))
+vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }))
+
+import { deriveSteps, useOnboardingStore } from '../onboarding-store'
+import { authApi } from '@/lib/api/auth'
+import { trackEvent } from '@/lib/analytics'
+
+describe('deriveSteps', () => {
+  const base = { overlayCount: 0, sourceCount: 0, themeId: null, obsCopied: false }
+
+  it('fresh user: only create_overlay is active', () => {
+    const steps = deriveSteps(base)
+    expect(steps.map((s) => [s.id, s.done, s.active])).toEqual([
+      ['create_overlay', false, true],
+      ['connect_source', false, false],
+      ['choose_theme', false, false],
+      ['copy_obs', false, false],
+    ])
+  })
+
+  it('overlay without sources: connect_source becomes active', () => {
+    const steps = deriveSteps({ ...base, overlayCount: 1 })
+    expect(steps.find((s) => s.active)?.id).toBe('connect_source')
+    expect(steps[0].done).toBe(true)
+  })
+
+  it('sources without theme: choose_theme becomes active', () => {
+    const steps = deriveSteps({ ...base, overlayCount: 1, sourceCount: 2 })
+    expect(steps.find((s) => s.active)?.id).toBe('choose_theme')
+  })
+
+  it('theme picked: copy_obs becomes active; empty theme string counts as unpicked', () => {
+    expect(
+      deriveSteps({ ...base, overlayCount: 1, sourceCount: 1, themeId: 'minimal-theme' }).find(
+        (s) => s.active
+      )?.id
+    ).toBe('copy_obs')
+    expect(
+      deriveSteps({ ...base, overlayCount: 1, sourceCount: 1, themeId: '' }).find((s) => s.active)
+        ?.id
+    ).toBe('choose_theme')
+  })
+
+  it('all done: no active step remains', () => {
+    const steps = deriveSteps({ overlayCount: 1, sourceCount: 1, themeId: 't', obsCopied: true })
+    expect(steps.every((s) => s.done)).toBe(true)
+    expect(steps.some((s) => s.active)).toBe(false)
+  })
+
+  it('regression (overlay deleted mid-flow) re-activates the earlier step', () => {
+    const steps = deriveSteps({ overlayCount: 0, sourceCount: 0, themeId: 't', obsCopied: true })
+    expect(steps.find((s) => s.active)?.id).toBe('create_overlay')
+  })
+})
+
+describe('useOnboardingStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    useOnboardingStore.setState({
+      status: 'inactive',
+      trigger: null,
+      activeOverlayId: null,
+      sessionSteps: { obsCopied: false, extrasDone: false },
+      minimized: false,
+      reportedSteps: [],
+    })
+  })
+
+  it('start() activates once and reports the trigger', () => {
+    useOnboardingStore.getState().start('auto')
+    useOnboardingStore.getState().start('auto') // no double-fire
+    expect(useOnboardingStore.getState().status).toBe('active')
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+    expect(trackEvent).toHaveBeenCalledWith('onboarding_started', { trigger: 'auto' })
+  })
+
+  it('markObsCopied persists per-user and reports completion once', () => {
+    useOnboardingStore.getState().start('auto')
+    useOnboardingStore.getState().markObsCopied()
+    useOnboardingStore.getState().markObsCopied()
+    expect(useOnboardingStore.getState().sessionSteps.obsCopied).toBe(true)
+    expect(JSON.parse(localStorage.getItem('onboarding-v1:user-1') ?? '{}').obsCopied).toBe(true)
+    const completions = vi
+      .mocked(trackEvent)
+      .mock.calls.filter(([name]) => name === 'onboarding_step_completed')
+    expect(completions).toEqual([['onboarding_step_completed', { step: 'copy_obs' }]])
+  })
+
+  it('start() after a round-trip restores session steps from localStorage', () => {
+    localStorage.setItem('onboarding-v1:user-1', JSON.stringify({ obsCopied: true }))
+    useOnboardingStore.getState().start('auto')
+    expect(useOnboardingStore.getState().sessionSteps.obsCopied).toBe(true)
+  })
+
+  it('finish() persists completed=true and deactivates', async () => {
+    useOnboardingStore.getState().start('settings')
+    await useOnboardingStore.getState().finish()
+    expect(useOnboardingStore.getState().status).toBe('inactive')
+    expect(authApi.updateOnboarding).toHaveBeenCalledWith(true)
+    expect(trackEvent).toHaveBeenCalledWith('onboarding_finished')
+  })
+
+  it('dismiss() records the abandoned step and persists', async () => {
+    useOnboardingStore.getState().start('auto')
+    await useOnboardingStore.getState().dismiss('connect_source')
+    expect(trackEvent).toHaveBeenCalledWith('onboarding_dismissed', { step: 'connect_source' })
+    expect(authApi.updateOnboarding).toHaveBeenCalledWith(true)
+  })
+
+  it('finish() retries persistence once on failure', async () => {
+    vi.mocked(authApi.updateOnboarding)
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ onboarding_completed_at: 'x' })
+    useOnboardingStore.getState().start('auto')
+    await useOnboardingStore.getState().finish()
+    expect(authApi.updateOnboarding).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/lib/stores/onboarding-store.ts
+++ b/frontend/src/lib/stores/onboarding-store.ts
@@ -1,0 +1,199 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Onboarding setup-guide store (retention initiative).
+ *
+ * The guide is a persistent CHECKLIST, not a modal wizard: connecting
+ * Twitch/YouTube/Kick is a full-window OAuth redirect that would destroy
+ * modal state, so the core steps are DERIVED from server data (overlay
+ * exists → source exists → theme picked) and trivially survive navigation.
+ * Only the two signals the server cannot observe (OBS link copied, extras
+ * step done) live client-side, mirrored to localStorage so the OAuth
+ * round-trip in the same browser doesn't repeat them.
+ *
+ * Server truth: users.onboarding_completed_at (NULL = guide shows).
+ * finish()/dismiss() persist via PATCH /api/v1/auth/me/onboarding and then
+ * refresh the auth store; the guide is re-armed from Settings with
+ * start('settings') after the API clears the flag.
+ */
+
+import { create } from 'zustand'
+import { authApi } from '../api/auth'
+import { useAuthStore } from './auth-store'
+import { trackEvent } from '../analytics'
+
+export type OnboardingStepId = 'create_overlay' | 'connect_source' | 'choose_theme' | 'copy_obs'
+
+export interface OnboardingStep {
+  id: OnboardingStepId
+  done: boolean
+  /** The first not-done step is the active one; later steps wait for it. */
+  active: boolean
+}
+
+export interface DeriveStepsInput {
+  overlayCount: number
+  sourceCount: number
+  themeId: string | null
+  obsCopied: boolean
+}
+
+/**
+ * Pure derivation of the core checklist from observable state. Steps are
+ * strictly ordered; regressions (e.g. the only overlay was deleted) simply
+ * re-activate the earlier step.
+ */
+export function deriveSteps(input: DeriveStepsInput): OnboardingStep[] {
+  const done: Record<OnboardingStepId, boolean> = {
+    create_overlay: input.overlayCount > 0,
+    connect_source: input.sourceCount > 0,
+    choose_theme: input.themeId !== null && input.themeId !== '',
+    copy_obs: input.obsCopied,
+  }
+  const order: OnboardingStepId[] = ['create_overlay', 'connect_source', 'choose_theme', 'copy_obs']
+  const firstOpen = order.find((id) => !done[id])
+  return order.map((id) => ({ id, done: done[id], active: id === firstOpen }))
+}
+
+interface SessionSteps {
+  obsCopied: boolean
+  extrasDone: boolean
+}
+
+const storageKey = (userId: string) => `onboarding-v1:${userId}`
+
+function readSessionSteps(userId: string): SessionSteps {
+  try {
+    const raw = localStorage.getItem(storageKey(userId))
+    if (!raw) return { obsCopied: false, extrasDone: false }
+    return { obsCopied: false, extrasDone: false, ...(JSON.parse(raw) as Partial<SessionSteps>) }
+  } catch {
+    return { obsCopied: false, extrasDone: false }
+  }
+}
+
+function writeSessionSteps(userId: string, steps: SessionSteps): void {
+  try {
+    localStorage.setItem(storageKey(userId), JSON.stringify(steps))
+  } catch {
+    // localStorage unavailable — the flow still works, steps just re-show.
+  }
+}
+
+interface OnboardingStore {
+  status: 'inactive' | 'active'
+  trigger: 'auto' | 'settings' | null
+  /** The overlay steps 2-4 bind to: last one visited in the editor. */
+  activeOverlayId: string | null
+  sessionSteps: SessionSteps
+  minimized: boolean
+  /** Analytics double-fire guard: step ids already reported as completed. */
+  reportedSteps: OnboardingStepId[]
+
+  start: (trigger: 'auto' | 'settings') => void
+  minimize: (minimized: boolean) => void
+  setActiveOverlay: (id: string) => void
+  markObsCopied: () => void
+  markExtrasDone: (skipped: boolean) => void
+  reportStepCompleted: (step: OnboardingStepId) => void
+  /** Dismiss = "don't show again" (restartable from Settings). */
+  dismiss: (currentStep: OnboardingStepId | 'extras') => Promise<void>
+  finish: () => Promise<void>
+}
+
+function currentUserId(): string {
+  return useAuthStore.getState().user?.id ?? 'anonymous'
+}
+
+/**
+ * Persist completed=true with one retry. The UI closes optimistically; if
+ * both attempts fail the flag stays NULL server-side and the guide re-shows
+ * on the next visit — annoying but never data-lossy.
+ */
+async function persistCompleted(): Promise<void> {
+  try {
+    await authApi.updateOnboarding(true)
+  } catch {
+    try {
+      await authApi.updateOnboarding(true)
+    } catch {
+      return
+    }
+  }
+  // Refresh /auth/me so onboarding_completed_at is current everywhere.
+  await useAuthStore.getState().init()
+}
+
+export const useOnboardingStore = create<OnboardingStore>((set, get) => ({
+  status: 'inactive',
+  trigger: null,
+  activeOverlayId: null,
+  sessionSteps: { obsCopied: false, extrasDone: false },
+  minimized: false,
+  reportedSteps: [],
+
+  start: (trigger) => {
+    if (get().status === 'active') return
+    set({
+      status: 'active',
+      trigger,
+      minimized: false,
+      reportedSteps: [],
+      sessionSteps: readSessionSteps(currentUserId()),
+    })
+    trackEvent('onboarding_started', { trigger })
+  },
+
+  minimize: (minimized) => set({ minimized }),
+
+  setActiveOverlay: (id) => set({ activeOverlayId: id }),
+
+  markObsCopied: () => {
+    const next = { ...get().sessionSteps, obsCopied: true }
+    writeSessionSteps(currentUserId(), next)
+    set({ sessionSteps: next })
+    get().reportStepCompleted('copy_obs')
+  },
+
+  markExtrasDone: (skipped) => {
+    const next = { ...get().sessionSteps, extrasDone: true }
+    writeSessionSteps(currentUserId(), next)
+    set({ sessionSteps: next })
+    if (skipped) trackEvent('onboarding_step_skipped', { step: 'extras' })
+    else trackEvent('onboarding_step_completed', { step: 'extras' })
+  },
+
+  reportStepCompleted: (step) => {
+    if (get().status !== 'active' || get().reportedSteps.includes(step)) return
+    set({ reportedSteps: [...get().reportedSteps, step] })
+    trackEvent('onboarding_step_completed', { step })
+  },
+
+  dismiss: async (currentStep) => {
+    trackEvent('onboarding_dismissed', { step: currentStep })
+    set({ status: 'inactive', trigger: null })
+    await persistCompleted()
+  },
+
+  finish: async () => {
+    trackEvent('onboarding_finished')
+    set({ status: 'inactive', trigger: null })
+    await persistCompleted()
+  },
+}))

--- a/frontend/tests/e2e/onboarding.spec.ts
+++ b/frontend/tests/e2e/onboarding.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * First-run setup guide (onboarding) E2E — network-route mocks only (auth is
+ * cookie/`/auth/me`-based; the legacy localStorage auth mock is dead).
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { expectNoNewA11yViolations } from './a11y-helpers'
+
+interface MockUser {
+  id: string
+  username: string
+  display_name: string
+  auth_provider: string
+  is_admin: boolean
+  is_premium: boolean
+  is_beta_tester: boolean
+  created_at: string
+  updated_at: string
+  onboarding_completed_at: string | null
+  impersonating?: boolean
+  impersonated_by?: string
+}
+
+const FRESH_USER: MockUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  username: 'fresh_streamer',
+  display_name: 'Fresh Streamer',
+  auth_provider: 'twitch',
+  is_admin: false,
+  is_premium: false,
+  is_beta_tester: false,
+  created_at: '2026-07-17T00:00:00Z',
+  updated_at: '2026-07-17T00:00:00Z',
+  onboarding_completed_at: null,
+}
+
+const OVERLAY = {
+  id: '22222222-2222-2222-2222-222222222222',
+  user_id: FRESH_USER.id,
+  name: 'My Stream',
+  description: '',
+  is_active: true,
+  is_public_for_viewers: false,
+  created_at: '2026-07-17T00:00:00Z',
+  updated_at: '2026-07-17T00:00:00Z',
+}
+
+const SOURCE = {
+  id: 'source-1',
+  overlay_id: OVERLAY.id,
+  platform: 'tiktok',
+  channel_id: 'somebody',
+  channel_name: 'somebody',
+  is_active: true,
+}
+
+const CONFIG = {
+  id: 'config-1',
+  overlay_id: OVERLAY.id,
+  display_settings: {},
+  filter_settings: {},
+  visual_settings: {},
+  enable_7tv: true,
+  enable_bttv: false,
+  enable_ffz: false,
+  theme_id: null as string | null,
+  custom_css: '',
+}
+
+async function mockApi(
+  page: Page,
+  {
+    user = FRESH_USER,
+    overlays = [] as (typeof OVERLAY)[],
+    sources = [] as (typeof SOURCE)[],
+    themeId = null as string | null,
+  } = {}
+) {
+  const json = (body: unknown) => ({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  })
+  // Catch-all first — Playwright matches routes last-registered-first.
+  await page.route('**/api/v1/**', (route) =>
+    route.fulfill({ status: 404, contentType: 'application/json', body: '{}' })
+  )
+  await page.route('**/api/v1/auth/me', (route) => route.fulfill(json(user)))
+  await page.route('**/api/v1/auth/guilds', (route) => route.fulfill(json([])))
+  await page.route('**/api/v1/overlays', (route) => route.fulfill(json(overlays)))
+  await page.route(`**/api/v1/overlays/${OVERLAY.id}`, (route) => route.fulfill(json(OVERLAY)))
+  await page.route(`**/api/v1/overlays/${OVERLAY.id}/sources`, (route) =>
+    route.fulfill(json(sources))
+  )
+  await page.route(`**/api/v1/overlays/${OVERLAY.id}/config`, (route) =>
+    route.fulfill(json({ ...CONFIG, theme_id: themeId }))
+  )
+}
+
+test.describe('first-run setup guide', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.route('https://cdn.jsdelivr.net/**', (route) => route.abort())
+  })
+
+  test('auto-opens for a fresh user on the dashboard', async ({ page }, testInfo) => {
+    await mockApi(page)
+    await page.goto('/dashboard')
+    const guide = page.getByRole('region', { name: 'Setup guide' })
+    await expect(guide).toBeVisible({ timeout: 20_000 })
+    await expect(guide.getByText('0 of 4 steps done')).toBeVisible()
+    await expect(guide.getByRole('button', { name: 'Create' })).toBeVisible()
+    // The wizard surface itself must scan clean — it is new code with no
+    // baseline entries.
+    await expectNoNewA11yViolations(page, 'dashboard-empty', testInfo)
+  })
+
+  test('does not open when onboarding is already completed', async ({ page }) => {
+    await mockApi(page, {
+      user: { ...FRESH_USER, onboarding_completed_at: '2026-01-01T00:00:00Z' },
+    })
+    await page.goto('/dashboard')
+    await expect(page.getByText('No overlays yet')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('region', { name: 'Setup guide' })).toHaveCount(0)
+  })
+
+  test('does not open for existing users with overlays (backfill-miss guard)', async ({ page }) => {
+    await mockApi(page, { overlays: [OVERLAY], sources: [SOURCE] })
+    await page.goto('/dashboard')
+    await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('region', { name: 'Setup guide' })).toHaveCount(0)
+  })
+
+  test('does not open while impersonating', async ({ page }) => {
+    await mockApi(page, {
+      user: { ...FRESH_USER, impersonating: true, impersonated_by: 'admin-1' },
+    })
+    await page.goto('/dashboard')
+    await expect(page.getByText('No overlays yet')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('region', { name: 'Setup guide' })).toHaveCount(0)
+  })
+
+  test('editor derives step completion and spotlights the active section', async ({
+    page,
+  }, testInfo) => {
+    // Straight to the editor via a HARD navigation — exactly what the OAuth
+    // add-source round-trip does. The editor re-arms the guide from the
+    // server flag; the in-memory store did not survive and must not need to.
+    await mockApi(page, { overlays: [], sources: [SOURCE], themeId: null })
+    await page.goto(`/overlays/${OVERLAY.id}`)
+    const guide = page.getByRole('region', { name: 'Setup guide' })
+    await expect(guide).toBeVisible({ timeout: 20_000 })
+    // Overlay exists (editor surface) + source exists → steps 1-2 done,
+    // choose_theme active.
+    await expect(guide.getByText('2 of 4 steps done')).toBeVisible()
+    await expect(guide.getByRole('button', { name: 'Show me' })).toBeVisible()
+    // The theme section is force-opened by the spotlight.
+    const themeTrigger = page.getByRole('button', { name: 'Theme', exact: true })
+    await expect(themeTrigger).toHaveAttribute('aria-expanded', 'true')
+    await expectNoNewA11yViolations(page, 'overlay-editor', testInfo)
+  })
+
+  test('dismiss confirms, persists, and hides the guide', async ({ page }) => {
+    await mockApi(page)
+    let patchBody: unknown = null
+    await page.route('**/api/v1/auth/me/onboarding', async (route) => {
+      patchBody = route.request().postDataJSON()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ onboarding_completed_at: '2026-07-17T12:00:00Z' }),
+      })
+    })
+    await page.goto('/dashboard')
+    const guide = page.getByRole('region', { name: 'Setup guide' })
+    await expect(guide).toBeVisible({ timeout: 20_000 })
+    await guide.getByRole('button', { name: 'Dismiss setup guide' }).click()
+    await page.getByRole('button', { name: 'Hide guide' }).click()
+    await expect(page.getByRole('region', { name: 'Setup guide' })).toHaveCount(0)
+    await expect.poll(() => patchBody).toEqual({ completed: true })
+  })
+
+  test('settings restart re-arms the guide and returns to the dashboard', async ({ page }) => {
+    await mockApi(page, {
+      user: { ...FRESH_USER, onboarding_completed_at: '2026-01-01T00:00:00Z' },
+    })
+    let patchBody: unknown = null
+    await page.route('**/api/v1/auth/me/onboarding', async (route) => {
+      patchBody = route.request().postDataJSON()
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ onboarding_completed_at: null }),
+      })
+    })
+    await page.goto('/settings')
+    await expect(page.getByRole('heading', { name: 'Setup guide' })).toBeVisible({
+      timeout: 20_000,
+    })
+    await page.getByRole('button', { name: 'Restart' }).click()
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 20_000 })
+    await expect(page.getByRole('region', { name: 'Setup guide' })).toBeVisible()
+    await expect.poll(() => patchBody).toEqual({ completed: false })
+  })
+})


### PR DESCRIPTION
## What

The user-facing half of the **retention initiative** (#560 backend flag, #561 plumbing): a persistent **setup-guide checklist** that walks a new streamer to "chat visible in OBS", auto-starting on first sign-in and restartable from Settings.

### Why a checklist, not a modal wizard
Connecting Twitch/YouTube/Kick is a **full-window OAuth redirect** — any modal state dies. So:
- Steps 1–3 (**create overlay → connect source → pick theme**) are **derived from server data** and recompute on every mount.
- The **editor re-arms the guide from the server flag** after hard navigations — the e2e proved the in-memory store alone loses the guide exactly on the OAuth return, which is the moment that matters most.
- Step 4 (**copy the OBS link**, with the 3-step OBS instructions) plus the extras/finale state live client-side, mirrored per-user to localStorage.

### The flow
1. Fresh user lands on /dashboard → guide opens (flag null + zero overlays, gated on fetch completion — the store's initial `loading:false` raced the zero-overlay guard) → empty-state CTA and the guide's Create button open the same **CreateOverlayDialog** → editor.
2. In the editor the guide is **inline at the top of the config panel** (the floating variant obscured controls underneath — caught by our own axe target-size gate) and **spotlights** exactly one section (`CollapsibleSection.forceOpen`: forced state never touches the user's saved preferences).
3. Optional extras (browser TTS is free; Premium link) → soft **Discord finale** → Finish persists `completed=true` (one retry + /auth/me refresh).
4. **Settings → Setup guide → Restart** re-arms it (works with existing overlays; steps show pre-checked reality).
5. Never auto-starts while impersonating (server also 403s writes).

### Funnel instrumentation (Umami, no PII)
`onboarding_started/step_viewed/step_completed/step_skipped/dismissed/finished/discord_clicked` + `obs_url_copied{surface:'onboarding'}` — measure exactly where new users drop off.

### Also
- "How do I add this to OBS?" help dialog next to the editor's Copy OBS URL button (shared `ObsHelpContent` — canonical copy, for everyone not just onboarders).

## Testing
- **7 new Playwright specs**: auto-start matrix (fresh/completed/has-overlays/impersonating), hard-navigation re-arm, derived progression + spotlight assertion, dismiss + settings-restart with PATCH body assertions, **axe scans of the checklist-open states**
- a11y smoke 7/7, unit 588 (deriveSteps matrix, store persistence/retry, forceOpen), storybook 52/52, a11y ESLint gate green (it caught an `autoFocus` during development), type-check clean

## Release note
Once deployed this completes the onboarding feature — the **Patreon announcement post** is the remaining release step per CLAUDE.md.