### PR TITLE
feat(discord): render image, GIF, and video chat attachments on overlays

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -38,6 +38,7 @@ Both ratchet files may only ever shrink: `frontend/eslint.a11y.suppressions.json
 - **3.3.8 Accessible Authentication passes by design**: login is OAuth-only (Twitch/YouTube/Kick) — no passwords, no CAPTCHA, no cognitive tests. If a password or CAPTCHA flow is ever added, it must be re-assessed.
 - **The Monaco custom-CSS editor captures Tab** (code editors legitimately do): the visible hint next to it documents the exit (Ctrl+M toggles tab capture; Escape then Tab leaves). If that ever proves insufficient for screen-reader users, the fallback is a plain-textarea toggle.
 - **`--color-text-dim` and `--color-text-sub`** were raised (0.575/0.60 oklch lightness) so tertiary/secondary text clears 4.5:1 on every surface tier; the token test locks this. Don't lower them.
+- **Chat media attachments use "hide", not "pause", for animated GIFs on the monitor** (`MessageAttachments`, `variant="compact"`): a raster GIF in an `<img>` cannot be paused without canvas readback of cross-origin CDN media, so 2.2.2 is met with a hide/show toggle (defaulting to hidden under reduced motion). Videos take the native-controls path instead. The broadcast overlay (`/overlay/[id]`) is out of scope, so GIFs animate freely there.
 
 ## Manual test scripts (run per significant UI change)
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -67,6 +67,11 @@ const nextConfig = {
       "script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at",
       "style-src 'self' 'unsafe-inline'",
       "connect-src 'self' wss: ws: https:",
+      // media-src governs <video>/<audio> sources. Chat message video attachments
+      // (Discord uploads, Tenor/Giphy link previews) are served from third-party
+      // https hosts; without this they fall back to default-src 'self' and are
+      // blocked. img-src already permits https: for image/GIF attachments.
+      "media-src 'self' https: data: blob:",
       "font-src 'self' data:",
       // frame-src governs which iframes a page may embed. It MUST list 'self' (the
       // editor's same-origin /overlays/:id/preview/embed iframe) plus the Twitch

--- a/frontend/src/app/docs/api/page.tsx
+++ b/frontend/src/app/docs/api/page.tsx
@@ -212,7 +212,7 @@ ws.run_forever()`}</Pre>
                   { name: 'channel_id', type: 'string', desc: 'Platform channel identifier.' },
                   { name: 'channel_name', type: 'string', desc: 'Human-readable channel name.' },
                   { name: 'user', type: 'object', desc: 'Author info (see below).' },
-                  { name: 'message', type: 'object', desc: '{ text, emotes[] } (see below).' },
+                  { name: 'message', type: 'object', desc: '{ text, emotes[], attachments[]? } (see below).' },
                   { name: 'timestamp', type: 'string', desc: 'RFC 3339 message time (UTC).' },
                   { name: 'metadata', type: 'object', desc: 'Free-form, platform-specific extras.' },
                   { name: 'event', type: 'object?', desc: 'Present only when the message is a platform event (see Events). Absent for normal chat.' },
