### PR TITLE
chore(discord-bot): use clientReady event and bump discord.js to 14.27.0

### DIFF
--- a/services/discord-bot/package-lock.json
+++ b/services/discord-bot/package-lock.json
@@ -14,7 +14,7 @@
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.220.0",
         "@opentelemetry/sdk-node": "^0.220.0",
         "axios": "^1.6.7",
-        "discord.js": "^14.14.1",
+        "discord.js": "^14.27.0",
         "redis": "^4.6.13"
       }
     },
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
-      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.2.tgz",
+      "integrity": "sha512-c5HI3hJuRWWrnpyCZAUYfIUTAEv9weX4tE2UfDqtM3ztizdKE9RFEf3G5IWhPyO+kPldUDpGv02XJAQzdUTC9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
@@ -74,10 +74,10 @@
         "@sapphire/async-queue": "^1.5.3",
         "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.40",
+        "discord-api-types": "^0.38.49",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"
@@ -96,16 +96,6 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
-      }
-    },
-    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
-      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/util": {
@@ -1757,9 +1747,9 @@
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
-      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
       "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
@@ -2178,24 +2168,24 @@
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.26.4",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
-      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.1",
+        "@discordjs/rest": "^2.6.2",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
-        "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.40",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.24.1"
+        "undici": "^6.27.0"
       },
       "engines": {
         "node": ">=18"

--- a/services/discord-bot/package.json
+++ b/services/discord-bot/package.json
@@ -22,7 +22,7 @@
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.220.0",
     "@opentelemetry/sdk-node": "^0.220.0",
     "axios": "^1.6.7",
-    "discord.js": "^14.14.1",
+    "discord.js": "^14.27.0",
     "redis": "^4.6.13"
   },
   "overrides": {

--- a/services/discord-bot/src/index.js
+++ b/services/discord-bot/src/index.js
@@ -430,8 +430,10 @@ async function start() {
     await redisSubscriber.subscribe('quota:alerts', handleQuotaAlert);
     console.log('✅ Subscribed to quota:alerts channel');
 
-    // Set up Discord ready event listener BEFORE login to avoid race condition
-    discordClient.once('ready', async () => {
+    // Set up Discord ready event listener BEFORE login to avoid race condition.
+    // 'clientReady' is the v14.26+ name for the old 'ready' event (which is
+    // deprecated and removed in v15).
+    discordClient.once('clientReady', async () => {
       console.log(`✅ Discord bot ready as ${discordClient.user.tag}`);
 
       // This rollout cleared the in-memory message IDs, so reclaim the messages


### PR DESCRIPTION
## What

Follow-up to #571. Two small maintenance changes to the quota bot:

1. **Fix the deprecation warning.** discord.js logged `The ready event has been renamed to clientReady ... and will only emit under that name in v15` on every startup. Renamed the listener from `ready` to `clientReady` (the current name for the same event since v14.26; `Events.Ready` no longer exists in 14.27).
2. **Bump the library.** `discord.js` 14.26.4 → **14.27.0** (latest stable; v15 is only a `dev` pre-release). lockfileVersion unchanged (3), `npm audit` clean.

## Verification

- `node --check src/index.js` passes.
- Confirmed against the installed lib: `Events.ClientReady === 'clientReady'` and the legacy `Events.Ready` is `undefined` in 14.27.0.
- Runtime confirmation comes from the post-deploy pod logs (bot reaches "ready as …" with no DeprecationWarning).

## Deploy

On merge, CI builds `allchat-discord-bot:main` and Keel (`policy: force`, `trigger: poll`) auto-rolls it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)