### PR TITLE
Admin dashboard usability revamp: owner links, clickable channels, viewer overhaul, global search

### DIFF
--- a/docs/adr/0033-admin-url-addressable-selection.md
+++ b/docs/adr/0033-admin-url-addressable-selection.md
@@ -1,0 +1,101 @@
+# ADR-0033: Admin Master-Detail with URL-Addressable Selection
+
+**Date**: 2026-07-17
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+The admin dashboard (`frontend/src/app/admin/*`) is a set of list+detail pages — users,
+overlays, sources, viewers, cosmetics, feature gates. Each page kept its selected entity and
+its filter state in opaque React component state (`useState`). Two problems followed from that:
+
+- **Entities could not be linked to each other.** A source row knew its `overlay_id`, but there
+  was no way to navigate from an overlay to its owning user, from a user to their sources, or
+  from a source back to the owning user, because selection lived in a component that another page
+  could not address. This was the single most common admin usability complaint: *"overlays are
+  not linked to their users."*
+- **Nothing was shareable.** An admin investigating a support ticket could not paste a link that
+  reopened the dashboard on the exact entity in question; the recipient had to be told which page
+  to open and which row to click.
+
+One page already pointed the way: the Overlays page read `?overlay=<id>` on load and auto-selected
+that overlay (`frontend/src/app/admin/overlays/page.tsx`), and the Sources page linked into it
+(`href={`/admin/overlays?overlay=${source.overlay_id}`}`). But the pattern was ad hoc — a single
+deep-link on a single page, not a convention the other pages followed.
+
+## Decision Drivers
+
+- Make every admin entity deep-linkable and cross-navigable, resolving the "not linked" complaint.
+- Make admin state shareable via URL for support hand-offs.
+- Reuse the pattern the Overlays page already proved (`?overlay=<id>`) rather than invent a new one.
+- Keep the change small and per-page — no framework/routing migration, no big-bang rewrite.
+
+## Considered Options
+
+1. **Standardize URL query parameters for selection and filters across every admin page.**
+   - ✅ Generalizes the existing `?overlay=<id>` pattern; deep-linkable and shareable; each page
+     reads params on mount and reflects selection/filter changes back into the URL; no new routes.
+   - ❌ Query strings are flatter than nested routes; each page needs a small read-params-on-mount
+     change.
+2. **Introduce real nested dynamic routes (`/admin/users/[id]`, `/admin/overlays/[id]`, …).**
+   - ✅ Canonical URLs, natural breadcrumbs, per-entity server components.
+   - ❌ A routing migration across every admin page plus a split of list vs detail layouts; higher
+     cost for a dashboard whose master-detail layout wants the list and the panel on screen together.
+     Rejected for now on migration cost.
+3. **Keep selection in React state, add cross-links as in-memory navigation only.**
+   - ✅ No URL work.
+   - ❌ Still not shareable, still not restorable on reload, still can't hand a link to another admin.
+     Rejected — it does not solve the actual complaint.
+
+## Decision Outcome
+
+**Chosen**: Option 1 — URL query parameters as the single source of truth for admin selection and
+filters.
+
+- **Selection is URL-addressable.** Every list+detail admin page reads its selection from the query
+  string on load (`?user=<id>`, `?overlay=<id>`, and the like) and writes the current selection back
+  into the URL when the admin picks a row. Reloading or sharing the URL reopens the same entity.
+- **Filters are URL-addressable too.** List filters live in the query string alongside selection —
+  `?filter=`, `?connected=`, `?platform=`, `?q=` — so a filtered view is itself linkable and restored
+  on reload.
+- **Master-detail is the standard layout.** Each page is a scrollable list next to a sticky side
+  detail panel; the URL selects which entity the panel shows. This is the layout the Overlays page
+  already used, promoted to the convention for all of them.
+- **No new `[id]` routes.** Selection stays in query params rather than nested dynamic segments. This
+  keeps list and detail co-resident, avoids a Next.js routing migration, and lets cross-links be plain
+  `href` strings into the existing pages (e.g. source → `/admin/overlays?overlay=<id>`,
+  overlay → `/admin/users?user=<owner_id>`, user → `/admin/sources?user=<id>`).
+
+## Consequences
+
+### Positive
+- Admin entities are cross-navigable: source → owning user, overlay → owner, user → their sources —
+  the "overlays are not linked to their users" complaint is resolved with plain links.
+- Every admin view is deep-linkable and shareable; a support hand-off is a URL.
+- The pattern is uniform, so future admin pages get deep-linking by following the same convention.
+- Zero routing/infra migration; changes are localized to each page's mount-time param read and its
+  selection/filter handlers.
+
+### Negative
+- Query strings are a flatter address space than nested routes; if the admin later needs canonical
+  per-entity URLs, breadcrumbs, or per-entity server rendering, the nested-route migration (Option 2)
+  remains the documented next step.
+- Each page carries a small amount of param-sync boilerplate (read on mount, write on change).
+
+## Implementation
+
+- **Frontend**: `frontend/src/app/admin/{users,overlays,sources,viewers,...}/page.tsx` — read
+  selection/filter query params on mount and reflect changes back into the URL; render the
+  scrollable-list + sticky-panel master-detail layout. Cross-links are `href`s into the sibling
+  admin pages' query params.
+- **Prior art**: `frontend/src/app/admin/overlays/page.tsx` already read `?overlay=<id>`;
+  `frontend/src/app/admin/sources/page.tsx` already linked into it. This ADR generalizes that.
+- **Routing**: unchanged — no new dynamic segments are added.
+
+## Related Decisions
+
+- [ADR-0034](./0034-admin-viewer-identity-model.md) — the viewer admin view, one of the pages
+  standardized on this pattern.
+- [ADR-0035](./0035-admin-global-entity-search.md) — global admin search deep-links its results
+  into the URL-addressable views defined here.

--- a/docs/adr/0034-admin-viewer-identity-model.md
+++ b/docs/adr/0034-admin-viewer-identity-model.md
@@ -1,0 +1,112 @@
+# ADR-0034: Admin Viewer Identity Model
+
+**Date**: 2026-07-17
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+A "viewer" in All-Chat is not a durable person. The `viewer_sessions` table
+(`migrations/011_viewer_authentication.sql`) stores **one OAuth session per
+`(platform, platform_user_id)`** (`UNIQUE(platform, platform_user_id)`). A single human who
+connects Twitch and YouTube, or reconnects on a new platform account, produces several
+independent `viewer_sessions` rows. Premium and moderation state key on a linked `viewer_id`,
+and migration 040 (`040_viewer_sessions_user_link.sql`) added `viewer_sessions.user_id` to link a
+viewer who *also* has a streamer (`users`) account so the badge enricher can resolve their
+All-Chat status.
+
+The one place a viewer's actual behavior is recorded is `viewer_message_history`
+(`viewer_session_id`, `streamer_user_id`, `overlay_id`, `channel_id`/`channel_name`, `message_text`,
+`sent_at`), indexed on `viewer_session_id`. That table was effectively **write-only** — the only
+thing that ever read it back was the DSGVO data export.
+
+The result: the admin viewer view was, in the maintainer's words, "basically useless." It listed raw
+sessions with no usage context (which streamers does this viewer actually chat in?), no linkage to a
+streamer account, and it surfaced the rate-limit counters `message_count_1min` / `message_count_1hour`
+as if they were engagement numbers — they are not, they are throttle bookkeeping that resets on a timer.
+
+## Decision Drivers
+
+- Operate on the unit that admin actions actually act on. Ban and premium act on a `viewer_sessions`
+  row (a `(platform, platform_user_id)` identity), so the admin view must too.
+- Give the view real context — which streamers/overlays a viewer participates in, and whether the
+  viewer is also a streamer — without a schema-heavy identity project.
+- Keep it cheap: reads must ride existing indexes, not new scans.
+- Stop presenting misleading numbers.
+- Do not paint ourselves into a corner: a future durable cross-session identity must be able to layer
+  on top without reworking this.
+
+## Considered Options
+
+1. **Operate on raw `viewer_sessions`, surface the linked streamer `user_id`, and add a read-only
+   per-session activity aggregate over `viewer_message_history`; explicitly defer durable identity.**
+   - ✅ Matches the ban/premium unit; adds streamer/overlay context and real usage counts using the
+     existing `idx_viewer_message_history_viewer_session_id`; no new PII; no new tables; a durable
+     identity can be built later on top.
+   - ❌ A human with several sessions still shows as several rows (no dedup yet).
+2. **Introduce a durable `viewer_identity` table now and dedup sessions into people.**
+   - ✅ One row per human; cross-session history in one place.
+   - ❌ Large schema + backfill + a matching heuristic (which sessions are the same person?) that is
+     itself error-prone, all to fix an *admin read view*. Ban/premium still key on sessions, so the
+     write path would have to be reconciled too. Rejected as premature — out of proportion to the
+     problem.
+3. **Leave the view on `viewer_sessions` but keep showing `message_count_1min`/`1hour`.**
+   - ✅ No work.
+   - ❌ Those are rate-limit counters, not engagement; presenting them as activity is the misleading
+     behavior we are trying to remove. Rejected.
+
+## Decision Outcome
+
+**Chosen**: Option 1.
+
+- **The admin viewer view operates on raw `viewer_sessions` rows** — the same `(platform,
+  platform_user_id)` unit that ban and premium act on, so what an admin sees is what an admin acts on.
+- **Surface the linked streamer `user_id` when present.** If `viewer_sessions.user_id` is set
+  (migration 040), the view shows that this viewer is also a streamer and links to the streamer's admin
+  record (via the URL-addressable pattern of ADR-0033).
+- **Add a READ-ONLY per-session activity aggregate over `viewer_message_history`.** Grouped by
+  `viewer_session_id` (using the existing index, so it is cheap), joined to `overlays` /
+  `users.username` via `streamer_user_id`, to answer *"whose chats does this viewer participate in,
+  and how much."* This makes `viewer_message_history` an admin-queryable **read surface** for the first
+  time. It stays strictly read-only from the admin view.
+- **Stop presenting `message_count_1min` / `message_count_1hour` as engagement.** They are rate-limit
+  bookkeeping; the real per-streamer usage now comes from the `viewer_message_history` aggregate.
+- **Do NOT introduce a durable cross-session viewer-identity table.** Session dedup — collapsing a
+  human's several sessions into one person — is explicitly deferred.
+
+## Consequences
+
+### Positive
+- The viewer view gains streamer/overlay context and real, per-streamer usage counts at low cost
+  (indexed group-by, no new scan).
+- `viewer_message_history` becomes a useful admin read surface instead of a write-only DSGVO artifact,
+  with no new PII beyond what admins already have access to.
+- Misleading rate-limit counters are no longer shown as engagement.
+- A future durable-identity model can layer on top of this view without reworking it.
+
+### Negative
+- No session dedup yet: one human with several platform sessions still appears as several viewer rows.
+  This is a deliberate deferral, not an oversight.
+- The activity aggregate reads message metadata (channel, streamer, timestamps) into the admin view;
+  this is existing PII under existing admin access, but it is now surfaced in one more place and should
+  be treated accordingly.
+
+## Implementation
+
+- **Data model**: no schema change. Reuses `viewer_sessions` (migration 011, `UNIQUE(platform,
+  platform_user_id)`), `viewer_sessions.user_id` (migration 040), and `viewer_message_history`
+  (migration 011, `idx_viewer_message_history_viewer_session_id`).
+- **Backend**: admin viewer list/detail endpoints add a read-only per-`viewer_session_id` aggregate
+  over `viewer_message_history` joined to `users.username`, plus the linked-streamer `user_id`.
+- **Frontend**: `frontend/src/app/admin/viewers/page.tsx` renders the master-detail viewer view
+  (ADR-0033), showing linked-streamer context and the activity aggregate, and drops the
+  `message_count_1min`/`1hour` presentation.
+
+## Related Decisions
+
+- [ADR-0033](./0033-admin-url-addressable-selection.md) — the URL-addressable master-detail pattern
+  this view links into (viewer → streamer account, viewer → overlays).
+- [ADR-0019](./0019-split-streamer-viewer-premium.md) — viewer premium keys on the linked `viewer_id`;
+  this view acts on the same session unit.
+- [ADR-0035](./0035-admin-global-entity-search.md) — global search resolves viewers by
+  username/`platform_user_id` into this view.

--- a/docs/adr/0035-admin-global-entity-search.md
+++ b/docs/adr/0035-admin-global-entity-search.md
@@ -1,0 +1,93 @@
+# ADR-0035: Admin Global Entity Search
+
+**Date**: 2026-07-17
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+The admin dashboard had no way to jump straight to an entity by name or id. To find a specific
+user, overlay, source, or viewer, an admin had to first *guess which page* held it — is this id a
+user? an overlay? a source? a viewer session? — open that page, and then page through the list
+(or filter it) to find the row. For a support request that arrives as "here's a username" or
+"here's an overlay id," that is several manual hops before any work starts.
+
+ADR-0033 made every admin entity URL-addressable and cross-navigable. What was still missing was a
+**single entry point** that takes a free-text query and lands the admin on the right entity in the
+right view, regardless of which kind of entity it is.
+
+## Decision Drivers
+
+- One search box that finds anything across the admin domain, so the admin never has to guess the
+  entity type first.
+- Results must land in the existing URL-addressable views (ADR-0033), not a bespoke result page —
+  reuse, don't fork.
+- Ship it without blocking on new backend surface if the existing admin endpoints already return the
+  data.
+- Keep a documented path to a real server-side search if client-side federation stops scaling.
+
+## Considered Options
+
+1. **Client-side federation over the existing admin list endpoints, returning typed results that
+   deep-link into the ADR-0033 views.**
+   - ✅ No new backend endpoint; reuses already-admin-accessible list APIs; typed results
+     (user/overlay/source/viewer) link straight into the URL-addressable views; simple to ship.
+   - ❌ Loads full lists client-side to match against — fine at current admin scale, but not free as
+     data grows.
+2. **A dedicated server-side `/api/v1/admin/search` endpoint from day one.**
+   - ✅ Efficient (indexed queries, no full-list transfer), scales past client federation.
+   - ❌ New endpoint, new query/index work, new authz surface — more up-front cost than the current
+     admin scale warrants. Deferred, not rejected: kept as the documented optimization.
+3. **Do nothing — rely on per-page filters (`?q=`, `?filter=`).**
+   - ✅ Already exists.
+   - ❌ Still requires guessing the entity type and opening the right page first; does not solve the
+     "find anything" problem. Rejected.
+
+## Decision Outcome
+
+**Chosen**: Option 1 — client-side federated global search now, with the server endpoint as a
+documented escape hatch.
+
+- **One global admin search** resolves a free-text query across the four admin entity types:
+  - **users** — by `username`, `display_name`, or `id`;
+  - **overlays** — by `name` or `id`;
+  - **sources** — by channel name / handle or `id`;
+  - **viewers** — by `username` or `platform_user_id`.
+- **Typed results deep-link into the URL-addressable views** from ADR-0033. Picking a user result
+  navigates to `/admin/users?user=<id>`, an overlay to `/admin/overlays?overlay=<id>`, and so on, so
+  search reuses and reinforces the addressable pattern rather than introducing a new result surface.
+- **Initial implementation federates over the already-admin-accessible list endpoints on the
+  client.** The search box fetches the admin lists it is already entitled to and matches the query
+  across the fields above, grouping matches by type.
+- **A dedicated server-side `/api/v1/admin/search` endpoint is noted as a future optimization** for
+  if/when client federation stops scaling (indexed, typed, no full-list transfer). It is the explicit
+  next step, not part of this initial cut.
+
+## Consequences
+
+### Positive
+- One entry point to find any admin entity by name or id; no more guessing which page holds it.
+- Search results reuse and reinforce the ADR-0033 URL-addressable views — one navigation model.
+- Ships without new backend surface, because it rides the existing admin list endpoints.
+
+### Negative
+- Client federation loads full lists to match against. This is acceptable at the current admin scale
+  but is the known scaling limit; the server-side `/api/v1/admin/search` endpoint is the documented
+  remedy when that limit is reached.
+- Match quality is only as good as the list payloads (the fields the list endpoints already return);
+  richer ranking would come with the server endpoint.
+
+## Implementation
+
+- **Frontend**: a global admin search component (in `frontend/src/components/admin/` and surfaced from
+  `frontend/src/app/admin/layout.tsx`) that federates over the existing admin user/overlay/source/
+  viewer list endpoints, produces typed results, and links each result into its ADR-0033 view.
+- **Backend**: none in the initial cut (reuses existing admin list endpoints). Future optimization:
+  `/api/v1/admin/search` behind the same admin authz.
+
+## Related Decisions
+
+- [ADR-0033](./0033-admin-url-addressable-selection.md) — the URL-addressable views search results
+  deep-link into; global search depends on and reinforces this pattern.
+- [ADR-0034](./0034-admin-viewer-identity-model.md) — defines the viewer entity (raw `viewer_sessions`)
+  that the viewer branch of search resolves.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -433,6 +433,39 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0033: Admin Master-Detail with URL-Addressable Selection
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-17
+**Problem**: Admin pages kept selection and filters in opaque React state, so entities could not be linked to each other or shared by URL (the #1 complaint: "overlays are not linked to their users"); only the Overlays page read `?overlay=<id>`, and it was never standardized
+**Decision**: Standardize every admin list+detail page on URL query params for selection *and* filters (`?user=`, `?overlay=`, `?filter=`, `?connected=`, `?platform=`, `?q=`), with a scrollable-list + sticky-panel master-detail layout; no new dynamic `[id]` routes (query params avoid a routing migration)
+**Impact**: Admin views become deep-linkable and cross-navigable (source → user, overlay → owner, user → their sources) and URLs are shareable for support, at the cost of a small per-page mount-time param read; nested routes noted as the future step. (ADR numbering shared with caesar-deployment, so this is 0033)
+**→ Read**: [0033-admin-url-addressable-selection.md](./0033-admin-url-addressable-selection.md)
+
+---
+
+### ADR-0034: Admin Viewer Identity Model
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-17
+**Problem**: The admin viewer view was "basically useless" — it listed raw `viewer_sessions` (one per `(platform, platform_user_id)`) with no streamer/usage context and surfaced rate-limit counters as if they were engagement; `viewer_message_history` was write-only (DSGVO export only)
+**Decision**: Operate on raw `viewer_sessions` (the unit ban/premium act on), surface the linked streamer `user_id` (migration 040), and add a READ-ONLY per-session activity aggregate over `viewer_message_history` (existing index, joined to `users.username`); stop presenting `message_count_1min/1hour`; do NOT introduce a durable cross-session identity table (dedup deferred)
+**Impact**: Viewer view gains streamer/overlay context and real usage counts cheaply; `viewer_message_history` becomes an admin read surface (no new PII); a future durable-identity model can layer on top. (ADR numbering shared with caesar-deployment, so this is 0034)
+**→ Read**: [0034-admin-viewer-identity-model.md](./0034-admin-viewer-identity-model.md)
+
+---
+
+### ADR-0035: Admin Global Entity Search
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-17
+**Problem**: There was no way to jump to an admin entity by name or id — an admin had to guess whether an id was a user/overlay/source/viewer and page through the right list
+**Decision**: Add a global admin search resolving a free-text query across users (username/display_name/id), overlays (name/id), sources (channel name/handle/id), and viewers (username/platform_user_id), returning typed results that deep-link into the ADR-0033 URL-addressable views; initial implementation federates over the existing admin list endpoints client-side, with a server-side `/api/v1/admin/search` endpoint noted as the future optimization
+**Impact**: One entry point to find anything; reuses and reinforces the URL-addressable pattern; client federation loads full lists (fine at current admin scale) with a server endpoint as the documented escape hatch. (ADR numbering shared with caesar-deployment, so this is 0035)
+**→ Read**: [0035-admin-global-entity-search.md](./0035-admin-global-entity-search.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number
@@ -556,11 +589,11 @@ Create a new ADR if:
 
 **Total ADRs**: 19
 **Status**: All accepted (✅)
-**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view, demand linger, EventSub chat-ownership partition, linked Twitch credentials, chat moderation write-path, premium entitlements via Patreon, streamer/viewer premium split)
+**Coverage**: Core architecture decisions (Go layout, message flow, databases, frontend, quota tracking, feature gates, resilience patterns, pronoun enrichment, zombie detection, OAuth scope minimisation, overlay observability view, demand linger, EventSub chat-ownership partition, linked Twitch credentials, chat moderation write-path, premium entitlements via Patreon, streamer/viewer premium split, engagement economy, source-liveness heartbeat, admin URL-addressable views + viewer identity model + global search)
 
 **Most Referenced**:
 1. ADR-0002 (Redis patterns) - Referenced by all listeners, message processor
 2. ADR-0001 (Go layout) - Referenced by all services
 3. ADR-0006 (Quota tracking) - Referenced by YouTube listener, overlay manager
 
-**Last Updated**: 2026-06-20
+**Last Updated**: 2026-07-17

--- a/frontend/src/app/admin/README.md
+++ b/frontend/src/app/admin/README.md
@@ -1,204 +1,93 @@
 # All-Chat Admin Dashboard
 
-The admin dashboard provides a comprehensive interface for managing users, overlays, and chat sources across the All-Chat platform.
+Operator console for managing users, overlays, chat sources, and viewers across
+the platform. All pages are gated behind `ProtectedRoute requireAdmin` (see
+`layout.tsx`) and talk to real backend admin APIs over the session cookie (the
+gateway's CookieToBearer middleware turns the httpOnly access cookie into a
+Bearer token; there is no JS-readable token).
 
-## Features
+## Navigation model (ADR-0033)
 
-### 1. Dashboard Home (`/admin`)
+Admin pages are **URL-addressable**: selection and filters live in query
+parameters, not opaque React state, so every view is deep-linkable and entities
+cross-link to one another. Layout is master-detail (a scrollable list plus a
+sticky detail panel).
 
-- Quick access cards for Users, Overlays, and Sources
-- Navigation to all admin sections
-- Quick stats overview
+Recognised parameters:
 
-### 2. Users Management (`/admin/users`)
+- `/admin/users?user=<id>` — auto-select a user; `?filter=active|banned|premium|beta` — preselect a tab
+- `/admin/overlays?overlay=<id>` — auto-select an overlay; `?connected=true` — connected-only view
+- `/admin/sources?user=<id>` — scope to one owner; `?platform=<p>` — preselect a platform
+- `/admin/viewers?q=<text>` — pre-fill the viewer search
+- `/admin/search?q=<text>` — global search
 
-- **User List**: View all registered users with their platform connections
-- **Platform Badges**: Visual indicators for connected platforms (Twitch, YouTube, Kick, TikTok)
-- **User Details Panel**:
-  - User ID, username, email
-  - Connected platform IDs
-  - List of user's overlays
-- **Selection**: Click on any user to view their details
+The sidebar (`components/AdminSidebar.tsx`) is the single source of truth for the
+nav link list (`ADMIN_LINKS`); the dashboard home grid is generated from it so
+the two can never drift.
 
-### 3. Overlays Management (`/admin/overlays`)
+## Pages
 
-- **Overlay List**: View all overlays across all users
-- **Source Count**: See how many sources are connected to each overlay
-- **Overlay Details Panel**:
-  - Overlay name and ID
-  - User ID
-  - Creation date
-- **Connected Sources Panel**:
-  - Platform (Twitch, YouTube, Kick, TikTok)
-  - Channel name and ID
-  - Active/Inactive status
-  - Creation date
-- **Quick Actions**: Open overlay in new tab
+### Dashboard home (`/admin`)
+Platform stats (users, banned, active overlays, sources) as clickable cards that
+deep-link into filtered lists, DAU/WAU/MAU active-user counts, a per-platform
+source breakdown, and the nav grid.
 
-### 4. Sources Management (`/admin/sources`)
+### Search (`/admin/search`, ADR-0035)
+One box that resolves a query across users, overlays, sources, and viewers and
+deep-links each hit into the addressable views. Users/overlays/sources are
+federated on the client over the admin list endpoints; viewers use the
+server-side `?q=` search.
 
-- **Platform Statistics**: Cards showing count per platform
-- **Advanced Filtering**:
-  - Search by channel name or ID
-  - Filter by platform (Twitch, YouTube, Kick, TikTok)
-  - Filter by status (Active/Inactive)
-- **Sources Table**: Comprehensive table with all sources
-- **Quick Links**: Navigate to overlay details
+### Users (`/admin/users`)
+List with avatar, platform badges, and status; search by username/display
+name/id/platform id; filter tabs (all/active/banned/premium/beta). Detail panel:
+impersonate, grant/revoke premium (optionally time-limited, ADR-0027),
+grant/revoke beta-tester (ADR-0020), ban/unban, and the user's overlays (linked
+to the admin overlay detail, with a secondary link to the live overlay) plus a
+"view this user's sources" link.
 
