### PR TITLE
feat(a11y): structural finale — both ratchets empty (Batches 6-9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ Each service has a detailed README:
 - [GETTING_STARTED.md](./docs/GETTING_STARTED.md) - Complete navigation guide for LLM agents
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - Pull request process, code review guidelines
 - [Testing Guide](./docs/TESTING_COMPREHENSIVE.md) - Unit, integration, E2E tests
+- [Accessibility](./docs/ACCESSIBILITY.md) - WCAG 2.2 AA scope, CI gates (shrink-only ratchets), contracts for new UI code
 
 ---
 

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,46 @@
+# Accessibility
+
+The app UI targets **WCAG 2.2 AA**. This is a living reference for the conformance scope, the CI gates that keep it from regressing, and the deliberate design decisions behind a few non-obvious calls. Update it in the same PR as any change that affects these facts.
+
+## Scope
+
+**In scope (app UI):** landing, docs, dashboard, overlay editor, settings (streamer + viewer), admin, upgrade, auth pages, and the viewer participate page.
+
+**Out of scope (broadcast surfaces):** everything rendered inside OBS — `/overlay/[id]` and its view/poll/prediction/credits render pages, and overlay marketplace theme CSS. These are streamer-chosen broadcast art:
+
+- Overlay chat themes have their own deliberate contrast floor of 3.0:1 (see `frontend/tests/e2e/theme-contrast.spec.ts`), below AA on purpose — it exists to catch invisible-text theme bugs, not to police stream aesthetics.
+- Viewer-defined chatter name colors are never contrast-adjusted or overridden.
+- The axe helper (`frontend/tests/e2e/a11y-helpers.ts`) codifies this exemption once via themed-chat selector exclusions; never widen it into a blanket disable.
+
+## CI gates (`.github/workflows/frontend-a11y.yml`, runs on every frontend PR)
+
+| Job | What it enforces |
+|---|---|
+| A11y lint + token contrast | `eslint.a11y.config.mjs` (jsx-a11y **strict**, inline disables ignored) with an **empty** suppressions file — any violation fails. Plus the design-token contrast lock (`frontend/src/app/__tests__/token-contrast.test.ts`): text tokens ≥4.5:1 on every surface tier, platform colors ≥3:1, conversion math pinned to the rendered `#020204` background. |
+| Storybook axe | Every story runs axe with violations as errors (`.storybook/preview.ts`, `a11y: { test: 'error' }`). New primitives and components need stories. |
+| Axe page smoke | `frontend/tests/e2e/a11y.spec.ts` scans the main pages (WCAG 2.2 AA tags) against `a11y-baseline.json` — a **shrink-only** baseline of pre-existing rule ids. New rule ids fail immediately; prune entries in the PR that fixes them (the spec logs prunable entries). |
+
+Both ratchet files may only ever shrink: `frontend/eslint.a11y.suppressions.json` (currently `{}`) and `frontend/tests/e2e/a11y-baseline.json`.
+
+## Contracts for new code
+
+- **Every page `<main>`** gets `id="main-content" tabIndex={-1}` — the root layout's skip link targets it.
+- **Forms**: use `ui/field` (auto-wired label/description/error associations) or explicit `htmlFor` via `useId`. Placeholders are hints, never the only label. Hints/units/errors associate via `aria-describedby`; error states set `aria-invalid`.
+- **Modals**: always `ui/dialog`; destructive confirmations always `ui/alert-dialog` (no outside-press dismissal, cancel first in DOM order). Never hand-roll `fixed inset-0` modals.
+- **Toasts/status**: one system — `toastManager` from `lib/toast`. Loading states get `role="status"` (+ `ui/visually-hidden` label when the state has no visible text); inline error banners get `role="alert"`.
+- **Motion**: CSS animation is globally collapsed under `prefers-reduced-motion`; JS-driven motion must check `hooks/useReducedMotion`. Anything auto-advancing needs a visible pause control (2.2.2).
+- **Targets**: interactive elements ≥24×24px **element box** — axe measures the element's bounding box, so pseudo-element hit areas do not count. Draw small visuals as inner spans/pseudo-elements inside a 24px control.
+- Repo lint additionally enforces `focus-visible:` (never bare `focus:`), no template-literal `className`, slate over gray.
+
+## Deliberate decisions (don't "fix" these without reading why)
+
+- **Split-pane dividers use `role="slider"`, not the APG window-splitter `separator`** (`ResizableSplit`, `SplitView`): aria-query models `separator` as non-interactive structure, so a focusable separator cannot pass the strict lint gate. Slider carries the same value/min/max/orientation and arrow-key semantics and announces the split percentage. Each divider also has ±10% step buttons — WCAG 2.5.7 requires a single-pointer no-drag alternative; keyboard alone does not satisfy it.
+- **3.3.8 Accessible Authentication passes by design**: login is OAuth-only (Twitch/YouTube/Kick) — no passwords, no CAPTCHA, no cognitive tests. If a password or CAPTCHA flow is ever added, it must be re-assessed.
+- **The Monaco custom-CSS editor captures Tab** (code editors legitimately do): the visible hint next to it documents the exit (Ctrl+M toggles tab capture; Escape then Tab leaves). If that ever proves insufficient for screen-reader users, the fallback is a plain-textarea toggle.
+- **`--color-text-dim` and `--color-text-sub`** were raised (0.575/0.60 oklch lightness) so tertiary/secondary text clears 4.5:1 on every surface tier; the token test locks this. Don't lower them.
+
+## Manual test scripts (run per significant UI change)
+
+**Keyboard:** load page → first Tab reveals the skip link → Enter lands focus in main → Tab through everything (visible focus ring, logical order, no traps — Monaco per its documented exit) → every dialog: open, interact, Escape, focus returns to trigger → operate switches (Space), sliders/dividers (arrows + step buttons), comboboxes, color pickers (popover + hex input).
+
+**Screen reader (NVDA/Firefox primary):** landmark and heading navigation are coherent; forms mode announces name/role/state/description for every field; validation errors announce and are re-findable; toasts announce without moving focus.

--- a/frontend/src/app/HomeClient.tsx
+++ b/frontend/src/app/HomeClient.tsx
@@ -238,7 +238,7 @@ export default function HomeClient() {
               {/* Twitch */}
               <button
                 onClick={handleTwitchLogin}
-                className="flex items-center gap-2.5 rounded-lg bg-twitch px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+                className="flex items-center gap-2.5 rounded-lg bg-twitch px-6 py-3 font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
                 aria-label="Sign in with Twitch"
               >
                 <svg
@@ -248,17 +248,18 @@ export default function HomeClient() {
                   aria-hidden="true"
                 >
                   <path
-                    fill="#FFFFFF"
+                    fill="currentColor"
                     d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"
                   />
                 </svg>
                 Sign in with Twitch
               </button>
 
-              {/* YouTube — exact brand red #FF0000, white text + icon per YouTube guidelines */}
+              {/* YouTube — exact brand red #FF0000; dark label for WCAG AA (white on
+                  #FF0000 is ~4.0:1), official white-on-red icon kept (logo exemption) */}
               <button
                 onClick={handleYouTubeLogin}
-                className="flex items-center gap-2.5 rounded-lg px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+                className="flex items-center gap-2.5 rounded-lg px-6 py-3 font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
                 style={
                   {
                     backgroundColor: '#FF0000',
@@ -524,7 +525,7 @@ export default function HomeClient() {
                 <Link
                   href="/docs/api"
                   onClick={() => trackEvent('cta_click', { cta: 'api-docs', location: 'promo' })}
-                  className="inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-twitch to-tiktok px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+                  className="inline-flex items-center gap-2 rounded-lg bg-linear-to-r from-twitch to-tiktok px-5 py-2.5 text-sm font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
                 >
                   <Code2 className="h-4 w-4" aria-hidden="true" />
                   Read the API docs

--- a/frontend/src/app/admin/overlays/page.tsx
+++ b/frontend/src/app/admin/overlays/page.tsx
@@ -256,6 +256,8 @@ export default function OverlaysPage() {
                     className="focus-visible:ring-ring flex-1 rounded-lg border border-border bg-surface-2 px-4 py-2 text-text placeholder:text-text-dim focus-visible:ring-2 focus-visible:outline-none"
                   />
                   <button
+                    type="button"
+                    aria-pressed={showConnectedOnly}
                     onClick={() => setShowConnectedOnly(!showConnectedOnly)}
                     className={clsx(
                       'flex shrink-0 items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors',
@@ -264,7 +266,10 @@ export default function OverlaysPage() {
                         : 'border-border bg-surface-2 text-text-sub hover:text-text'
                     )}
                   >
-                    <span className="inline-block h-2 w-2 rounded-full bg-kick" />
+                    <span
+                      aria-hidden="true"
+                      className="inline-block h-2 w-2 rounded-full bg-kick"
+                    />
                     Connected ({connectedCount})
                   </button>
                 </div>
@@ -291,6 +296,7 @@ export default function OverlaysPage() {
                         <button
                           type="button"
                           onClick={() => setSelectedOverlay(overlay)}
+                          aria-current={selectedOverlay?.id === overlay.id ? 'true' : undefined}
                           className="min-w-0 flex-1 cursor-pointer text-left after:absolute after:inset-0"
                         >
                           <div className="flex items-center">
@@ -494,6 +500,7 @@ export default function OverlaysPage() {
           ) : (
             <Card className="p-6 text-center">
               <svg
+                aria-hidden="true"
                 className="mx-auto h-12 w-12 text-text-dim"
                 fill="none"
                 stroke="currentColor"

--- a/frontend/src/app/admin/sources/page.tsx
+++ b/frontend/src/app/admin/sources/page.tsx
@@ -139,7 +139,12 @@ export default function SourcesPage() {
         <Card className="p-4">
           <div className="flex items-center gap-3">
             <div className="flex-shrink-0 rounded-lg bg-twitch/20 p-2">
-              <svg className="h-5 w-5 text-twitch" fill="currentColor" viewBox="0 0 20 20">
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5 text-twitch"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
                 <path d="M2 10a8 8 0 018-8v8h8a8 8 0 11-16 0z" />
                 <path d="M12 2.252A8.014 8.014 0 0117.748 8H12V2.252z" />
               </svg>
@@ -154,7 +159,12 @@ export default function SourcesPage() {
         <Card className="p-4">
           <div className="flex items-center gap-3">
             <div className="flex-shrink-0 rounded-lg bg-youtube/20 p-2">
-              <svg className="h-5 w-5 text-youtube" fill="currentColor" viewBox="0 0 20 20">
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5 text-youtube"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
                 <path d="M2 6a2 2 0 012-2h6a2 2 0 012 2v8a2 2 0 01-2 2H4a2 2 0 01-2-2V6zM14.553 7.106A1 1 0 0014 8v4a1 1 0 00.553.894l2 1A1 1 0 0018 13V7a1 1 0 00-1.447-.894l-2 1z" />
               </svg>
             </div>
@@ -168,7 +178,12 @@ export default function SourcesPage() {
         <Card className="p-4">
           <div className="flex items-center gap-3">
             <div className="flex-shrink-0 rounded-lg bg-kick/20 p-2">
-              <svg className="h-5 w-5 text-kick" fill="currentColor" viewBox="0 0 20 20">
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5 text-kick"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
                 <path
                   fillRule="evenodd"
                   d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z"
@@ -186,7 +201,12 @@ export default function SourcesPage() {
         <Card className="p-4">
           <div className="flex items-center gap-3">
             <div className="flex-shrink-0 rounded-lg bg-tiktok/20 p-2">
-              <svg className="h-5 w-5 text-tiktok" fill="currentColor" viewBox="0 0 20 20">
+              <svg
+                aria-hidden="true"
+                className="h-5 w-5 text-tiktok"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
                 <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
               </svg>
             </div>
@@ -273,14 +293,27 @@ export default function SourcesPage() {
             </div>
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
+                <caption className="sr-only">Chat sources</caption>
                 <thead className="border-b border-border bg-surface-2">
                   <tr>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Platform</th>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Channel</th>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Overlay</th>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Status</th>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Created</th>
-                    <th className="px-4 py-3 text-left font-medium text-text-sub">Actions</th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Platform
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Channel
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Overlay
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Status
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Created
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
@@ -318,6 +351,7 @@ export default function SourcesPage() {
                       <td className="px-4 py-3 text-sm">
                         <Link
                           href={`/admin/overlays?overlay=${source.overlay_id}`}
+                          aria-label={`View overlay ${source.overlay_name} for channel ${source.channel_name}`}
                           className="font-medium text-text-sub transition-colors hover:text-text"
                         >
                           View

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -452,6 +452,7 @@ export default function UsersPage() {
                     <button
                       type="button"
                       onClick={() => setSelectedUser(user)}
+                      aria-current={selectedUser?.id === user.id ? 'true' : undefined}
                       className={clsx(
                         'w-full cursor-pointer px-4 py-4 text-left transition-colors hover:bg-surface-2',
                         selectedUser?.id === user.id && 'bg-surface-2'
@@ -601,6 +602,7 @@ export default function UsersPage() {
                           onClick={() => setImpersonateDialogUser(selectedUser)}
                         >
                           <svg
+                            aria-hidden="true"
                             className="h-4 w-4"
                             fill="none"
                             stroke="currentColor"
@@ -672,6 +674,7 @@ export default function UsersPage() {
                             <Button
                               variant="outline"
                               className="w-full"
+                              aria-label={`Revoke Premium for ${selectedUser.username}`}
                               onClick={() => setPremiumDialogUser(selectedUser)}
                             >
                               Revoke Premium
@@ -721,6 +724,7 @@ export default function UsersPage() {
                           <Button
                             variant="outline"
                             className="w-full border-amber-500/40 text-amber-400 hover:border-amber-500/60 hover:bg-amber-500/10"
+                            aria-label={`Grant Premium to ${selectedUser.username}`}
                             onClick={() => {
                               // Reset the duration selection to the default (Permanent)
                               // each time the grant dialog opens.
@@ -799,6 +803,7 @@ export default function UsersPage() {
                             <Button
                               variant="outline"
                               className="w-full"
+                              aria-label={`Revoke Beta Tester for ${selectedUser.username}`}
                               onClick={() => setBetaDialogUser(selectedUser)}
                             >
                               Revoke Beta Tester
@@ -849,6 +854,7 @@ export default function UsersPage() {
                           <Button
                             variant="outline"
                             className="w-full border-violet-500/40 text-violet-400 hover:border-violet-500/60 hover:bg-violet-500/10"
+                            aria-label={`Grant Beta Tester to ${selectedUser.username}`}
                             onClick={() => setBetaDialogUser(selectedUser)}
                           >
                             Grant Beta Tester
@@ -911,6 +917,7 @@ export default function UsersPage() {
                             <Button
                               variant="outline"
                               className="w-full"
+                              aria-label={`Unban User ${selectedUser.username}`}
                               onClick={() => setUnbanDialogUser(selectedUser)}
                             >
                               Unban User
@@ -940,6 +947,7 @@ export default function UsersPage() {
                     <Button
                       variant="destructive"
                       className="w-full"
+                      aria-label={`Ban User ${selectedUser.username}`}
                       onClick={() => {
                         setUserToBan(selectedUser)
                         setBanReason('')
@@ -972,6 +980,7 @@ export default function UsersPage() {
                                 </div>
                               </div>
                               <svg
+                                aria-hidden="true"
                                 className="h-4 w-4 text-text-dim"
                                 fill="none"
                                 stroke="currentColor"
@@ -998,6 +1007,7 @@ export default function UsersPage() {
           ) : (
             <Card className="p-6 text-center">
               <svg
+                aria-hidden="true"
                 className="mx-auto h-12 w-12 text-text-dim"
                 fill="none"
                 stroke="currentColor"

--- a/frontend/src/app/admin/viewers/page.tsx
+++ b/frontend/src/app/admin/viewers/page.tsx
@@ -187,6 +187,7 @@ export default function AdminViewersPage() {
     }
     return (
       <button
+        aria-label={`${viewer.is_premium ? 'Premium' : 'Free'}: change premium status for ${viewer.username}`}
         className={clsx(
           'inline-flex items-center rounded px-2 py-0.5 text-xs font-medium transition-colors',
           viewer.is_premium
@@ -211,6 +212,7 @@ export default function AdminViewersPage() {
         <Button
           variant="outline"
           size="sm"
+          aria-label={`${banningId === viewer.id ? 'Unbanning' : 'Unban'} ${viewer.username}`}
           disabled={banningId === viewer.id}
           onClick={() => setUnbanDialogViewer(viewer)}
         >
@@ -222,6 +224,7 @@ export default function AdminViewersPage() {
       <Button
         variant="destructive"
         size="sm"
+        aria-label={`Ban ${viewer.username}`}
         disabled={banningId === viewer.id}
         onClick={() => handleBanClick(viewer)}
       >
@@ -271,17 +274,30 @@ export default function AdminViewersPage() {
         <Card className="hidden overflow-hidden md:block">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
+              <caption className="sr-only">Viewers</caption>
               <thead className="border-b border-border bg-surface-2">
                 <tr>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Username</th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Platform</th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Last Message</th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Username
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Platform
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Last Message
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
                     Msg Count (1m/1h)
                   </th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Premium</th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Status</th>
-                  <th className="px-4 py-3 text-left font-medium text-text-sub">Actions</th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Premium
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Status
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
@@ -294,10 +310,10 @@ export default function AdminViewersPage() {
                 ) : (
                   viewers.map((viewer) => (
                     <tr key={viewer.id} className="transition-colors hover:bg-surface-2">
-                      <td className="px-4 py-3">
+                      <th scope="row" className="px-4 py-3 text-left font-normal">
                         <div className="text-sm font-medium text-text">{viewer.username}</div>
                         <div className="text-xs text-text-sub">{viewer.display_name}</div>
-                      </td>
+                      </th>
                       <td className="px-4 py-3">
                         <span className="text-sm text-text-sub capitalize">{viewer.platform}</span>
                       </td>

--- a/frontend/src/app/auth/callback/page.tsx
+++ b/frontend/src/app/auth/callback/page.tsx
@@ -161,7 +161,7 @@ function AuthCallbackContent() {
           <p className="mb-4 text-lg text-youtube">{error}</p>
           <Link
             href="/"
-            className="inline-block rounded-lg bg-twitch px-6 py-2 font-semibold text-white transition-opacity hover:opacity-90"
+            className="inline-block rounded-lg bg-twitch px-6 py-2 font-semibold text-bg transition-opacity hover:opacity-90"
           >
             Return to Home
           </Link>

--- a/frontend/src/app/chat/auth-error/page.tsx
+++ b/frontend/src/app/chat/auth-error/page.tsx
@@ -48,7 +48,7 @@ function AuthErrorContent() {
         <div className="space-y-4">
           <Link
             href="/"
-            className="block rounded-lg bg-twitch px-6 py-3 font-semibold text-white transition-colors hover:bg-twitch/80"
+            className="block rounded-lg bg-twitch px-6 py-3 font-semibold text-bg transition-colors hover:bg-twitch/80"
           >
             Return to Home
           </Link>

--- a/frontend/src/app/chat/auth-success/page.tsx
+++ b/frontend/src/app/chat/auth-success/page.tsx
@@ -183,7 +183,7 @@ function AuthSuccessContent() {
           <p className="mb-4 text-lg text-youtube">{error}</p>
           <Link
             href="/"
-            className="inline-block rounded-lg bg-twitch px-6 py-2 font-semibold text-white transition-colors hover:bg-twitch/80"
+            className="inline-block rounded-lg bg-twitch px-6 py-2 font-semibold text-bg transition-colors hover:bg-twitch/80"
           >
             Return to Home
           </Link>

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -136,7 +136,7 @@ export default function DocsPage() {
             </p>
             <p className="text-sm text-text-sub">
               Building a bot, alert box, or analytics tool?{' '}
-              <Link href="/docs/api" className="text-twitch hover:underline">
+              <Link href="/docs/api" className="text-twitch underline underline-offset-2">
                 See the Developer API →
               </Link>
             </p>

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -1184,11 +1184,11 @@ function AddSourceForm({
       <div className="grid grid-cols-1 gap-2">
         <button
           onClick={() => startOAuth(`/api/v1/auth/twitch/add-source/${overlayId}`)}
-          className="flex items-center gap-2.5 rounded-lg bg-twitch px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+          className="flex items-center gap-2.5 rounded-lg bg-twitch px-4 py-2.5 text-sm font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
         >
           <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
             <path
-              fill="#FFFFFF"
+              fill="currentColor"
               d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"
             />
           </svg>
@@ -1197,7 +1197,7 @@ function AddSourceForm({
 
         <button
           onClick={() => startOAuth(`/api/v1/auth/youtube/add-source/${overlayId}`)}
-          className="flex items-center gap-2.5 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+          className="flex items-center gap-2.5 rounded-lg px-4 py-2.5 text-sm font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
           style={
             { backgroundColor: '#FF0000', '--tw-ring-color': '#FF0000' } as React.CSSProperties
           }
@@ -2883,6 +2883,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                 <CollapsibleSection
                   id="theme"
                   title="Theme"
+                  headingLevel={2}
                   storageKey="editor-panel-sections-v1"
                   defaultOpen={true}
                   forceOpen={sectionForce('theme')}
@@ -2903,6 +2904,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                 <CollapsibleSection
                   id="appearance"
                   title="Appearance"
+                  headingLevel={2}
                   storageKey="editor-panel-sections-v1"
                   defaultOpen={false}
                   forceOpen={sectionForce('appearance')}
@@ -2968,6 +2970,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                 <CollapsibleSection
                   id="sources"
                   title="Sources"
+                  headingLevel={2}
                   storageKey="editor-panel-sections-v1"
                   defaultOpen={true}
                   forceOpen={sectionForce('sources')}
@@ -3065,6 +3068,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               <CollapsibleSection
                 id="behavior"
                 title="Behavior"
+                headingLevel={2}
                 storageKey="editor-panel-sections-v1"
                 defaultOpen={false}
               >
@@ -3300,6 +3304,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               <CollapsibleSection
                 id="engagement"
                 title="Engagement"
+                headingLevel={2}
                 storageKey="editor-panel-sections-v1"
                 defaultOpen={false}
               >
@@ -3310,6 +3315,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               <CollapsibleSection
                 id="expert"
                 title="Expert"
+                headingLevel={2}
                 storageKey="editor-panel-sections-v1"
                 defaultOpen={false}
               >
@@ -3503,6 +3509,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               <CollapsibleSection
                 id="danger-zone"
                 title="Danger Zone"
+                headingLevel={2}
                 storageKey="editor-panel-sections-v1"
                 defaultOpen={false}
               >
@@ -3534,16 +3541,19 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
               >
                 {isSavingConfig ? 'Saving...' : 'Save Configuration'}
               </Button>
-              {configAlert && (
-                <p
-                  className={cn(
-                    'mt-2 text-center text-sm',
-                    configAlert.type === 'success' ? 'text-green-400' : 'text-destructive'
-                  )}
-                >
-                  {configAlert.message}
-                </p>
-              )}
+              {/* Always-mounted live region so save success/failure announces
+                  to screen readers (WCAG 4.1.3) — conditionally mounting the
+                  role="status" element would not announce reliably. */}
+              <p
+                role="status"
+                className={cn(
+                  'text-center text-sm',
+                  configAlert && 'mt-2',
+                  configAlert?.type === 'success' ? 'text-green-400' : 'text-destructive'
+                )}
+              >
+                {configAlert?.message}
+              </p>
             </div>
           </div>
         </div>

--- a/frontend/src/app/settings/viewer/page.tsx
+++ b/frontend/src/app/settings/viewer/page.tsx
@@ -24,6 +24,7 @@ import { AppNav } from '@/components/AppNav'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { buildGradientCSS } from '@/lib/utils/gradient'
+import { cn } from '@/lib/utils'
 import { safeExternalRedirect } from '@/lib/auth/redirect-allowlist'
 import type { NameGradient } from '@/lib/types/message'
 import { UserAvatar } from '@/components/UserAvatar'
@@ -65,7 +66,10 @@ function PlatformBadge({ platform }: { platform: string }) {
   if (!found) return null
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-white ${found.color}`}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-bg',
+        found.color
+      )}
     >
       {found.label}
     </span>
@@ -129,7 +133,7 @@ function UnauthenticatedState() {
           <div className="flex flex-col gap-3 sm:flex-row">
             <button
               onClick={() => viewerLogin('twitch')}
-              className="flex items-center gap-2.5 rounded-lg bg-twitch px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+              className="flex items-center gap-2.5 rounded-lg bg-twitch px-6 py-3 font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
             >
               <svg
                 className="h-5 w-5 shrink-0"
@@ -138,7 +142,7 @@ function UnauthenticatedState() {
                 aria-hidden="true"
               >
                 <path
-                  fill="#FFFFFF"
+                  fill="currentColor"
                   d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"
                 />
               </svg>
@@ -146,7 +150,7 @@ function UnauthenticatedState() {
             </button>
             <button
               onClick={() => viewerLogin('youtube')}
-              className="flex items-center gap-2.5 rounded-lg px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
+              className="flex items-center gap-2.5 rounded-lg px-6 py-3 font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
               style={{ backgroundColor: '#FF0000', ['--tw-ring-color' as string]: '#FF0000' }}
             >
               <svg

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -136,7 +136,7 @@ export default function UpgradePage() {
                   href={PATREON_JOIN_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="font-medium text-twitch hover:underline"
+                  className="font-medium text-twitch underline underline-offset-2"
                 >
                   Patreon
                 </a>{' '}
@@ -147,7 +147,10 @@ export default function UpgradePage() {
               <Check className="mt-0.5 h-4 w-4 shrink-0 text-twitch" />
               <span>
                 Connect your Patreon account on the{' '}
-                <Link href="/settings/premium" className="font-medium text-twitch hover:underline">
+                <Link
+                  href="/settings/premium"
+                  className="font-medium text-twitch underline underline-offset-2"
+                >
                   Premium settings
                 </Link>{' '}
                 page.
@@ -162,7 +165,10 @@ export default function UpgradePage() {
 
         <p className="text-center text-xs text-text-dim">
           Just want viewer cosmetics?{' '}
-          <Link href="/settings/viewer/premium" className="text-text-sub hover:underline">
+          <Link
+            href="/settings/viewer/premium"
+            className="text-text-sub underline underline-offset-2"
+          >
             See viewer premium
           </Link>
           .

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useAuthStore } from '@/lib/stores/auth-store'
@@ -63,19 +62,24 @@ export function AppNav() {
   }
 
   return (
-    <nav className="sticky top-0 z-50 flex h-[60px] items-center border-b border-border bg-nav-bg px-8 backdrop-blur-[20px]">
+    <nav className="sticky top-0 z-50 flex h-[60px] items-center border-b border-border bg-nav-bg px-3 backdrop-blur-[20px] sm:px-8">
       <Link
         href="/dashboard"
-        className="mr-10 flex items-center gap-2.5 rounded-sm focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+        className="mr-4 flex shrink-0 items-center gap-2.5 rounded-sm focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none sm:mr-10"
       >
         <InfinityLogo size={28} />
         <span className="text-base font-extrabold tracking-tight text-text">all-chat</span>
       </Link>
-      <div className="flex h-full gap-0.5">
+      {/* Scrolls within itself on narrow viewports so the PAGE never scrolls
+          horizontally (WCAG 1.4.10 reflow at 320px). */}
+      <div className="flex h-full gap-0.5 overflow-x-auto">
         <Link href="/dashboard" className={isActive('/dashboard') ? activeClass : inactiveClass}>
           Dashboard
         </Link>
-        <Link href="/settings/viewer" className={isActive('/settings/viewer') ? activeClass : inactiveClass}>
+        <Link
+          href="/settings/viewer"
+          className={isActive('/settings/viewer') ? activeClass : inactiveClass}
+        >
           Flairs
         </Link>
         {user?.is_admin && (
@@ -83,10 +87,7 @@ export function AppNav() {
             Admin
           </Link>
         )}
-        <Link
-          href="/settings"
-          className={pathname === '/settings' ? activeClass : inactiveClass}
-        >
+        <Link href="/settings" className={pathname === '/settings' ? activeClass : inactiveClass}>
           Settings
         </Link>
         <Link href="/docs" className={isActive('/docs') ? activeClass : inactiveClass}>
@@ -96,7 +97,7 @@ export function AppNav() {
       {isLoggedIn && (
         <button
           onClick={handleLogout}
-          className="ml-auto text-sm text-text-sub hover:text-text transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-twitch rounded-sm px-3 py-1.5"
+          className="ml-auto rounded-sm px-3 py-1.5 text-sm text-text-sub transition-colors hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
         >
           Log out
         </button>

--- a/frontend/src/components/CookieBanner.tsx
+++ b/frontend/src/components/CookieBanner.tsx
@@ -192,7 +192,7 @@ export default function CookieBanner() {
               <div className="flex flex-wrap gap-3">
                 <button
                   onClick={acknowledgeBanner}
-                  className="rounded-lg bg-twitch px-6 py-2.5 font-medium text-white transition-colors hover:bg-twitch/80 focus-visible:ring-3 focus-visible:ring-twitch/50 focus-visible:outline-none"
+                  className="rounded-lg bg-twitch px-6 py-2.5 font-medium text-bg transition-colors hover:bg-twitch/80 focus-visible:ring-3 focus-visible:ring-twitch/50 focus-visible:outline-none"
                 >
                   I Understand
                 </button>

--- a/frontend/src/components/EventSubMigrationBanner.tsx
+++ b/frontend/src/components/EventSubMigrationBanner.tsx
@@ -121,14 +121,14 @@ export function EventSubMigrationBanner({
             : `${count} of your Twitch channels use the legacy connection`}
         </p>
         <p className="mt-0.5 text-text-sub">
-          The old IRC chat connection is being retired and can drop messages when many streams
-          are live. Reconnect to move to the new connection and keep your chat reliable.
+          The old IRC chat connection is being retired and can drop messages when many streams are
+          live. Reconnect to move to the new connection and keep your chat reliable.
         </p>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <button
           onClick={handleUpgrade}
-          className="rounded-md bg-twitch px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          className="rounded-md bg-twitch px-3 py-1.5 text-xs font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
         >
           Reconnect now
         </button>

--- a/frontend/src/components/ImpersonationBanner.tsx
+++ b/frontend/src/components/ImpersonationBanner.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import { useRouter } from 'next/navigation'
 import { useAuthStore } from '@/lib/stores/auth-store'
 
@@ -45,9 +44,18 @@ export default function ImpersonationBanner() {
   }
 
   return (
-    <div className="flex items-center justify-between bg-orange-600 px-4 py-2 text-white shadow-md">
+    <div
+      role="status"
+      className="flex items-center justify-between bg-orange-600 px-4 py-2 text-white shadow-md"
+    >
       <div className="flex items-center gap-3">
-        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <svg
+          aria-hidden="true"
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -61,8 +69,9 @@ export default function ImpersonationBanner() {
         </div>
       </div>
       <button
+        type="button"
         onClick={handleExitImpersonation}
-        className="rounded bg-white px-4 py-1 font-medium text-orange-600 transition-colors hover:bg-orange-50"
+        className="rounded bg-white px-4 py-1 font-medium text-orange-600 transition-colors hover:bg-orange-50 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-orange-600 focus-visible:outline-none"
       >
         Exit & Return to Admin
       </button>

--- a/frontend/src/components/MaintenanceBanner.tsx
+++ b/frontend/src/components/MaintenanceBanner.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import { useEffect, useState } from 'react'
 import { Wrench, X } from 'lucide-react'
 import { maintenanceApi } from '@/lib/api/maintenance'
@@ -61,15 +60,16 @@ export function MaintenanceBanner() {
         return (
           <div
             key={mw.id}
+            role="status"
             className={cn(
               'flex items-center gap-3 rounded-lg px-4 py-3 text-sm',
               active
-                ? 'bg-amber-500/10 text-amber-300 border border-amber-500/20'
-                : 'bg-blue-500/10 text-blue-300 border border-blue-500/20'
+                ? 'border border-amber-500/20 bg-amber-500/10 text-amber-300'
+                : 'border border-blue-500/20 bg-blue-500/10 text-blue-300'
             )}
           >
             <Wrench className="size-4 shrink-0" aria-hidden="true" />
-            <span className="flex-1 min-w-0">
+            <span className="min-w-0 flex-1">
               {active ? (
                 <>
                   <strong>Maintenance in progress:</strong> {mw.title} — Expected completion:{' '}
@@ -82,14 +82,17 @@ export function MaintenanceBanner() {
                   {DATE_FORMAT.format(new Date(mw.ends_at))}
                 </>
               )}
-              {mw.description && <span className="ml-1 text-xs opacity-75">({mw.description})</span>}
+              {mw.description && (
+                <span className="ml-1 text-xs opacity-75">({mw.description})</span>
+              )}
             </span>
             <button
+              type="button"
               onClick={() => setDismissed((prev) => new Set(prev).add(mw.id))}
-              aria-label="Dismiss maintenance banner"
-              className="shrink-0 rounded p-0.5 opacity-60 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current"
+              aria-label={`Dismiss maintenance banner: ${mw.title}`}
+              className="shrink-0 rounded p-0.5 opacity-60 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-current focus-visible:outline-none"
             >
-              <X className="size-3.5" />
+              <X className="size-3.5" aria-hidden="true" />
             </button>
           </div>
         )

--- a/frontend/src/components/MonacoCSSEditor.tsx
+++ b/frontend/src/components/MonacoCSSEditor.tsx
@@ -43,7 +43,7 @@ export default function MonacoCSSEditor({
   placeholder = '/* Enter your custom CSS here */',
   readOnly = false,
 }: MonacoCSSEditorProps) {
-  const editorRef = useRef<any>(null)
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null)
 
   const handleEditorDidMount: OnMount = (editor, monaco) => {
     editorRef.current = editor
@@ -82,32 +82,40 @@ export default function MonacoCSSEditor({
   }, [value])
 
   return (
-    <div className="overflow-hidden rounded-lg border border-border">
-      <Editor
-        height={height}
-        defaultLanguage="css"
-        value={value}
-        onChange={handleEditorChange}
-        onMount={handleEditorDidMount}
-        theme="vs-dark"
-        options={{
-          readOnly,
-          minimap: { enabled: false },
-          fontSize: 13,
-          lineNumbers: 'on',
-          renderLineHighlight: 'all',
-          scrollBeyondLastLine: false,
-          automaticLayout: true,
-          tabSize: 2,
-          wordWrap: 'on',
-          wrappingIndent: 'indent',
-        }}
-        loading={
-          <div className="flex h-full items-center justify-center bg-bg">
-            <div className="text-sm text-text-dim">Loading editor...</div>
-          </div>
-        }
-      />
+    // role="group" + aria-label mark the editor region for assistive tech;
+    // the hint below documents Monaco's built-in keyboard-trap escape
+    // (WCAG 2.1.2): Ctrl+M toggles tab-focus mode, Escape releases focus.
+    <div role="group" aria-label="Custom CSS editor">
+      <p className="mb-1 text-xs text-text-dim">
+        Press Ctrl+M to toggle Tab capturing; Escape then Tab leaves the editor.
+      </p>
+      <div className="overflow-hidden rounded-lg border border-border">
+        <Editor
+          height={height}
+          defaultLanguage="css"
+          value={value}
+          onChange={handleEditorChange}
+          onMount={handleEditorDidMount}
+          theme="vs-dark"
+          options={{
+            readOnly,
+            minimap: { enabled: false },
+            fontSize: 13,
+            lineNumbers: 'on',
+            renderLineHighlight: 'all',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 2,
+            wordWrap: 'on',
+            wrappingIndent: 'indent',
+          }}
+          loading={
+            <div className="flex h-full items-center justify-center bg-bg">
+              <div className="text-sm text-text-dim">Loading editor...</div>
+            </div>
+          }
+        />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -84,7 +84,7 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
           </p>
           <button
             onClick={() => router.push('/dashboard')}
-            className="rounded-lg bg-twitch px-6 py-2 font-semibold text-white transition hover:opacity-90"
+            className="rounded-lg bg-twitch px-6 py-2 font-semibold text-bg transition hover:opacity-90"
           >
             Go to Dashboard
           </button>

--- a/frontend/src/components/ThemeSwitcher.tsx
+++ b/frontend/src/components/ThemeSwitcher.tsx
@@ -172,7 +172,9 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
         {/* Caption + dots */}
         <div className="flex items-center justify-between gap-4 border-t border-border p-4 text-left">
           <div className="min-w-0">
-            <h3 className="truncate text-base font-semibold text-text">{current.theme.name}</h3>
+            {/* h2: the switcher sits directly under the page h1, so h3 would
+                skip a level in the landing's heading outline. */}
+            <h2 className="truncate text-base font-semibold text-text">{current.theme.name}</h2>
             <p className="truncate text-sm text-text-sub">{current.theme.description}</p>
           </div>
           <div
@@ -200,17 +202,25 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
             {RESOLVED.map((t, i) => {
               const isActive = i === active
               return (
+                // The button itself is 24x24 (WCAG 2.5.8 target size — axe
+                // measures the element box, so padding on a 10px dot wouldn't
+                // count); the visual dot is the inner span, unchanged.
                 <button
                   key={t.id}
                   type="button"
                   onClick={() => select(i)}
                   aria-label={`Show ${t.label}`}
                   aria-current={isActive}
-                  className={clsx(
-                    'h-2.5 rounded-full transition-all focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none',
-                    isActive ? 'w-6 bg-twitch' : 'w-2.5 bg-border-md hover:bg-text-sub'
-                  )}
-                />
+                  className="group flex h-6 w-6 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:ring-twitch focus-visible:ring-offset-2 focus-visible:ring-offset-surface focus-visible:outline-none"
+                >
+                  <span
+                    aria-hidden="true"
+                    className={clsx(
+                      'h-2.5 rounded-full transition-all',
+                      isActive ? 'w-6 bg-twitch' : 'w-2.5 bg-border-md group-hover:bg-text-sub'
+                    )}
+                  />
+                </button>
               )
             })}
           </div>

--- a/frontend/src/components/appearance/AppearancePanel.tsx
+++ b/frontend/src/components/appearance/AppearancePanel.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import React from 'react'
 import type { VisualSettings } from '@/lib/types/visual-settings'
 import type { FilterSettings, DisplaySettings } from '@/lib/types/overlay'
@@ -91,38 +90,38 @@ export function AppearancePanel({
 }: AppearancePanelProps): React.ReactElement {
   return (
     <div className="flex flex-col gap-0">
-      <CollapsibleSection id="typography" title="Typography">
+      <CollapsibleSection id="typography" title="Typography" headingLevel={3}>
         <TypographyGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
-      <CollapsibleSection id="colors" title="Colors">
+      <CollapsibleSection id="colors" title="Colors" headingLevel={3}>
         <ColorsGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
-      <CollapsibleSection id="background" title="Background & Bubbles">
+      <CollapsibleSection id="background" title="Background & Bubbles" headingLevel={3}>
         <BackgroundGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
-      <CollapsibleSection id="visibility" title="Visibility">
+      <CollapsibleSection id="visibility" title="Visibility" headingLevel={3}>
         <VisibilityGroup
           visualSettings={visualSettings}
           onChange={onChange}
           visibilityDefaults={visibilityDefaults}
         />
       </CollapsibleSection>
-      <CollapsibleSection id="sizing" title="Sizing">
+      <CollapsibleSection id="sizing" title="Sizing" headingLevel={3}>
         <SizingGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
-      <CollapsibleSection id="platform-colors" title="Platform Colors">
+      <CollapsibleSection id="platform-colors" title="Platform Colors" headingLevel={3}>
         <PlatformColorsGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
-      <CollapsibleSection id="events" title="Events">
+      <CollapsibleSection id="events" title="Events" headingLevel={3}>
         <EventsGroup visualSettings={visualSettings} onChange={onChange} />
       </CollapsibleSection>
       {filterSettings && onFilterChange && (
-        <CollapsibleSection id="filters" title="Filters">
+        <CollapsibleSection id="filters" title="Filters" headingLevel={3}>
           <FilterGroup filterSettings={filterSettings} onChange={onFilterChange} />
         </CollapsibleSection>
       )}
       {displaySettings && onSoundChange && (
-        <CollapsibleSection id="sounds" title="Notification Sounds">
+        <CollapsibleSection id="sounds" title="Notification Sounds" headingLevel={3}>
           <SoundGroup
             displaySettings={displaySettings}
             onChange={onSoundChange}
@@ -131,7 +130,7 @@ export function AppearancePanel({
         </CollapsibleSection>
       )}
       {displaySettings && onTTSChange && overlayId && (
-        <CollapsibleSection id="tts" title="Text-to-Speech">
+        <CollapsibleSection id="tts" title="Text-to-Speech" headingLevel={3}>
           <TTSGroup
             displaySettings={displaySettings}
             onChange={onTTSChange}

--- a/frontend/src/components/appearance/CollapsibleSection.tsx
+++ b/frontend/src/components/appearance/CollapsibleSection.tsx
@@ -48,6 +48,13 @@ export interface CollapsibleSectionProps {
    * survive onboarding untouched.
    */
   forceOpen?: boolean
+  /**
+   * When set, wraps the trigger in an <h2>/<h3>/<h4> so screen-reader users
+   * can jump between sections via heading navigation (WCAG 1.3.1 / 2.4.6).
+   * The heading carries no styling of its own — the trigger keeps its
+   * existing classes. Undefined (default) keeps the bare trigger markup.
+   */
+  headingLevel?: 2 | 3 | 4
 }
 
 export function CollapsibleSection({
@@ -57,6 +64,7 @@ export function CollapsibleSection({
   storageKey = STORAGE_KEY,
   defaultOpen = false,
   forceOpen,
+  headingLevel,
 }: CollapsibleSectionProps): React.ReactElement {
   const [open, setOpen] = useState<boolean>(() => {
     const stored = readStoredSections(storageKey)
@@ -75,15 +83,24 @@ export function CollapsibleSection({
     }
   }
 
+  const trigger = (
+    <Collapsible.Trigger className="flex w-full items-center justify-between py-2 text-sm font-medium text-text transition-colors hover:text-text-sub">
+      <span>{title}</span>
+      <ChevronDown
+        aria-hidden="true"
+        className="h-4 w-4 text-text-dim transition-transform duration-200 data-[open]:rotate-180"
+        data-open={(forceOpen ?? open) ? '' : undefined}
+      />
+    </Collapsible.Trigger>
+  )
+
+  // Tailwind preflight zeroes heading margins and inherits font styles, so
+  // the heading wrapper adds structure without visual change.
+  const HeadingTag = headingLevel !== undefined ? (`h${headingLevel}` as const) : null
+
   return (
     <Collapsible.Root open={forceOpen ?? open} onOpenChange={handleOpenChange}>
-      <Collapsible.Trigger className="flex w-full items-center justify-between py-2 text-sm font-medium text-text transition-colors hover:text-text-sub">
-        <span>{title}</span>
-        <ChevronDown
-          className="h-4 w-4 text-text-dim transition-transform duration-200 data-[open]:rotate-180"
-          data-open={(forceOpen ?? open) ? '' : undefined}
-        />
-      </Collapsible.Trigger>
+      {HeadingTag !== null ? <HeadingTag>{trigger}</HeadingTag> : trigger}
       <Collapsible.Panel
         keepMounted
         className="max-h-0 overflow-hidden transition-all duration-200 data-[open]:max-h-[2000px]"

--- a/frontend/src/components/appearance/__tests__/CollapsibleSection.test.tsx
+++ b/frontend/src/components/appearance/__tests__/CollapsibleSection.test.tsx
@@ -180,6 +180,58 @@ describe('CollapsibleSection', () => {
   })
 })
 
+describe('CollapsibleSection headingLevel (heading navigation)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
+  it('headingLevel={3} wraps the trigger in an h3 so it is reachable via heading navigation', () => {
+    render(
+      <CollapsibleSection id="typography" title="Typography" headingLevel={3}>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    const heading = screen.getByRole('heading', { level: 3 })
+    const trigger = screen.getByRole('button')
+    expect(heading.contains(trigger)).toBe(true)
+  })
+
+  it('headingLevel={2} renders an h2 wrapper', () => {
+    render(
+      <CollapsibleSection id="sources" title="Sources" headingLevel={2}>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    expect(screen.getByRole('heading', { level: 2 })).toBeDefined()
+  })
+
+  it('without headingLevel there is no heading wrapper (markup unchanged)', () => {
+    render(
+      <CollapsibleSection id="colors" title="Colors">
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    expect(screen.queryByRole('heading')).toBeNull()
+    expect(screen.getByRole('button')).toBeDefined()
+  })
+
+  it('trigger still toggles and persists when wrapped in a heading', () => {
+    render(
+      <CollapsibleSection id="behavior" title="Behavior" headingLevel={2}>
+        <span>child content</span>
+      </CollapsibleSection>
+    )
+    const trigger = screen.getByRole('button')
+    fireEvent.click(trigger)
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      'appearance-panel-sections-v1',
+      expect.any(String)
+    )
+  })
+})
+
 describe('CollapsibleSection forceOpen (onboarding spotlight)', () => {
   beforeEach(() => {
     localStorageMock.clear()

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -207,7 +207,7 @@ export function OnboardingChecklist({
     >
       <header className="flex items-center justify-between gap-2 border-b border-border p-3">
         <div className="min-w-0">
-          <h2 className="text-sm font-semibold text-text">Setup guide</h2>
+          <p className="text-sm font-semibold text-text">Setup guide</p>
           <p className="text-xs text-text-sub" aria-live="polite">
             {coreDone ? 'All steps done!' : `${doneCount} of ${steps.length} steps done`}
           </p>
@@ -271,14 +271,14 @@ export function OnboardingChecklist({
 
           {activeStep?.id === 'copy_obs' && !coreDone && (
             <div className="rounded-lg border border-border bg-surface-2 p-3">
-              <h3 className="mb-1.5 text-xs font-semibold text-text">In OBS:</h3>
+              <p className="mb-1.5 text-xs font-semibold text-text">In OBS:</p>
               <ObsHelpContent />
             </div>
           )}
 
           {showExtras && (
             <div className="rounded-lg border border-border bg-surface-2 p-3">
-              <h3 className="text-sm font-semibold text-text">Optional: go further</h3>
+              <p className="text-sm font-semibold text-text">Optional: go further</p>
               {/* Feature names/claims mirror app/upgrade/page.tsx — keep in sync. */}
               <ul className="mt-2 space-y-2 text-sm">
                 <li>
@@ -368,7 +368,7 @@ export function OnboardingChecklist({
 
           {showFinale && (
             <div className="rounded-lg border border-border bg-surface-2 p-3">
-              <h3 className="text-sm font-semibold text-text">You&apos;re live! 🎉</h3>
+              <p className="text-sm font-semibold text-text">You&apos;re live! 🎉</p>
               <p className="mt-1 text-sm text-text-sub">
                 Questions, feedback, or theme requests? Our community is happy to help.
               </p>

--- a/frontend/src/components/overlay/ChatSendBar.tsx
+++ b/frontend/src/components/overlay/ChatSendBar.tsx
@@ -143,8 +143,7 @@ export function ChatSendBar({ sources, onEnable, onReauth }: ChatSendBarProps) {
     onEnable(platform)
   }
 
-  const targetPlatform: SendPlatform =
-    selection.kind === 'all' ? 'all' : selection.platform
+  const targetPlatform: SendPlatform = selection.kind === 'all' ? 'all' : selection.platform
 
   const handleError = (err: unknown) => {
     if (!(err instanceof ApiError)) {
@@ -177,9 +176,7 @@ export function ChatSendBar({ sources, onEnable, onReauth }: ChatSendBarProps) {
       const retry = body.retry_after_seconds
       setFeedback({
         kind: 'error',
-        text: retry
-          ? `Rate limited — try again in ${retry}s.`
-          : 'Rate limited — please slow down.',
+        text: retry ? `Rate limited — try again in ${retry}s.` : 'Rate limited — please slow down.',
       })
       return
     }
@@ -251,7 +248,8 @@ export function ChatSendBar({ sources, onEnable, onReauth }: ChatSendBarProps) {
           {platformSources.map((s) => {
             const platform = s.platform as SingleSendPlatform
             const enabled = s.can_send === true
-            const active = enabled && selection.kind === 'platform' && selection.platform === platform
+            const active =
+              enabled && selection.kind === 'platform' && selection.platform === platform
             return (
               <button
                 key={platform}
@@ -320,16 +318,14 @@ export function ChatSendBar({ sources, onEnable, onReauth }: ChatSendBarProps) {
             onChange={(e) => setText(e.target.value)}
             maxLength={MAX_MESSAGE_LENGTH}
             disabled={sending}
-            placeholder={
-              selection.kind === 'all' ? 'Message all platforms…' : 'Send a message…'
-            }
+            placeholder={selection.kind === 'all' ? 'Message all platforms…' : 'Send a message…'}
             autoComplete="off"
             className="min-w-0 flex-1 rounded-lg border border-border bg-bg px-3 py-1.5 text-sm text-text placeholder:text-text-dim focus-visible:border-border-md focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:opacity-60"
           />
           <button
             type="submit"
             disabled={!canSubmit}
-            className="flex shrink-0 items-center gap-1.5 rounded-lg bg-twitch px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex shrink-0 items-center gap-1.5 rounded-lg bg-twitch px-3 py-1.5 text-xs font-semibold text-bg transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Send className="h-3.5 w-3.5" />
             Send

--- a/frontend/src/components/overlay/EngagementControls.tsx
+++ b/frontend/src/components/overlay/EngagementControls.tsx
@@ -49,7 +49,7 @@ const MAX_PREDICTION_OUTCOMES = 10
 const inputClass =
   'w-full rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none'
 const primaryButtonClass =
-  'rounded-lg bg-twitch px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-twitch/90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50'
+  'rounded-lg bg-twitch px-3 py-1.5 text-xs font-semibold text-bg transition-colors hover:bg-twitch/90 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50'
 const secondaryButtonClass =
   'rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-text-sub transition-colors hover:border-border-md hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50'
 

--- a/frontend/src/components/theme-marketplace/ThemeCard.tsx
+++ b/frontend/src/components/theme-marketplace/ThemeCard.tsx
@@ -96,7 +96,10 @@ export default function ThemeCard({
         {/* Tags */}
         <div className="mb-4 flex flex-wrap gap-1.5">
           {theme.tags.map((tag) => (
-            <span key={tag} className={clsx('rounded border px-1.5 py-0.5 text-xs', getTagColor(tag))}>
+            <span
+              key={tag}
+              className={clsx('rounded border px-1.5 py-0.5 text-xs', getTagColor(tag))}
+            >
               {tag}
             </span>
           ))}
@@ -105,7 +108,7 @@ export default function ThemeCard({
         {/* Apply Button */}
         <button
           onClick={() => onApply(theme)}
-          className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-twitch px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-twitch/90"
+          className="mt-auto flex w-full items-center justify-center gap-2 rounded-lg bg-twitch px-4 py-2 text-sm font-semibold text-bg transition-colors hover:bg-twitch/90"
         >
           <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />

--- a/frontend/src/components/theme-marketplace/ThemeFilters.tsx
+++ b/frontend/src/components/theme-marketplace/ThemeFilters.tsx
@@ -96,7 +96,7 @@ export default function ThemeFilters({
                 className={clsx(
                   'rounded-full border px-3 py-1 text-sm font-medium transition-colors',
                   isSelected
-                    ? 'border-twitch bg-twitch text-white'
+                    ? 'border-twitch bg-twitch text-bg'
                     : 'border-border bg-surface-2 text-text-sub hover:bg-surface-2/80'
                 )}
               >

--- a/frontend/src/components/ui/__tests__/button.test.ts
+++ b/frontend/src/components/ui/__tests__/button.test.ts
@@ -19,16 +19,18 @@
 import { describe, it, expect } from 'vitest'
 
 describe('button component gradient variant', () => {
-  it('buttonVariants gradient variant includes linear-gradient', async () => {
+  it('buttonVariants gradient variant uses the token gradient (twitch → tiktok)', async () => {
     const { buttonVariants } = await import('../button')
     const result = buttonVariants({ variant: 'gradient' })
-    expect(result).toContain('bg-[linear-gradient(90deg,#9146FF,#69C9D0)]')
+    expect(result).toContain('bg-linear-to-r')
+    expect(result).toContain('from-twitch')
+    expect(result).toContain('to-tiktok')
   })
 
-  it('buttonVariants gradient variant includes text-white and font-semibold', async () => {
+  it('buttonVariants gradient variant includes dark text (WCAG AA) and font-semibold', async () => {
     const { buttonVariants } = await import('../button')
     const result = buttonVariants({ variant: 'gradient' })
-    expect(result).toContain('text-white')
+    expect(result).toContain('text-bg')
     expect(result).toContain('font-semibold')
   })
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -18,7 +18,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 import { Button as ButtonPrimitive } from '@base-ui/react/button'
 import { cva, type VariantProps } from 'class-variance-authority'
 
@@ -40,7 +39,9 @@ const buttonVariants = cva(
           'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20',
         link: 'text-primary underline-offset-4 hover:underline',
         gradient:
-          'bg-[linear-gradient(90deg,#9146FF,#69C9D0)] text-white font-semibold border-transparent',
+          // Token endpoints (twitch #a37bff → tiktok #69c9d0) so the dark label
+          // clears WCAG AA on both ends; the old #9146FF end failed with any text.
+          'bg-linear-to-r from-twitch to-tiktok text-bg font-semibold border-transparent',
       },
       size: {
         default:

--- a/frontend/src/lib/dashboard-button-styles.ts
+++ b/frontend/src/lib/dashboard-button-styles.ts
@@ -25,8 +25,8 @@
  * so both render the returning user's provider colour identically.
  */
 export const DASHBOARD_BUTTON_STYLES: Record<string, { bg: string; ring: string; text: string }> = {
-  twitch: { bg: 'bg-twitch', ring: 'focus-visible:ring-twitch', text: 'text-white' },
-  youtube: { bg: 'bg-youtube', ring: 'focus-visible:ring-youtube', text: 'text-white' },
+  twitch: { bg: 'bg-twitch', ring: 'focus-visible:ring-twitch', text: 'text-bg' },
+  youtube: { bg: 'bg-youtube', ring: 'focus-visible:ring-youtube', text: 'text-bg' },
   kick: { bg: 'bg-kick', ring: 'focus-visible:ring-kick', text: 'text-bg' },
 }
 

--- a/frontend/tests/e2e/a11y-baseline.json
+++ b/frontend/tests/e2e/a11y-baseline.json
@@ -1,10 +1,10 @@
 {
-  "__doc": "Known pre-existing axe violation rule IDs per page, recorded when the a11y gate was introduced (2026-07-17, union of repeated runs). NEW rule IDs fail CI immediately. Entries may only ever be REMOVED (in the PR that fixes them — the spec logs prunable entries). Never add to this file. Fix mapping: target-size → Batch 9 sweep (WCAG 2.5.8); link-in-text-block → Batch 7 landing/docs/upgrade pass (1.4.1); color-contrast (badge text on platform colors, muted text) → Batches 5/7; aria-required-attr in the editor → Batch 2 primitives.",
-  "landing": ["color-contrast", "target-size"],
-  "docs": ["color-contrast", "link-in-text-block"],
-  "upgrade": ["color-contrast", "link-in-text-block"],
-  "dashboard-populated": ["color-contrast"],
-  "dashboard-empty": ["color-contrast"],
-  "settings": ["color-contrast"],
+  "__doc": "Known pre-existing axe violation rule IDs per page. NEW rule IDs fail CI immediately. Entries may only ever be REMOVED (in the PR that fixes them — the spec logs prunable entries). Never add to this file. As of 2026-07-17 the baseline is EMPTY: the original inventory (target-size, link-in-text-block, color-contrast, aria-required-attr) was fully remediated across the a11y initiative batches.",
+  "landing": [],
+  "docs": [],
+  "upgrade": [],
+  "dashboard-populated": [],
+  "dashboard-empty": [],
+  "settings": [],
   "overlay-editor": []
 }

--- a/frontend/tests/e2e/a11y-helpers.ts
+++ b/frontend/tests/e2e/a11y-helpers.ts
@@ -63,8 +63,12 @@ export async function expectNoNewA11yViolations(
     document.head.appendChild(style)
   })
   // Let async-hydrating widgets (comboboxes, editors, fetch-gated sections)
-  // reach their final DOM so the scan sees the same page every run.
-  await page.waitForLoadState('networkidle')
+  // reach their final DOM so the scan sees the same page every run. Bounded
+  // and best-effort: unmocked EXTERNAL requests (theme-marketplace GitHub
+  // sync, webfonts) can keep the network busy indefinitely, which used to
+  // hang this wait into the test timeout. The content anchor was already
+  // asserted and animations are frozen, so scanning after the bound is safe.
+  await page.waitForLoadState('networkidle', { timeout: 8_000 }).catch(() => {})
 
   let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS)
   for (const selector of THEMED_CHAT_SELECTORS) {


### PR DESCRIPTION
## What

**The final batches of the WCAG 2.2 AA initiative.** With this PR, both shrink-only ratchets are **empty**: the jsx-a11y suppressions file (`{}` since #573) and now the **axe page baseline** — every rule id in the original inventory is remediated, so any future axe violation or lint error on the covered surfaces fails CI with no escape hatch.

### ⚠️ Visual change — please eyeball
Dark text (`#020204`) replaces white on the bright platform backgrounds, with numerically verified ratios (same math as the token test):
- twitch purple buttons/chips: 3.07:1 → **6.75:1** (incl. dark Twitch glyphs)
- YouTube red: 3.41:1 → **6.08:1** (labels dark; the official white play logo kept — logo exemption)
- viewer badge chips: up to **9.3:1**
- **Button `gradient` variant recolored** to token endpoints (twitch→tiktok) with dark text — no text color passes both ends of the old `#9146FF→#69C9D0` gradient (white fails the teal end at 1.93:1). Affects the upgrade CTA, onboarding checklist, share modals, Storybook.
- Discord blurple keeps white text (4.61:1, passes).

### Structure & semantics
- **Editor**: `CollapsibleSection` gains `headingLevel` — 7 page sections are h2s, 10 appearance groups h3s (SR heading navigation); save indicator `role=status`; Monaco gets `role=group` + a visible tab-capture exit hint (2.1.2). Onboarding checklist headings demoted to styled text (its h2 preceded the editor h1).
- **Landing/docs/upgrade**: prose links underlined at rest (1.4.1); carousel dots are real 24×24 buttons (2.5.8); heading-order fix; 3.2.6 verified.
- **Admin**: viewers table caption + th scopes; every per-user action button carries row context ("Ban User username") with 2.5.3 label-in-name respected; banners `role=status`.

### Two real bugs found by the Batch 9 sweep
- **Reflow (1.4.10)**: AppNav stretched *every* authed page to 422px at a 320px viewport — nav links now scroll within the nav. Verified overflow-free in the browser at 320px.
- **Axe smoke could hang**: the networkidle settle now bounded (8s best-effort) — unmocked external requests (theme GitHub sync, webfonts) occasionally kept it waiting into the test timeout.

### Docs
`docs/ACCESSIBILITY.md` — living conformance reference: scope + the broadcast-surface exemption, the three CI gates and ratchet rules, contracts for new UI code, and the deliberate decisions log (slider-role splitters, 3.3.8 passes by design, Monaco policy). Linked from CLAUDE.md.

## Testing
type-check clean · unit 611 · storybook axe 52/52 · a11y lint zero suppressions · e2e a11y smoke + onboarding **15/15 ×3** against the empty baseline · 320px reflow probes clean