### PR TITLE
feat(onboarding): tour all premium features in the optional extras step

### DIFF
--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -278,45 +278,87 @@ export function OnboardingChecklist({
 
           {showExtras && (
             <div className="rounded-lg border border-border bg-surface-2 p-3">
-              <h3 className="text-sm font-semibold text-text">Optional: make it yours</h3>
-              <p className="mt-1 text-sm text-text-sub">
-                Have chat read aloud with text-to-speech (free with your browser&apos;s voices), or
-                see what{' '}
+              <h3 className="text-sm font-semibold text-text">Optional: go further</h3>
+              {/* Feature names/claims mirror app/upgrade/page.tsx — keep in sync. */}
+              <ul className="mt-2 space-y-2 text-sm">
+                <li>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-text">Text-to-speech</span>
+                    {surface === 'editor' && onSpotlightSection ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          trackEvent('cta_click', { cta: 'tts', location: 'onboarding-extras' })
+                          onSpotlightSection('appearance')
+                        }}
+                      >
+                        Show me
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!activeOverlayId}
+                        onClick={() => {
+                          trackEvent('cta_click', { cta: 'tts', location: 'onboarding-extras' })
+                          if (activeOverlayId) router.push(`/overlays/${activeOverlayId}`)
+                        }}
+                      >
+                        Show me
+                      </Button>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-sub">
+                    Read chat aloud. Browser voices are free; ElevenLabs voices are Premium.
+                  </p>
+                </li>
+                <li>
+                  <span className="font-medium text-text">Moderate from your overlay</span>
+                  <p className="text-xs text-text-sub">
+                    Delete, timeout, and ban straight from the Monitor View button at the top of the
+                    editor. (Premium)
+                  </p>
+                </li>
+                <li>
+                  <span className="font-medium text-text">Shared chat</span>
+                  <p className="text-xs text-text-sub">
+                    Combine several channels into one conversation via the Share Overlay button.
+                    (Premium)
+                  </p>
+                </li>
+                <li>
+                  <span className="font-medium text-text">YouTube stream selection</span>
+                  <p className="text-xs text-text-sub">
+                    Pick exactly which broadcast an overlay listens to, per YouTube source in
+                    Sources. (Premium)
+                  </p>
+                </li>
+                <li>
+                  <span className="font-medium text-text">Viewer flairs</span>
+                  <p className="text-xs text-text-sub">
+                    Premium cosmetics for chatters, like animated name gradients, under Flairs in
+                    the navigation.
+                  </p>
+                </li>
+              </ul>
+              <p className="mt-2 text-xs text-text-sub">
                 <a
                   href={PATREON_JOIN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={() =>
+                    trackEvent('cta_click', { cta: 'premium', location: 'onboarding-extras' })
+                  }
                   className="font-medium text-text underline decoration-dotted underline-offset-2 hover:text-twitch"
                 >
-                  Premium
-                </a>{' '}
-                adds.
+                  See everything Premium includes
+                </a>
               </p>
               <div className="mt-2 flex gap-2">
-                {surface === 'editor' && onSpotlightSection ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      onSpotlightSection('appearance')
-                      markExtrasDone(false)
-                    }}
-                  >
-                    Set up TTS
-                  </Button>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={!activeOverlayId}
-                    onClick={() => {
-                      markExtrasDone(false)
-                      if (activeOverlayId) router.push(`/overlays/${activeOverlayId}`)
-                    }}
-                  >
-                    Set up TTS
-                  </Button>
-                )}
+                <Button size="sm" variant="outline" onClick={() => markExtrasDone(false)}>
+                  Done
+                </Button>
                 <Button size="sm" variant="ghost" onClick={() => markExtrasDone(true)}>
                   Skip
                 </Button>

--- a/frontend/tests/e2e/onboarding.spec.ts
+++ b/frontend/tests/e2e/onboarding.spec.ts
@@ -220,4 +220,37 @@ test.describe('first-run setup guide', () => {
     await expect(page.getByRole('region', { name: 'Setup guide' })).toBeVisible()
     await expect.poll(() => patchBody).toEqual({ completed: false })
   })
+
+  test('extras step tours every premium feature after the core steps', async ({
+    page,
+  }, testInfo) => {
+    // All core steps satisfied: overlay + source + theme from the API mocks,
+    // OBS-copied from the per-user localStorage mirror.
+    await mockApi(page, { overlays: [], sources: [SOURCE], themeId: 'minimal-theme' })
+    await page.addInitScript(
+      ([userId]) => {
+        localStorage.setItem(`onboarding-v1:${userId}`, JSON.stringify({ obsCopied: true }))
+      },
+      [FRESH_USER.id]
+    )
+    await page.goto(`/overlays/${OVERLAY.id}`)
+    const guide = page.getByRole('region', { name: 'Setup guide' })
+    await expect(guide).toBeVisible({ timeout: 20_000 })
+    await expect(guide.getByText('All steps done!')).toBeVisible()
+    // The optional tour names every premium feature (copy mirrors /upgrade).
+    await expect(guide.getByText('Optional: go further')).toBeVisible()
+    for (const feature of [
+      'Text-to-speech',
+      'Moderate from your overlay',
+      'Shared chat',
+      'YouTube stream selection',
+      'Viewer flairs',
+    ]) {
+      await expect(guide.getByText(feature)).toBeVisible()
+    }
+    await expectNoNewA11yViolations(page, 'overlay-editor', testInfo)
+    // Done advances to the finale with the Discord invite.
+    await guide.getByRole('button', { name: 'Done' }).click()
+    await expect(guide.getByRole('link', { name: 'Join the Discord' })).toBeVisible()
+  })
 })


### PR DESCRIPTION
## What

Per feedback: the setup guide's optional extras step covered only TTS. It now gives new streamers a quick tour of **everything** All-Chat can do beyond the basics, with names and claims mirrored from `/upgrade` (keep-in-sync comment added):

- **Text-to-speech** — "Show me" spotlights the editor's appearance section (browser voices free, ElevenLabs voices Premium)
- **Moderate from your overlay** — points to the Monitor View button (Premium)
- **Shared chat** — points to the Share Overlay button (Premium)
- **YouTube stream selection** — per-source in Sources (Premium)
- **Viewer flairs** — Flairs in the navigation
- Plus a "See everything Premium includes" link

Explicit **Done/Skip** buttons replace the TTS-only exit; feature CTAs fire `cta_click {location: 'onboarding-extras'}`.

## Testing
New e2e reaches the extras state (API mocks + seeded per-user obsCopied mirror), asserts all five features render, **axe-scans the extras-open state**, and walks Done → Discord finale. 8/8 onboarding specs green; a11y lint gate green; type-check clean.