-## Navigation
+### Overlays (`/admin/overlays`)
+List with live-connection status (and a "status unavailable" notice when the
+connection endpoint can't be read). Detail panel resolves the **owner** to a
+linked `@username` (not a bare UUID) and lists connected sources with channel
+links.
 
-The admin dashboard uses a consistent navigation bar with:
+### Sources (`/admin/sources`)
+Every source across all overlays, filterable by platform/status and searchable
+by channel/overlay/owner. Each channel resolves to its public platform page via
+`ChannelLink`; each row links to its overlay and to its owning user.
 
-- **All-Chat Admin** brand/logo (links to dashboard home)
-- **Users** - User management
-- **Overlays** - Overlay and source management
-- **Sources** - System-wide source overview
-- **Back to App** - Return to main application
+### Viewers (`/admin/viewers`, ADR-0034)
+Server-side search, platform/status/premium filters, and pagination with a
+correct full-dataset total. Each row shows the avatar, platform badge, platform
+user id, and a link to the viewer's platform profile. An **Activity** dialog
+surfaces cross-streamer context (total messages, last seen, and the
+streamers/overlays the viewer chats in) from the per-session aggregate over
+`viewer_message_history`. Ban/unban and grant/revoke premium are inline.
 
-## Data Structure
+### Cosmetics / Features / Maintenance
+`/admin/cosmetics` manages the avatar-frame and flair catalog; `/admin/features`
+manages premium feature gates (ADR-0008); `/admin/maintenance` toggles
+maintenance mode.
 
-### User
+## Channel resolution
 
-```typescript
-{
-  id: string;
-  username: string;
-  email: string;
-  created_at: string;
-  twitch_id?: string;
-  youtube_id?: string;
-  kick_id?: string;
-  tiktok_id?: string;
-}
-```
+`lib/platform-channel-url.ts` + `components/ChannelLink.tsx` turn a source's
+stored channel identifier into a link to the real platform page:
 
-### Overlay
+- twitch -> `twitch.tv/{login}`, kick -> `kick.com/{slug}`, tiktok -> `tiktok.com/@{username}`
+- youtube -> only when a real `@handle` or canonical `UC…` channel id is present (the account-linked `youtube_id` is a Google account id, not a channel id, and is deliberately never linked)
+- discord (snowflake) / shared_overlay (overlay UUID) -> plain text
 
-```typescript
-{
-  id: string;
-  name: string;
-  user_id: string;
-  created_at: string;
-  updated_at: string;
-  sources_count?: number;
-}
-```
+## Backend endpoints
 
-### Source
+- overlay-manager: `GET /api/v1/admin/overlays`, `/admin/overlays/active`, `/admin/overlays/:id/sources`, `/admin/sources`, `/admin/user-overlays/:id` — overlay/source responses include `owner_username`/`owner_display_name` (joined from `users`) and `channel_handle`.
+- auth-service: `GET /api/v1/admin/users`, `/admin/viewers` (with `q`/`is_banned`/`is_premium`/`platform`/`limit`/`offset` and a `total`), `/admin/viewers/:session_id/activity`, plus ban/unban/premium/beta mutations and impersonation.
+- share-service: admin feature gates.
 
-```typescript
-{
-  id: string
-  overlay_id: string
-  overlay_name: string
-  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok'
-  channel_id: string
-  channel_name: string
-  is_active: boolean
-  created_at: string
-  user_id: string
-}
-```
+## Related ADRs
 
-## API Integration
-
-Currently using mock data for demonstration. To connect to real APIs:
-
-### Users API
-
-```typescript
-// Fetch all users
-GET / api / v1 / admin / users
-Authorization: Bearer<token>
-
-// Fetch user overlays
-GET / api / v1 / overlays ? (user_id = <user_id>Authorization) : Bearer<token>
-```
-
-### Overlays API
-
-```typescript
-// Fetch all overlays (admin)
-GET /api/v1/admin/overlays
-Authorization: Bearer <token>
-
-// Fetch overlay sources
-GET /api/v1/overlays/:id/sources
-Authorization: Bearer <token>
-```
-
-### Sources API
-
-```typescript
-// Fetch all sources (admin)
-GET / api / v1 / admin / sources
-Authorization: Bearer<token>
-```
-
-## Styling
-
-The admin dashboard uses Tailwind CSS with:
-
-- **Color Scheme**: Clean white backgrounds with gray accents
-- **Platform Colors**:
-  - Twitch: Purple (`bg-purple-100 text-purple-800`)
-  - YouTube: Red (`bg-red-100 text-red-800`)
-  - Kick: Green (`bg-green-100 text-green-800`)
-  - TikTok: Pink (`bg-pink-100 text-pink-800`)
-- **Status Colors**:
-  - Active: Green
-  - Inactive: Gray
-- **Interactive Elements**: Hover effects on cards and rows
-
-## Future Enhancements
-
-1. **Backend Integration**:
-   - Create admin-specific API endpoints
-   - Implement user management actions (edit, delete, suspend)
-   - Add overlay management actions (edit, delete)
-   - Implement source management actions (activate, deactivate, delete)
-
-2. **Real-time Updates**:
-   - WebSocket integration for live source status
-   - Real-time user activity monitoring
-   - Live message count per source
-
-3. **Analytics**:
-   - User growth charts
-   - Message volume per platform
-   - Popular channels/overlays
-   - System health metrics
-
-4. **Authentication**:
-   - Admin role verification
-   - Permission-based access control
-   - Audit logs for admin actions
-
-5. **Advanced Features**:
-   - Bulk operations
-   - CSV export
-   - Advanced search and filters
-   - User impersonation (for support)
-
-## Development
-
-To run the admin dashboard locally:
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-Visit `http://localhost:3000/admin` to access the admin dashboard.
-
-## Production Build
-
-The admin pages are included in the main frontend build:
-
-```bash
-npm run build
-```
-
-The admin routes are pre-rendered as static content for optimal performance.
+- ADR-0033 — admin URL-addressable selection
+- ADR-0034 — admin viewer identity model
+- ADR-0035 — admin global entity search
+- ADR-0008 — premium feature gates · ADR-0020 — beta-tester role · ADR-0027 — time-limited premium overrides

--- a/frontend/src/app/admin/overlays/page.tsx
+++ b/frontend/src/app/admin/overlays/page.tsx
@@ -105,9 +105,11 @@ export default function OverlaysPage() {
         setOverlays(data)
         setLoading(false)
 
-        // Deep-link: auto-select an overlay passed via ?overlay=<id>
-        // (e.g. from the Sources page "View" action).
-        const targetId = new URLSearchParams(window.location.search).get('overlay')
+        // Deep-links (read post-await, client-only). ?overlay=<id> auto-selects
+        // an overlay (from the Sources owner/View links); ?connected=true opens
+        // the connected-only view (from the dashboard "Active Overlays" card).
+        const params = new URLSearchParams(window.location.search)
+        const targetId = params.get('overlay')
         if (targetId) {
           const match = (data as Overlay[]).find((o) => o.id === targetId)
           if (match) {
@@ -115,6 +117,9 @@ export default function OverlaysPage() {
             // Surface the target in the (potentially long) list.
             setSearchTerm(match.name)
           }
+        }
+        if (params.get('connected') === 'true') {
+          setShowConnectedOnly(true)
         }
       } catch (err) {
         console.error('Failed to load overlays:', err)

--- a/frontend/src/app/admin/overlays/page.tsx
+++ b/frontend/src/app/admin/overlays/page.tsx
@@ -24,7 +24,6 @@ import clsx from 'clsx'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlatformBadge } from '@/components/ui/badge'
-import type { Platform } from '@/lib/platform-colors'
 import { formatConnectedFor } from '@/lib/utils'
 
 // Connections open longer than this are highlighted so admins can spot overlays
@@ -49,9 +48,12 @@ interface ActiveOverlay {
 
 interface OverlaySource {
   id: string
-  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok'
+  // Matches the Sources page union; the badge neutral-styles anything it does
+  // not recognize (discord, shared_overlay), so no cast is needed.
+  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'discord' | 'shared_overlay'
   channel_id: string
   channel_name: string
+  channel_handle?: string | null
   is_active: boolean
   created_at: string
 }
@@ -68,7 +70,15 @@ export default function OverlaysPage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [showConnectedOnly, setShowConnectedOnly] = useState(false)
+  // Ticking clock so the "connected for" / long-open highlighting stays fresh
+  // without calling Date.now() during render (react-hooks/purity).
+  const [now, setNow] = useState(() => Date.now())
   const detailRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(t)
+  }, [])
 
   // Fetch all overlays
   useEffect(() => {
@@ -208,7 +218,7 @@ export default function OverlaysPage() {
   const selectedSince = selectedOverlay ? connectedSince.get(selectedOverlay.id) : undefined
   const selectedConnectedFor = formatConnectedFor(selectedSince)
   const selectedLongOpen =
-    selectedConnected && !!selectedSince && Date.now() - Date.parse(selectedSince) >= LONG_OPEN_MS
+    selectedConnected && !!selectedSince && now - Date.parse(selectedSince) >= LONG_OPEN_MS
 
   if (error) {
     return (
@@ -280,7 +290,7 @@ export default function OverlaysPage() {
                   const since = connectedSince.get(overlay.id)
                   const connectedFor = formatConnectedFor(since)
                   const isLongOpen =
-                    isConnected && !!since && Date.now() - Date.parse(since) >= LONG_OPEN_MS
+                    isConnected && !!since && now - Date.parse(since) >= LONG_OPEN_MS
                   return (
                     <li
                       key={overlay.id}
@@ -466,7 +476,7 @@ export default function OverlaysPage() {
                           <div className="flex items-start justify-between">
                             <div className="flex-1">
                               <div className="flex items-center space-x-2">
-                                <PlatformBadge platform={source.platform as Platform} size="sm" />
+                                <PlatformBadge platform={source.platform} size="sm" />
                                 {source.is_active ? (
                                   <span className="inline-flex items-center rounded bg-kick/10 px-2 py-0.5 text-xs font-medium text-kick">
                                     Active

--- a/frontend/src/app/admin/overlays/page.tsx
+++ b/frontend/src/app/admin/overlays/page.tsx
@@ -24,6 +24,7 @@ import clsx from 'clsx'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlatformBadge } from '@/components/ui/badge'
+import { ChannelLink } from '@/components/ChannelLink'
 import { formatConnectedFor } from '@/lib/utils'
 
 // Connections open longer than this are highlighted so admins can spot overlays
@@ -34,6 +35,8 @@ interface Overlay {
   id: string
   name: string
   user_id: string
+  owner_username?: string
+  owner_display_name?: string
   created_at: string
   updated_at: string
   sources_count?: number
@@ -70,6 +73,9 @@ export default function OverlaysPage() {
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [showConnectedOnly, setShowConnectedOnly] = useState(false)
+  // True when the live-connection endpoint can't be read, so the UI can say
+  // "status unknown" instead of implying every overlay is disconnected.
+  const [connectionStatusUnavailable, setConnectionStatusUnavailable] = useState(false)
   // Ticking clock so the "connected for" / long-open highlighting stays fresh
   // without calling Date.now() during render (react-hooks/purity).
   const [now, setNow] = useState(() => Date.now())
@@ -134,9 +140,14 @@ export default function OverlaysPage() {
                 .map((o) => [o.overlay_id, o.connected_since as string])
             )
           )
+          setConnectionStatusUnavailable(false)
+        } else {
+          // A failed status read must not masquerade as "everything idle".
+          setConnectionStatusUnavailable(true)
         }
       } catch (err) {
         console.error('Failed to load active overlays:', err)
+        setConnectionStatusUnavailable(true)
       }
     }
 
@@ -203,7 +214,8 @@ export default function OverlaysPage() {
     return (
       o.name.toLowerCase().includes(term) ||
       o.id.toLowerCase().includes(term) ||
-      o.user_id.toLowerCase().includes(term)
+      o.user_id.toLowerCase().includes(term) ||
+      (o.owner_username?.toLowerCase().includes(term) ?? false)
     )
   })
 
@@ -239,6 +251,13 @@ export default function OverlaysPage() {
         </p>
       </div>
 
+      {connectionStatusUnavailable && (
+        <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-400">
+          Live connection status is currently unavailable, so overlays may show as &ldquo;not
+          connected&rdquo; even if they are live.
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         {/* Overlays List */}
         <div className="lg:col-span-2">
@@ -260,7 +279,7 @@ export default function OverlaysPage() {
                 <div className="mt-4 flex items-center gap-3">
                   <input
                     type="text"
-                    placeholder="Search by overlay name, ID, or user ID..."
+                    placeholder="Search by overlay name, ID, or owner..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                     className="focus-visible:ring-ring flex-1 rounded-lg border border-border bg-surface-2 px-4 py-2 text-text placeholder:text-text-dim focus-visible:ring-2 focus-visible:outline-none"
@@ -350,6 +369,7 @@ export default function OverlaysPage() {
                           <Link
                             href={`/overlay/${overlay.id}`}
                             target="_blank"
+                            rel="noopener noreferrer"
                             aria-label={`Open overlay ${overlay.name} in a new tab`}
                             className="relative text-sm text-text-sub transition-colors hover:text-text"
                             onClick={(e) => e.stopPropagation()}
@@ -388,6 +408,13 @@ export default function OverlaysPage() {
                     </li>
                   )
                 })}
+                {orderedOverlays.length === 0 && (
+                  <li className="px-4 py-10 text-center text-sm text-text-dim">
+                    {overlays.length === 0
+                      ? 'No overlays found.'
+                      : 'No overlays match your search or filter.'}
+                  </li>
+                )}
               </ul>
             </Card>
           )}
@@ -415,8 +442,25 @@ export default function OverlaysPage() {
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-sm font-medium text-text-sub">User ID</dt>
-                      <dd className="mt-1 font-mono text-xs break-all text-text">
+                      <dt className="text-sm font-medium text-text-sub">Owner</dt>
+                      <dd className="mt-1 text-sm">
+                        {selectedOverlay.user_id ? (
+                          <Link
+                            href={`/admin/users?user=${selectedOverlay.user_id}`}
+                            className="text-primary hover:underline"
+                          >
+                            {selectedOverlay.owner_username
+                              ? `@${selectedOverlay.owner_username}`
+                              : 'View user'}
+                            {selectedOverlay.owner_display_name
+                              ? ` (${selectedOverlay.owner_display_name})`
+                              : ''}
+                          </Link>
+                        ) : (
+                          <span className="text-text-dim">Unknown</span>
+                        )}
+                      </dd>
+                      <dd className="mt-1 font-mono text-xs break-all text-text-dim">
                         {selectedOverlay.user_id}
                       </dd>
                     </div>
@@ -487,8 +531,14 @@ export default function OverlaysPage() {
                                   </span>
                                 )}
                               </div>
-                              <p className="mt-1 text-sm font-medium text-text">
-                                {source.channel_name}
+                              <p className="mt-1">
+                                <ChannelLink
+                                  platform={source.platform}
+                                  channelId={source.channel_id}
+                                  channelName={source.channel_name}
+                                  channelHandle={source.channel_handle}
+                                  className="text-sm font-medium text-text"
+                                />
                               </p>
                               <p className="mt-1 font-mono text-xs text-text-sub">
                                 {source.channel_id}

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -25,6 +25,8 @@ import { Users, LayoutGrid, Radio, Eye, Ban, Activity } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PlatformBadge } from '@/components/ui/badge'
+import { ADMIN_LINKS } from '@/components/AdminSidebar'
 
 interface AdminStats {
   total_users: number
@@ -144,56 +146,49 @@ export default function AdminDashboard() {
         />
       </div>
 
-      {/* Navigation cards */}
+      {/* Sources by platform (the payload already carries the breakdown). */}
+      {stats?.total_sources && Object.keys(stats.total_sources).length > 0 && (
+        <>
+          <h2 className="mb-4 text-lg font-semibold text-text">Sources by platform</h2>
+          <div className="mb-8 flex flex-wrap gap-2">
+            {Object.entries(stats.total_sources)
+              .sort((a, b) => b[1] - a[1])
+              .map(([platform, count]) => (
+                <Link
+                  key={platform}
+                  href={`/admin/sources?platform=${platform}`}
+                  className="inline-flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-1.5 transition-colors hover:bg-surface-2"
+                >
+                  <PlatformBadge platform={platform} size="sm" />
+                  <span className="text-sm font-semibold text-text">{count.toLocaleString()}</span>
+                </Link>
+              ))}
+          </div>
+        </>
+      )}
+
+      {/* Navigation cards — generated from the same source as the sidebar rail so
+          the two can't drift. The Dashboard entry (exact) is the current page. */}
       <h2 className="mb-4 text-lg font-semibold text-text">Manage</h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <Link href="/admin/users">
-          <Card className="cursor-pointer p-5 transition-colors hover:bg-surface-2">
-            <div className="flex items-center gap-3">
-              <Users className="size-6 text-text-sub" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-medium text-text">Users</p>
-                <p className="text-xs text-text-sub">View and manage users</p>
-              </div>
-            </div>
-          </Card>
-        </Link>
-
-        <Link href="/admin/overlays">
-          <Card className="cursor-pointer p-5 transition-colors hover:bg-surface-2">
-            <div className="flex items-center gap-3">
-              <LayoutGrid className="size-6 text-text-sub" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-medium text-text">Overlays</p>
-                <p className="text-xs text-text-sub">Manage overlays</p>
-              </div>
-            </div>
-          </Card>
-        </Link>
-
-        <Link href="/admin/sources">
-          <Card className="cursor-pointer p-5 transition-colors hover:bg-surface-2">
-            <div className="flex items-center gap-3">
-              <Radio className="size-6 text-text-sub" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-medium text-text">Sources</p>
-                <p className="text-xs text-text-sub">View all sources</p>
-              </div>
-            </div>
-          </Card>
-        </Link>
-
-        <Link href="/admin/viewers">
-          <Card className="cursor-pointer p-5 transition-colors hover:bg-surface-2">
-            <div className="flex items-center gap-3">
-              <Eye className="size-6 text-text-sub" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-medium text-text">Viewers</p>
-                <p className="text-xs text-text-sub">View all viewers</p>
-              </div>
-            </div>
-          </Card>
-        </Link>
+        {ADMIN_LINKS.filter((link) => !link.exact).map((link) => {
+          const Icon = link.icon
+          return (
+            <Link key={link.href} href={link.href}>
+              <Card className="cursor-pointer p-5 transition-colors hover:bg-surface-2">
+                <div className="flex items-center gap-3">
+                  <Icon className="size-6 text-text-sub" aria-hidden="true" />
+                  <div>
+                    <p className="text-sm font-medium text-text">{link.label}</p>
+                    {link.description && (
+                      <p className="text-xs text-text-sub">{link.description}</p>
+                    )}
+                  </div>
+                </div>
+              </Card>
+            </Link>
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -44,13 +44,15 @@ function StatCard({
   label,
   value,
   icon: Icon,
+  href,
 }: {
   label: string
   value: number | undefined
   icon: LucideIcon
+  href?: string
 }) {
-  return (
-    <Card className="p-6">
+  const body = (
+    <Card className={href ? 'p-6 transition-colors hover:bg-surface-2' : 'p-6'}>
       <div className="mb-2 flex items-center gap-3">
         <Icon className="size-5 text-text-sub" aria-hidden="true" />
         <span className="text-sm text-text-sub">{label}</span>
@@ -61,6 +63,13 @@ function StatCard({
         <p className="text-3xl font-bold text-text">{value.toLocaleString()}</p>
       )}
     </Card>
+  )
+  return href ? (
+    <Link href={href} className="block">
+      {body}
+    </Link>
+  ) : (
+    body
   )
 }
 
@@ -106,18 +115,26 @@ export default function AdminDashboard() {
           label="Total Users"
           value={loading ? undefined : stats?.total_users}
           icon={Users}
+          href="/admin/users"
         />
         <StatCard
           label="Banned Users"
           value={loading ? undefined : stats?.banned_users}
           icon={Ban}
+          href="/admin/users?filter=banned"
         />
         <StatCard
           label="Active Overlays"
           value={loading ? undefined : stats?.active_overlays}
           icon={LayoutGrid}
+          href="/admin/overlays?connected=true"
         />
-        <StatCard label="Total Sources" value={loading ? undefined : totalSources} icon={Radio} />
+        <StatCard
+          label="Total Sources"
+          value={loading ? undefined : totalSources}
+          icon={Radio}
+          href="/admin/sources"
+        />
       </div>
 
       {/* Active users */}

--- a/frontend/src/app/admin/search/page.tsx
+++ b/frontend/src/app/admin/search/page.tsx
@@ -167,7 +167,6 @@ export default function AdminSearchPage() {
 
       <input
         type="search"
-        autoFocus
         placeholder="Search users, overlays, sources, viewers..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}

--- a/frontend/src/app/admin/search/page.tsx
+++ b/frontend/src/app/admin/search/page.tsx
@@ -1,0 +1,301 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Global admin entity search (ADR-0035).
+ *
+ * Resolves a free-text query across users, overlays, sources, and viewers and
+ * deep-links each hit into the URL-addressable admin views (ADR-0033). Users,
+ * overlays, and sources are federated on the client over the existing admin
+ * list endpoints; viewers use the server-side ?q= search.
+ */
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Card } from '@/components/ui/card'
+import { PlatformBadge } from '@/components/ui/badge'
+import { UserAvatar } from '@/components/UserAvatar'
+
+const GROUP_LIMIT = 8
+
+interface UserRow {
+  id: string
+  username: string
+  display_name: string
+  profile_image_url: string
+  is_premium: boolean
+  is_banned: boolean
+}
+interface OverlayRow {
+  id: string
+  name: string
+  user_id: string
+  owner_username?: string
+  sources_count?: number
+}
+interface SourceRow {
+  id: string
+  overlay_id: string
+  overlay_name: string
+  platform: string
+  channel_id: string
+  channel_name: string
+  channel_handle?: string | null
+  owner_username?: string
+  user_id: string
+}
+interface ViewerRow {
+  id: string
+  platform: string
+  username: string
+  display_name: string
+  platform_user_id: string
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: 'same-origin' })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+function readInitialQuery(): string {
+  if (typeof window === 'undefined') return ''
+  return new URLSearchParams(window.location.search).get('q') ?? ''
+}
+
+export default function AdminSearchPage() {
+  // Seed both from ?q= via lazy initializers (e.g. arriving from a deep link) so
+  // results appear immediately without a synchronous setState in an effect.
+  const [query, setQuery] = useState(readInitialQuery)
+  const [debounced, setDebounced] = useState(() => readInitialQuery().trim())
+  const [users, setUsers] = useState<UserRow[]>([])
+  const [overlays, setOverlays] = useState<OverlayRow[]>([])
+  const [sources, setSources] = useState<SourceRow[]>([])
+  const [viewers, setViewers] = useState<ViewerRow[]>([])
+  const [loading, setLoading] = useState(false)
+
+  // Debounce the query.
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 300)
+    return () => clearTimeout(t)
+  }, [query])
+
+  useEffect(() => {
+    const term = debounced.toLowerCase()
+    if (!term) return // render shows the prompt; keep prior results untouched
+    let cancelled = false
+
+    async function run() {
+      setLoading(true)
+      try {
+        const [allUsers, allOverlays, allSources, viewerResp] = await Promise.all([
+          getJson<UserRow[]>('/api/v1/admin/users'),
+          getJson<OverlayRow[]>('/api/v1/admin/overlays'),
+          getJson<SourceRow[]>('/api/v1/admin/sources'),
+          getJson<{ viewers: ViewerRow[] }>(
+            `/api/v1/admin/viewers?limit=${GROUP_LIMIT}&q=${encodeURIComponent(debounced)}`
+          ),
+        ])
+        if (cancelled) return
+        setUsers(
+          allUsers.filter(
+            (u) =>
+              u.username.toLowerCase().includes(term) ||
+              u.display_name.toLowerCase().includes(term) ||
+              u.id.toLowerCase().includes(term)
+          )
+        )
+        setOverlays(
+          allOverlays.filter(
+            (o) =>
+              o.name.toLowerCase().includes(term) ||
+              o.id.toLowerCase().includes(term) ||
+              (o.owner_username?.toLowerCase().includes(term) ?? false)
+          )
+        )
+        setSources(
+          allSources.filter(
+            (s) =>
+              s.channel_name.toLowerCase().includes(term) ||
+              s.channel_id.toLowerCase().includes(term) ||
+              (s.channel_handle?.toLowerCase().includes(term) ?? false) ||
+              (s.owner_username?.toLowerCase().includes(term) ?? false)
+          )
+        )
+        setViewers(viewerResp.viewers ?? [])
+      } catch (err) {
+        if (!cancelled) console.error('Global search failed:', err)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [debounced])
+
+  const hasResults =
+    users.length > 0 || overlays.length > 0 || sources.length > 0 || viewers.length > 0
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-text">Search</h1>
+        <p className="mt-1 text-sm text-text-sub">
+          Find any user, overlay, source, or viewer and jump straight to it
+        </p>
+      </div>
+
+      <input
+        type="search"
+        autoFocus
+        placeholder="Search users, overlays, sources, viewers..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        aria-label="Global admin search"
+        className="focus-visible:ring-ring mb-6 w-full rounded-lg border border-border bg-surface-2 px-4 py-3 text-text placeholder:text-text-dim focus-visible:ring-2 focus-visible:outline-none"
+      />
+
+      {!debounced ? (
+        <Card className="p-8 text-center text-sm text-text-dim">
+          Type at least one character to search.
+        </Card>
+      ) : loading && !hasResults ? (
+        <Card className="p-8 text-center text-sm text-text-dim">Searching...</Card>
+      ) : !hasResults ? (
+        <Card className="p-8 text-center text-sm text-text-dim">
+          Nothing matches &ldquo;{debounced}&rdquo;.
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {users.length > 0 && (
+            <ResultGroup title="Users" count={users.length}>
+              {users.slice(0, GROUP_LIMIT).map((u) => (
+                <Link
+                  key={u.id}
+                  href={`/admin/users?user=${u.id}`}
+                  className="flex items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-surface-2"
+                >
+                  <UserAvatar avatarUrl={u.profile_image_url} displayName={u.display_name} size={32} />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text">{u.display_name}</div>
+                    <div className="truncate text-xs text-text-sub">@{u.username}</div>
+                  </div>
+                  <div className="ml-auto flex gap-1">
+                    {u.is_premium && (
+                      <span className="rounded bg-amber-400/10 px-2 py-0.5 text-xs font-medium text-amber-400">
+                        Premium
+                      </span>
+                    )}
+                    {u.is_banned && (
+                      <span className="bg-destructive/10 text-destructive rounded px-2 py-0.5 text-xs font-medium">
+                        Banned
+                      </span>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </ResultGroup>
+          )}
+
+          {overlays.length > 0 && (
+            <ResultGroup title="Overlays" count={overlays.length}>
+              {overlays.slice(0, GROUP_LIMIT).map((o) => (
+                <Link
+                  key={o.id}
+                  href={`/admin/overlays?overlay=${o.id}`}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-surface-2"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text">{o.name}</div>
+                    <div className="truncate text-xs text-text-sub">
+                      {o.owner_username ? `@${o.owner_username}` : o.user_id.slice(0, 8)}
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-xs text-text-dim">{o.sources_count ?? 0} sources</span>
+                </Link>
+              ))}
+            </ResultGroup>
+          )}
+
+          {sources.length > 0 && (
+            <ResultGroup title="Sources" count={sources.length}>
+              {sources.slice(0, GROUP_LIMIT).map((s) => (
+                <Link
+                  key={s.id}
+                  href={`/admin/overlays?overlay=${s.overlay_id}`}
+                  className="flex items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-surface-2"
+                >
+                  <PlatformBadge platform={s.platform} size="sm" />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text">{s.channel_name}</div>
+                    <div className="truncate text-xs text-text-sub">
+                      in {s.overlay_name}
+                      {s.owner_username ? ` · @${s.owner_username}` : ''}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </ResultGroup>
+          )}
+
+          {viewers.length > 0 && (
+            <ResultGroup title="Viewers" count={viewers.length}>
+              {viewers.slice(0, GROUP_LIMIT).map((v) => (
+                <Link
+                  key={v.id}
+                  href={`/admin/viewers?q=${encodeURIComponent(v.username)}`}
+                  className="flex items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-surface-2"
+                >
+                  <PlatformBadge platform={v.platform} size="sm" />
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-text">{v.display_name}</div>
+                    <div className="truncate text-xs text-text-sub">@{v.username}</div>
+                  </div>
+                </Link>
+              ))}
+            </ResultGroup>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ResultGroup({
+  title,
+  count,
+  children,
+}: {
+  title: string
+  count: number
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <h2 className="mb-2 text-sm font-semibold text-text-sub">
+        {title} {count > GROUP_LIMIT ? `(showing ${GROUP_LIMIT} of ${count})` : `(${count})`}
+      </h2>
+      <div className="space-y-2">{children}</div>
+    </section>
+  )
+}

--- a/frontend/src/app/admin/sources/page.tsx
+++ b/frontend/src/app/admin/sources/page.tsx
@@ -23,13 +23,14 @@ import Link from 'next/link'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlatformBadge } from '@/components/ui/badge'
-import type { Platform } from '@/lib/platform-colors'
 
 interface Source {
   id: string
   overlay_id: string
   overlay_name: string
-  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok'
+  // Stored platforms outgrow the chromatic set (discord, shared_overlay); the
+  // badge neutral-styles anything it doesn't recognize, so no cast is needed.
+  platform: 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'discord' | 'shared_overlay'
   channel_id: string
   channel_name: string
   is_active: boolean
@@ -39,7 +40,6 @@ interface Source {
 
 export default function SourcesPage() {
   const [sources, setSources] = useState<Source[]>([])
-  const [filteredSources, setFilteredSources] = useState<Source[]>([])
   const [platformFilter, setPlatformFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [searchTerm, setSearchTerm] = useState('')
@@ -66,7 +66,6 @@ export default function SourcesPage() {
 
         const data = await response.json()
         setSources(data)
-        setFilteredSources(data)
         setLoading(false)
       } catch (err) {
         console.error('Failed to load sources:', err)
@@ -78,35 +77,21 @@ export default function SourcesPage() {
     fetchSources()
   }, [])
 
-  // Filter sources based on platform, status, and search
-  useEffect(() => {
-    let filtered = [...sources]
-
-    // Platform filter
-    if (platformFilter !== 'all') {
-      filtered = filtered.filter((s) => s.platform === platformFilter)
-    }
-
-    // Status filter
-    if (statusFilter === 'active') {
-      filtered = filtered.filter((s) => s.is_active)
-    } else if (statusFilter === 'inactive') {
-      filtered = filtered.filter((s) => !s.is_active)
-    }
-
-    // Search filter
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase()
-      filtered = filtered.filter(
-        (s) =>
-          s.channel_name.toLowerCase().includes(term) ||
-          s.channel_id.toLowerCase().includes(term) ||
-          s.overlay_name.toLowerCase().includes(term)
+  // Derived during render (no state-in-effect): filter by platform, status, search.
+  const searchLower = searchTerm.trim().toLowerCase()
+  const filteredSources = sources.filter((s) => {
+    if (platformFilter !== 'all' && s.platform !== platformFilter) return false
+    if (statusFilter === 'active' && !s.is_active) return false
+    if (statusFilter === 'inactive' && s.is_active) return false
+    if (searchLower) {
+      return (
+        s.channel_name.toLowerCase().includes(searchLower) ||
+        s.channel_id.toLowerCase().includes(searchLower) ||
+        s.overlay_name.toLowerCase().includes(searchLower)
       )
     }
-
-    setFilteredSources(filtered)
-  }, [platformFilter, statusFilter, searchTerm, sources])
+    return true
+  })
 
   const platformCounts = {
     twitch: sources.filter((s) => s.platform === 'twitch').length,
@@ -320,7 +305,7 @@ export default function SourcesPage() {
                   {filteredSources.map((source) => (
                     <tr key={source.id} className="transition-colors hover:bg-surface-2">
                       <td className="px-4 py-3">
-                        <PlatformBadge platform={source.platform as Platform} size="sm" />
+                        <PlatformBadge platform={source.platform} size="sm" />
                       </td>
                       <td className="px-4 py-3">
                         <div className="text-sm font-medium text-text">{source.channel_name}</div>
@@ -380,7 +365,7 @@ export default function SourcesPage() {
                       {source.channel_id}
                     </div>
                   </div>
-                  <PlatformBadge platform={source.platform as Platform} size="sm" />
+                  <PlatformBadge platform={source.platform} size="sm" />
                 </div>
                 <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-sub">
                   <Link

--- a/frontend/src/app/admin/sources/page.tsx
+++ b/frontend/src/app/admin/sources/page.tsx
@@ -23,6 +23,7 @@ import Link from 'next/link'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { PlatformBadge } from '@/components/ui/badge'
+import { ChannelLink } from '@/components/ChannelLink'
 
 interface Source {
   id: string
@@ -33,9 +34,20 @@ interface Source {
   platform: 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'discord' | 'shared_overlay'
   channel_id: string
   channel_name: string
+  channel_handle?: string | null
   is_active: boolean
   created_at: string
   user_id: string
+  owner_username?: string
+  owner_display_name?: string
+}
+
+// Short, stable label for a source's owner: the resolved username, else a
+// truncated user id (orphaned/unjoined rows), else a dash.
+function ownerLabel(source: Source): string {
+  if (source.owner_username) return `@${source.owner_username}`
+  if (source.user_id) return source.user_id.slice(0, 8)
+  return '—'
 }
 
 export default function SourcesPage() {
@@ -43,6 +55,9 @@ export default function SourcesPage() {
   const [platformFilter, setPlatformFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [searchTerm, setSearchTerm] = useState('')
+  // Optional owner scope from ?user=<id> (set when arriving from the Users page
+  // "View this user's sources" link). Narrows the list to one owner.
+  const [userFilter, setUserFilter] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const searchId = useId()
@@ -66,6 +81,14 @@ export default function SourcesPage() {
 
         const data = await response.json()
         setSources(data)
+        // Scope from URL (client-only; read post-await): ?user=<id> owner scope
+        // and ?platform=<p> (e.g. from the dashboard's per-platform breakdown).
+        const params = new URLSearchParams(window.location.search)
+        setUserFilter(params.get('user'))
+        const p = params.get('platform')
+        if (p && ['twitch', 'youtube', 'kick', 'tiktok', 'discord', 'shared_overlay'].includes(p)) {
+          setPlatformFilter(p)
+        }
         setLoading(false)
       } catch (err) {
         console.error('Failed to load sources:', err)
@@ -77,9 +100,11 @@ export default function SourcesPage() {
     fetchSources()
   }, [])
 
-  // Derived during render (no state-in-effect): filter by platform, status, search.
+  // Derived during render (no state-in-effect): filter by owner scope, platform,
+  // status, and search (channel name/id, overlay name, owner username).
   const searchLower = searchTerm.trim().toLowerCase()
   const filteredSources = sources.filter((s) => {
+    if (userFilter && s.user_id !== userFilter) return false
     if (platformFilter !== 'all' && s.platform !== platformFilter) return false
     if (statusFilter === 'active' && !s.is_active) return false
     if (statusFilter === 'inactive' && s.is_active) return false
@@ -87,11 +112,17 @@ export default function SourcesPage() {
       return (
         s.channel_name.toLowerCase().includes(searchLower) ||
         s.channel_id.toLowerCase().includes(searchLower) ||
-        s.overlay_name.toLowerCase().includes(searchLower)
+        s.overlay_name.toLowerCase().includes(searchLower) ||
+        (s.owner_username?.toLowerCase().includes(searchLower) ?? false)
       )
     }
     return true
   })
+
+  // Label the active owner scope with a resolved username when we have one.
+  const userFilterLabel = userFilter
+    ? (sources.find((s) => s.user_id === userFilter)?.owner_username ?? userFilter.slice(0, 8))
+    : null
 
   const platformCounts = {
     twitch: sources.filter((s) => s.platform === 'twitch').length,
@@ -118,6 +149,28 @@ export default function SourcesPage() {
           View and manage all chat sources across overlays
         </p>
       </div>
+
+      {/* Owner scope (from ?user=) */}
+      {userFilter && (
+        <div className="mb-4 flex items-center gap-3 rounded-lg border border-border bg-surface-2 px-4 py-2 text-sm">
+          <span className="text-text-sub">
+            Showing sources owned by{' '}
+            <Link
+              href={`/admin/users?user=${userFilter}`}
+              className="font-medium text-text hover:underline"
+            >
+              {userFilterLabel}
+            </Link>
+          </span>
+          <button
+            type="button"
+            onClick={() => setUserFilter(null)}
+            className="ml-auto text-text-sub transition-colors hover:text-text"
+          >
+            Clear
+          </button>
+        </div>
+      )}
 
       {/* Stats Cards */}
       <div className="mb-6 grid grid-cols-2 gap-4 lg:grid-cols-4">
@@ -213,7 +266,7 @@ export default function SourcesPage() {
             <input
               id={searchId}
               type="text"
-              placeholder="Search by channel name or ID..."
+              placeholder="Search by channel, overlay, or owner..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="focus-visible:ring-ring block w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-text placeholder:text-text-dim focus-visible:ring-2 focus-visible:outline-none sm:text-sm"
@@ -267,6 +320,10 @@ export default function SourcesPage() {
             <Skeleton key={i} className="h-10 w-full rounded-lg" />
           ))}
         </Card>
+      ) : filteredSources.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-text-dim">
+          {sources.length === 0 ? 'No sources found.' : 'No sources match your filters.'}
+        </Card>
       ) : (
         <>
           {/* Desktop table */}
@@ -291,13 +348,13 @@ export default function SourcesPage() {
                       Overlay
                     </th>
                     <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Owner
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
                       Status
                     </th>
                     <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
                       Created
-                    </th>
-                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                      Actions
                     </th>
                   </tr>
                 </thead>
@@ -308,7 +365,13 @@ export default function SourcesPage() {
                         <PlatformBadge platform={source.platform} size="sm" />
                       </td>
                       <td className="px-4 py-3">
-                        <div className="text-sm font-medium text-text">{source.channel_name}</div>
+                        <ChannelLink
+                          platform={source.platform}
+                          channelId={source.channel_id}
+                          channelName={source.channel_name}
+                          channelHandle={source.channel_handle}
+                          className="text-sm font-medium text-text"
+                        />
                         <div className="font-mono text-xs text-text-sub">{source.channel_id}</div>
                       </td>
                       <td className="px-4 py-3">
@@ -318,6 +381,18 @@ export default function SourcesPage() {
                         >
                           {source.overlay_name}
                         </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        {source.user_id ? (
+                          <Link
+                            href={`/admin/users?user=${source.user_id}`}
+                            className="text-sm text-text-sub transition-colors hover:text-text"
+                          >
+                            {ownerLabel(source)}
+                          </Link>
+                        ) : (
+                          <span className="text-sm text-text-dim">—</span>
+                        )}
                       </td>
                       <td className="px-4 py-3">
                         {source.is_active ? (
@@ -332,15 +407,6 @@ export default function SourcesPage() {
                       </td>
                       <td className="px-4 py-3 text-sm text-text-sub">
                         {new Date(source.created_at).toLocaleDateString()}
-                      </td>
-                      <td className="px-4 py-3 text-sm">
-                        <Link
-                          href={`/admin/overlays?overlay=${source.overlay_id}`}
-                          aria-label={`View overlay ${source.overlay_name} for channel ${source.channel_name}`}
-                          className="font-medium text-text-sub transition-colors hover:text-text"
-                        >
-                          View
-                        </Link>
                       </td>
                     </tr>
                   ))}
@@ -358,9 +424,13 @@ export default function SourcesPage() {
               <Card key={source.id} className="p-4">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-text">
-                      {source.channel_name}
-                    </div>
+                    <ChannelLink
+                      platform={source.platform}
+                      channelId={source.channel_id}
+                      channelName={source.channel_name}
+                      channelHandle={source.channel_handle}
+                      className="truncate text-sm font-medium text-text"
+                    />
                     <div className="truncate font-mono text-xs text-text-sub">
                       {source.channel_id}
                     </div>
@@ -374,6 +444,14 @@ export default function SourcesPage() {
                   >
                     {source.overlay_name}
                   </Link>
+                  {source.user_id && (
+                    <Link
+                      href={`/admin/users?user=${source.user_id}`}
+                      className="truncate transition-colors hover:text-text"
+                    >
+                      {ownerLabel(source)}
+                    </Link>
+                  )}
                   <span>{new Date(source.created_at).toLocaleDateString()}</span>
                   {source.is_active ? (
                     <span className="inline-flex items-center rounded-full bg-kick/10 px-2 py-0.5 font-medium text-kick">

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -102,17 +102,22 @@ export default function UsersPage() {
         setUsers(data)
         setLoading(false)
 
-        // Deep-link: auto-select a user passed via ?user=<id> (e.g. from the
-        // Overlays/Sources pages' owner links). Mirrors the Overlays ?overlay=
-        // pattern. Read post-await so it is client-only and not a synchronous
-        // setState in the effect body.
-        const targetId = new URLSearchParams(window.location.search).get('user')
+        // Deep-links (read post-await so they're client-only, not a synchronous
+        // setState in the effect body). ?user=<id> auto-selects a user (from the
+        // Overlays/Sources owner links); ?filter=<tab> pre-selects a filter tab
+        // (from the dashboard stat cards).
+        const params = new URLSearchParams(window.location.search)
+        const targetId = params.get('user')
         if (targetId) {
           const match = (data as User[]).find((u) => u.id === targetId)
           if (match) {
             setSelectedUser(match)
             setSearchTerm(match.username)
           }
+        }
+        const f = params.get('filter')
+        if (f === 'active' || f === 'banned' || f === 'premium' || f === 'beta') {
+          setFilter(f)
         }
       } catch (err) {
         console.error('Failed to load users:', err)
@@ -474,7 +479,7 @@ export default function UsersPage() {
                   </button>
                 </div>
               </div>
-              <ul className="divide-y divide-border">
+              <ul className="max-h-[70vh] divide-y divide-border overflow-y-auto">
                 {displayUsers.map((user) => (
                   <li key={user.id}>
                     <button
@@ -566,7 +571,7 @@ export default function UsersPage() {
         </div>
 
         {/* User Details Panel */}
-        <div className="lg:col-span-1">
+        <div className="lg:sticky lg:top-8 lg:col-span-1 lg:self-start">
           {selectedUser ? (
             <Card className="overflow-hidden">
               <div className="flex items-center gap-3 border-b border-border px-4 py-5">

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -29,6 +29,7 @@ import { Dialog } from '@/components/ui/dialog'
 import { toastManager } from '@/lib/toast'
 import { useAuthStore } from '@/lib/stores/auth-store'
 import { PremiumDurationChooser } from '@/components/admin/PremiumDurationChooser'
+import { UserAvatar } from '@/components/UserAvatar'
 
 interface User {
   id: string
@@ -65,7 +66,7 @@ export default function UsersPage() {
   const [error, setError] = useState<string | null>(null)
   const [impersonating, setImpersonating] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
-  const [filter, setFilter] = useState<'all' | 'active' | 'banned' | 'premium'>('all')
+  const [filter, setFilter] = useState<'all' | 'active' | 'banned' | 'premium' | 'beta'>('all')
   const [showBanModal, setShowBanModal] = useState(false)
   const [userToBan, setUserToBan] = useState<User | null>(null)
   const [banReason, setBanReason] = useState('')
@@ -100,6 +101,19 @@ export default function UsersPage() {
         const data = await response.json()
         setUsers(data)
         setLoading(false)
+
+        // Deep-link: auto-select a user passed via ?user=<id> (e.g. from the
+        // Overlays/Sources pages' owner links). Mirrors the Overlays ?overlay=
+        // pattern. Read post-await so it is client-only and not a synchronous
+        // setState in the effect body.
+        const targetId = new URLSearchParams(window.location.search).get('user')
+        if (targetId) {
+          const match = (data as User[]).find((u) => u.id === targetId)
+          if (match) {
+            setSelectedUser(match)
+            setSearchTerm(match.username)
+          }
+        }
       } catch (err) {
         console.error('Failed to load users:', err)
         setError('Failed to load users')
@@ -336,13 +350,15 @@ export default function UsersPage() {
     if (filter === 'banned' && !u.is_banned) return false
     if (filter === 'active' && u.is_banned) return false
     if (filter === 'premium' && !u.is_premium) return false
+    if (filter === 'beta' && !u.is_beta_tester) return false
 
-    // Search filter
+    // Search filter (id lets an owner deep-link land even before it's typed)
     if (searchTerm) {
       const term = searchTerm.toLowerCase()
       return (
         u.username.toLowerCase().includes(term) ||
         u.display_name.toLowerCase().includes(term) ||
+        u.id.toLowerCase().includes(term) ||
         u.twitch_id?.toLowerCase().includes(term) ||
         u.youtube_id?.toLowerCase().includes(term) ||
         u.kick_id?.toLowerCase().includes(term)
@@ -365,6 +381,7 @@ export default function UsersPage() {
   const bannedCount = users.filter((u) => u.is_banned).length
   const activeCount = users.filter((u) => !u.is_banned).length
   const premiumCount = users.filter((u) => u.is_premium).length
+  const betaCount = users.filter((u) => u.is_beta_tester).length
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8">
@@ -444,6 +461,17 @@ export default function UsersPage() {
                   >
                     Premium ({premiumCount})
                   </button>
+                  <button
+                    onClick={() => setFilter('beta')}
+                    className={clsx(
+                      'border-b-2 px-1 pb-2 text-sm font-medium transition-colors',
+                      filter === 'beta'
+                        ? 'border-violet-400 text-violet-400'
+                        : 'border-transparent text-text-sub hover:border-border hover:text-text'
+                    )}
+                  >
+                    Beta ({betaCount})
+                  </button>
                 </div>
               </div>
               <ul className="divide-y divide-border">
@@ -458,10 +486,16 @@ export default function UsersPage() {
                         selectedUser?.id === user.id && 'bg-surface-2'
                       )}
                     >
-                      <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          <div className="flex items-center">
-                            <p className="text-sm font-medium text-text">{user.display_name}</p>
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex min-w-0 flex-1 items-center gap-3">
+                          <UserAvatar
+                            avatarUrl={user.profile_image_url}
+                            displayName={user.display_name}
+                            size={36}
+                          />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center">
+                              <p className="text-sm font-medium text-text">{user.display_name}</p>
                             <div className="ml-2 flex space-x-1">
                               {user.is_beta_tester && (
                                 <span className="inline-flex items-center rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 text-xs font-medium text-violet-400">
@@ -495,10 +529,11 @@ export default function UsersPage() {
                               )}
                             </div>
                           </div>
-                          <p className="text-sm text-text-sub">@{user.username}</p>
-                          <p className="mt-1 text-xs text-text-dim">
-                            Joined {new Date(user.created_at).toLocaleDateString()}
-                          </p>
+                            <p className="text-sm text-text-sub">@{user.username}</p>
+                            <p className="mt-1 text-xs text-text-dim">
+                              Joined {new Date(user.created_at).toLocaleDateString()}
+                            </p>
+                          </div>
                         </div>
                         <div>
                           <svg
@@ -520,6 +555,11 @@ export default function UsersPage() {
                     </button>
                   </li>
                 ))}
+                {displayUsers.length === 0 && (
+                  <li className="px-4 py-10 text-center text-sm text-text-dim">
+                    No users match your search or filter.
+                  </li>
+                )}
               </ul>
             </Card>
           )}
@@ -529,8 +569,18 @@ export default function UsersPage() {
         <div className="lg:col-span-1">
           {selectedUser ? (
             <Card className="overflow-hidden">
-              <div className="border-b border-border px-4 py-5">
-                <h3 className="text-base font-medium text-text">User Details</h3>
+              <div className="flex items-center gap-3 border-b border-border px-4 py-5">
+                <UserAvatar
+                  avatarUrl={selectedUser.profile_image_url}
+                  displayName={selectedUser.display_name}
+                  size={44}
+                />
+                <div className="min-w-0">
+                  <h3 className="truncate text-base font-medium text-text">
+                    {selectedUser.display_name}
+                  </h3>
+                  <p className="truncate text-sm text-text-sub">@{selectedUser.username}</p>
+                </div>
               </div>
               <div className="px-4 py-5">
                 <dl className="space-y-4">
@@ -966,34 +1016,41 @@ export default function UsersPage() {
                   {userOverlays.length > 0 ? (
                     <ul className="space-y-2">
                       {userOverlays.map((overlay) => (
-                        <li key={overlay.id}>
+                        <li
+                          key={overlay.id}
+                          className="flex items-center gap-2 rounded-lg border border-border bg-surface-2 px-3 py-2 transition-colors hover:bg-surface-2/80"
+                        >
+                          {/* Primary: admin detail (owner-linked, in-app). */}
+                          <Link href={`/admin/overlays?overlay=${overlay.id}`} className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-medium text-text">
+                              {overlay.name}
+                            </div>
+                            <div className="text-xs text-text-sub">
+                              {overlay.sources_count} sources
+                            </div>
+                          </Link>
+                          {/* Secondary: open the live overlay in a new tab. */}
                           <Link
                             href={`/overlay/${overlay.id}`}
                             target="_blank"
-                            className="block rounded-lg border border-border bg-surface-2 px-3 py-2 transition-colors hover:bg-surface-2/80"
+                            rel="noopener noreferrer"
+                            aria-label={`Open the live ${overlay.name} overlay (opens in a new tab)`}
+                            className="shrink-0 text-text-dim transition-colors hover:text-text"
                           >
-                            <div className="flex items-center justify-between">
-                              <div>
-                                <div className="text-sm font-medium text-text">{overlay.name}</div>
-                                <div className="text-xs text-text-sub">
-                                  {overlay.sources_count} sources
-                                </div>
-                              </div>
-                              <svg
-                                aria-hidden="true"
-                                className="h-4 w-4 text-text-dim"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  strokeWidth="2"
-                                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                                />
-                              </svg>
-                            </div>
+                            <svg
+                              aria-hidden="true"
+                              className="h-4 w-4"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth="2"
+                                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                              />
+                            </svg>
                           </Link>
                         </li>
                       ))}
@@ -1001,6 +1058,12 @@ export default function UsersPage() {
                   ) : (
                     <p className="text-sm text-text-dim italic">No overlays yet</p>
                   )}
+                  <Link
+                    href={`/admin/sources?user=${selectedUser.id}`}
+                    className="mt-3 inline-block text-xs font-medium text-primary hover:underline"
+                  >
+                    View this user&rsquo;s sources
+                  </Link>
                 </div>
               </div>
             </Card>

--- a/frontend/src/app/admin/viewers/page.tsx
+++ b/frontend/src/app/admin/viewers/page.tsx
@@ -104,9 +104,16 @@ export default function AdminViewersPage() {
   const [refreshKey, setRefreshKey] = useState(0)
 
   // Discovery controls (server-side). `searchInput` is the immediate field
-  // value; `search` is the debounced value actually sent to the API.
-  const [searchInput, setSearchInput] = useState('')
-  const [search, setSearch] = useState('')
+  // value; `search` is the debounced value actually sent to the API. Both are
+  // seeded from ?q= (e.g. arriving from global search) via a lazy initializer
+  // so there's no synchronous setState in an effect.
+  const [initialQuery] = useState(() =>
+    typeof window === 'undefined'
+      ? ''
+      : (new URLSearchParams(window.location.search).get('q') ?? '')
+  )
+  const [searchInput, setSearchInput] = useState(initialQuery)
+  const [search, setSearch] = useState(initialQuery)
   const [statusFilter, setStatusFilter] = useState<'all' | 'banned' | 'active'>('all')
   const [premiumFilter, setPremiumFilter] = useState<'all' | 'premium' | 'free'>('all')
   const [platformFilter, setPlatformFilter] = useState('all')

--- a/frontend/src/app/admin/viewers/page.tsx
+++ b/frontend/src/app/admin/viewers/page.tsx
@@ -19,14 +19,10 @@
 /**
  * Admin Viewer Management Page
  *
- * Allows admins to view all viewer sessions and ban/unban users.
- *
- * Features:
- * - List all viewer sessions
- * - View message counts and rate limits
- * - Ban viewers with reason
- * - Unban viewers
- * - See ban status and reasons
+ * Find a viewer (server-side search + filters + pagination), inspect their
+ * cross-streamer activity, and ban/unban or grant/revoke premium. Search,
+ * filters, and the total count are resolved server-side (ADR-0034) so they are
+ * correct across the whole dataset, not just the loaded page.
  *
  * Route: /admin/viewers
  */
@@ -34,6 +30,7 @@
 'use client'
 
 import { useEffect, useId, useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import clsx from 'clsx'
 import { useAuthStore } from '@/lib/stores/auth-store'
@@ -45,6 +42,9 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Dialog } from '@/components/ui/dialog'
 import { toastManager } from '@/lib/toast'
 import { PremiumDurationChooser } from '@/components/admin/PremiumDurationChooser'
+import { UserAvatar } from '@/components/UserAvatar'
+import { PlatformBadge } from '@/components/ui/badge'
+import { ChannelLink } from '@/components/ChannelLink'
 
 interface ViewerSession {
   id: string
@@ -52,24 +52,66 @@ interface ViewerSession {
   platform_user_id: string
   username: string
   display_name: string
+  avatar_url?: string | null
   last_message_at: string | null
   message_count_1min: number
   message_count_1hour: number
   is_premium: boolean
   premium_expires_at?: string | null
   viewer_id: string | null
+  // Linked streamer account (viewer who is also a streamer), when present.
+  user_id?: string | null
   is_banned: boolean
   banned_at: string | null
   banned_reason: string | null
   created_at: string
 }
 
+interface ViewerListResponse {
+  viewers: ViewerSession[]
+  total: number
+  limit: number
+  offset: number
+}
+
+interface ViewerActivityStreamer {
+  streamer_user_id: string
+  streamer_username: string
+  overlay_id?: string | null
+  channel_name: string
+  platform: string
+  message_count: number
+  last_sent_at: string
+}
+
+interface ViewerActivity {
+  total_messages: number
+  last_sent_at: string | null
+  streamers: ViewerActivityStreamer[]
+}
+
+const PAGE_SIZE = 50
+
 export default function AdminViewersPage() {
   const router = useRouter()
   const { user } = useAuthStore()
 
   const [viewers, setViewers] = useState<ViewerSession[]>([])
+  const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  // Bumped by mutations (ban/premium) to force a refetch without threading an
+  // external fetch function through the effect.
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  // Discovery controls (server-side). `searchInput` is the immediate field
+  // value; `search` is the debounced value actually sent to the API.
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<'all' | 'banned' | 'active'>('all')
+  const [premiumFilter, setPremiumFilter] = useState<'all' | 'premium' | 'free'>('all')
+  const [platformFilter, setPlatformFilter] = useState('all')
+  const [offset, setOffset] = useState(0)
+
   const [banningId, setBanningId] = useState<string | null>(null)
   const [banReason, setBanReason] = useState('')
   const [showBanModal, setShowBanModal] = useState(false)
@@ -81,29 +123,84 @@ export default function AdminViewersPage() {
   // means the custom day count is empty/out of range and the grant is blocked.
   const [grantDurationSeconds, setGrantDurationSeconds] = useState<number | null>(null)
   const [grantDurationValid, setGrantDurationValid] = useState(true)
+  // Activity (streamer context) dialog.
+  const [activityViewer, setActivityViewer] = useState<ViewerSession | null>(null)
+  const [activity, setActivity] = useState<ViewerActivity | null>(null)
+  const [activityLoading, setActivityLoading] = useState(false)
   const banReasonId = useId()
+  const searchId = useId()
+  const statusId = useId()
+  const premiumId = useId()
+  const platformId = useId()
 
   useEffect(() => {
     if (!user?.is_admin) {
       router.push('/dashboard')
-      return
     }
-
-    fetchViewers()
   }, [user, router])
 
-  const fetchViewers = async () => {
+  // Debounce the search box so we don't hit the API on every keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearch(searchInput)
+      setOffset(0)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [searchInput])
+
+  // Fetch is defined inline in the effect (state is set only after the await, so
+  // it never runs synchronously in the effect body) and re-runs whenever the
+  // filters, page, or refreshKey change. Initial loading=true shows the skeleton
+  // on first load; refetches swap the list in place.
+  useEffect(() => {
+    if (!user?.is_admin) return
+    let cancelled = false
+
+    async function run() {
+      try {
+        const params = new URLSearchParams()
+        params.set('limit', String(PAGE_SIZE))
+        params.set('offset', String(offset))
+        if (search.trim()) params.set('q', search.trim())
+        if (statusFilter !== 'all') params.set('is_banned', String(statusFilter === 'banned'))
+        if (premiumFilter !== 'all') params.set('is_premium', String(premiumFilter === 'premium'))
+        if (platformFilter !== 'all') params.set('platform', platformFilter)
+
+        const response = await apiClient.get<ViewerListResponse>(
+          `/api/v1/admin/viewers?${params.toString()}`
+        )
+        if (cancelled) return
+        setViewers(response.viewers ?? [])
+        setTotal(response.total ?? 0)
+      } catch (error) {
+        if (cancelled) return
+        console.error('Failed to fetch viewers:', error)
+        toastManager.add({ title: 'Failed to load viewers', type: 'error' })
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [user, offset, search, statusFilter, premiumFilter, platformFilter, refreshKey])
+
+  const refetchViewers = () => setRefreshKey((k) => k + 1)
+
+  const openActivity = async (viewer: ViewerSession) => {
+    setActivityViewer(viewer)
+    setActivity(null)
+    setActivityLoading(true)
     try {
-      setLoading(true)
-      const response = await apiClient.get<{ viewers: ViewerSession[] }>(
-        '/api/v1/admin/viewers?limit=100'
-      )
-      setViewers(response.viewers)
+      const data = await apiClient.get<ViewerActivity>(`/api/v1/admin/viewers/${viewer.id}/activity`)
+      setActivity(data)
     } catch (error) {
-      console.error('Failed to fetch viewers:', error)
-      toastManager.add({ title: 'Failed to load viewers', type: 'error' })
+      console.error('Failed to fetch viewer activity:', error)
+      toastManager.add({ title: 'Failed to load activity', type: 'error' })
     } finally {
-      setLoading(false)
+      setActivityLoading(false)
     }
   }
 
@@ -125,7 +222,7 @@ export default function AdminViewersPage() {
       setShowBanModal(false)
       setSelectedViewer(null)
       setBanReason('')
-      fetchViewers()
+      refetchViewers()
     } catch (error) {
       console.error('Failed to ban viewer:', error)
       toastManager.add({ title: 'Failed to ban viewer', type: 'error' })
@@ -140,7 +237,7 @@ export default function AdminViewersPage() {
       await apiClient.post(`/api/v1/admin/viewers/${viewerId}/unban`, {})
       toastManager.add({ title: `${username} unbanned successfully`, type: 'success' })
       setUnbanDialogViewer(null)
-      fetchViewers()
+      refetchViewers()
     } catch (error) {
       console.error('Failed to unban viewer:', error)
       toastManager.add({ title: 'Failed to unban viewer', type: 'error' })
@@ -165,7 +262,7 @@ export default function AdminViewersPage() {
         type: 'success',
       })
       setPremiumDialogViewer(null)
-      fetchViewers()
+      refetchViewers()
     } catch (error) {
       console.error('Failed to update viewer premium:', error)
       toastManager.add({ title: 'Failed to update premium status', type: 'error' })
@@ -174,16 +271,21 @@ export default function AdminViewersPage() {
     }
   }
 
-  const bannedCount = viewers.filter((v) => v.is_banned).length
-  const activeCount = viewers.filter((v) => !v.is_banned).length
-  const premiumCount = viewers.filter((v) => v.is_premium).length
+  const pageStart = total === 0 ? 0 : offset + 1
+  const pageEnd = Math.min(offset + viewers.length, total)
+  const hasPrev = offset > 0
+  const hasNext = offset + PAGE_SIZE < total
 
   // Interactive controls shared between the desktop table and the mobile card list.
   // These render only triggers; the dialogs themselves are hosted once at page level
   // (below) so they aren't duplicated across the table/card breakpoints.
   function renderPremiumControl(viewer: ViewerSession) {
     if (!viewer.viewer_id) {
-      return <span className="text-xs text-text-dim">—</span>
+      return (
+        <span className="text-xs text-text-dim" title="Session-only viewer (no linked account)">
+          —
+        </span>
+      )
     }
     return (
       <button
@@ -206,30 +308,58 @@ export default function AdminViewersPage() {
     )
   }
 
-  function renderActionControl(viewer: ViewerSession) {
-    if (viewer.is_banned) {
-      return (
-        <Button
-          variant="outline"
-          size="sm"
-          aria-label={`${banningId === viewer.id ? 'Unbanning' : 'Unban'} ${viewer.username}`}
-          disabled={banningId === viewer.id}
-          onClick={() => setUnbanDialogViewer(viewer)}
-        >
-          {banningId === viewer.id ? 'Unbanning...' : 'Unban'}
-        </Button>
-      )
-    }
+  function renderActionControls(viewer: ViewerSession) {
     return (
-      <Button
-        variant="destructive"
-        size="sm"
-        aria-label={`Ban ${viewer.username}`}
-        disabled={banningId === viewer.id}
-        onClick={() => handleBanClick(viewer)}
-      >
-        Ban
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => openActivity(viewer)}>
+          Activity
+        </Button>
+        {viewer.is_banned ? (
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label={`${banningId === viewer.id ? 'Unbanning' : 'Unban'} ${viewer.username}`}
+            disabled={banningId === viewer.id}
+            onClick={() => setUnbanDialogViewer(viewer)}
+          >
+            {banningId === viewer.id ? 'Unbanning...' : 'Unban'}
+          </Button>
+        ) : (
+          <Button
+            variant="destructive"
+            size="sm"
+            aria-label={`Ban ${viewer.username}`}
+            disabled={banningId === viewer.id}
+            onClick={() => handleBanClick(viewer)}
+          >
+            Ban
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  function renderIdentity(viewer: ViewerSession) {
+    return (
+      <div className="flex min-w-0 items-center gap-3">
+        <UserAvatar
+          avatarUrl={viewer.avatar_url ?? undefined}
+          displayName={viewer.display_name || viewer.username}
+          size={32}
+        />
+        <div className="min-w-0">
+          <ChannelLink
+            platform={viewer.platform}
+            channelId={viewer.username}
+            channelName={viewer.display_name || viewer.username}
+            className="truncate text-sm font-medium text-text"
+          />
+          <div className="truncate text-xs text-text-sub">@{viewer.username}</div>
+          <div className="truncate font-mono text-[0.65rem] text-text-dim">
+            {viewer.platform_user_id}
+          </div>
+        </div>
+      </div>
     )
   }
 
@@ -238,84 +368,137 @@ export default function AdminViewersPage() {
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-text">Viewer Management</h1>
-          <p className="mt-1 text-sm text-text-sub">Manage viewer sessions and bans</p>
+          <p className="mt-1 text-sm text-text-sub">
+            Search viewer sessions, inspect activity, and manage bans and premium
+          </p>
         </div>
-        <span className="text-sm text-text-sub">{viewers.length} total</span>
+        <span className="text-sm text-text-sub">{total.toLocaleString()} matching</span>
       </div>
 
-      {/* Stats */}
-      <div className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <Card className="p-4">
-          <div className="text-xs text-text-sub">Total Viewers</div>
-          <div className="text-2xl font-bold text-text">{viewers.length}</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xs text-text-sub">Premium</div>
-          <div className="text-2xl font-bold text-amber-400">{premiumCount}</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xs text-text-sub">Banned</div>
-          <div className="text-destructive text-2xl font-bold">{bannedCount}</div>
-        </Card>
-        <Card className="p-4">
-          <div className="text-xs text-text-sub">Active</div>
-          <div className="text-2xl font-bold text-kick">{activeCount}</div>
-        </Card>
-      </div>
+      {/* Search + filters (server-side) */}
+      <Card className="mb-6 p-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="lg:col-span-2">
+            <label htmlFor={searchId} className="mb-2 block text-sm font-medium text-text-sub">
+              Search
+            </label>
+            <input
+              id={searchId}
+              type="text"
+              placeholder="Username, display name, or platform user ID..."
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className="focus-visible:ring-ring block w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-text placeholder:text-text-dim focus-visible:ring-2 focus-visible:outline-none sm:text-sm"
+            />
+          </div>
+          <div>
+            <label htmlFor={platformId} className="mb-2 block text-sm font-medium text-text-sub">
+              Platform
+            </label>
+            <select
+              id={platformId}
+              value={platformFilter}
+              onChange={(e) => {
+                setPlatformFilter(e.target.value)
+                setOffset(0)
+              }}
+              className="focus-visible:ring-ring block w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-text focus-visible:ring-2 focus-visible:outline-none sm:text-sm"
+            >
+              <option value="all">All platforms</option>
+              <option value="twitch">Twitch</option>
+              <option value="youtube">YouTube</option>
+              <option value="kick">Kick</option>
+              <option value="tiktok">TikTok</option>
+            </select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor={statusId} className="mb-2 block text-sm font-medium text-text-sub">
+                Status
+              </label>
+              <select
+                id={statusId}
+                value={statusFilter}
+                onChange={(e) => {
+                  setStatusFilter(e.target.value as typeof statusFilter)
+                  setOffset(0)
+                }}
+                className="focus-visible:ring-ring block w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-text focus-visible:ring-2 focus-visible:outline-none sm:text-sm"
+              >
+                <option value="all">Any</option>
+                <option value="active">Active</option>
+                <option value="banned">Banned</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor={premiumId} className="mb-2 block text-sm font-medium text-text-sub">
+                Premium
+              </label>
+              <select
+                id={premiumId}
+                value={premiumFilter}
+                onChange={(e) => {
+                  setPremiumFilter(e.target.value as typeof premiumFilter)
+                  setOffset(0)
+                }}
+                className="focus-visible:ring-ring block w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-text focus-visible:ring-2 focus-visible:outline-none sm:text-sm"
+              >
+                <option value="all">Any</option>
+                <option value="premium">Premium</option>
+                <option value="free">Free</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </Card>
 
-      {/* Viewers Table */}
+      {/* Viewers Table (desktop) */}
       {loading ? (
         <Card className="space-y-3 p-6">
           {Array.from({ length: 8 }).map((_, i) => (
             <Skeleton key={i} className="h-10 w-full rounded-lg" />
           ))}
         </Card>
+      ) : viewers.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-text-dim">
+          No viewer sessions match your search or filters.
+        </Card>
       ) : (
-        <Card className="hidden overflow-hidden md:block">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <caption className="sr-only">Viewers</caption>
-              <thead className="border-b border-border bg-surface-2">
-                <tr>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Username
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Platform
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Last Message
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Msg Count (1m/1h)
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Premium
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Status
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
-                    Actions
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border">
-                {viewers.length === 0 ? (
+        <>
+          <Card className="hidden overflow-hidden md:block">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <caption className="sr-only">Viewers</caption>
+                <thead className="border-b border-border bg-surface-2">
                   <tr>
-                    <td colSpan={7} className="px-4 py-8 text-center text-text-dim">
-                      No viewer sessions found
-                    </td>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Viewer
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Platform
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Last Message
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Premium
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Status
+                    </th>
+                    <th scope="col" className="px-4 py-3 text-left font-medium text-text-sub">
+                      Actions
+                    </th>
                   </tr>
-                ) : (
-                  viewers.map((viewer) => (
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {viewers.map((viewer) => (
                     <tr key={viewer.id} className="transition-colors hover:bg-surface-2">
                       <th scope="row" className="px-4 py-3 text-left font-normal">
-                        <div className="text-sm font-medium text-text">{viewer.username}</div>
-                        <div className="text-xs text-text-sub">{viewer.display_name}</div>
+                        {renderIdentity(viewer)}
                       </th>
                       <td className="px-4 py-3">
-                        <span className="text-sm text-text-sub capitalize">{viewer.platform}</span>
+                        <PlatformBadge platform={viewer.platform} size="sm" />
                       </td>
                       <td className="px-4 py-3 text-sm text-text-sub">
                         {viewer.last_message_at
@@ -323,9 +506,6 @@ export default function AdminViewersPage() {
                               addSuffix: true,
                             })
                           : 'Never'}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-text-sub">
-                        {viewer.message_count_1min}/{viewer.message_count_1hour}
                       </td>
                       <td className="px-4 py-3">{renderPremiumControl(viewer)}</td>
                       <td className="px-4 py-3">
@@ -346,29 +526,20 @@ export default function AdminViewersPage() {
                           </span>
                         )}
                       </td>
-                      <td className="px-4 py-3">{renderActionControl(viewer)}</td>
+                      <td className="px-4 py-3">{renderActionControls(viewer)}</td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </Card>
-      )}
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
 
-      {/* Mobile card list */}
-      {!loading && (
-        <div className="space-y-3 md:hidden">
-          {viewers.length === 0 ? (
-            <Card className="p-6 text-center text-text-dim">No viewer sessions found</Card>
-          ) : (
-            viewers.map((viewer) => (
+          {/* Mobile card list */}
+          <div className="space-y-3 md:hidden">
+            {viewers.map((viewer) => (
               <Card key={viewer.id} className="p-4">
                 <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-text">{viewer.username}</div>
-                    <div className="truncate text-xs text-text-sub">{viewer.display_name}</div>
-                  </div>
+                  {renderIdentity(viewer)}
                   {viewer.is_banned ? (
                     <span className="bg-destructive/10 text-destructive inline-flex shrink-0 items-center rounded px-2 py-0.5 text-xs font-medium">
                       BANNED
@@ -380,14 +551,11 @@ export default function AdminViewersPage() {
                   )}
                 </div>
                 <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-sub">
-                  <span className="capitalize">{viewer.platform}</span>
+                  <PlatformBadge platform={viewer.platform} size="sm" />
                   <span>
                     {viewer.last_message_at
                       ? formatDistanceToNow(new Date(viewer.last_message_at), { addSuffix: true })
                       : 'Never'}
-                  </span>
-                  <span>
-                    {viewer.message_count_1min}/{viewer.message_count_1hour} msgs
                   </span>
                 </div>
                 {viewer.is_banned && viewer.banned_reason && (
@@ -395,13 +563,129 @@ export default function AdminViewersPage() {
                 )}
                 <div className="mt-3 flex items-center justify-between gap-3">
                   {renderPremiumControl(viewer)}
-                  {renderActionControl(viewer)}
+                  {renderActionControls(viewer)}
                 </div>
               </Card>
-            ))
-          )}
-        </div>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          <div className="mt-4 flex items-center justify-between text-sm text-text-sub">
+            <span>
+              Showing {pageStart.toLocaleString()}–{pageEnd.toLocaleString()} of{' '}
+              {total.toLocaleString()}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasPrev}
+                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasNext}
+                onClick={() => setOffset(offset + PAGE_SIZE)}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </>
       )}
+
+      {/* Activity dialog — streamer context for a viewer */}
+      <Dialog.Root
+        open={!!activityViewer}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActivityViewer(null)
+            setActivity(null)
+          }
+        }}
+      >
+        {activityViewer && (
+          <Dialog.Content>
+            <Dialog.Title>Activity for &ldquo;{activityViewer.username}&rdquo;</Dialog.Title>
+            <Dialog.Description>
+              Messages this viewer has sent through All-Chat, and whose chats they appear in.
+            </Dialog.Description>
+            {activityLoading ? (
+              <div className="mt-4 space-y-2">
+                <Skeleton className="h-10 w-full rounded-lg" />
+                <Skeleton className="h-10 w-full rounded-lg" />
+              </div>
+            ) : activity ? (
+              <div className="mt-4">
+                <div className="mb-4 flex gap-6 text-sm">
+                  <div>
+                    <div className="text-xs text-text-sub">Total messages</div>
+                    <div className="text-lg font-semibold text-text">
+                      {activity.total_messages.toLocaleString()}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-text-sub">Last message</div>
+                    <div className="text-lg font-semibold text-text">
+                      {activity.last_sent_at
+                        ? formatDistanceToNow(new Date(activity.last_sent_at), { addSuffix: true })
+                        : 'Never'}
+                    </div>
+                  </div>
+                </div>
+                {activity.streamers.length > 0 ? (
+                  <ul className="max-h-72 space-y-2 overflow-y-auto">
+                    {activity.streamers.map((s, i) => (
+                      <li
+                        key={`${s.streamer_user_id}-${s.overlay_id ?? i}`}
+                        className="rounded-lg border border-border p-3"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <Link
+                              href={`/admin/users?user=${s.streamer_user_id}`}
+                              className="text-sm font-medium text-primary hover:underline"
+                            >
+                              {s.streamer_username ? `@${s.streamer_username}` : 'View streamer'}
+                            </Link>
+                            <div className="mt-0.5 flex items-center gap-2 text-xs text-text-sub">
+                              <PlatformBadge platform={s.platform} size="sm" />
+                              <span className="truncate">{s.channel_name}</span>
+                            </div>
+                          </div>
+                          <div className="shrink-0 text-right">
+                            <div className="text-sm font-semibold text-text">
+                              {s.message_count.toLocaleString()}
+                            </div>
+                            {s.overlay_id && (
+                              <Link
+                                href={`/admin/overlays?overlay=${s.overlay_id}`}
+                                className="text-xs text-text-sub hover:underline"
+                              >
+                                overlay
+                              </Link>
+                            )}
+                          </div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm text-text-dim italic">
+                    No message activity recorded for this viewer.
+                  </p>
+                )}
+              </div>
+            ) : null}
+            <div className="mt-6 flex justify-end">
+              <Dialog.Close render={<Button variant="outline">Close</Button>} />
+            </div>
+          </Dialog.Content>
+        )}
+      </Dialog.Root>
 
       {/* Premium toggle confirmation — single instance shared by table + cards */}
       <Dialog.Root

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -41,22 +41,41 @@ import { Dialog } from '@/components/ui/dialog'
 import { useAuthStore } from '@/lib/stores/auth-store'
 import { cn } from '@/lib/utils'
 
-interface AdminLink {
+export interface AdminLink {
   href: string
   label: string
   icon: LucideIcon
   exact?: boolean
+  // Shown on the dashboard home nav grid (not the rail).
+  description?: string
 }
 
-const ADMIN_LINKS: AdminLink[] = [
+// Single source of truth for admin navigation, shared by the sidebar rail and
+// the dashboard home grid so the two can never drift apart.
+export const ADMIN_LINKS: AdminLink[] = [
   { href: '/admin', label: 'Dashboard', icon: LayoutDashboard, exact: true },
-  { href: '/admin/users', label: 'Users', icon: Users },
-  { href: '/admin/overlays', label: 'Overlays', icon: LayoutGrid },
-  { href: '/admin/sources', label: 'Sources', icon: Radio },
-  { href: '/admin/viewers', label: 'Viewers', icon: Eye },
-  { href: '/admin/cosmetics', label: 'Cosmetics', icon: Sparkles },
-  { href: '/admin/features', label: 'Features', icon: Flag },
-  { href: '/admin/maintenance', label: 'Maintenance', icon: Wrench },
+  { href: '/admin/users', label: 'Users', icon: Users, description: 'View and manage users' },
+  {
+    href: '/admin/overlays',
+    label: 'Overlays',
+    icon: LayoutGrid,
+    description: 'Overlays and their owners',
+  },
+  { href: '/admin/sources', label: 'Sources', icon: Radio, description: 'Every chat source' },
+  { href: '/admin/viewers', label: 'Viewers', icon: Eye, description: 'Viewer sessions and bans' },
+  {
+    href: '/admin/cosmetics',
+    label: 'Cosmetics',
+    icon: Sparkles,
+    description: 'Avatar frames and flairs',
+  },
+  { href: '/admin/features', label: 'Features', icon: Flag, description: 'Premium feature gates' },
+  {
+    href: '/admin/maintenance',
+    label: 'Maintenance',
+    icon: Wrench,
+    description: 'Maintenance mode and ops',
+  },
 ]
 
 function isActive(pathname: string | null, href: string, exact?: boolean): boolean {
@@ -145,10 +164,14 @@ export function AdminSidebar() {
   const pathname = usePathname()
   const [open, setOpen] = useState(false)
 
-  // Close the mobile drawer whenever the route changes.
-  useEffect(() => {
+  // Close the mobile drawer whenever the route changes. Done during render via
+  // React's "previous value" pattern rather than an effect, which avoids a
+  // synchronous setState in an effect body (react-hooks/set-state-in-effect).
+  const [lastPathname, setLastPathname] = useState(pathname)
+  if (pathname !== lastPathname) {
+    setLastPathname(pathname)
     setOpen(false)
-  }, [pathname])
+  }
 
   // Close the drawer when the viewport grows to the desktop breakpoint, so the
   // dialog's focus trap and scroll lock don't linger invisibly behind the rail.

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -23,6 +23,7 @@ import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import {
   LayoutDashboard,
+  Search,
   Users,
   LayoutGrid,
   Radio,
@@ -54,6 +55,7 @@ export interface AdminLink {
 // the dashboard home grid so the two can never drift apart.
 export const ADMIN_LINKS: AdminLink[] = [
   { href: '/admin', label: 'Dashboard', icon: LayoutDashboard, exact: true },
+  { href: '/admin/search', label: 'Search', icon: Search, description: 'Find any user, overlay, source, or viewer' },
   { href: '/admin/users', label: 'Users', icon: Users, description: 'View and manage users' },
   {
     href: '/admin/overlays',

--- a/frontend/src/components/ChannelLink.tsx
+++ b/frontend/src/components/ChannelLink.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { ExternalLink } from 'lucide-react'
+import clsx from 'clsx'
+import { channelUrl } from '@/lib/platform-channel-url'
+
+/**
+ * Renders a chat source's channel name as a link to its public page on the
+ * origin platform (twitch.tv/…, kick.com/…, tiktok.com/@…, youtube.com/@…).
+ * When no trustworthy URL can be built (discord, shared_overlay, ambiguous
+ * YouTube ids) it falls back to plain text, so it is always safe to use.
+ */
+export function ChannelLink({
+  platform,
+  channelId,
+  channelName,
+  channelHandle,
+  className,
+}: {
+  platform: string
+  channelId: string
+  channelName?: string
+  channelHandle?: string | null
+  className?: string
+}) {
+  const url = channelUrl(platform, channelId, channelHandle)
+  const label = channelName || channelId || channelHandle || 'unknown'
+
+  if (!url) {
+    return <span className={className}>{label}</span>
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Open ${label} on ${platform} (opens in a new tab)`}
+      className={clsx('inline-flex items-center gap-1 hover:underline', className)}
+    >
+      {label}
+      <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 opacity-70" />
+    </a>
+  )
+}

--- a/frontend/src/components/__tests__/ChannelLink.test.tsx
+++ b/frontend/src/components/__tests__/ChannelLink.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { ChannelLink } from '../ChannelLink'
+
+describe('ChannelLink', () => {
+  afterEach(cleanup)
+
+  it('links a Twitch source to its channel page and opens safely in a new tab', () => {
+    const { getByRole } = render(
+      <ChannelLink platform="twitch" channelId="xqc" channelName="xQc" />
+    )
+    const link = getByRole('link') as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('https://twitch.tv/xqc')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+    expect(link.textContent).toContain('xQc')
+  })
+
+  it('renders plain text (no link) for a non-addressable platform', () => {
+    const { queryByRole, getByText } = render(
+      <ChannelLink platform="shared_overlay" channelId="overlay-uuid" channelName="Shared" />
+    )
+    expect(queryByRole('link')).toBeNull()
+    expect(getByText('Shared')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/ui/__tests__/badge.test.tsx
+++ b/frontend/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+
+/**
+ * PlatformBadge tests (TDD).
+ *
+ * Regression guard: rendering a source whose platform is not a chromatic key
+ * (e.g. 'shared_overlay', which has no PLATFORM_COLORS entry and no CSS color
+ * var) must NOT throw. Previously `PLATFORM_COLORS[platform].text` dereferenced
+ * undefined and crashed the whole admin page.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { PlatformBadge } from '../badge'
+
+describe('PlatformBadge', () => {
+  it('renders a known platform with its color class and label', () => {
+    const { getByText } = render(<PlatformBadge platform="twitch" />)
+    const badge = getByText('TWITCH')
+    expect(badge.className).toContain('text-twitch')
+    expect(badge.getAttribute('data-platform')).toBe('twitch')
+  })
+
+  it('does not throw for an unknown platform and falls back to system styling', () => {
+    let rendered: ReturnType<typeof render> | undefined
+    expect(() => {
+      rendered = render(<PlatformBadge platform="shared_overlay" />)
+    }).not.toThrow()
+    // Friendly label: underscores become spaces.
+    const badge = rendered!.getByText('SHARED OVERLAY')
+    // System fallback text color (not a broken/undefined class).
+    expect(badge.className).toContain('text-text-sub')
+  })
+
+  it('renders discord (in the color map) without throwing', () => {
+    expect(() => render(<PlatformBadge platform="discord" />)).not.toThrow()
+  })
+})

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -45,24 +45,32 @@ function Badge({
   return <span data-slot="badge" className={cn(badgeVariants({ size, className }))} {...props} />
 }
 
-// Platform-coded badge with glow dot
+// Platform-coded badge with glow dot.
+//
+// `platform` is typed as `string` (not `Platform`) on purpose: admin surfaces
+// render sources whose platform can be `discord` or `shared_overlay`, and the
+// set of stored platforms can outgrow the chromatic color map. Any platform
+// without a PLATFORM_COLORS entry (and thus without a `--color-*` / glow CSS
+// var) falls back to neutral `system` styling instead of dereferencing
+// undefined and crashing the page.
 function PlatformBadge({
   platform,
   size,
   className,
 }: {
-  platform: Platform
+  platform: string
   size?: 'default' | 'sm'
   className?: string
 }) {
-  const isSystem = platform === 'system'
+  const resolved: Platform = platform in PLATFORM_COLORS ? (platform as Platform) : 'system'
+  const isSystem = resolved === 'system'
   const glowStyle = isSystem
     ? { backgroundColor: 'var(--color-text-dim)', boxShadow: 'none' }
     : {
-        backgroundColor: `var(--color-${platform})`,
-        boxShadow: `var(--shadow-glow-${platform})`,
+        backgroundColor: `var(--color-${resolved})`,
+        boxShadow: `var(--shadow-glow-${resolved})`,
       }
-  const textClass = PLATFORM_COLORS[platform].text
+  const textClass = PLATFORM_COLORS[resolved].text
 
   return (
     <span
@@ -75,7 +83,7 @@ function PlatformBadge({
         style={glowStyle}
         aria-hidden="true"
       />
-      {platform.toUpperCase()}
+      {platform.replace(/_/g, ' ').toUpperCase()}
     </span>
   )
 }

--- a/frontend/src/lib/__tests__/platform-channel-url.test.ts
+++ b/frontend/src/lib/__tests__/platform-channel-url.test.ts
@@ -1,0 +1,65 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { channelUrl } from '../platform-channel-url'
+
+describe('channelUrl', () => {
+  it('builds a Twitch URL from the login (lowercased)', () => {
+    expect(channelUrl('twitch', 'XQC')).toBe('https://twitch.tv/xqc')
+  })
+
+  it('builds a Kick URL from the slug', () => {
+    expect(channelUrl('kick', 'xqc')).toBe('https://kick.com/xqc')
+  })
+
+  it('builds a TikTok URL, tolerating a leading @', () => {
+    expect(channelUrl('tiktok', 'someone')).toBe('https://www.tiktok.com/@someone')
+    expect(channelUrl('tiktok', '@someone')).toBe('https://www.tiktok.com/@someone')
+  })
+
+  it('prefers a YouTube @handle when present', () => {
+    expect(channelUrl('youtube', 'UCsomethingignored0000000', '@MrBeast')).toBe(
+      'https://www.youtube.com/@MrBeast'
+    )
+    expect(channelUrl('youtube', '', 'MrBeast')).toBe('https://www.youtube.com/@MrBeast')
+  })
+
+  it('builds a YouTube /channel/ URL only for a canonical UC… id', () => {
+    expect(channelUrl('youtube', 'UC-lHJZR3Gqxm24_Vd_AJ5Yw')).toBe(
+      'https://www.youtube.com/channel/UC-lHJZR3Gqxm24_Vd_AJ5Yw'
+    )
+  })
+
+  it('returns null for a YouTube id that is not a UC… channel id and no handle', () => {
+    // e.g. a legacy row holding a handle/display in channel_id, or a Google account id.
+    expect(channelUrl('youtube', 'someLegacyValue')).toBeNull()
+    expect(channelUrl('youtube', '')).toBeNull()
+  })
+
+  it('returns null for non-addressable platforms', () => {
+    expect(channelUrl('discord', '123456789012345678')).toBeNull()
+    expect(channelUrl('shared_overlay', 'some-overlay-uuid')).toBeNull()
+    expect(channelUrl('unknown', 'x')).toBeNull()
+  })
+
+  it('returns null when the identifier is empty', () => {
+    expect(channelUrl('twitch', '')).toBeNull()
+    expect(channelUrl('kick', '   ')).toBeNull()
+  })
+})

--- a/frontend/src/lib/platform-channel-url.ts
+++ b/frontend/src/lib/platform-channel-url.ts
@@ -1,0 +1,73 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Resolve a chat source to its public channel page on the origin platform.
+ *
+ * Grounded in how the backend stores each platform's channel identifier
+ * (see services/overlay-manager/handlers/sources.go):
+ *   - twitch: `channelId` is the lowercased login  -> twitch.tv/{login}
+ *   - kick:   `channelId` is the slug (non-numeric) -> kick.com/{slug}
+ *   - tiktok: `channelId` is the username           -> tiktok.com/@{username}
+ *   - youtube: ambiguous. Prefer a real @handle when we have one; otherwise
+ *     only build a /channel/ link when `channelId` is a genuine `UC…` channel
+ *     id. The account-linked `youtube_id` elsewhere is a Google account id, not
+ *     a channel id, so callers must pass the SOURCE channel id here, never that.
+ *   - discord: `channelId` is a numeric snowflake (not web-addressable) -> null
+ *   - shared_overlay / anything else: not a real channel -> null
+ *
+ * Returns `null` when no trustworthy public URL can be built; callers render
+ * plain text in that case.
+ */
+export function channelUrl(
+  platform: string,
+  channelId: string,
+  channelHandle?: string | null
+): string | null {
+  const id = (channelId ?? '').trim()
+  const handle = (channelHandle ?? '').trim()
+
+  switch (platform) {
+    case 'twitch': {
+      const login = (id || handle).toLowerCase()
+      return login ? `https://twitch.tv/${encodeURIComponent(login)}` : null
+    }
+    case 'kick': {
+      const slug = id || handle
+      return slug ? `https://kick.com/${encodeURIComponent(slug)}` : null
+    }
+    case 'tiktok': {
+      const username = (id || handle).replace(/^@+/, '')
+      return username ? `https://www.tiktok.com/@${encodeURIComponent(username)}` : null
+    }
+    case 'youtube': {
+      if (handle) {
+        const h = handle.replace(/^@+/, '')
+        return h ? `https://www.youtube.com/@${encodeURIComponent(h)}` : null
+      }
+      // Only trust a /channel/ link for a canonical UC… channel id.
+      if (/^UC[A-Za-z0-9_-]{20,}$/.test(id)) {
+        return `https://www.youtube.com/channel/${encodeURIComponent(id)}`
+      }
+      return null
+    }
+    default:
+      // discord (snowflake), shared_overlay (overlay UUID), unknown.
+      return null
+  }
+}

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -458,6 +458,7 @@ func main() {
 
 		// Viewer management
 		admin.GET("/viewers", adminViewerHandler.HandleListViewers)
+		admin.GET("/viewers/:session_id/activity", adminViewerHandler.HandleGetViewerActivity)
 		admin.POST("/viewers/:session_id/ban", adminViewerHandler.HandleBanViewer)
 		admin.POST("/viewers/:session_id/unban", adminViewerHandler.HandleUnbanViewer)
 		admin.POST("/viewers/:session_id/premium", adminViewerHandler.HandleSetViewerPremium)

--- a/services/auth-service/handlers/admin_viewers.go
+++ b/services/auth-service/handlers/admin_viewers.go
@@ -46,7 +46,10 @@ type BanRequest struct {
 	Reason string `json:"reason"`
 }
 
-// HandleListViewers lists all viewer sessions with pagination
+// HandleListViewers lists viewer sessions with pagination, search and filters.
+// Query params: limit/offset (pagination), q (case-insensitive search over
+// username/display_name/platform_user_id), is_banned and is_premium (bool,
+// applied only when present), platform (exact match).
 func (h *AdminViewerHandler) HandleListViewers(c *gin.Context) {
 	// Parse pagination parameters
 	limit := 50
@@ -64,8 +67,25 @@ func (h *AdminViewerHandler) HandleListViewers(c *gin.Context) {
 		}
 	}
 
+	// Build the filter. Bool filters apply only when the param is present so the
+	// UI can distinguish "any" from "explicitly false".
+	filter := repository.ViewerListFilter{
+		Query:    c.Query("q"),
+		Platform: c.Query("platform"),
+	}
+	if v := c.Query("is_banned"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			filter.IsBanned = &b
+		}
+	}
+	if v := c.Query("is_premium"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			filter.IsPremium = &b
+		}
+	}
+
 	ctx := c.Request.Context()
-	sessions, err := h.viewerRepo.ListAll(ctx, limit, offset)
+	sessions, total, err := h.viewerRepo.ListAll(ctx, filter, limit, offset)
 	if err != nil {
 		h.log.Error("Failed to list viewers", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list viewers"})
@@ -80,9 +100,31 @@ func (h *AdminViewerHandler) HandleListViewers(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"viewers": sessions,
+		"total":   total,
 		"limit":   limit,
 		"offset":  offset,
 	})
+}
+
+// HandleGetViewerActivity returns a viewer session's message-sending history
+// summary (totals + per-streamer breakdown) for the admin Viewers page.
+func (h *AdminViewerHandler) HandleGetViewerActivity(c *gin.Context) {
+	sessionIDStr := c.Param("session_id")
+	sessionID, err := uuid.Parse(sessionIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session ID"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	activity, err := h.viewerRepo.GetViewerActivity(ctx, sessionID)
+	if err != nil {
+		h.log.Error("Failed to get viewer activity", zap.Error(err), zap.String("session_id", sessionIDStr))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get viewer activity"})
+		return
+	}
+
+	c.JSON(http.StatusOK, activity)
 }
 
 // HandleBanViewer bans a viewer from sending messages

--- a/services/auth-service/handlers/admin_viewers_test.go
+++ b/services/auth-service/handlers/admin_viewers_test.go
@@ -97,6 +97,31 @@ func TestHandleSetViewerPremium_InvalidBody(t *testing.T) {
 	}
 }
 
+// TestHandleGetViewerActivity_InvalidSessionID: a non-UUID session id is rejected
+// with 400 before any DB access, so a nil repo proves the short-circuit.
+func TestHandleGetViewerActivity_InvalidSessionID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	logger := zap.NewNop()
+	handler := &AdminViewerHandler{log: logger, viewerRepo: nil}
+	r.GET("/admin/viewers/:session_id/activity", handler.HandleGetViewerActivity)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/viewers/not-a-uuid/activity", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["error"] != "invalid session ID" {
+		t.Errorf("unexpected error: %s", resp["error"])
+	}
+}
+
 // TestHandleSetViewerPremium_RejectsBadDuration: a non-positive or over-cap
 // duration_seconds is rejected with 400 before any DB access (ADR-0027). A nil repo
 // proves the validation short-circuits before the repo is touched.

--- a/services/auth-service/models/viewer.go
+++ b/services/auth-service/models/viewer.go
@@ -41,6 +41,7 @@ type ViewerSession struct {
 	IsPremium           bool       `json:"is_premium"`             // Whether viewer has premium access
 	PremiumExpiresAt    *time.Time `json:"premium_expires_at"`     // ADR-0027: time-limited admin premium deadline (NULL = permanent)
 	ViewerID            *uuid.UUID `json:"viewer_id"`              // Linked viewer identity ID
+	UserID              *string    `json:"user_id"`                // Linked streamer account (viewer_sessions.user_id, migration 040); NULL when the viewer has no streamer account
 	IsBanned            bool       `json:"is_banned"`              // Whether viewer is banned
 	BannedAt            *time.Time `json:"banned_at"`              // When viewer was banned
 	BannedReason        *string    `json:"banned_reason"`          // Reason for ban

--- a/services/auth-service/repository/viewer_repository.go
+++ b/services/auth-service/repository/viewer_repository.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caesar/all-chat/services/auth-service/models"
@@ -316,9 +317,56 @@ func (r *ViewerRepository) DecryptRefreshToken(token string) (string, error) {
 	return r.cipher.Decrypt(token)
 }
 
-// ListAll returns all viewer sessions with pagination
-func (r *ViewerRepository) ListAll(ctx context.Context, limit, offset int) ([]models.ViewerSession, error) {
-	query := `
+// ViewerListFilter narrows the viewer session listing for the admin Viewers page.
+// A zero value applies no filtering (returns everything, paginated). Query is a
+// case-insensitive substring match on username / display_name / platform_user_id;
+// IsBanned and IsPremium are equality filters applied only when non-nil; Platform
+// is an equality filter applied only when non-empty.
+type ViewerListFilter struct {
+	Query     string
+	IsBanned  *bool
+	IsPremium *bool
+	Platform  string
+}
+
+// ListAll returns viewer sessions matching filter, paginated by limit/offset, plus
+// the total number of rows matching the filter (ignoring limit/offset) so the admin
+// UI can render pagination. The total is computed with COUNT(*) OVER(), which is
+// evaluated over the full filtered set before LIMIT/OFFSET are applied.
+func (r *ViewerRepository) ListAll(ctx context.Context, filter ViewerListFilter, limit, offset int) ([]models.ViewerSession, int, error) {
+	conditions := make([]string, 0, 4)
+	args := make([]interface{}, 0, 6)
+	argIdx := 1
+
+	if filter.Query != "" {
+		conditions = append(conditions, fmt.Sprintf(
+			"(vs.username ILIKE $%d OR vs.display_name ILIKE $%d OR vs.platform_user_id ILIKE $%d)",
+			argIdx, argIdx, argIdx))
+		args = append(args, "%"+filter.Query+"%")
+		argIdx++
+	}
+	if filter.IsBanned != nil {
+		conditions = append(conditions, fmt.Sprintf("vs.is_banned = $%d", argIdx))
+		args = append(args, *filter.IsBanned)
+		argIdx++
+	}
+	if filter.IsPremium != nil {
+		conditions = append(conditions, fmt.Sprintf("COALESCE(v.is_premium, false) = $%d", argIdx))
+		args = append(args, *filter.IsPremium)
+		argIdx++
+	}
+	if filter.Platform != "" {
+		conditions = append(conditions, fmt.Sprintf("vs.platform = $%d", argIdx))
+		args = append(args, filter.Platform)
+		argIdx++
+	}
+
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	query := fmt.Sprintf(`
 		SELECT vs.id, vs.platform, vs.platform_user_id, vs.username, vs.display_name, vs.avatar_url,
 		       vs.access_token, vs.refresh_token, vs.token_expires_at,
 		       vs.last_message_at, vs.message_count_1min, vs.message_count_1hour,
@@ -326,23 +374,29 @@ func (r *ViewerRepository) ListAll(ctx context.Context, limit, offset int) ([]mo
 		       COALESCE(v.is_premium, false) AS is_premium,
 		       v.premium_admin_override_expires_at,
 		       vs.viewer_id,
+		       vs.user_id,
 		       vs.is_banned, vs.banned_at, vs.banned_reason,
-		       vs.created_at, vs.updated_at
+		       vs.created_at, vs.updated_at,
+		       COUNT(*) OVER() AS total_count
 		FROM viewer_sessions vs
 		LEFT JOIN viewers v ON vs.viewer_id = v.id
+		%s
 		ORDER BY vs.created_at DESC
-		LIMIT $1 OFFSET $2
-	`
+		LIMIT $%d OFFSET $%d
+	`, whereClause, argIdx, argIdx+1)
+	args = append(args, limit, offset)
 
-	rows, err := r.db.Query(ctx, query, limit, offset)
+	rows, err := r.db.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list viewer sessions: %w", err)
+		return nil, 0, fmt.Errorf("failed to list viewer sessions: %w", err)
 	}
 	defer rows.Close()
 
 	sessions := make([]models.ViewerSession, 0)
+	total := 0
 	for rows.Next() {
 		var session models.ViewerSession
+		var rowTotal int
 		err := rows.Scan(
 			&session.ID,
 			&session.Platform,
@@ -361,19 +415,104 @@ func (r *ViewerRepository) ListAll(ctx context.Context, limit, offset int) ([]mo
 			&session.IsPremium,
 			&session.PremiumExpiresAt,
 			&session.ViewerID,
+			&session.UserID,
 			&session.IsBanned,
 			&session.BannedAt,
 			&session.BannedReason,
 			&session.CreatedAt,
 			&session.UpdatedAt,
+			&rowTotal,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan viewer session: %w", err)
+			return nil, 0, fmt.Errorf("failed to scan viewer session: %w", err)
 		}
+		total = rowTotal
 		sessions = append(sessions, session)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("failed to iterate viewer sessions: %w", err)
+	}
 
-	return sessions, nil
+	return sessions, total, nil
+}
+
+// ViewerActivityStreamer is one streamer/overlay/channel a viewer has sent
+// messages to, with per-group counts (part of ViewerActivity).
+type ViewerActivityStreamer struct {
+	StreamerUserID   string    `json:"streamer_user_id"`
+	StreamerUsername string    `json:"streamer_username"`
+	OverlayID        *string   `json:"overlay_id"`
+	ChannelName      string    `json:"channel_name"`
+	Platform         string    `json:"platform"`
+	MessageCount     int       `json:"message_count"`
+	LastSentAt       time.Time `json:"last_sent_at"`
+}
+
+// ViewerActivity summarizes a viewer session's message-sending history for the
+// admin Viewers page: overall totals plus a breakdown by streamer/channel.
+type ViewerActivity struct {
+	TotalMessages int                      `json:"total_messages"`
+	LastSentAt    *time.Time               `json:"last_sent_at"`
+	Streamers     []ViewerActivityStreamer `json:"streamers"`
+}
+
+// GetViewerActivity aggregates a viewer session's message history. TotalMessages
+// and LastSentAt are the overall count / most-recent timestamp; Streamers is the
+// per-(streamer, overlay, channel, platform) breakdown resolving the streamer's
+// username, ordered by most-recent activity and capped at 10. All reads are
+// scoped by viewer_session_id (indexed), so this is cheap.
+func (r *ViewerRepository) GetViewerActivity(ctx context.Context, viewerSessionID uuid.UUID) (*ViewerActivity, error) {
+	activity := &ViewerActivity{Streamers: make([]ViewerActivityStreamer, 0)}
+
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*), MAX(sent_at)
+		FROM viewer_message_history
+		WHERE viewer_session_id = $1
+	`, viewerSessionID).Scan(&activity.TotalMessages, &activity.LastSentAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to aggregate viewer activity: %w", err)
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT h.streamer_user_id,
+		       COALESCE(u.username, '') AS streamer_username,
+		       h.overlay_id,
+		       h.channel_name,
+		       h.platform,
+		       COUNT(*) AS message_count,
+		       MAX(h.sent_at) AS last_sent_at
+		FROM viewer_message_history h
+		LEFT JOIN users u ON u.id = h.streamer_user_id
+		WHERE h.viewer_session_id = $1
+		GROUP BY h.streamer_user_id, u.username, h.overlay_id, h.channel_name, h.platform
+		ORDER BY MAX(h.sent_at) DESC
+		LIMIT 10
+	`, viewerSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list viewer activity streamers: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var s ViewerActivityStreamer
+		if err := rows.Scan(
+			&s.StreamerUserID,
+			&s.StreamerUsername,
+			&s.OverlayID,
+			&s.ChannelName,
+			&s.Platform,
+			&s.MessageCount,
+			&s.LastSentAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan viewer activity streamer: %w", err)
+		}
+		activity.Streamers = append(activity.Streamers, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate viewer activity streamers: %w", err)
+	}
+
+	return activity, nil
 }
 
 // BanViewer bans a viewer from sending messages

--- a/services/auth-service/repository/viewer_repository_test.go
+++ b/services/auth-service/repository/viewer_repository_test.go
@@ -1,0 +1,418 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupViewerRepoTestDB starts a PostgreSQL container with the schema the
+// ViewerRepository list/activity queries touch: users, overlays, viewers,
+// viewer_sessions (incl. the migration-040 user_id link) and
+// viewer_message_history.
+func setupViewerRepoTestDB(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:16-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "testuser",
+			"POSTGRES_PASSWORD": "testpass",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Skipf("cannot start postgres testcontainer (docker unavailable?): %v", err)
+	}
+
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		t.Fatalf("container port: %v", err)
+	}
+
+	pool, err := pgxpool.New(ctx, "postgres://testuser:testpass@"+host+":"+port.Port()+"/testdb?sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection pool: %v", err)
+	}
+
+	schema := `
+		CREATE TABLE users (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			username VARCHAR(50) NOT NULL
+		);
+		CREATE TABLE overlays (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID REFERENCES users(id) ON DELETE CASCADE
+		);
+		CREATE TABLE viewers (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			is_premium BOOLEAN NOT NULL DEFAULT FALSE,
+			premium_admin_override_expires_at TIMESTAMP NULL
+		);
+		CREATE TABLE viewer_sessions (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			platform VARCHAR(50) NOT NULL,
+			platform_user_id VARCHAR(100) NOT NULL,
+			username VARCHAR(100) NOT NULL,
+			display_name VARCHAR(200) NOT NULL,
+			avatar_url TEXT,
+			access_token TEXT NOT NULL DEFAULT '',
+			refresh_token TEXT,
+			token_expires_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			last_message_at TIMESTAMP,
+			message_count_1min INTEGER DEFAULT 0,
+			message_count_1hour INTEGER DEFAULT 0,
+			rate_limit_reset_1min TIMESTAMP,
+			rate_limit_reset_1hour TIMESTAMP,
+			viewer_id UUID REFERENCES viewers(id) ON DELETE SET NULL,
+			user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+			is_banned BOOLEAN NOT NULL DEFAULT FALSE,
+			banned_at TIMESTAMP,
+			banned_reason TEXT,
+			created_at TIMESTAMP DEFAULT NOW(),
+			updated_at TIMESTAMP DEFAULT NOW()
+		);
+		CREATE TABLE viewer_message_history (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			viewer_session_id UUID NOT NULL REFERENCES viewer_sessions(id) ON DELETE CASCADE,
+			streamer_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			overlay_id UUID REFERENCES overlays(id) ON DELETE SET NULL,
+			platform VARCHAR(50) NOT NULL,
+			channel_id VARCHAR(100) NOT NULL,
+			channel_name VARCHAR(100) NOT NULL,
+			message_text TEXT NOT NULL,
+			sent_at TIMESTAMP DEFAULT NOW(),
+			success BOOLEAN DEFAULT TRUE,
+			error_message TEXT,
+			created_at TIMESTAMP DEFAULT NOW()
+		);
+	`
+	if _, err := pool.Exec(ctx, schema); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	return pool, func() {
+		pool.Close()
+		_ = container.Terminate(ctx)
+	}
+}
+
+// insertViewer inserts a viewers row and returns its id.
+func insertViewer(t *testing.T, pool *pgxpool.Pool, isPremium bool) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO viewers (is_premium) VALUES ($1) RETURNING id`, isPremium).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert viewer: %v", err)
+	}
+	return id
+}
+
+// insertUserNamed inserts a users row with the given username and returns its id.
+func insertUserNamed(t *testing.T, pool *pgxpool.Pool, username string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (username) VALUES ($1) RETURNING id`, username).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	return id
+}
+
+type sessionSpec struct {
+	platform       string
+	platformUserID string
+	username       string
+	displayName    string
+	viewerID       *uuid.UUID
+	isBanned       bool
+}
+
+// insertSession inserts a viewer_sessions row and returns its id.
+func insertSession(t *testing.T, pool *pgxpool.Pool, s sessionSpec) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO viewer_sessions (platform, platform_user_id, username, display_name, viewer_id, is_banned)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id`,
+		s.platform, s.platformUserID, s.username, s.displayName, s.viewerID, s.isBanned).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	return id
+}
+
+// insertMessage inserts a viewer_message_history row at a specific sent_at.
+func insertMessage(t *testing.T, pool *pgxpool.Pool, sessionID, streamerID uuid.UUID, overlayID *uuid.UUID, platform, channelName string, sentAt time.Time) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO viewer_message_history
+			(viewer_session_id, streamer_user_id, overlay_id, platform, channel_id, channel_name, message_text, sent_at)
+		VALUES ($1, $2, $3, $4, 'chan-id', $5, 'hello', $6)`,
+		sessionID, streamerID, overlayID, platform, channelName, sentAt)
+	if err != nil {
+		t.Fatalf("insert message: %v", err)
+	}
+}
+
+func TestListAll_QueryMatchesUsernameDisplayNamePlatformUserID(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "111", username: "AliceStream", displayName: "Alice"})
+	insertSession(t, pool, sessionSpec{platform: "kick", platformUserID: "222", username: "bob", displayName: "BobbyDisplay"})
+	insertSession(t, pool, sessionSpec{platform: "youtube", platformUserID: "UC_charlie_999", username: "carol", displayName: "Carol"})
+	insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "333", username: "dave", displayName: "Dave"})
+
+	// Match on username (case-insensitive substring).
+	sessions, total, err := repo.ListAll(ctx, repository.ViewerListFilter{Query: "alice"}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll query username: %v", err)
+	}
+	if total != 1 || len(sessions) != 1 || sessions[0].Username != "AliceStream" {
+		t.Fatalf("query 'alice' -> total=%d len=%d, want the AliceStream row", total, len(sessions))
+	}
+
+	// Match on display_name.
+	sessions, total, err = repo.ListAll(ctx, repository.ViewerListFilter{Query: "bobbydisplay"}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll query display_name: %v", err)
+	}
+	if total != 1 || len(sessions) != 1 || sessions[0].Username != "bob" {
+		t.Fatalf("query 'bobbydisplay' -> total=%d len=%d, want the bob row", total, len(sessions))
+	}
+
+	// Match on platform_user_id.
+	sessions, total, err = repo.ListAll(ctx, repository.ViewerListFilter{Query: "charlie"}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll query platform_user_id: %v", err)
+	}
+	if total != 1 || len(sessions) != 1 || sessions[0].Username != "carol" {
+		t.Fatalf("query 'charlie' -> total=%d len=%d, want the carol row", total, len(sessions))
+	}
+}
+
+func TestListAll_BannedPremiumPlatformFilters(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	premiumViewer := insertViewer(t, pool, true)
+	freeViewer := insertViewer(t, pool, false)
+
+	insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "1", username: "banned_premium", displayName: "d", viewerID: &premiumViewer, isBanned: true})
+	insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "2", username: "active_premium", displayName: "d", viewerID: &premiumViewer, isBanned: false})
+	insertSession(t, pool, sessionSpec{platform: "kick", platformUserID: "3", username: "active_free", displayName: "d", viewerID: &freeViewer, isBanned: false})
+	insertSession(t, pool, sessionSpec{platform: "kick", platformUserID: "4", username: "banned_noviewer", displayName: "d", isBanned: true})
+
+	banned := true
+	_, total, err := repo.ListAll(ctx, repository.ViewerListFilter{IsBanned: &banned}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll is_banned: %v", err)
+	}
+	if total != 2 { // banned_premium, banned_noviewer
+		t.Errorf("is_banned=true total = %d, want 2", total)
+	}
+
+	premium := true
+	_, total, err = repo.ListAll(ctx, repository.ViewerListFilter{IsPremium: &premium}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll is_premium: %v", err)
+	}
+	if total != 2 { // banned_premium, active_premium
+		t.Errorf("is_premium=true total = %d, want 2", total)
+	}
+
+	notPremium := false
+	_, total, err = repo.ListAll(ctx, repository.ViewerListFilter{IsPremium: &notPremium}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll is_premium=false: %v", err)
+	}
+	if total != 2 { // active_free, banned_noviewer (NULL viewer -> COALESCE false)
+		t.Errorf("is_premium=false total = %d, want 2", total)
+	}
+
+	_, total, err = repo.ListAll(ctx, repository.ViewerListFilter{Platform: "kick"}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll platform: %v", err)
+	}
+	if total != 2 { // active_free, banned_noviewer
+		t.Errorf("platform=kick total = %d, want 2", total)
+	}
+
+	// Combined: banned AND premium -> only banned_premium.
+	sessions, total, err := repo.ListAll(ctx, repository.ViewerListFilter{IsBanned: &banned, IsPremium: &premium}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll combined: %v", err)
+	}
+	if total != 1 || len(sessions) != 1 || sessions[0].Username != "banned_premium" {
+		t.Fatalf("banned+premium -> total=%d len=%d, want the banned_premium row", total, len(sessions))
+	}
+}
+
+func TestListAll_TotalReflectsFullMatchNotPage(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		insertSession(t, pool, sessionSpec{
+			platform:       "twitch",
+			platformUserID: uuid.NewString(),
+			username:       "match_user",
+			displayName:    "d",
+		})
+	}
+	// A non-matching row that must be excluded from total.
+	insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "x", username: "other", displayName: "d"})
+
+	sessions, total, err := repo.ListAll(ctx, repository.ViewerListFilter{Query: "match_user"}, 2, 0)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Errorf("page len = %d, want 2 (limit)", len(sessions))
+	}
+	if total != 5 {
+		t.Errorf("total = %d, want 5 (full match count, not the page)", total)
+	}
+}
+
+func TestListAll_PopulatesUserID(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	streamerID := insertUserNamed(t, pool, "linked_streamer")
+	_, err := pool.Exec(ctx, `
+		INSERT INTO viewer_sessions (platform, platform_user_id, username, display_name, user_id)
+		VALUES ('twitch', 'linked', 'linkeduser', 'd', $1)`, streamerID)
+	if err != nil {
+		t.Fatalf("insert linked session: %v", err)
+	}
+
+	sessions, _, err := repo.ListAll(ctx, repository.ViewerListFilter{Query: "linkeduser"}, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("want 1 session, got %d", len(sessions))
+	}
+	if sessions[0].UserID == nil || *sessions[0].UserID != streamerID.String() {
+		t.Errorf("UserID = %v, want %s", sessions[0].UserID, streamerID.String())
+	}
+}
+
+func TestGetViewerActivity_AggregatesAndReturnsStreamers(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	session := insertSession(t, pool, sessionSpec{platform: "twitch", platformUserID: "v1", username: "viewer", displayName: "d"})
+	streamerA := insertUserNamed(t, pool, "streamerAlpha")
+	streamerB := insertUserNamed(t, pool, "streamerBeta")
+
+	base := time.Now().UTC().Truncate(time.Second).Add(-time.Hour)
+	// streamerA: 3 messages (latest most recent), streamerB: 1 message (older).
+	insertMessage(t, pool, session, streamerA, nil, "twitch", "alpha_chan", base.Add(10*time.Minute))
+	insertMessage(t, pool, session, streamerA, nil, "twitch", "alpha_chan", base.Add(20*time.Minute))
+	insertMessage(t, pool, session, streamerA, nil, "twitch", "alpha_chan", base.Add(30*time.Minute))
+	insertMessage(t, pool, session, streamerB, nil, "kick", "beta_chan", base.Add(5*time.Minute))
+
+	activity, err := repo.GetViewerActivity(ctx, session)
+	if err != nil {
+		t.Fatalf("GetViewerActivity: %v", err)
+	}
+
+	if activity.TotalMessages != 4 {
+		t.Errorf("TotalMessages = %d, want 4", activity.TotalMessages)
+	}
+	if activity.LastSentAt == nil || !activity.LastSentAt.Equal(base.Add(30*time.Minute)) {
+		t.Errorf("LastSentAt = %v, want %v", activity.LastSentAt, base.Add(30*time.Minute))
+	}
+	if len(activity.Streamers) != 2 {
+		t.Fatalf("Streamers len = %d, want 2", len(activity.Streamers))
+	}
+	// Ordered by MAX(sent_at) DESC: streamerA first.
+	if activity.Streamers[0].StreamerUsername != "streamerAlpha" {
+		t.Errorf("Streamers[0].StreamerUsername = %q, want streamerAlpha", activity.Streamers[0].StreamerUsername)
+	}
+	if activity.Streamers[0].StreamerUserID != streamerA.String() {
+		t.Errorf("Streamers[0].StreamerUserID = %q, want %s", activity.Streamers[0].StreamerUserID, streamerA.String())
+	}
+	if activity.Streamers[0].MessageCount != 3 {
+		t.Errorf("Streamers[0].MessageCount = %d, want 3", activity.Streamers[0].MessageCount)
+	}
+	if activity.Streamers[0].ChannelName != "alpha_chan" {
+		t.Errorf("Streamers[0].ChannelName = %q, want alpha_chan", activity.Streamers[0].ChannelName)
+	}
+	if activity.Streamers[1].StreamerUsername != "streamerBeta" || activity.Streamers[1].MessageCount != 1 {
+		t.Errorf("Streamers[1] = %+v, want streamerBeta count 1", activity.Streamers[1])
+	}
+}
+
+func TestGetViewerActivity_EmptyForUnknownSession(t *testing.T) {
+	pool, cleanup := setupViewerRepoTestDB(t)
+	defer cleanup()
+	repo := repository.NewViewerRepository(pool, nil, nil)
+	ctx := context.Background()
+
+	activity, err := repo.GetViewerActivity(ctx, uuid.New())
+	if err != nil {
+		t.Fatalf("GetViewerActivity: %v", err)
+	}
+	if activity.TotalMessages != 0 {
+		t.Errorf("TotalMessages = %d, want 0", activity.TotalMessages)
+	}
+	if activity.LastSentAt != nil {
+		t.Errorf("LastSentAt = %v, want nil", activity.LastSentAt)
+	}
+	if len(activity.Streamers) != 0 {
+		t.Errorf("Streamers len = %d, want 0", len(activity.Streamers))
+	}
+}

--- a/services/overlay-manager/handlers/admin.go
+++ b/services/overlay-manager/handlers/admin.go
@@ -53,23 +53,27 @@ func (h *AdminHandler) ListOverlays(c *gin.Context) {
 	}
 
 	type OverlayResponse struct {
-		ID           string `json:"id"`
-		Name         string `json:"name"`
-		UserID       string `json:"user_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		SourcesCount int    `json:"sources_count"`
+		ID               string `json:"id"`
+		Name             string `json:"name"`
+		UserID           string `json:"user_id"`
+		OwnerUsername    string `json:"owner_username"`
+		OwnerDisplayName string `json:"owner_display_name"`
+		CreatedAt        string `json:"created_at"`
+		UpdatedAt        string `json:"updated_at"`
+		SourcesCount     int    `json:"sources_count"`
 	}
 
 	response := make([]OverlayResponse, len(overlays))
 	for i, overlay := range overlays {
 		response[i] = OverlayResponse{
-			ID:           overlay.ID,
-			Name:         overlay.Name,
-			UserID:       overlay.UserID,
-			CreatedAt:    overlay.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:    overlay.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			SourcesCount: overlay.SourcesCount,
+			ID:               overlay.ID,
+			Name:             overlay.Name,
+			UserID:           overlay.UserID,
+			OwnerUsername:    overlay.OwnerUsername,
+			OwnerDisplayName: overlay.OwnerDisplayName,
+			CreatedAt:        overlay.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:        overlay.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			SourcesCount:     overlay.SourcesCount,
 		}
 	}
 
@@ -91,29 +95,35 @@ func (h *AdminHandler) ListAllSources(c *gin.Context) {
 
 	// Include overlay information for each source
 	type SourceResponse struct {
-		ID          string `json:"id"`
-		OverlayID   string `json:"overlay_id"`
-		OverlayName string `json:"overlay_name"`
-		Platform    string `json:"platform"`
-		ChannelID   string `json:"channel_id"`
-		ChannelName string `json:"channel_name"`
-		IsActive    bool   `json:"is_active"`
-		CreatedAt   string `json:"created_at"`
-		UserID      string `json:"user_id"`
+		ID               string  `json:"id"`
+		OverlayID        string  `json:"overlay_id"`
+		OverlayName      string  `json:"overlay_name"`
+		Platform         string  `json:"platform"`
+		ChannelID        string  `json:"channel_id"`
+		ChannelName      string  `json:"channel_name"`
+		ChannelHandle    *string `json:"channel_handle,omitempty"`
+		IsActive         bool    `json:"is_active"`
+		CreatedAt        string  `json:"created_at"`
+		UserID           string  `json:"user_id"`
+		OwnerUsername    string  `json:"owner_username"`
+		OwnerDisplayName string  `json:"owner_display_name"`
 	}
 
 	response := make([]SourceResponse, 0, len(sources))
 	for _, source := range sources {
 		response = append(response, SourceResponse{
-			ID:          source.ID,
-			OverlayID:   source.OverlayID,
-			OverlayName: source.OverlayName,
-			Platform:    source.Platform,
-			ChannelID:   source.ChannelID,
-			ChannelName: source.ChannelName,
-			IsActive:    source.IsActive,
-			CreatedAt:   source.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			UserID:      source.UserID,
+			ID:               source.ID,
+			OverlayID:        source.OverlayID,
+			OverlayName:      source.OverlayName,
+			Platform:         source.Platform,
+			ChannelID:        source.ChannelID,
+			ChannelName:      source.ChannelName,
+			ChannelHandle:    source.ChannelHandle,
+			IsActive:         source.IsActive,
+			CreatedAt:        source.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UserID:           source.UserID,
+			OwnerUsername:    source.OwnerUsername,
+			OwnerDisplayName: source.OwnerDisplayName,
 		})
 	}
 
@@ -136,23 +146,27 @@ func (h *AdminHandler) GetUserOverlays(c *gin.Context) {
 	}
 
 	type OverlayResponse struct {
-		ID           string `json:"id"`
-		Name         string `json:"name"`
-		UserID       string `json:"user_id"`
-		CreatedAt    string `json:"created_at"`
-		UpdatedAt    string `json:"updated_at"`
-		SourcesCount int    `json:"sources_count"`
+		ID               string `json:"id"`
+		Name             string `json:"name"`
+		UserID           string `json:"user_id"`
+		OwnerUsername    string `json:"owner_username"`
+		OwnerDisplayName string `json:"owner_display_name"`
+		CreatedAt        string `json:"created_at"`
+		UpdatedAt        string `json:"updated_at"`
+		SourcesCount     int    `json:"sources_count"`
 	}
 
 	response := make([]OverlayResponse, len(overlays))
 	for i, overlay := range overlays {
 		response[i] = OverlayResponse{
-			ID:           overlay.ID,
-			Name:         overlay.Name,
-			UserID:       overlay.UserID,
-			CreatedAt:    overlay.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:    overlay.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			SourcesCount: overlay.SourcesCount,
+			ID:               overlay.ID,
+			Name:             overlay.Name,
+			UserID:           overlay.UserID,
+			OwnerUsername:    overlay.OwnerUsername,
+			OwnerDisplayName: overlay.OwnerDisplayName,
+			CreatedAt:        overlay.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:        overlay.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			SourcesCount:     overlay.SourcesCount,
 		}
 	}
 

--- a/services/overlay-manager/repository/overlay_repo.go
+++ b/services/overlay-manager/repository/overlay_repo.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -276,10 +277,13 @@ func (r *OverlayRepository) GetAllOverlays(ctx context.Context) ([]*models.Overl
 	return overlays, nil
 }
 
-// OverlayWithSourceCount is an overlay paired with its number of chat sources.
+// OverlayWithSourceCount is an overlay paired with its number of chat sources and its
+// owner's identity (LEFT-joined from users; empty strings when the owner row is absent).
 type OverlayWithSourceCount struct {
 	models.Overlay
-	SourcesCount int
+	SourcesCount     int
+	OwnerUsername    string
+	OwnerDisplayName string
 }
 
 // GetAllOverlaysWithSourceCount returns every overlay together with its source
@@ -287,10 +291,12 @@ type OverlayWithSourceCount struct {
 // ListByOverlayID per overlay just to count rows.
 func (r *OverlayRepository) GetAllOverlaysWithSourceCount(ctx context.Context) ([]*OverlayWithSourceCount, error) {
 	query := `
-		SELECT o.id, o.user_id, o.name, o.created_at, o.updated_at, COUNT(s.id) AS sources_count
+		SELECT o.id, o.user_id, o.name, o.created_at, o.updated_at, COUNT(s.id) AS sources_count,
+		       u.username, u.display_name
 		FROM overlays o
 		LEFT JOIN overlay_chat_sources s ON s.overlay_id = o.id
-		GROUP BY o.id
+		LEFT JOIN users u ON u.id = o.user_id
+		GROUP BY o.id, u.id, u.username, u.display_name
 		ORDER BY o.created_at DESC
 	`
 
@@ -303,9 +309,12 @@ func (r *OverlayRepository) GetAllOverlaysWithSourceCount(ctx context.Context) (
 	var overlays []*OverlayWithSourceCount
 	for rows.Next() {
 		var o OverlayWithSourceCount
-		if err := rows.Scan(&o.ID, &o.UserID, &o.Name, &o.CreatedAt, &o.UpdatedAt, &o.SourcesCount); err != nil {
+		var username, displayName sql.NullString
+		if err := rows.Scan(&o.ID, &o.UserID, &o.Name, &o.CreatedAt, &o.UpdatedAt, &o.SourcesCount, &username, &displayName); err != nil {
 			return nil, fmt.Errorf("failed to scan overlay: %w", err)
 		}
+		o.OwnerUsername = username.String
+		o.OwnerDisplayName = displayName.String
 		overlays = append(overlays, &o)
 	}
 
@@ -320,11 +329,13 @@ func (r *OverlayRepository) GetAllOverlaysWithSourceCount(ctx context.Context) (
 // counts in one aggregated query, replacing a per-overlay ListByOverlayID loop.
 func (r *OverlayRepository) ListByUserIDWithSourceCount(ctx context.Context, userID string) ([]*OverlayWithSourceCount, error) {
 	query := `
-		SELECT o.id, o.user_id, o.name, o.created_at, o.updated_at, COUNT(s.id) AS sources_count
+		SELECT o.id, o.user_id, o.name, o.created_at, o.updated_at, COUNT(s.id) AS sources_count,
+		       u.username, u.display_name
 		FROM overlays o
 		LEFT JOIN overlay_chat_sources s ON s.overlay_id = o.id
+		LEFT JOIN users u ON u.id = o.user_id
 		WHERE o.user_id = $1
-		GROUP BY o.id
+		GROUP BY o.id, u.id, u.username, u.display_name
 		ORDER BY o.created_at DESC
 	`
 
@@ -337,9 +348,12 @@ func (r *OverlayRepository) ListByUserIDWithSourceCount(ctx context.Context, use
 	overlays := []*OverlayWithSourceCount{}
 	for rows.Next() {
 		var o OverlayWithSourceCount
-		if err := rows.Scan(&o.ID, &o.UserID, &o.Name, &o.CreatedAt, &o.UpdatedAt, &o.SourcesCount); err != nil {
+		var username, displayName sql.NullString
+		if err := rows.Scan(&o.ID, &o.UserID, &o.Name, &o.CreatedAt, &o.UpdatedAt, &o.SourcesCount, &username, &displayName); err != nil {
 			return nil, fmt.Errorf("failed to scan overlay: %w", err)
 		}
+		o.OwnerUsername = username.String
+		o.OwnerDisplayName = displayName.String
 		overlays = append(overlays, &o)
 	}
 

--- a/services/overlay-manager/repository/overlay_repo_test.go
+++ b/services/overlay-manager/repository/overlay_repo_test.go
@@ -81,6 +81,14 @@ func setupTestDatabase(t *testing.T) (*OverlayRepository, func()) {
 			updated_at TIMESTAMP DEFAULT NOW(),
 			UNIQUE(overlay_id, platform, channel_id)
 		);
+
+		-- Minimal users table (owned by auth-service; shared DB in prod). Required so the
+		-- LEFT JOIN that surfaces the overlay owner in the admin queries resolves.
+		CREATE TABLE IF NOT EXISTS users (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			username VARCHAR(50) NOT NULL,
+			display_name VARCHAR(100)
+		);
 	`)
 	require.NoError(t, err)
 
@@ -410,6 +418,86 @@ func TestOverlayRepository_Delete(t *testing.T) {
 			}
 		})
 	}
+}
+
+// seedUser inserts a users row with the given username/display_name and returns its ID.
+func seedUser(t *testing.T, repo *OverlayRepository, username, displayName string) string {
+	t.Helper()
+	ctx := context.Background()
+	id := uuid.New().String()
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO users (id, username, display_name) VALUES ($1, $2, $3)`,
+		id, username, displayName,
+	)
+	require.NoError(t, err)
+	return id
+}
+
+// TestGetAllOverlaysWithSourceCount_Owner verifies the admin listing joins the owner's
+// username/display_name from the users table, counts sources, and — via the LEFT JOIN —
+// still returns overlays whose owner has no matching users row (orphaned) with empty owner
+// fields rather than dropping them.
+func TestGetAllOverlaysWithSourceCount_Owner(t *testing.T) {
+	repo, cleanup := setupTestDatabase(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Owned overlay: seed a user, an overlay owned by them, and one source.
+	ownerID := seedUser(t, repo, "caesarlp", "CaesarLP")
+	owned := &models.Overlay{UserID: ownerID, Name: "Owned Overlay", IsActive: true}
+	require.NoError(t, repo.Create(ctx, owned))
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO overlay_chat_sources (overlay_id, platform, channel_id, channel_name)
+		 VALUES ($1, 'twitch', 'caesarlp', 'CaesarLP')`, owned.ID)
+	require.NoError(t, err)
+
+	// Orphaned overlay: user_id points at a non-existent users row.
+	orphan := &models.Overlay{UserID: uuid.New().String(), Name: "Orphan Overlay", IsActive: true}
+	require.NoError(t, repo.Create(ctx, orphan))
+
+	results, err := repo.GetAllOverlaysWithSourceCount(ctx)
+	require.NoError(t, err)
+
+	byID := map[string]*OverlayWithSourceCount{}
+	for _, r := range results {
+		byID[r.ID] = r
+	}
+
+	require.Contains(t, byID, owned.ID)
+	assert.Equal(t, "caesarlp", byID[owned.ID].OwnerUsername)
+	assert.Equal(t, "CaesarLP", byID[owned.ID].OwnerDisplayName)
+	assert.Equal(t, 1, byID[owned.ID].SourcesCount)
+
+	require.Contains(t, byID, orphan.ID, "orphaned overlay must still appear (LEFT JOIN)")
+	assert.Equal(t, "", byID[orphan.ID].OwnerUsername, "missing owner => empty username")
+	assert.Equal(t, "", byID[orphan.ID].OwnerDisplayName, "missing owner => empty display name")
+	assert.Equal(t, 0, byID[orphan.ID].SourcesCount)
+}
+
+// TestListByUserIDWithSourceCount_Owner verifies the per-user admin listing applies the same
+// owner join.
+func TestListByUserIDWithSourceCount_Owner(t *testing.T) {
+	repo, cleanup := setupTestDatabase(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	ownerID := seedUser(t, repo, "streamer1", "Streamer One")
+	overlay := &models.Overlay{UserID: ownerID, Name: "My Overlay", IsActive: true}
+	require.NoError(t, repo.Create(ctx, overlay))
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO overlay_chat_sources (overlay_id, platform, channel_id, channel_name)
+		 VALUES ($1, 'youtube', 'chan-1', 'Chan One')`, overlay.ID)
+	require.NoError(t, err)
+
+	results, err := repo.ListByUserIDWithSourceCount(ctx, ownerID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "streamer1", results[0].OwnerUsername)
+	assert.Equal(t, "Streamer One", results[0].OwnerDisplayName)
+	assert.Equal(t, 1, results[0].SourcesCount)
 }
 
 func TestOverlayRepository_GetByIDAndUserID(t *testing.T) {

--- a/services/overlay-manager/repository/source_repo.go
+++ b/services/overlay-manager/repository/source_repo.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -313,11 +314,15 @@ func (r *SourceRepository) GetAllSources(ctx context.Context) ([]*models.ChatSou
 	return sources, nil
 }
 
-// SourceWithOverlay is a chat source joined with metadata from its owning overlay.
+// SourceWithOverlay is a chat source joined with metadata from its owning overlay,
+// including the overlay owner's identity (LEFT-joined from users; empty strings when the
+// owner row is absent).
 type SourceWithOverlay struct {
 	models.ChatSource
-	OverlayName string
-	UserID      string
+	OverlayName      string
+	UserID           string
+	OwnerUsername    string
+	OwnerDisplayName string
 }
 
 // GetAllSourcesWithOverlay returns every source joined with its overlay's name and
@@ -328,9 +333,11 @@ func (r *SourceRepository) GetAllSourcesWithOverlay(ctx context.Context) ([]*Sou
 	query := `
 		SELECT s.id, s.overlay_id, s.platform, s.channel_id, s.channel_name, s.channel_handle,
 		       s.is_active, s.created_at, s.updated_at,
-		       o.name, o.user_id
+		       o.name, o.user_id,
+		       u.username, u.display_name
 		FROM overlay_chat_sources s
 		JOIN overlays o ON o.id = s.overlay_id
+		LEFT JOIN users u ON u.id = o.user_id
 		ORDER BY s.created_at DESC
 	`
 
@@ -343,9 +350,12 @@ func (r *SourceRepository) GetAllSourcesWithOverlay(ctx context.Context) ([]*Sou
 	var sources []*SourceWithOverlay
 	for rows.Next() {
 		var sw SourceWithOverlay
-		if err := rows.Scan(&sw.ID, &sw.OverlayID, &sw.Platform, &sw.ChannelID, &sw.ChannelName, &sw.ChannelHandle, &sw.IsActive, &sw.CreatedAt, &sw.UpdatedAt, &sw.OverlayName, &sw.UserID); err != nil {
+		var username, displayName sql.NullString
+		if err := rows.Scan(&sw.ID, &sw.OverlayID, &sw.Platform, &sw.ChannelID, &sw.ChannelName, &sw.ChannelHandle, &sw.IsActive, &sw.CreatedAt, &sw.UpdatedAt, &sw.OverlayName, &sw.UserID, &username, &displayName); err != nil {
 			return nil, fmt.Errorf("failed to scan source: %w", err)
 		}
+		sw.OwnerUsername = username.String
+		sw.OwnerDisplayName = displayName.String
 		sources = append(sources, &sw)
 	}
 

--- a/services/overlay-manager/repository/source_repo_test.go
+++ b/services/overlay-manager/repository/source_repo_test.go
@@ -95,6 +95,7 @@ func setupSourceTestDatabase(t *testing.T) (*SourceRepository, func()) {
 		CREATE TABLE IF NOT EXISTS users (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			username VARCHAR(50) NOT NULL,
+			display_name VARCHAR(100),
 			auth_provider VARCHAR(20) NOT NULL DEFAULT 'twitch',
 			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
 			token_expires_at TIMESTAMP NOT NULL DEFAULT NOW()
@@ -437,6 +438,68 @@ func TestListByOverlayIDForUser_IsOwnChannel(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, sources[0].IsOwnChannel,
 		"linked twitch_oauth_tokens owner must own the channel even with an expired token (re-consent is the point)")
+}
+
+// TestGetAllSourcesWithOverlay_Owner verifies that the admin source listing surfaces the
+// owning overlay's owner (username/display_name, LEFT-joined from users) and the source's
+// channel_handle. An orphaned owner (overlay.user_id with no users row) must yield empty
+// owner fields rather than dropping the source.
+func TestGetAllSourcesWithOverlay_Owner(t *testing.T) {
+	repo, cleanup := setupSourceTestDatabase(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Owner-backed overlay.
+	ownerID := uuid.New().String()
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO users (id, username, display_name, auth_provider) VALUES ($1, 'caesarlp', 'CaesarLP', 'twitch')`,
+		ownerID)
+	require.NoError(t, err)
+
+	ownedOverlay := uuid.New().String()
+	_, err = repo.pool.Exec(ctx,
+		`INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, $3)`,
+		ownedOverlay, ownerID, "Owned Overlay")
+	require.NoError(t, err)
+
+	handle := "@caesarlp"
+	require.NoError(t, repo.Create(ctx, &models.ChatSource{
+		OverlayID:     ownedOverlay,
+		Platform:      "youtube",
+		ChannelID:     "UC123",
+		ChannelName:   "CaesarLP",
+		ChannelHandle: &handle,
+		IsActive:      true,
+	}))
+
+	// Orphaned overlay: user_id has no matching users row.
+	orphanOverlay := createTestOverlay(t, repo)
+	require.NoError(t, repo.Create(ctx, &models.ChatSource{
+		OverlayID:   orphanOverlay,
+		Platform:    "twitch",
+		ChannelID:   "orphan-chan",
+		ChannelName: "Orphan",
+		IsActive:    true,
+	}))
+
+	sources, err := repo.GetAllSourcesWithOverlay(ctx)
+	require.NoError(t, err)
+
+	byOverlay := map[string]*SourceWithOverlay{}
+	for _, s := range sources {
+		byOverlay[s.OverlayID] = s
+	}
+
+	require.Contains(t, byOverlay, ownedOverlay)
+	assert.Equal(t, "caesarlp", byOverlay[ownedOverlay].OwnerUsername)
+	assert.Equal(t, "CaesarLP", byOverlay[ownedOverlay].OwnerDisplayName)
+	assert.Equal(t, "Owned Overlay", byOverlay[ownedOverlay].OverlayName)
+	require.NotNil(t, byOverlay[ownedOverlay].ChannelHandle, "channel_handle must pass through")
+	assert.Equal(t, "@caesarlp", *byOverlay[ownedOverlay].ChannelHandle)
+
+	require.Contains(t, byOverlay, orphanOverlay, "orphaned source must still appear")
+	assert.Equal(t, "", byOverlay[orphanOverlay].OwnerUsername, "missing owner => empty username")
+	assert.Equal(t, "", byOverlay[orphanOverlay].OwnerDisplayName, "missing owner => empty display name")
 }
 
 // TestListByOverlayID_DefaultsIsOwnChannelFalse ensures the back-compat method that omits a


### PR DESCRIPTION
Revamps the admin dashboard around the reported complaints: overlays/sources not linked to their users, channels not resolving to the real platform page, the viewer view being unusable, and general inconsistency. Driven by an audit (see the plan) and ADRs 0033–0035.

## Complaints addressed

1. **Overlays not linked to their users.** overlay-manager now `LEFT JOIN`s the shared-DB `users` table into the admin overlay/source list queries and returns `owner_username`/`owner_display_name`. The Overlays detail shows a linked `@username` (not a bare UUID); Sources gains an Owner column; both deep-link to `/admin/users?user=<id>`.
2. **Sources should resolve to the actual channel.** New `platform-channel-url` helper + `ChannelLink` component render a source's channel as a link to twitch.tv / kick.com / tiktok.com / youtube (YouTube only with a real `@handle` or canonical `UC…` id; discord/shared_overlay stay plain text). Wired into Sources and the Overlays sources sub-panel. `channel_handle` is now passed through the admin API.
3. **Viewer view was useless.** Rebuilt on server-side discovery (auth-service): debounced search + platform/status/premium filters + pagination with a correct full-dataset total; avatar, platform badge, platform user id, and a profile link per row; and an **Activity** dialog showing cross-streamer context (total messages, last seen, streamers/overlays) from a new per-session aggregate over `viewer_message_history`.
4. **General usability.** URL-addressable selection/filters across pages (ADR-0033) so entities cross-link and views are shareable; a **global search** page (ADR-0035) that resolves any user/overlay/source/viewer and deep-links it; clickable dashboard stat cards + a per-platform source breakdown; user avatars; empty states; a "connection status unavailable" notice; sidebar/home nav generated from one source.

## Also fixed
- **Live crash:** `PlatformBadge` threw a `TypeError` on any platform without a color entry (e.g. `shared_overlay`), taking down the whole page. Now falls back to neutral styling; admin platform unions widened; unsafe casts removed.

## Backend
- overlay-manager: owner join + `channel_handle` in admin responses (repo + handler, testcontainer tests).
- auth-service: viewer `ListAll` filters + total, `viewer_sessions.user_id`, `GET /admin/viewers/:session_id/activity` (repo + handler tests).

## ADRs
- 0033 admin URL-addressable selection · 0034 admin viewer identity model · 0035 admin global entity search. Numbering verified free across all-chat and caesar-deployment.

## Verification
- New unit tests: `platform-channel-url`, `ChannelLink`, `PlatformBadge` crash regression (all green).
- Backend repo/handler tests pass via testcontainers (real Postgres).
- `tsc --noEmit` clean; `eslint` clean on every touched file; full `next build` succeeds and all `/admin/*` routes (incl. `/admin/search`) build.
- Pre-existing repo-wide `eslint`/jsdom-test failures (React 19 / react-hooks v7 toolchain drift) are untouched by this branch and unrelated.

## Deferred (noted, not blocking)
- Extraction of shared `AdminPage`/`AdminTable` primitives and unifying the remaining confirm dialogs (cosmetics one-click delete, maintenance `window.confirm`) — lowest-value/highest-churn; the cosmetics page carries pre-existing lint debt that would balloon the diff.
- Server-side pagination for the users/overlays/sources lists (only needed at larger scale) and admin source mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)