### PR TITLE
feat(frontend): make display-only overlay widgets embeddable cross-origin

### DIFF
--- a/docs/security/SECURITY_AUDIT_REPORT.md
+++ b/docs/security/SECURITY_AUDIT_REPORT.md
@@ -116,6 +116,7 @@ The dominant residual risk is **infra/config hardening** (zero k8s `securityCont
 - **Loc:** `frontend/next.config.js` (no `headers()`); `nginx.conf`; no `middleware.ts`
 - **Evidence:** Overlay `/overlay/[id]` public URL, no `frame-ancestors` → iframable. Missing CSP/HSTS/X-Content-Type-Options/Referrer-Policy.
 - **Fix:** Add `headers()` block: strict CSP per route (`default-src 'self'`; overlay `frame-ancestors 'none'`); standard hardening headers.
+- **Status:** ✅ DONE (`frontend/next.config.js` `headers()`). Framing policy is tiered: app + editor SplitView embed → `frame-ancestors 'self'`; all `/overlay/*` locked-by-default → `frame-ancestors 'none'` (keeps the interactive routes `/overlay/:id/participate` (viewer login + points) and `/overlay/:id/view` (authenticated monitor) un-framable, plus any future sub-route). Display-only OBS widgets — `/overlay/:id` (chat), `/poll`, `/prediction`, `/credits` — are re-opened to `frame-ancestors *` so streamers can embed them anywhere (OBS, Streamlabs, personal sites, dashboards); these carry no auth or viewer identity, so clickjacking risk is negligible. `frame-ancestors` is authoritative (browsers ignore the residual `X-Frame-Options: SAMEORIGIN` on widget routes per CSP L2). Contract pinned by `frontend/src/app/__tests__/security-headers.test.ts`.
 
 ### M11 — Frontend: embed postMessage listener skips origin check
 - **Loc:** `frontend/src/app/overlays/[id]/preview/embed/page.tsx:284-388`

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -48,10 +48,18 @@ const nextConfig = {
     ]
   },
 
-  // Security headers (M10). Per-route CSP + standard hardening. The overlay
-  // public route (/overlay/:id) gets frame-ancestors 'none' so it cannot be
-  // iframed by third parties; everything else allows 'self' framing (editor
-  // SplitView embeds /overlays/:id/preview/embed same-origin).
+  // Security headers (M10). Per-route CSP + standard hardening. Framing policy
+  // is tiered (frame-ancestors is the authoritative control; browsers ignore
+  // X-Frame-Options whenever frame-ancestors is present, CSP L2 §"Relation to
+  // X-Frame-Options"):
+  //   - app + editor SplitView embed  → frame-ancestors 'self' (same-origin)
+  //   - all /overlay/* by default     → frame-ancestors 'none' (locked; keeps
+  //     the interactive routes — /overlay/:id/participate (viewer login +
+  //     points) and /overlay/:id/view (authenticated monitor) — un-framable,
+  //     and any future overlay sub-route locked-by-default)
+  //   - display-only OBS widgets      → frame-ancestors * (embeddable anywhere:
+  //     OBS, Streamlabs, personal sites, third-party dashboards). These carry
+  //     no auth or viewer identity, so clickjacking risk is negligible.
   // TODO(prod): replace script-src 'unsafe-inline' with a per-request nonce
   // (Next.js unstable_inline + generateNonce) once CSP-nonce middleware is in
   // place; 'unsafe-inline' is required now for Next dev + inline RSC chunks.
@@ -86,7 +94,10 @@ const nextConfig = {
     const hardening = [
       { key: 'X-Content-Type-Options', value: 'nosniff' },
       { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-      { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()' },
+      {
+        key: 'Permissions-Policy',
+        value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+      },
       // HSTS is honored by browsers only over HTTPS; safe to emit in dev (ignored on http).
       { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
       // Legacy framing fallback. CSP frame-ancestors is the authoritative defense
@@ -97,29 +108,48 @@ const nextConfig = {
       { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
     ]
 
+    const csp = (frameAncestors) => [...cspBase, `frame-ancestors ${frameAncestors}`].join('; ')
+
+    // Display-only OBS browser-source widgets. Public, no auth, no viewer
+    // identity — safe to embed anywhere. Single-segment `:id` (no `*`) so these
+    // match ONLY the exact widget route and never the interactive sub-routes
+    // (participate/view), which stay locked by the /overlay/:id* rule above.
+    const embeddableWidgets = [
+      '/overlay/:id', // OBS chat overlay
+      '/overlay/:id/poll', // poll widget (aggregate only)
+      '/overlay/:id/prediction', // prediction widget (aggregate only)
+      '/overlay/:id/credits', // end-of-stream credit roll
+    ]
+
     return [
       {
         // Editor embed (same-origin iframe) + everything else. X-Frame-Options
         // SAMEORIGIN comes from the shared hardening array.
         source: '/:path*',
-        headers: [
-          ...hardening,
-          { key: 'Content-Security-Policy', value: [...cspBase, "frame-ancestors 'self'"].join('; ') },
-        ],
+        headers: [...hardening, { key: 'Content-Security-Policy', value: csp("'self'") }],
       },
       {
-        // Public overlay route: prevent third-party iframing. Listed AFTER the
-        // catch-all so its stricter headers override for /overlay/* paths
-        // (audit L6 — previously both routes set X-Frame-Options, emitting
-        // conflicting DENY + SAMEORIGIN). The explicit DENY below overrides
-        // the hardening default (SAMEORIGIN) within this entry.
+        // Lock every overlay route by default (participate/view + anything added
+        // later). Listed AFTER the catch-all so its stricter headers override
+        // for /overlay/* paths (audit L6 — previously both routes set
+        // X-Frame-Options, emitting conflicting DENY + SAMEORIGIN). The explicit
+        // DENY overrides the hardening default (SAMEORIGIN) within this entry.
         source: '/overlay/:id*',
         headers: [
           ...hardening,
-          { key: 'Content-Security-Policy', value: [...cspBase, "frame-ancestors 'none'"].join('; ') },
+          { key: 'Content-Security-Policy', value: csp("'none'") },
           { key: 'X-Frame-Options', value: 'DENY' },
         ],
       },
+      // Re-open the display-only widgets. Listed LAST so their headers override
+      // the /overlay/:id* lockdown per matching path. frame-ancestors * makes
+      // them embeddable; X-Frame-Options is reset to SAMEORIGIN (from the shared
+      // hardening) so the legacy header no longer hard-blocks — modern browsers
+      // ignore it anyway because frame-ancestors is present.
+      ...embeddableWidgets.map((source) => ({
+        source,
+        headers: [...hardening, { key: 'Content-Security-Policy', value: csp('*') }],
+      })),
     ]
   },
 

--- a/frontend/src/app/__tests__/security-headers.test.ts
+++ b/frontend/src/app/__tests__/security-headers.test.ts
@@ -1,0 +1,121 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Contract for the per-route framing policy declared in `next.config.js`.
+ *
+ * The overlay display widgets (chat / poll / prediction / credits) are public
+ * OBS browser sources with no auth or viewer identity, so they must be
+ * embeddable anywhere (`frame-ancestors *`). Everything else under `/overlay`
+ * — notably the viewer participation page (login + points) and the
+ * authenticated monitor — stays frame-locked (`frame-ancestors 'none'`), and
+ * the rest of the app allows only same-origin framing (editor SplitView embed).
+ *
+ * Next.js applies header rules top-to-bottom and the last matching rule wins
+ * per header key, so the assertions here pin both the values AND that the
+ * embeddable widget rules are declared after the `/overlay/:id*` lockdown.
+ */
+
+import { createRequire } from 'node:module'
+
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+// next.config.js is a CommonJS module at the frontend root.
+const nextConfig = require('../../../next.config.js') as {
+  headers: () => Promise<Array<{ source: string; headers: Array<{ key: string; value: string }> }>>
+}
+
+const WIDGET_SOURCES = [
+  '/overlay/:id',
+  '/overlay/:id/poll',
+  '/overlay/:id/prediction',
+  '/overlay/:id/credits',
+] as const
+
+async function rules() {
+  return nextConfig.headers()
+}
+
+function ruleFor(
+  all: Awaited<ReturnType<typeof rules>>,
+  source: string
+): { source: string; headers: Array<{ key: string; value: string }> } | undefined {
+  return all.find((r) => r.source === source)
+}
+
+function csp(rule?: { headers: Array<{ key: string; value: string }> }): string {
+  return rule?.headers.find((h) => h.key === 'Content-Security-Policy')?.value ?? ''
+}
+
+function xfo(rule?: { headers: Array<{ key: string; value: string }> }): string[] {
+  return (rule?.headers ?? []).filter((h) => h.key === 'X-Frame-Options').map((h) => h.value)
+}
+
+function indexOfSource(all: Awaited<ReturnType<typeof rules>>, source: string): number {
+  return all.findIndex((r) => r.source === source)
+}
+
+describe('next.config framing policy', () => {
+  it('the app catch-all allows only same-origin framing', async () => {
+    const all = await rules()
+    const catchAll = ruleFor(all, '/:path*')
+    expect(catchAll).toBeDefined()
+    expect(csp(catchAll)).toContain("frame-ancestors 'self'")
+    expect(xfo(catchAll)).toContain('SAMEORIGIN')
+  })
+
+  it('locks all overlay routes by default so new sub-routes are not silently framable', async () => {
+    const all = await rules()
+    const base = ruleFor(all, '/overlay/:id*')
+    expect(base).toBeDefined()
+    expect(csp(base)).toContain("frame-ancestors 'none'")
+    expect(xfo(base)).toContain('DENY')
+  })
+
+  it('makes the display-only widgets embeddable by any site', async () => {
+    const all = await rules()
+    for (const source of WIDGET_SOURCES) {
+      const rule = ruleFor(all, source)
+      expect(rule, `expected an embeddable rule for ${source}`).toBeDefined()
+      // Full policy is preserved (last-wins replaces the whole CSP header), not
+      // just the frame-ancestors directive.
+      expect(csp(rule), source).toContain("default-src 'self'")
+      expect(csp(rule), source).toContain('frame-ancestors *')
+      // Must not hard-block via the legacy header on a route we are opening up.
+      expect(xfo(rule), source).not.toContain('DENY')
+    }
+  })
+
+  it('declares each widget override after the /overlay lockdown so it wins', async () => {
+    const all = await rules()
+    const lockdown = indexOfSource(all, '/overlay/:id*')
+    expect(lockdown).toBeGreaterThanOrEqual(0)
+    for (const source of WIDGET_SOURCES) {
+      expect(indexOfSource(all, source), source).toBeGreaterThan(lockdown)
+    }
+  })
+
+  it('keeps interactive/authenticated overlay routes frame-locked (no widget override)', async () => {
+    const all = await rules()
+    // participate (viewer login + points) and view (ProtectedRoute) must NOT be
+    // in the embeddable set — they inherit the /overlay/:id* lockdown.
+    expect(ruleFor(all, '/overlay/:id/participate')).toBeUndefined()
+    expect(ruleFor(all, '/overlay/:id/view')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

Every `/overlay/*` route matched a single `frame-ancestors 'none'` rule in `frontend/next.config.js`, so the **public OBS browser-source widgets** could not be embedded in an iframe by third parties. Streamers trying to embed their chat overlay (or a poll/prediction/credits widget) in their own site or a dashboard hit:

```
Framing 'https://allch.at/' violates the following Content Security Policy
directive: "frame-ancestors 'none'". The request has been blocked.
```

## Change

Tiered per-route framing policy:

| Route | `frame-ancestors` | Framable? |
|---|---|---|
| App + editor SplitView embed (`/:path*`) | `'self'` | same-origin only (unchanged) |
| `/overlay/:id` (chat), `/poll`, `/prediction`, `/credits` | `*` | **anywhere** (OBS, Streamlabs, sites, dashboards) |
| `/overlay/:id/participate`, `/overlay/:id/view`, any future sub-route | `'none'` | locked |

Design is **lock-all-`/overlay`-by-default, then explicitly re-open the known-safe display widgets**, so a new overlay sub-route is locked until someone deliberately opens it.

`participate` (viewer login + points wagering) and `view` (authenticated monitor, `ProtectedRoute`) stay locked because framing them enables clickjacking of a real login/spend flow. The display widgets carry no auth or viewer identity, so clickjacking risk is negligible.

The residual `X-Frame-Options: SAMEORIGIN` on the widget routes is unavoidable (the catch-all matches every path) but harmless: browsers ignore `X-Frame-Options` whenever `frame-ancestors` is present (CSP L2 §"Relation to X-Frame-Options").

## Verification

- **TDD:** new `frontend/src/app/__tests__/security-headers.test.ts` pins the contract (RED → GREEN).
- **Live headers:** ran `next dev` and confirmed per-route `Content-Security-Policy` / `X-Frame-Options` values.
- **Real cross-origin embed (Playwright):** a parent page on a different origin framed all six overlay routes. The 4 display widgets loaded and executed their client code cross-origin; the 2 interactive routes produced exactly the `frame-ancestors 'none'` block — reproducing the original error, now scoped only to the locked routes.

## Docs

Updated the M10 entry in `docs/security/SECURITY_AUDIT_REPORT.md` (system of record for the CSP controls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)