@@ -235,17 +235,33 @@ ws.run_forever()`}</Pre>
                 ]}
               />
 
-              <h3>message and emotes</h3>
+              <h3>message, emotes, and attachments</h3>
               <p>
-                <Code>message</Code> is <Code>{`{ "text": string, "emotes": Emote[] }`}</Code>. Each{' '}
+                <Code>message</Code> is{' '}
+                <Code>{`{ "text": string, "emotes": Emote[], "attachments"?: Attachment[] }`}</Code>. Each{' '}
                 <Code>Emote</Code>:
               </p>
               <FieldTable
                 rows={[
                   { name: 'code', type: 'string', desc: 'Emote text token, e.g. "Kappa".' },
-                  { name: 'provider', type: 'string', desc: '"twitch" | "7tv" | "bttv" | "ffz" | platform.' },
+                  { name: 'provider', type: 'string', desc: '"twitch" | "7tv" | "bttv" | "ffz" | "discord" | platform.' },
                   { name: 'url', type: 'string', desc: 'CDN image URL.' },
                   { name: 'positions', type: 'int[][]', desc: 'Array of [start, end] index pairs into text where the emote occurs.' },
+                ]}
+              />
+              <p>
+                <Code>attachments</Code> is present only when a message carries media (Discord image/GIF/video
+                uploads and Tenor/Giphy link previews today). Each <Code>Attachment</Code>:
+              </p>
+              <FieldTable
+                rows={[
+                  { name: 'type', type: 'string', desc: '"image" or "video". GIFs are images that animate.' },
+                  { name: 'url', type: 'string', desc: 'Media URL.' },
+                  { name: 'content_type', type: 'string?', desc: 'MIME type, e.g. "image/gif", "video/mp4".' },
+                  { name: 'width / height', type: 'int?', desc: 'Intrinsic pixel dimensions when known.' },
+                  { name: 'thumb_url', type: 'string?', desc: 'Poster frame for videos when available.' },
+                  { name: 'spoiler', type: 'bool?', desc: 'True when the sender marked the media a spoiler.' },
+                  { name: 'filename', type: 'string?', desc: 'Original filename (used for alt text).' },
                 ]}
               />
               <p>

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -93,6 +93,7 @@ import { UserAvatar } from '@/components/UserAvatar'
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { PremiumBadge } from '@/components/PremiumBadge'
 import { EventContent } from '@/components/overlay/EventContent'
+import { MessageAttachments } from '@/components/overlay/MessageAttachments'
 import '@/styles/events.css'
 
 // Default display duration (seconds) for an event based on its tier. Pure
@@ -884,6 +885,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                   >
                     {message.event ? renderEventContent(message) : renderMessageContent(message)}
                   </div>
+
+                  {!message.event && <MessageAttachments message={message} />}
 
                   {/* Timestamp */}
                   {showTimestamps && (

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -49,6 +49,7 @@ import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inlin
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { PremiumBadge } from '@/components/PremiumBadge'
 import { EventContent } from '@/components/overlay/EventContent'
+import { MessageAttachments } from '@/components/overlay/MessageAttachments'
 import { shouldFilterMessage } from '@/lib/utils/filterMessage'
 import type { FilterSettings } from '@/lib/types/overlay'
 import { createSoundPlayer } from '@/lib/utils/soundPlayer'
@@ -906,6 +907,8 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                             ? renderEventContent(message)
                             : renderMessageContent(message)}
                         </div>
+
+                        {!message.event && <MessageAttachments message={message} />}
 
                         {/* Timestamp */}
                         <div className="mt-1 text-xs text-slate-500">

--- a/frontend/src/components/overlay/ChatRow.tsx
+++ b/frontend/src/components/overlay/ChatRow.tsx
@@ -22,6 +22,7 @@ import clsx from 'clsx'
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { PremiumBadge } from '@/components/PremiumBadge'
 import { UserAvatar } from '@/components/UserAvatar'
+import { MessageAttachments } from '@/components/overlay/MessageAttachments'
 import { PlatformGlyph, PlatformGlyphs } from '@/components/overlay/PlatformGlyph'
 import {
   ModerationControls,
@@ -175,6 +176,7 @@ export function ChatRow({
             onUnban={moderation.onUnban}
           />
         )}
+        {!item.event && <MessageAttachments message={item} variant="compact" />}
       </div>
     </div>
   )

--- a/frontend/src/components/overlay/MessageAttachments.tsx
+++ b/frontend/src/components/overlay/MessageAttachments.tsx
@@ -1,0 +1,233 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Attachments come from arbitrary remote media hosts (Discord CDN, Tenor, Giphy),
+ * so they are rendered with plain <img>/<video> rather than next/image: image
+ * optimization is disabled globally (next.config images.unoptimized) so <Image>
+ * would add no value, and its host allowlist would reject these varied hosts.
+ * The CSP permits https: for img-src and media-src.
+ */
+/* eslint-disable @next/next/no-img-element */
+
+'use client'
+
+import clsx from 'clsx'
+import { useState } from 'react'
+
+import { useReducedMotion } from '@/hooks/useReducedMotion'
+import type { Attachment, ChatMessage } from '@/lib/types/message'
+
+type Variant = 'overlay' | 'compact'
+
+interface MessageAttachmentsProps {
+  message: ChatMessage
+  variant?: Variant
+}
+
+/**
+ * Renders a chat message's image/GIF/video attachments as capped thumbnails on
+ * the line(s) below the text. Event messages carry no attachments, so callers
+ * only need to render this for regular chat.
+ *
+ * - `overlay` variant is the broadcast surface (out of the WCAG scope): videos
+ *   autoplay muted+looping and GIFs animate freely — that is the intended look.
+ * - `compact` variant is the in-app monitor/dashboard (in the WCAG scope): every
+ *   auto-moving item gets a control per WCAG 2.2.2 — videos never autoplay and
+ *   expose native controls, and animated GIFs get a hide/show toggle (defaulting
+ *   to hidden when the viewer prefers reduced motion). Static images are inert
+ *   and need no control.
+ */
+export function MessageAttachments({ message, variant = 'overlay' }: MessageAttachmentsProps) {
+  // Called once here (not per item) so a message with several attachments makes a
+  // single matchMedia subscription.
+  const reducedMotion = useReducedMotion()
+  const attachments = message.message?.attachments ?? []
+  if (attachments.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-1 flex flex-wrap gap-2">
+      {attachments.map((attachment, index) => (
+        <AttachmentItem
+          key={`${attachment.url}-${index}`}
+          attachment={attachment}
+          variant={variant}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+    </div>
+  )
+}
+
+function AttachmentItem({
+  attachment,
+  variant,
+  reducedMotion,
+}: {
+  attachment: Attachment
+  variant: Variant
+  reducedMotion: boolean
+}) {
+  const [revealed, setRevealed] = useState(false)
+
+  const blurred = Boolean(attachment.spoiler) && !revealed
+
+  const mediaSizing = clsx(
+    'block h-auto w-auto rounded-md',
+    variant === 'compact' ? 'max-h-32 max-w-48' : 'max-h-64 max-w-full'
+  )
+  const mediaEffect = clsx(mediaSizing, blurred && 'scale-105 blur-xl')
+
+  // Animated GIFs auto-loop with no native controls, so on the in-scope compact
+  // surface they need a hide/show mechanism to satisfy WCAG 2.2.2. Spoilers are
+  // handled by their own reveal gate below. The broadcast overlay is out of scope.
+  if (variant === 'compact' && !attachment.spoiler && isAnimatedGif(attachment)) {
+    return (
+      <AnimatedGifControl
+        attachment={attachment}
+        sizing={mediaSizing}
+        startHidden={reducedMotion}
+      />
+    )
+  }
+
+  let media: React.ReactNode
+  if (attachment.type === 'video') {
+    const autoplay = variant === 'overlay' && !reducedMotion
+    media = (
+      <video
+        src={attachment.url}
+        poster={attachment.thumb_url}
+        aria-label={videoLabel(attachment)}
+        className={mediaEffect}
+        muted
+        loop
+        playsInline
+        autoPlay={autoplay}
+        controls={!autoplay}
+        preload="metadata"
+      />
+    )
+  } else {
+    media = (
+      <img
+        src={attachment.url}
+        alt={imageAlt(attachment)}
+        width={attachment.width || undefined}
+        height={attachment.height || undefined}
+        className={mediaEffect}
+        loading="lazy"
+        decoding="async"
+      />
+    )
+  }
+
+  if (!attachment.spoiler) {
+    return <div className="inline-flex overflow-hidden rounded-md">{media}</div>
+  }
+
+  return (
+    <div className="relative inline-flex overflow-hidden rounded-md">
+      {media}
+      <button
+        type="button"
+        onClick={() => setRevealed((value) => !value)}
+        aria-pressed={revealed}
+        className={clsx(
+          'absolute rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white',
+          revealed
+            ? 'right-1 top-1 min-h-6 min-w-6 bg-black/60 px-2 py-1 text-xs text-white'
+            : 'inset-0 flex items-center justify-center bg-black/40 text-sm font-medium text-white'
+        )}
+      >
+        {revealed ? 'Hide' : 'Spoiler — reveal'}
+      </button>
+    </div>
+  )
+}
+
+/**
+ * An animated GIF on the in-scope monitor with a WCAG 2.2.2 hide/show control.
+ * "Hide" is an accepted mechanism for auto-moving content; defaulting to hidden
+ * under reduced motion respects the viewer's preference. drawing a still frame
+ * would require canvas readback of cross-origin media, so hiding is the robust
+ * choice here.
+ */
+function AnimatedGifControl({
+  attachment,
+  sizing,
+  startHidden,
+}: {
+  attachment: Attachment
+  sizing: string
+  startHidden: boolean
+}) {
+  const [hidden, setHidden] = useState(startHidden)
+
+  return (
+    <div className="relative inline-flex overflow-hidden rounded-md">
+      {hidden ? (
+        <span className="flex h-16 w-24 items-center justify-center rounded-md bg-surface-2 px-2 text-center text-xs text-text-sub">
+          {imageAlt(attachment)}
+        </span>
+      ) : (
+        <img
+          src={attachment.url}
+          alt={imageAlt(attachment)}
+          width={attachment.width || undefined}
+          height={attachment.height || undefined}
+          className={sizing}
+          loading="lazy"
+          decoding="async"
+        />
+      )}
+      <button
+        type="button"
+        onClick={() => setHidden((value) => !value)}
+        aria-pressed={!hidden}
+        className="absolute right-1 top-1 min-h-6 min-w-6 rounded bg-black/60 px-2 py-1 text-xs text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        {hidden ? 'Show GIF' : 'Hide GIF'}
+      </button>
+    </div>
+  )
+}
+
+function isAnimatedGif(attachment: Attachment): boolean {
+  return attachment.type === 'image' && Boolean(attachment.content_type?.includes('gif'))
+}
+
+function mediaKind(attachment: Attachment): string {
+  if (attachment.type === 'video') {
+    return 'video clip'
+  }
+  if (attachment.content_type?.includes('gif')) {
+    return 'GIF'
+  }
+  return 'image'
+}
+
+function imageAlt(attachment: Attachment): string {
+  return attachment.filename?.trim() || `Shared ${mediaKind(attachment)}`
+}
+
+function videoLabel(attachment: Attachment): string {
+  return attachment.filename?.trim() || 'Shared video clip'
+}

--- a/frontend/src/components/overlay/__tests__/MessageAttachments.test.tsx
+++ b/frontend/src/components/overlay/__tests__/MessageAttachments.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})
+
+// useReducedMotion reads window.matchMedia; jsdom has no implementation.
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false, // motion-on
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+})
+
+import { MessageAttachments } from '../MessageAttachments'
+import type { Attachment, ChatMessage } from '@/lib/types/message'
+
+function makeMessage(attachments: Attachment[]): ChatMessage {
+  return {
+    id: 'm1',
+    overlay_id: 'o1',
+    platform: 'discord',
+    channel_id: 'c1',
+    channel_name: 'general',
+    user: { id: 'u1', username: 'bob', display_name: 'Bob', badges: [] },
+    message: { text: 'hello', emotes: [], attachments },
+    timestamp: new Date('2024-01-01T00:00:00Z').toISOString(),
+    metadata: {},
+  } as ChatMessage
+}
+
+describe('MessageAttachments', () => {
+  it('renders nothing when there are no attachments', () => {
+    const { container } = render(<MessageAttachments message={makeMessage([])} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders an image with its filename as alt text', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([{ type: 'image', url: 'https://x/cat.png', filename: 'cat.png' }])}
+      />
+    )
+    const img = screen.getByAltText('cat.png')
+    expect(img.tagName).toBe('IMG')
+    expect(img.getAttribute('src')).toBe('https://x/cat.png')
+    expect(img.getAttribute('loading')).toBe('lazy')
+  })
+
+  it('falls back to a descriptive alt for GIFs without a filename', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([{ type: 'image', url: 'https://x/a.gif', content_type: 'image/gif' }])}
+      />
+    )
+    expect(screen.getByAltText('Shared GIF')).toBeTruthy()
+  })
+
+  it('renders a video with an accessible label', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([{ type: 'video', url: 'https://x/clip.mp4' }])}
+      />
+    )
+    const video = screen.getByLabelText('Shared video clip')
+    expect(video.tagName).toBe('VIDEO')
+    // Videos are always muted so they never play audio on the broadcast.
+    expect((video as HTMLVideoElement).muted).toBe(true)
+  })
+
+  it('autoplays videos without controls on the overlay surface', () => {
+    render(
+      <MessageAttachments message={makeMessage([{ type: 'video', url: 'https://x/clip.mp4' }])} />
+    )
+    const video = screen.getByLabelText('Shared video clip') as HTMLVideoElement
+    expect(video.autoplay).toBe(true)
+    expect(video.controls).toBe(false)
+  })
+
+  it('exposes controls instead of autoplay in the compact surface (WCAG 2.2.2)', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([{ type: 'video', url: 'https://x/clip.mp4' }])}
+        variant="compact"
+      />
+    )
+    const video = screen.getByLabelText('Shared video clip') as HTMLVideoElement
+    expect(video.autoplay).toBe(false)
+    expect(video.controls).toBe(true)
+  })
+
+  it('blurs spoilers behind a reveal control that toggles', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([
+          { type: 'image', url: 'https://x/s.png', filename: 's.png', spoiler: true },
+        ])}
+      />
+    )
+    const img = screen.getByAltText('s.png')
+    expect(img.className).toContain('blur-xl')
+
+    const revealBtn = screen.getByRole('button', { name: /reveal/i })
+    fireEvent.click(revealBtn)
+
+    // After revealing, the blur is gone and the control flips to "Hide".
+    expect(screen.getByAltText('s.png').className).not.toContain('blur-xl')
+    expect(screen.getByRole('button', { name: /hide/i })).toBeTruthy()
+  })
+
+  it('renders multiple attachments', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([
+          { type: 'image', url: 'https://x/1.png', filename: '1.png' },
+          { type: 'image', url: 'https://x/2.png', filename: '2.png' },
+        ])}
+      />
+    )
+    expect(screen.getByAltText('1.png')).toBeTruthy()
+    expect(screen.getByAltText('2.png')).toBeTruthy()
+  })
+
+  it('gives animated GIFs a hide/show control on the compact monitor (WCAG 2.2.2)', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([
+          { type: 'image', url: 'https://x/a.gif', content_type: 'image/gif', filename: 'a.gif' },
+        ])}
+        variant="compact"
+      />
+    )
+    // Shown by default (motion on) with a Hide control.
+    expect(screen.getByAltText('a.gif').tagName).toBe('IMG')
+    fireEvent.click(screen.getByRole('button', { name: /hide gif/i }))
+    // Hidden: the animating img is removed and the control flips to Show.
+    expect(screen.queryByAltText('a.gif')).toBeNull()
+    expect(screen.getByRole('button', { name: /show gif/i })).toBeTruthy()
+  })
+
+  it('leaves GIFs animating with no control on the broadcast overlay (out of scope)', () => {
+    render(
+      <MessageAttachments
+        message={makeMessage([
+          { type: 'image', url: 'https://x/a.gif', content_type: 'image/gif', filename: 'a.gif' },
+        ])}
+      />
+    )
+    expect(screen.getByAltText('a.gif').tagName).toBe('IMG')
+    expect(screen.queryByRole('button', { name: /gif/i })).toBeNull()
+  })
+
+  it('defaults animated GIFs to hidden under reduced motion on the monitor', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true, // reduced motion
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+    render(
+      <MessageAttachments
+        message={makeMessage([
+          { type: 'image', url: 'https://x/a.gif', content_type: 'image/gif', filename: 'a.gif' },
+        ])}
+        variant="compact"
+      />
+    )
+    expect(screen.queryByAltText('a.gif')).toBeNull()
+    expect(screen.getByRole('button', { name: /show gif/i })).toBeTruthy()
+  })
+})

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -124,13 +124,31 @@ export interface Badge {
 export interface MessageInfo {
   text: string;
   emotes: Emote[];
+  attachments?: Attachment[];
 }
 
 export interface Emote {
   code: string;
-  provider: 'twitch' | '7tv' | 'bttv' | 'ffz' | 'youtube';
+  provider: 'twitch' | '7tv' | 'bttv' | 'ffz' | 'youtube' | 'discord';
   url: string;
   positions: number[][];
+}
+
+/**
+ * A renderable image/GIF/video shared in a chat message (Discord uploads and
+ * Tenor/Giphy link previews today). `type` is 'image' or 'video'; GIFs arrive as
+ * images that animate natively. `thumb_url` is an optional poster frame for
+ * videos; `spoiler` marks media the sender flagged so the overlay can blur it.
+ */
+export interface Attachment {
+  type: 'image' | 'video';
+  url: string;
+  content_type?: string;
+  width?: number;
+  height?: number;
+  thumb_url?: string;
+  spoiler?: boolean;
+  filename?: string;
 }
 
 export interface PlatformStatus {

--- a/services/discord-listener/gateway/client.go
+++ b/services/discord-listener/gateway/client.go
@@ -498,7 +498,11 @@ func (c *GatewayClient) HandleMessageCreate(ctx context.Context, msg MessageCrea
 	c.mu.Unlock()
 
 	if !firstSeen {
-		if msg.Content == "" {
+		// An image/GIF-only message legitimately has empty content, so only treat
+		// empty content as an intent problem when there is no attachment or embed
+		// either — otherwise a media-only first message is misread as a disabled
+		// MESSAGE_CONTENT intent and suppresses every later message.
+		if msg.Content == "" && len(msg.Attachments) == 0 && len(msg.Embeds) == 0 {
 			// Empty content on first MESSAGE_CREATE means MESSAGE_CONTENT privileged intent
 			// is not enabled in the Discord Developer Portal. Log once and drop the message
 			// but keep the service running — halting here causes a reconnect loop that silently
@@ -559,6 +563,13 @@ func (c *GatewayClient) HandleMessageCreate(ctx context.Context, msg MessageCrea
 		"text":         text,
 		"tags":         tags,
 		"timestamp":    ts,
+	}
+
+	// Forward renderable image/GIF/video media (uploaded attachments + Tenor/Giphy
+	// link previews). Omitted entirely when the message carries no media so the
+	// wire format is unchanged for plain text messages.
+	if attachments := buildRawAttachments(msg); len(attachments) > 0 {
+		rawMsg["attachments"] = attachments
 	}
 
 	// Record message received (passed all filters, about to publish)

--- a/services/discord-listener/gateway/media.go
+++ b/services/discord-listener/gateway/media.go
@@ -1,0 +1,157 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package gateway
+
+import "strings"
+
+// maxAttachmentsPerMessage bounds how many media items a single message can carry
+// downstream, so a message with dozens of uploads cannot flood an overlay.
+const maxAttachmentsPerMessage = 4
+
+// spoilerFilenamePrefix marks an uploaded attachment as a spoiler (Discord clients
+// prepend it when the user ticks "Mark as spoiler").
+const spoilerFilenamePrefix = "SPOILER_"
+
+// RawAttachment is the normalized media item forwarded on the raw message. It is
+// deliberately mirrored by publisher.Attachment (matching JSON tags) so it survives
+// the map -> JSON -> RawMessage round-trip performed by the publisher adapter.
+type RawAttachment struct {
+	Type        string `json:"type"`                   // "image" or "video"
+	URL         string `json:"url"`                    // display URL (Discord proxy preferred)
+	ContentType string `json:"content_type,omitempty"` // MIME, e.g. image/gif, video/mp4
+	Width       int    `json:"width,omitempty"`
+	Height      int    `json:"height,omitempty"`
+	ThumbURL    string `json:"thumb_url,omitempty"` // poster frame for videos
+	Spoiler     bool   `json:"spoiler,omitempty"`
+	Filename    string `json:"filename,omitempty"` // for alt text (spoiler prefix stripped)
+}
+
+// buildRawAttachments extracts renderable image/video media from a Discord message:
+// uploaded attachments first, then media-bearing embeds (Tenor/Giphy link previews
+// and pasted image links). Non-media attachments/embeds (documents, plain link
+// previews, articles) are ignored. The result is capped at maxAttachmentsPerMessage.
+func buildRawAttachments(msg MessageCreateData) []RawAttachment {
+	out := make([]RawAttachment, 0)
+
+	for _, a := range msg.Attachments {
+		kind := classifyMediaType(a.ContentType)
+		if kind == "" {
+			continue // not an image or video (document, audio, ...)
+		}
+		url := a.ProxyURL
+		if url == "" {
+			url = a.URL
+		}
+		if url == "" {
+			continue
+		}
+		spoiler := strings.HasPrefix(a.Filename, spoilerFilenamePrefix)
+		out = append(out, RawAttachment{
+			Type:        kind,
+			URL:         url,
+			ContentType: a.ContentType,
+			Width:       a.Width,
+			Height:      a.Height,
+			Spoiler:     spoiler,
+			Filename:    strings.TrimPrefix(a.Filename, spoilerFilenamePrefix),
+		})
+		if len(out) >= maxAttachmentsPerMessage {
+			return out
+		}
+	}
+
+	for _, e := range msg.Embeds {
+		att, ok := attachmentFromEmbed(e)
+		if !ok {
+			continue
+		}
+		out = append(out, att)
+		if len(out) >= maxAttachmentsPerMessage {
+			return out
+		}
+	}
+
+	return out
+}
+
+// classifyMediaType maps a MIME type to the coarse attachment kind the overlay
+// knows how to render. GIFs are image/gif and animate natively in an <img>, so
+// they are classified as images. Anything that is not image/* or video/* is
+// dropped (returns "").
+func classifyMediaType(contentType string) string {
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		return "image"
+	case strings.HasPrefix(contentType, "video/"):
+		return "video"
+	default:
+		return ""
+	}
+}
+
+// attachmentFromEmbed pulls renderable media out of an auto-generated embed.
+// gifv/video embeds (Tenor, Giphy, direct video links) become looping videos;
+// image embeds become images. Discord always re-hosts embed media on its own
+// CDN, so proxy_url is preferred over the third-party url. Returns ok=false for
+// embeds with no usable media (articles, plain links, rich embeds).
+func attachmentFromEmbed(e DiscordEmbed) (RawAttachment, bool) {
+	switch e.Type {
+	case "gifv", "video":
+		if e.Video == nil {
+			return RawAttachment{}, false
+		}
+		url := firstNonEmptyURL(e.Video.ProxyURL, e.Video.URL)
+		if url == "" {
+			return RawAttachment{}, false
+		}
+		att := RawAttachment{
+			Type:   "video",
+			URL:    url,
+			Width:  e.Video.Width,
+			Height: e.Video.Height,
+		}
+		if e.Thumbnail != nil {
+			att.ThumbURL = firstNonEmptyURL(e.Thumbnail.ProxyURL, e.Thumbnail.URL)
+		}
+		return att, true
+	case "image":
+		if e.Image == nil {
+			return RawAttachment{}, false
+		}
+		url := firstNonEmptyURL(e.Image.ProxyURL, e.Image.URL)
+		if url == "" {
+			return RawAttachment{}, false
+		}
+		return RawAttachment{
+			Type:   "image",
+			URL:    url,
+			Width:  e.Image.Width,
+			Height: e.Image.Height,
+		}, true
+	default:
+		return RawAttachment{}, false
+	}
+}
+
+func firstNonEmptyURL(candidates ...string) string {
+	for _, c := range candidates {
+		if c != "" {
+			return c
+		}
+	}
+	return ""
+}

--- a/services/discord-listener/gateway/media_test.go
+++ b/services/discord-listener/gateway/media_test.go
@@ -1,0 +1,205 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyMediaType(t *testing.T) {
+	cases := map[string]string{
+		"image/png":       "image",
+		"image/jpeg":      "image",
+		"image/gif":       "image",
+		"image/webp":      "image",
+		"video/mp4":       "video",
+		"video/webm":      "video",
+		"application/pdf": "",
+		"audio/mpeg":      "",
+		"":                "",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, classifyMediaType(in), "classifyMediaType(%q)", in)
+	}
+}
+
+func TestBuildRawAttachments_UploadedImage(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{{
+			Filename:    "cat.png",
+			ContentType: "image/png",
+			URL:         "https://cdn.discordapp.com/attachments/1/2/cat.png",
+			ProxyURL:    "https://media.discordapp.net/attachments/1/2/cat.png",
+			Width:       800,
+			Height:      600,
+		}},
+	}
+
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "image", got[0].Type)
+	// proxy_url is preferred over url
+	assert.Equal(t, "https://media.discordapp.net/attachments/1/2/cat.png", got[0].URL)
+	assert.Equal(t, "image/png", got[0].ContentType)
+	assert.Equal(t, 800, got[0].Width)
+	assert.Equal(t, 600, got[0].Height)
+	assert.False(t, got[0].Spoiler)
+	assert.Equal(t, "cat.png", got[0].Filename)
+}
+
+func TestBuildRawAttachments_GifIsImage(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{{
+			Filename:    "dance.gif",
+			ContentType: "image/gif",
+			ProxyURL:    "https://media.discordapp.net/dance.gif",
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "image", got[0].Type, "GIFs are images that animate natively")
+}
+
+func TestBuildRawAttachments_Video(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{{
+			Filename:    "clip.mp4",
+			ContentType: "video/mp4",
+			ProxyURL:    "https://media.discordapp.net/clip.mp4",
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "video", got[0].Type)
+}
+
+func TestBuildRawAttachments_Spoiler(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{{
+			Filename:    "SPOILER_ending.png",
+			ContentType: "image/png",
+			ProxyURL:    "https://media.discordapp.net/ending.png",
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Spoiler)
+	assert.Equal(t, "ending.png", got[0].Filename, "spoiler prefix stripped from filename")
+}
+
+func TestBuildRawAttachments_FallsBackToURL(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{{
+			Filename:    "cat.png",
+			ContentType: "image/png",
+			URL:         "https://cdn.discordapp.com/cat.png",
+			// no ProxyURL
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "https://cdn.discordapp.com/cat.png", got[0].URL)
+}
+
+func TestBuildRawAttachments_DropsNonMediaAndURLLess(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{
+			{Filename: "notes.pdf", ContentType: "application/pdf", ProxyURL: "https://x/notes.pdf"},
+			{Filename: "empty.png", ContentType: "image/png"}, // no url at all
+		},
+	}
+	got := buildRawAttachments(msg)
+	assert.Empty(t, got)
+}
+
+func TestBuildRawAttachments_GifvEmbed(t *testing.T) {
+	msg := MessageCreateData{
+		Embeds: []DiscordEmbed{{
+			Type: "gifv",
+			URL:  "https://tenor.com/view/foo",
+			Video: &DiscordEmbedMedia{
+				URL:      "https://media.tenor.com/foo.mp4",
+				ProxyURL: "https://media.discordapp.net/external/abc/foo.mp4",
+				Width:    498,
+				Height:   280,
+			},
+			Thumbnail: &DiscordEmbedMedia{
+				ProxyURL: "https://media.discordapp.net/external/abc/foo.png",
+			},
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "video", got[0].Type)
+	assert.Equal(t, "https://media.discordapp.net/external/abc/foo.mp4", got[0].URL, "embed proxy_url preferred")
+	assert.Equal(t, "https://media.discordapp.net/external/abc/foo.png", got[0].ThumbURL)
+	assert.Equal(t, 498, got[0].Width)
+}
+
+func TestBuildRawAttachments_ImageEmbed(t *testing.T) {
+	msg := MessageCreateData{
+		Embeds: []DiscordEmbed{{
+			Type:  "image",
+			Image: &DiscordEmbedMedia{ProxyURL: "https://media.discordapp.net/ext/pic.png", Width: 100, Height: 100},
+		}},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, 1)
+	assert.Equal(t, "image", got[0].Type)
+	assert.Equal(t, "https://media.discordapp.net/ext/pic.png", got[0].URL)
+}
+
+func TestBuildRawAttachments_IgnoresNonMediaEmbeds(t *testing.T) {
+	msg := MessageCreateData{
+		Embeds: []DiscordEmbed{
+			{Type: "article", URL: "https://news.example/story"},
+			{Type: "link", URL: "https://example.com"},
+			{Type: "rich"},
+			{Type: "gifv"}, // gifv with no video object
+			{Type: "image"}, // image with no image object
+		},
+	}
+	got := buildRawAttachments(msg)
+	assert.Empty(t, got)
+}
+
+func TestBuildRawAttachments_CapAndOrder(t *testing.T) {
+	msg := MessageCreateData{
+		Attachments: []DiscordAttachment{
+			{Filename: "a.png", ContentType: "image/png", ProxyURL: "https://x/a.png"},
+			{Filename: "b.png", ContentType: "image/png", ProxyURL: "https://x/b.png"},
+			{Filename: "c.png", ContentType: "image/png", ProxyURL: "https://x/c.png"},
+			{Filename: "d.png", ContentType: "image/png", ProxyURL: "https://x/d.png"},
+			{Filename: "e.png", ContentType: "image/png", ProxyURL: "https://x/e.png"},
+		},
+		Embeds: []DiscordEmbed{
+			{Type: "image", Image: &DiscordEmbedMedia{ProxyURL: "https://x/embed.png"}},
+		},
+	}
+	got := buildRawAttachments(msg)
+	require.Len(t, got, maxAttachmentsPerMessage)
+	// uploads come before embeds and the cap trims the tail
+	assert.Equal(t, "https://x/a.png", got[0].URL)
+	assert.Equal(t, "https://x/d.png", got[3].URL)
+}
+
+func TestBuildRawAttachments_Empty(t *testing.T) {
+	assert.Empty(t, buildRawAttachments(MessageCreateData{}))
+}

--- a/services/discord-listener/gateway/message_media_test.go
+++ b/services/discord-listener/gateway/message_media_test.go
@@ -1,0 +1,157 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package gateway_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/caesar/all-chat/services/discord-listener/gateway"
+	"github.com/caesar/all-chat/services/discord-listener/publisher"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mediaCapturePublisher records the last raw message map so a test can assert on
+// what HandleMessageCreate actually published.
+type mediaCapturePublisher struct {
+	last  interface{}
+	calls int
+}
+
+func (p *mediaCapturePublisher) Publish(_ context.Context, msg interface{}) error {
+	p.calls++
+	p.last = msg
+	return nil
+}
+
+// roundTripToRawMessage mirrors the production publisherAdapter: it marshals the
+// gateway's map[string]interface{} and unmarshals it into publisher.RawMessage.
+// This exercises the cross-struct JSON contract end to end.
+func roundTripToRawMessage(t *testing.T, published interface{}) publisher.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(published)
+	require.NoError(t, err)
+	var raw publisher.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	return raw
+}
+
+func TestHandleMessageCreate_ForwardsAttachments(t *testing.T) {
+	pub := &mediaCapturePublisher{}
+	reg := &mockChannelRegistry{overlayID: "overlay-1", found: true}
+	store := &mockSessionStore{}
+
+	client := gateway.NewGatewayClient(
+		"token", "wss://gateway.discord.gg", store, nil, reg, pub, nil,
+	)
+
+	msg := gateway.MessageCreateData{
+		ID:        "msg-1",
+		ChannelID: "channel-1",
+		Content:   "look at this",
+		Author:    gateway.DiscordUser{ID: "user-1", Username: "someone"},
+		Attachments: []gateway.DiscordAttachment{{
+			Filename:    "SPOILER_cat.gif",
+			ContentType: "image/gif",
+			ProxyURL:    "https://media.discordapp.net/cat.gif",
+			Width:       200,
+			Height:      150,
+		}},
+		Embeds: []gateway.DiscordEmbed{{
+			Type:      "gifv",
+			Video:     &gateway.DiscordEmbedMedia{ProxyURL: "https://media.discordapp.net/ext/foo.mp4", Width: 480, Height: 270},
+			Thumbnail: &gateway.DiscordEmbedMedia{ProxyURL: "https://media.discordapp.net/ext/foo.png"},
+		}},
+	}
+
+	require.NoError(t, client.HandleMessageCreate(context.Background(), msg))
+	require.Equal(t, 1, pub.calls)
+
+	raw := roundTripToRawMessage(t, pub.last)
+	require.Len(t, raw.Attachments, 2, "both the upload and the gifv embed must survive the wire contract")
+
+	// Uploaded image (GIF), spoiler-flagged.
+	assert.Equal(t, "image", raw.Attachments[0].Type)
+	assert.Equal(t, "https://media.discordapp.net/cat.gif", raw.Attachments[0].URL)
+	assert.Equal(t, "image/gif", raw.Attachments[0].ContentType)
+	assert.True(t, raw.Attachments[0].Spoiler)
+	assert.Equal(t, "cat.gif", raw.Attachments[0].Filename)
+
+	// Tenor/Giphy-style gifv embed -> looping video with a poster.
+	assert.Equal(t, "video", raw.Attachments[1].Type)
+	assert.Equal(t, "https://media.discordapp.net/ext/foo.mp4", raw.Attachments[1].URL)
+	assert.Equal(t, "https://media.discordapp.net/ext/foo.png", raw.Attachments[1].ThumbURL)
+}
+
+// TestHandleMessageCreate_ImageOnlyPublishes guards the empty-content fix: a
+// media-only message (empty content) must still publish rather than being
+// misread as a disabled MESSAGE_CONTENT intent.
+func TestHandleMessageCreate_ImageOnlyPublishes(t *testing.T) {
+	pub := &mediaCapturePublisher{}
+	reg := &mockChannelRegistry{overlayID: "overlay-1", found: true}
+	store := &mockSessionStore{}
+
+	client := gateway.NewGatewayClient(
+		"token", "wss://gateway.discord.gg", store, nil, reg, pub, nil,
+	)
+
+	msg := gateway.MessageCreateData{
+		ID:        "msg-2",
+		ChannelID: "channel-1",
+		Content:   "", // image-only message
+		Author:    gateway.DiscordUser{ID: "user-1", Username: "someone"},
+		Attachments: []gateway.DiscordAttachment{{
+			Filename:    "pic.png",
+			ContentType: "image/png",
+			ProxyURL:    "https://media.discordapp.net/pic.png",
+		}},
+	}
+
+	require.NoError(t, client.HandleMessageCreate(context.Background(), msg))
+	require.Equal(t, 1, pub.calls, "media-only message must publish")
+
+	raw := roundTripToRawMessage(t, pub.last)
+	require.Len(t, raw.Attachments, 1)
+	assert.Equal(t, "https://media.discordapp.net/pic.png", raw.Attachments[0].URL)
+}
+
+// TestHandleMessageCreate_NoAttachmentsOmitsField confirms plain text messages
+// carry no attachments field (wire format unchanged for the common case).
+func TestHandleMessageCreate_NoAttachmentsOmitsField(t *testing.T) {
+	pub := &mediaCapturePublisher{}
+	reg := &mockChannelRegistry{overlayID: "overlay-1", found: true}
+	store := &mockSessionStore{}
+
+	client := gateway.NewGatewayClient(
+		"token", "wss://gateway.discord.gg", store, nil, reg, pub, nil,
+	)
+
+	msg := gateway.MessageCreateData{
+		ID:        "msg-3",
+		ChannelID: "channel-1",
+		Content:   "just text",
+		Author:    gateway.DiscordUser{ID: "user-1", Username: "someone"},
+	}
+
+	require.NoError(t, client.HandleMessageCreate(context.Background(), msg))
+	require.Equal(t, 1, pub.calls)
+
+	raw := roundTripToRawMessage(t, pub.last)
+	assert.Empty(t, raw.Attachments)
+}

--- a/services/discord-listener/gateway/types.go
+++ b/services/discord-listener/gateway/types.go
@@ -110,14 +110,49 @@ type InvalidSessionData struct {
 
 // MessageCreateData is the payload for the MESSAGE_CREATE dispatch event
 type MessageCreateData struct {
-	ID        string         `json:"id"`
-	ChannelID string         `json:"channel_id"`
-	GuildID   string         `json:"guild_id"`
-	Content   string         `json:"content"`
-	Timestamp string         `json:"timestamp"`
-	Author    DiscordUser    `json:"author"`
-	Member    *DiscordMember `json:"member"`
-	Mentions  []DiscordUser  `json:"mentions"`
+	ID          string              `json:"id"`
+	ChannelID   string              `json:"channel_id"`
+	GuildID     string              `json:"guild_id"`
+	Content     string              `json:"content"`
+	Timestamp   string              `json:"timestamp"`
+	Author      DiscordUser         `json:"author"`
+	Member      *DiscordMember      `json:"member"`
+	Mentions    []DiscordUser       `json:"mentions"`
+	Attachments []DiscordAttachment `json:"attachments"`
+	Embeds      []DiscordEmbed      `json:"embeds"`
+}
+
+// DiscordAttachment is an uploaded file attached to a message (image, GIF, video, ...).
+// content_type is the server-detected MIME type; url/proxy_url point at the CDN.
+type DiscordAttachment struct {
+	ID          string `json:"id"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	Size        int    `json:"size"`
+	URL         string `json:"url"`
+	ProxyURL    string `json:"proxy_url"`
+	Width       int    `json:"width"`
+	Height      int    `json:"height"`
+}
+
+// DiscordEmbed is a rich embed or auto-generated link preview. Tenor/Giphy links
+// arrive as embeds of type "gifv" (an mp4 that loops); pasted image links arrive
+// as type "image". Only media-bearing embeds are surfaced downstream.
+type DiscordEmbed struct {
+	Type      string             `json:"type"` // "image", "gifv", "video", "link", "rich", ...
+	URL       string             `json:"url"`
+	Thumbnail *DiscordEmbedMedia `json:"thumbnail"`
+	Image     *DiscordEmbedMedia `json:"image"`
+	Video     *DiscordEmbedMedia `json:"video"`
+}
+
+// DiscordEmbedMedia is the image/thumbnail/video object nested inside an embed.
+// proxy_url is Discord's own re-hosted copy (always on *.discordapp.net).
+type DiscordEmbedMedia struct {
+	URL      string `json:"url"`
+	ProxyURL string `json:"proxy_url"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
 }
 
 // DiscordUser represents the author of a Discord message

--- a/services/discord-listener/publisher/stream_publisher.go
+++ b/services/discord-listener/publisher/stream_publisher.go
@@ -51,10 +51,26 @@ type RawMessage struct {
 	Username    string                 `json:"username,omitempty"`
 	Text        string                 `json:"text,omitempty"`
 	Tags        map[string]string      `json:"tags,omitempty"`
+	Attachments []Attachment           `json:"attachments,omitempty"`
 	RawMessage  json.RawMessage        `json:"raw_message,omitempty"`
 	EventType   string                 `json:"event_type,omitempty"`
 	EventData   map[string]interface{} `json:"event_data,omitempty"`
 	Timestamp   time.Time              `json:"timestamp"`
+}
+
+// Attachment is a renderable image/GIF/video item carried alongside a chat
+// message. Its JSON tags mirror gateway.RawAttachment (producer side) and the
+// message-processor's models.Attachment (consumer side) so the payload survives
+// serialization end to end.
+type Attachment struct {
+	Type        string `json:"type"`
+	URL         string `json:"url"`
+	ContentType string `json:"content_type,omitempty"`
+	Width       int    `json:"width,omitempty"`
+	Height      int    `json:"height,omitempty"`
+	ThumbURL    string `json:"thumb_url,omitempty"`
+	Spoiler     bool   `json:"spoiler,omitempty"`
+	Filename    string `json:"filename,omitempty"`
 }
 
 // Publisher is the interface that wraps the Publish method.

--- a/services/message-processor/README.md
+++ b/services/message-processor/README.md
@@ -400,6 +400,13 @@ err := redis.Publish(ctx, channel, messageJSON).Err()
 }
 ```
 
+`message` may also carry an optional `attachments` array of media shared in the
+message (Discord image/GIF/video uploads and Tenor/Giphy link previews today).
+Each attachment is `{ type: "image" | "video", url, content_type?, width?,
+height?, thumb_url?, spoiler?, filename? }`. GIFs arrive as `type: "image"` and
+animate natively. Discord custom emoji (`<:name:id>` / `<a:name:id>`) are parsed
+by the Discord normalizer into the `emotes` array with `provider: "discord"`.
+
 ---
 
 ## Testing

--- a/services/message-processor/models/message.go
+++ b/services/message-processor/models/message.go
@@ -33,6 +33,7 @@ type RawChatMessage struct {
 	Text        string            `json:"text"`
 	Timestamp   time.Time         `json:"timestamp"`
 	Tags        map[string]string `json:"tags"`
+	Attachments []Attachment      `json:"attachments,omitempty"`
 	RawMessage  json.RawMessage   `json:"raw_message,omitempty"`
 
 	// Event support (backwards compatible - omitted for chat messages)
@@ -85,10 +86,11 @@ type Badge struct {
 	IconURL string `json:"icon_url"` // URL to badge image
 }
 
-// MessageInfo contains the message content and emotes
+// MessageInfo contains the message content, emotes, and media attachments
 type MessageInfo struct {
-	Text   string  `json:"text"`
-	Emotes []Emote `json:"emotes"`
+	Text        string       `json:"text"`
+	Emotes      []Emote      `json:"emotes"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
 // Emote represents an emote in the message
@@ -97,6 +99,22 @@ type Emote struct {
 	Provider  string  `json:"provider"`
 	URL       string  `json:"url"`
 	Positions [][]int `json:"positions"` // [[start, end], [start, end]]
+}
+
+// Attachment is a renderable image/GIF/video shared in a chat message (Discord
+// uploads and Tenor/Giphy link previews today). Type is "image" or "video";
+// GIFs are images that animate natively. ThumbURL is an optional poster frame
+// for videos. Spoiler marks media the sender flagged as a spoiler so the overlay
+// can blur it.
+type Attachment struct {
+	Type        string `json:"type"`
+	URL         string `json:"url"`
+	ContentType string `json:"content_type,omitempty"`
+	Width       int    `json:"width,omitempty"`
+	Height      int    `json:"height,omitempty"`
+	ThumbURL    string `json:"thumb_url,omitempty"`
+	Spoiler     bool   `json:"spoiler,omitempty"`
+	Filename    string `json:"filename,omitempty"`
 }
 
 // EventInfo contains information about platform events (subscriptions, donations, etc.)

--- a/services/message-processor/normalizer/discord_normalizer.go
+++ b/services/message-processor/normalizer/discord_normalizer.go
@@ -18,9 +18,24 @@ package normalizer
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/caesar/all-chat/services/message-processor/models"
+)
+
+// discordEmojiRe matches Discord custom-emoji tokens in message text:
+// <:name:id> (static) and <a:name:id> (animated). Names are 2-32 chars of
+// [A-Za-z0-9_]; ids are snowflake digits.
+var discordEmojiRe = regexp.MustCompile(`<(a?):([A-Za-z0-9_]{2,32}):(\d+)>`)
+
+const (
+	// maxDiscordAttachments bounds media items per message downstream (defence in
+	// depth; the discord-listener already caps producer-side).
+	maxDiscordAttachments = 4
+	// maxDiscordEmotes bounds inline custom emoji per message so an emoji-spam
+	// message cannot bloat the payload.
+	maxDiscordEmotes = 20
 )
 
 // DiscordNormalizer normalizes Discord chat messages to unified format
@@ -64,14 +79,75 @@ func (n *DiscordNormalizer) Normalize(raw *models.RawChatMessage, overlayID stri
 			AvatarURL:   raw.Tags["avatar_url"],
 		},
 		Message: models.MessageInfo{
-			Text:   raw.Text,
-			Emotes: []models.Emote{},
+			Text:        raw.Text,
+			Emotes:      parseDiscordEmotes(raw.Text),
+			Attachments: normalizeAttachments(raw.Attachments),
 		},
 		Timestamp: raw.Timestamp,
 		Metadata:  map[string]interface{}{},
 	}
 
 	return unified, nil
+}
+
+// parseDiscordEmotes extracts inline custom-emoji tokens (<:name:id> / <a:name:id>)
+// from the message text and returns them as emotes pointing at the Discord CDN.
+// Positions are byte offsets with an inclusive end index, matching the convention
+// used by the shared emote enricher and consumed by the frontend renderer.
+// Animated emoji resolve to a .gif URL (which animates natively); static ones to .png.
+func parseDiscordEmotes(text string) []models.Emote {
+	matches := discordEmojiRe.FindAllStringSubmatchIndex(text, -1)
+	if len(matches) == 0 {
+		return []models.Emote{}
+	}
+
+	emotes := make([]models.Emote, 0, len(matches))
+	for _, m := range matches {
+		if len(emotes) >= maxDiscordEmotes {
+			break
+		}
+		// m indices: [fullStart, fullEnd, g1Start, g1End, g2Start, g2End, g3Start, g3End]
+		fullStart, fullEnd := m[0], m[1]
+		animated := m[3] > m[2] // the "a" group matched non-empty
+		name := text[m[4]:m[5]]
+		id := text[m[6]:m[7]]
+
+		ext := "png"
+		if animated {
+			ext = "gif"
+		}
+		url := fmt.Sprintf("https://cdn.discordapp.com/emojis/%s.%s?size=48&quality=lossless", id, ext)
+
+		emotes = append(emotes, models.Emote{
+			Code:      name,
+			Provider:  "discord",
+			URL:       url,
+			Positions: [][]int{{fullStart, fullEnd - 1}},
+		})
+	}
+	return emotes
+}
+
+// normalizeAttachments passes forwarded media through to the unified message,
+// dropping entries without a usable URL and capping the count as defence in depth.
+func normalizeAttachments(atts []models.Attachment) []models.Attachment {
+	if len(atts) == 0 {
+		return nil
+	}
+	out := make([]models.Attachment, 0, len(atts))
+	for _, a := range atts {
+		if a.URL == "" || (a.Type != "image" && a.Type != "video") {
+			continue
+		}
+		out = append(out, a)
+		if len(out) >= maxDiscordAttachments {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // extractDiscordBadges parses a comma-separated badge tag string into a Badge slice.

--- a/services/message-processor/normalizer/discord_normalizer_test.go
+++ b/services/message-processor/normalizer/discord_normalizer_test.go
@@ -17,6 +17,7 @@
 package normalizer
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -215,6 +216,177 @@ func TestDiscordNormalizer_NoBadges(t *testing.T) {
 	}
 	if len(unified.User.Badges) != 0 {
 		t.Errorf("Badges: expected 0 badges, got %d", len(unified.User.Badges))
+	}
+}
+
+func TestParseDiscordEmotes_StaticAndAnimated(t *testing.T) {
+	emotes := parseDiscordEmotes("hi <:pepe:123> and <a:blob:456> !")
+	if len(emotes) != 2 {
+		t.Fatalf("expected 2 emotes, got %d", len(emotes))
+	}
+
+	if emotes[0].Code != "pepe" || emotes[0].Provider != "discord" {
+		t.Errorf("emote[0]: want {pepe discord}, got {%s %s}", emotes[0].Code, emotes[0].Provider)
+	}
+	wantStatic := "https://cdn.discordapp.com/emojis/123.png?size=48&quality=lossless"
+	if emotes[0].URL != wantStatic {
+		t.Errorf("emote[0].URL: want %s, got %s", wantStatic, emotes[0].URL)
+	}
+
+	if emotes[1].Code != "blob" {
+		t.Errorf("emote[1].Code: want blob, got %s", emotes[1].Code)
+	}
+	wantAnimated := "https://cdn.discordapp.com/emojis/456.gif?size=48&quality=lossless"
+	if emotes[1].URL != wantAnimated {
+		t.Errorf("emote[1].URL (animated must be .gif): want %s, got %s", wantAnimated, emotes[1].URL)
+	}
+}
+
+func TestParseDiscordEmotes_Positions(t *testing.T) {
+	text := "hi <:pepe:123> yo"
+	emotes := parseDiscordEmotes(text)
+	if len(emotes) != 1 {
+		t.Fatalf("expected 1 emote, got %d", len(emotes))
+	}
+	pos := emotes[0].Positions
+	if len(pos) != 1 || len(pos[0]) != 2 {
+		t.Fatalf("unexpected positions shape: %v", pos)
+	}
+	start, end := pos[0][0], pos[0][1]
+	// Byte offsets with inclusive end, matching the frontend renderer's
+	// text.slice(start, end+1) contract.
+	if start != 3 || end != 13 {
+		t.Errorf("positions: want [3 13], got [%d %d]", start, end)
+	}
+	if got := text[start : end+1]; got != "<:pepe:123>" {
+		t.Errorf("sliced token: want <:pepe:123>, got %q", got)
+	}
+}
+
+func TestParseDiscordEmotes_None(t *testing.T) {
+	emotes := parseDiscordEmotes("just plain text, no emoji")
+	if emotes == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(emotes) != 0 {
+		t.Errorf("expected 0 emotes, got %d", len(emotes))
+	}
+}
+
+func TestParseDiscordEmotes_IgnoresMalformed(t *testing.T) {
+	// A colon-wrapped word is a plain-text emoji shortcode, not a custom emoji token.
+	emotes := parseDiscordEmotes("nice :thumbsup: <notanemoji>")
+	if len(emotes) != 0 {
+		t.Errorf("expected 0 emotes for non-token text, got %d", len(emotes))
+	}
+}
+
+func TestParseDiscordEmotes_Cap(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < maxDiscordEmotes+5; i++ {
+		sb.WriteString("<:ee:1> ")
+	}
+	emotes := parseDiscordEmotes(sb.String())
+	if len(emotes) != maxDiscordEmotes {
+		t.Errorf("expected cap of %d, got %d", maxDiscordEmotes, len(emotes))
+	}
+}
+
+func TestNormalizeAttachments_FiltersInvalidAndCaps(t *testing.T) {
+	in := []models.Attachment{
+		{Type: "image", URL: "https://x/1.png"},
+		{Type: "image", URL: ""},          // dropped: no url
+		{Type: "audio", URL: "https://x/a.mp3"}, // dropped: unknown type
+		{Type: "video", URL: "https://x/2.mp4"},
+		{Type: "image", URL: "https://x/3.png"},
+		{Type: "image", URL: "https://x/4.png"},
+		{Type: "image", URL: "https://x/5.png"}, // beyond cap
+	}
+	out := normalizeAttachments(in)
+	if len(out) != maxDiscordAttachments {
+		t.Fatalf("expected cap of %d, got %d", maxDiscordAttachments, len(out))
+	}
+	if out[0].URL != "https://x/1.png" || out[1].URL != "https://x/2.mp4" {
+		t.Errorf("unexpected order/filtering: %+v", out)
+	}
+}
+
+func TestNormalizeAttachments_EmptyReturnsNil(t *testing.T) {
+	if normalizeAttachments(nil) != nil {
+		t.Error("nil input should return nil")
+	}
+	if normalizeAttachments([]models.Attachment{{Type: "audio", URL: "https://x/a.mp3"}}) != nil {
+		t.Error("all-filtered input should return nil")
+	}
+}
+
+func TestDiscordNormalizer_WithAttachmentsAndEmotes(t *testing.T) {
+	n := NewDiscordNormalizer()
+	raw := makeDiscordRaw()
+	raw.Text = "look <:kek:99>"
+	raw.Attachments = []models.Attachment{
+		{Type: "image", URL: "https://media.discordapp.net/cat.gif", ContentType: "image/gif", Spoiler: true, Filename: "cat.gif"},
+	}
+
+	unified, err := n.Normalize(raw, "overlay-1")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(unified.Message.Emotes) != 1 {
+		t.Fatalf("expected 1 inline emote, got %d", len(unified.Message.Emotes))
+	}
+	if unified.Message.Emotes[0].Code != "kek" {
+		t.Errorf("emote code: want kek, got %s", unified.Message.Emotes[0].Code)
+	}
+	if len(unified.Message.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(unified.Message.Attachments))
+	}
+	att := unified.Message.Attachments[0]
+	if att.Type != "image" || att.URL != "https://media.discordapp.net/cat.gif" || !att.Spoiler {
+		t.Errorf("unexpected attachment: %+v", att)
+	}
+}
+
+// TestDiscordNormalizer_ParsesWireJSON feeds the exact JSON the discord-listener
+// publishes to chat:raw through the real deserialization path (ParseRawMessage ->
+// Normalize), verifying the cross-service attachment contract on the consumer side.
+func TestDiscordNormalizer_ParsesWireJSON(t *testing.T) {
+	wire := []byte(`{
+		"message_id":"m1","platform":"discord","overlay_id":"","channel_id":"c1",
+		"channel_name":"general","user_id":"u1","username":"bob","text":"gg <:pog:42>",
+		"tags":{"member_nick":"Bob"},
+		"attachments":[
+			{"type":"image","url":"https://media.discordapp.net/cat.gif","content_type":"image/gif","width":200,"height":150,"spoiler":true,"filename":"cat.gif"},
+			{"type":"video","url":"https://media.discordapp.net/ext/foo.mp4","thumb_url":"https://media.discordapp.net/ext/foo.png"}
+		],
+		"timestamp":"2024-01-01T00:00:00Z"
+	}`)
+
+	raw, err := models.ParseRawMessage(wire)
+	if err != nil {
+		t.Fatalf("ParseRawMessage failed: %v", err)
+	}
+
+	unified, err := NewDiscordNormalizer().Normalize(raw, "overlay-1")
+	if err != nil {
+		t.Fatalf("Normalize failed: %v", err)
+	}
+
+	if len(unified.Message.Attachments) != 2 {
+		t.Fatalf("expected 2 attachments from wire JSON, got %d", len(unified.Message.Attachments))
+	}
+	if unified.Message.Attachments[0].Type != "image" ||
+		unified.Message.Attachments[0].URL != "https://media.discordapp.net/cat.gif" ||
+		!unified.Message.Attachments[0].Spoiler {
+		t.Errorf("attachment[0] mismatch: %+v", unified.Message.Attachments[0])
+	}
+	if unified.Message.Attachments[1].Type != "video" ||
+		unified.Message.Attachments[1].ThumbURL != "https://media.discordapp.net/ext/foo.png" {
+		t.Errorf("attachment[1] mismatch: %+v", unified.Message.Attachments[1])
+	}
+	if len(unified.Message.Emotes) != 1 || unified.Message.Emotes[0].Code != "pog" {
+		t.Errorf("expected inline discord emote 'pog', got %+v", unified.Message.Emotes)
 	}
 }
 


### PR DESCRIPTION
## Summary

Discord chat messages previously dropped every image, GIF, and video. This adds media support end to end so overlays render Discord uploads, Tenor/Giphy link previews, and inline custom Discord emoji. Built Discord-first as groundwork for Twitch's upcoming chat GIFs (Twitch's mechanism is still unknown, and "stop ignoring Discord images/GIFs" was independently wanted).

Base feature, **no premium gate**.

## Wire contract

`MessageInfo` gains `attachments: Attachment[]` where `Attachment = { type: "image" | "video", url, content_type?, width?, height?, thumb_url?, spoiler?, filename? }`, defined with identical JSON tags in three layers (`publisher.Attachment`, `models.Attachment`, the TS type). GIFs are `type: "image"` (animate natively); Tenor/Giphy arrive as Discord `gifv`/`video` embeds. Inline custom Discord emoji (`<:name:id>` / `<a:name:id>`) ride the existing `emotes[]` array with `provider: "discord"`.

The API gateway needs no change: it forwards the pub/sub payload as raw `json.RawMessage` bytes, so new fields pass through untouched.

## Changes by layer

- **discord-listener**: parse `attachments` + `embeds` from `MESSAGE_CREATE`, classify to image/video, respect the `SPOILER_` flag, prefer Discord-proxied URLs, cap at 4 per message. Also fixes the empty-content check so a media-only message (which legitimately has blank text) is no longer misread as a disabled `MESSAGE_CONTENT` intent.
- **message-processor**: `Attachment` on `MessageInfo`/`RawChatMessage`; the Discord normalizer maps attachments through and parses inline custom emoji into `emotes` (animated to `.gif`, static to `.png`) using byte-offset positions consistent with the emote enricher.
- **frontend**: new `MessageAttachments` renders capped thumbnails below the text (`<img>` for images/GIFs, `<video muted loop>` autoplay on the broadcast overlay / native controls on the in-app monitor). Spoilers blur behind a reveal control. Added `media-src` to the CSP so video is not blocked. Wired into all three render surfaces (live overlay, editor preview, monitor row).
- **docs**: API message schema, message-processor README, and `ACCESSIBILITY.md`.

## Accessibility

- Attachment images carry meaningful `alt`; videos are always muted (satisfies `media-has-caption` and avoids stray audio on stream).
- The in-scope monitor (`ChatRow`, compact variant) gives every auto-moving item a WCAG 2.2.2 control: videos expose native controls instead of autoplaying, and animated GIFs get a hide/show toggle (defaulting to hidden under reduced motion). The broadcast overlay route is out of the a11y scope, so GIFs animate freely there. Rationale recorded in `ACCESSIBILITY.md`.

## Testing

- Go: both services build + `vet` + full test suites pass, including two cross-service wire-seam tests (producer round-trip through `publisher.RawMessage`; consumer parse of the exact wire JSON).
- Frontend: typecheck clean, lint clean under the main and strict-a11y configs, 11 `MessageAttachments` render tests.
- An adversarial multi-dimension review (wire-contract, Go correctness, frontend, security, a11y) surfaced one real issue (animated GIFs lacked a pause/hide control on the in-scope monitor), now fixed and covered by tests.

## Follow-ups (not in this PR)

- Deploy: no DB migration, no new service or NetworkPolicy. discord-listener + message-processor roll out via Keel; the frontend needs a rebuild for the CSP `media-src` change.
- Publish the Patreon post once deployed.

## Known limitation

Emote/attachment positions use Go byte offsets while the frontend slices by JS string index. They diverge only when multibyte text precedes an inline emoji, and it fails safe (the emoji is left as text). This matches the pre-existing behavior of the 7TV/BTTV/FFZ emote enricher.
