### PR TITLE
fix(discord-bot): keep a single quota message across rollouts

### DIFF
--- a/services/discord-bot/README.md
+++ b/services/discord-bot/README.md
@@ -145,6 +145,10 @@ Every hour (configurable), the bot fetches the current quota status from the You
 - Polling speed multiplier
 - Top 5 quota-consuming channels
 
+### Single Message per Kind (Rollout Cleanup)
+
+The bot keeps only one status message (and one alert message) visible in the channel instead of posting a new one on every deploy. During a process lifetime it edits its existing messages in place. On startup — after a rollout or restart, which clears the in-memory message IDs — it scans recent channel history for its own quota messages, reuses the most recent one (editing it in place, so no new notification is sent), and deletes the older stale duplicates. Only the bot's own messages are touched, so no extra Discord permissions are required.
+
 ## Discord Embed Examples
 
 ### Quota Status Embed (Healthy)

--- a/services/discord-bot/src/index.js
+++ b/services/discord-bot/src/index.js
@@ -49,6 +49,12 @@ redisClient.on('error', (err) => console.error('Redis Client Error:', err));
 let statusMessageId = null;
 let alertMessageId = null;
 
+// Embed titles used to identify this bot's own quota messages when reclaiming
+// the channel after a rollout, so only a single message of each kind stays
+// visible (see reclaimMessage).
+const QUOTA_STATUS_TITLE = '📊 YouTube API Quota Status';
+const QUOTA_ALERT_TITLE_MARKER = 'Quota Alert:';
+
 /**
  * Creates a Discord embed for quota status
  */
@@ -74,7 +80,7 @@ function createQuotaEmbed(data) {
   const resetsAtFormatted = `<t:${Math.floor(resetsAt.getTime() / 1000)}:R>`;
 
   const embed = new EmbedBuilder()
-    .setTitle('📊 YouTube API Quota Status')
+    .setTitle(QUOTA_STATUS_TITLE)
     .setColor(color)
     .setDescription(`**Current State:** ${getStateEmoji(state)} ${state}`)
     .addFields(
@@ -366,6 +372,51 @@ async function handleQuotaAlert(message) {
 }
 
 /**
+ * Reclaims this bot's existing quota messages after a rollout.
+ *
+ * A rollout restarts the process, which clears the in-memory message IDs. Without
+ * this, the bot would post a fresh message on every deploy and orphan the previous
+ * one, piling up stale duplicates in the channel. This scans recent channel history
+ * for the bot's own messages matching `matchesEmbed`, keeps the most recent one
+ * (returned so postQuota* can edit it in place instead of sending a new one), and
+ * deletes the rest so only a single message of that kind stays visible.
+ *
+ * @param {import('discord.js').TextBasedChannel} channel
+ * @param {(embed: import('discord.js').Embed) => boolean} matchesEmbed
+ * @param {string} label - human-readable name for logging
+ * @returns {Promise<string|null>} id of the surviving message, or null if none exists
+ */
+async function reclaimMessage(channel, matchesEmbed, label) {
+  try {
+    // Own-message embeds are readable without the MessageContent intent, and a
+    // bot may always delete its own messages, so no extra Discord perms needed.
+    const recent = await channel.messages.fetch({ limit: 100 });
+    const mine = [...recent.values()]
+      .filter((msg) => msg.author.id === discordClient.user.id && msg.embeds.some(matchesEmbed))
+      .sort((a, b) => b.createdTimestamp - a.createdTimestamp);
+
+    if (mine.length === 0) {
+      return null;
+    }
+
+    const [survivor, ...stale] = mine;
+    for (const msg of stale) {
+      try {
+        await msg.delete();
+        console.log(`🗑️  Removed stale ${label} message (ID: ${msg.id})`);
+      } catch (error) {
+        console.error(`Failed to remove stale ${label} message ${msg.id}:`, error.message);
+      }
+    }
+    console.log(`♻️  Reusing existing ${label} message (ID: ${survivor.id}); removed ${stale.length} stale`);
+    return survivor.id;
+  } catch (error) {
+    console.error(`Failed to reclaim ${label} messages:`, error.message);
+    return null;
+  }
+}
+
+/**
  * Start the bot
  */
 async function start() {
@@ -383,7 +434,29 @@ async function start() {
     discordClient.once('ready', async () => {
       console.log(`✅ Discord bot ready as ${discordClient.user.tag}`);
 
-      // Post initial status
+      // This rollout cleared the in-memory message IDs, so reclaim the messages
+      // this bot posted before the restart: keep the most recent status and alert
+      // message and delete the rest, so only one of each stays visible instead of
+      // a new duplicate accumulating on every deploy.
+      try {
+        const channel = await discordClient.channels.fetch(DISCORD_CHANNEL_ID);
+        if (channel) {
+          statusMessageId = await reclaimMessage(
+            channel,
+            (embed) => embed.title === QUOTA_STATUS_TITLE,
+            'quota status'
+          );
+          alertMessageId = await reclaimMessage(
+            channel,
+            (embed) => (embed.title || '').includes(QUOTA_ALERT_TITLE_MARKER),
+            'quota alert'
+          );
+        }
+      } catch (error) {
+        console.error('Failed to reclaim existing quota messages on startup:', error.message);
+      }
+
+      // Post initial status (edits the reclaimed message in place when present)
       console.log('Posting initial quota status...');
       await postQuotaStatus();
 


### PR DESCRIPTION
## Problem

Whenever the Discord quota bot rolls out (its process restarts), it posted a **new** quota status message and orphaned the previous one. The in-memory message IDs (`statusMessageId` / `alertMessageId`) are lost on restart, so `postQuotaStatus()` fell into the "first time" branch and `channel.send(...)` created a fresh message every deploy — stale quota messages accumulated in the channel.

## Fix

On the Discord `ready` event, the bot now **reclaims its own quota messages** from recent channel history before posting:

- Scans the last 100 channel messages for the bot's own quota status / alert embeds (matched by embed title).
- Keeps the **most recent** one and adopts its ID, so `postQuotaStatus()` / `postQuotaEvent()` **edit it in place** (no new notification/ping).
- **Deletes the older duplicates**, so only one message of each kind stays visible.

Only the bot's own messages are touched, so no extra Discord permissions (`ManageMessages`) are needed. It's self-correcting: cleans up duplicates left by *all* prior rollouts, not just the last one.

## Notes

- Verified with `node --check` (service has no test/lint harness).
- Sweep reads the last 100 messages; if more ever pile up it converges over successive restarts. In-process editing keeps it from growing during normal operation.
- Deploy: on merge, CI builds `allchat-discord-bot:main` and Keel (`policy: force`, `trigger: poll`) auto-rolls it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)