### PR TITLE
fix(emote-service): concurrent-map crash, 404-as-error metric, futile non-Twitch lookups

### DIFF
--- a/services/emote-service/README.md
+++ b/services/emote-service/README.md
@@ -173,19 +173,19 @@ The emote service enables users on **YouTube, Kick, and TikTok** to use Twitch's
 1. **Preloading**: On startup, the service fetches all Twitch global emotes and caches them for 30 days.
 2. **Platform Detection**: When the message processor requests emotes with `?platform=youtube` (or kick/tiktok), the service automatically includes Twitch global emotes.
 3. **No Duplication**: For Twitch channels, global emotes are included only once (not fetched twice).
-4. **Channel Emotes Excluded**: Only Twitch **global** emotes are included (not channel-specific or subscription emotes, as those require paid subscriptions).
+4. **Global Twitch emotes for everyone**: The Twitch **global** set is always included for non-Twitch platforms (channel/subscription emotes still require the viewer's own Twitch entitlements).
+5. **Twitch-keyed providers via the linked account**: BTTV, FFZ, and Twitch channel emotes are keyed by *Twitch* identity, so a platform channel id (e.g. a YouTube channel id) can't resolve them. For a non-Twitch platform the service uses the overlay's linked `twitch_channel` hint to fetch those providers, and **skips them entirely when there is no linked Twitch account** — a lookup with a platform id is a guaranteed 404 and a wasted upstream call. (7TV, being multi-platform, is resolved via its own platform connections.)
 
 ### Example Flow
 
 ```
-YouTube Viewer: "That was amazing Kappa PogChamp"
+YouTube Viewer (overlay linked to twitch.tv/BLVTumi): "amazing Kappa PogChamp"
                         ↓
-Message Processor: GET /emotes/channel/youtubechannel?platform=youtube
+Message Processor: GET /emotes/channel/UC...ytChannelId?platform=youtube&twitch_channel=BLVTumi
                         ↓
 Emote Service Returns:
-  - 7TV emotes (for youtubechannel)
-  - BTTV emotes (for youtubechannel)
-  - FFZ emotes (for youtubechannel)
+  - 7TV emotes           (resolved via the YouTube platform connection / linked Twitch)
+  - BTTV + FFZ emotes    (resolved via the linked twitch_channel BLVTumi; skipped if unlinked)
   - Twitch global emotes (Kappa, PogChamp, etc.)
                         ↓
 Message displayed with all emote images rendered
@@ -197,6 +197,21 @@ Message displayed with all emote images rendered
 - **No API Overhead**: Twitch global emotes cached for 30 days (only ~300 emotes)
 - **Automatic Updates**: Cache refreshes when emotes expire or service restarts
 - **Fair Usage**: Only free global emotes are included (respects Twitch's paid subscription model)
+
+## Observability
+
+**`emote_api_calls_total{service, provider, result}`** counts upstream provider calls. The
+`result` label distinguishes three outcomes — do **not** read `not_found` as a failure:
+
+- `success` — emotes returned.
+- `not_found` — the provider has no emotes for this channel (HTTP 404). This is the **normal**
+  case for most channels on BTTV/FFZ and for channels without a 7TV set, so a high `not_found`
+  rate is expected and benign. It scales with lookup volume (unique channels/users), not with
+  provider health.
+- `error` — a real failure (5xx, timeout, network). This is the only label worth alerting on.
+
+(Before this split, 404s were counted as `error`, which made a healthy service look like it was
+failing during a busy multistream — see the 2026-07-17 message-processor lag investigation.)
 
 ## Development
 

--- a/services/emote-service/clients/bttv.go
+++ b/services/emote-service/clients/bttv.go
@@ -86,6 +86,10 @@ func (c *BTTVClient) FetchEmotes(ctx context.Context, channel string) ([]models.
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		// Channel has no BTTV emotes — the normal case for most channels, not a failure.
+		return nil, fmt.Errorf("bttv: no emotes for channel %q: %w", channel, ErrNotFound)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}

--- a/services/emote-service/clients/bttv_test.go
+++ b/services/emote-service/clients/bttv_test.go
@@ -103,7 +103,7 @@ func TestBTTVClient_FetchEmotes(t *testing.T) {
 			mockResponse:   `{"message": "user not found"}`,
 			wantEmoteCount: 0,
 			wantErr:        true,
-			errContains:    "failed to fetch emotes",
+			errContains:    "not found",
 		},
 		{
 			name:           "server error",

--- a/services/emote-service/clients/errors.go
+++ b/services/emote-service/clients/errors.go
@@ -1,0 +1,26 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import "errors"
+
+// ErrNotFound signals that a provider has no emotes for the requested channel — an HTTP
+// 404 / unknown-channel response. This is the NORMAL case for most channels on BTTV and
+// FFZ (few streamers have those sets) and for channels without a 7TV set, so callers
+// classify it as a benign "not_found" miss rather than a real API failure. Wrap it with
+// %w so callers can detect it via errors.Is.
+var ErrNotFound = errors.New("emotes not found for channel")

--- a/services/emote-service/clients/errors_test.go
+++ b/services/emote-service/clients/errors_test.go
@@ -1,0 +1,54 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestProviderNotFoundWrapsErrNotFound locks the contract the emote handler relies on to
+// classify a benign "channel has no emotes here" 404 as not_found rather than a real
+// error: each Twitch-keyed provider must wrap ErrNotFound on a 404 so errors.Is detects it.
+func TestProviderNotFoundWrapsErrNotFound(t *testing.T) {
+	notFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer notFound.Close()
+
+	t.Run("bttv", func(t *testing.T) {
+		c := NewBTTVClient(zap.NewNop())
+		c.baseURL = notFound.URL
+		if _, err := c.FetchEmotes(context.Background(), "nochannel"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("bttv 404: expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ffz", func(t *testing.T) {
+		c := NewFFZClient(zap.NewNop())
+		c.baseURL = notFound.URL
+		if _, err := c.FetchEmotes(context.Background(), "nochannel"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("ffz 404: expected ErrNotFound, got %v", err)
+		}
+	})
+}

--- a/services/emote-service/clients/ffz.go
+++ b/services/emote-service/clients/ffz.go
@@ -47,8 +47,8 @@ type FFZResponse struct {
 	} `json:"room"`
 	Sets map[string]struct {
 		Emoticons []struct {
-			ID   int    `json:"id"`
-			Name string `json:"name"`
+			ID   int               `json:"id"`
+			Name string            `json:"name"`
 			URLs map[string]string `json:"urls"`
 		} `json:"emoticons"`
 	} `json:"sets"`
@@ -86,6 +86,10 @@ func (c *FFZClient) FetchEmotes(ctx context.Context, channel string) ([]models.E
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		// Channel has no FFZ room — the normal case for most channels, not a failure.
+		return nil, fmt.Errorf("ffz: no emotes for channel %q: %w", channel, ErrNotFound)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}

--- a/services/emote-service/clients/ffz_test.go
+++ b/services/emote-service/clients/ffz_test.go
@@ -128,7 +128,7 @@ func TestFFZClient_FetchEmotes(t *testing.T) {
 			mockResponse:   `{"error": "room not found"}`,
 			wantEmoteCount: 0,
 			wantErr:        true,
-			errContains:    "failed to fetch emotes",
+			errContains:    "not found",
 		},
 		{
 			name:           "server error",

--- a/services/emote-service/clients/seventv.go
+++ b/services/emote-service/clients/seventv.go
@@ -122,12 +122,12 @@ func (c *SevenTVClient) FetchEmotes(ctx context.Context, channel string) ([]mode
 
 	// Merge emotes, avoiding duplicates (channel emotes take precedence)
 	emoteMap := make(map[string]models.Emote)
-	
+
 	// Add global emotes first
 	for _, emote := range globalEmotes {
 		emoteMap[emote.Code] = emote
 	}
-	
+
 	// Add channel emotes (overwrites globals if same code exists)
 	for _, emote := range channelEmotes {
 		emoteMap[emote.Code] = emote
@@ -181,6 +181,10 @@ func (c *SevenTVClient) fetchChannelEmotes(ctx context.Context, channel string) 
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		// No 7TV set for this channel — a benign miss, not a failure.
+		return nil, fmt.Errorf("7tv: no emote set for channel: %w", ErrNotFound)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}
@@ -336,7 +340,7 @@ func (c *SevenTVClient) fetchPlatformConnectionEmotes(ctx context.Context, platf
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("7TV %s connection not found for %s", platform, channel)
+		return nil, fmt.Errorf("7TV %s connection not found for %s: %w", platform, channel, ErrNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("7TV %s connection returned status %d", platform, resp.StatusCode)

--- a/services/emote-service/clients/seventv_test.go
+++ b/services/emote-service/clients/seventv_test.go
@@ -173,7 +173,7 @@ func TestSevenTVClient_FetchEmotes(t *testing.T) {
 			mockTwitchID:      "9999",
 			channelStatusCode: http.StatusNotFound,
 			wantErr:           true,
-			errContains:       "status code 404",
+			errContains:       "not found",
 			twitchCalled:      true,
 		},
 		{

--- a/services/emote-service/clients/twitch.go
+++ b/services/emote-service/clients/twitch.go
@@ -112,7 +112,7 @@ func (c *TwitchClient) GetUserID(ctx context.Context, login string) (string, err
 	}
 
 	if len(body.Data) == 0 || body.Data[0].ID == "" {
-		return "", fmt.Errorf("twitch user %q not found", login)
+		return "", fmt.Errorf("twitch user %q not found: %w", login, ErrNotFound)
 	}
 
 	id := body.Data[0].ID

--- a/services/emote-service/clients/twitch_emotes.go
+++ b/services/emote-service/clients/twitch_emotes.go
@@ -44,16 +44,14 @@ type twitchChatEmote struct {
 }
 
 type TwitchEmoteClient struct {
-	helix       *TwitchClient
-	logger      *zap.Logger
-	globalCache map[string]models.Emote // In-memory cache of global emote codes
+	helix  *TwitchClient
+	logger *zap.Logger
 }
 
 func NewTwitchEmoteClient(helix *TwitchClient, logger *zap.Logger) *TwitchEmoteClient {
 	return &TwitchEmoteClient{
-		helix:       helix,
-		logger:      logger.With(zap.String("provider", "twitch")),
-		globalCache: make(map[string]models.Emote),
+		helix:  helix,
+		logger: logger.With(zap.String("provider", "twitch")),
 	}
 }
 
@@ -99,14 +97,7 @@ func (c *TwitchEmoteClient) fetchGlobal(ctx context.Context) ([]models.Emote, er
 		return nil, fmt.Errorf("failed to fetch global emotes: %w", err)
 	}
 	emotes := convertTwitchEmotes(resp, "global")
-
-	// Update in-memory cache with global emote codes
-	for _, emote := range emotes {
-		c.globalCache[emote.Code] = emote
-	}
-
-	c.logger.Info("Updated global emote cache", zap.Int("count", len(emotes)))
-
+	c.logger.Debug("Fetched Twitch global emotes", zap.Int("count", len(emotes)))
 	return emotes, nil
 }
 
@@ -241,16 +232,4 @@ func mergeEmoteSets(global, channel []models.Emote) []models.Emote {
 	})
 
 	return merged
-}
-
-// IsGlobalEmote checks if an emote code is a known Twitch global emote
-func (c *TwitchEmoteClient) IsGlobalEmote(code string) bool {
-	_, exists := c.globalCache[code]
-	return exists
-}
-
-// GetGlobalEmote retrieves a global emote by code from the in-memory cache
-func (c *TwitchEmoteClient) GetGlobalEmote(code string) (models.Emote, bool) {
-	emote, exists := c.globalCache[code]
-	return emote, exists
 }

--- a/services/emote-service/clients/twitch_emotes_race_test.go
+++ b/services/emote-service/clients/twitch_emotes_race_test.go
@@ -1,0 +1,75 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// TestTwitchEmoteClient_ConcurrentFetchGlobal_NoRace hammers FetchEmotes from many
+// goroutines against one shared client. The emote handler fans provider fetches out
+// concurrently and reuses a single TwitchEmoteClient, so fetchGlobal ran concurrently
+// and wrote a shared map with no lock -> `fatal error: concurrent map writes` crashed
+// the pod under load (observed in prod 2026-07-17, emote-service exit code 2). This must
+// run clean under -race.
+func TestTwitchEmoteClient_ConcurrentFetchGlobal_NoRace(t *testing.T) {
+	globalPayload := `{"template":"https://static-cdn.jtvnw.net/emoticons/v2/{id}/{format}/{theme_mode}/{scale}","data":[` +
+		`{"id":"1","name":"Kappa","format":["static"],"theme_mode":["dark"],"scale":["1.0"]},` +
+		`{"id":"2","name":"PogChamp","format":["static"],"theme_mode":["dark"],"scale":["1.0"]}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost { // app-token endpoint
+			fmt.Fprint(w, `{"access_token":"tok","expires_in":3600}`)
+			return
+		}
+		fmt.Fprint(w, globalPayload) // /helix/chat/emotes/global
+	}))
+	defer srv.Close()
+
+	helix := NewTwitchClient("cid", "secret", zap.NewNop())
+	helix.apiBase = srv.URL
+	helix.tokenURL = srv.URL + "/oauth2/token"
+	helix.usersURL = srv.URL + "/helix/users"
+
+	client := NewTwitchEmoteClient(helix, zap.NewNop())
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			emotes, err := client.FetchEmotes(context.Background(), "global")
+			if err != nil {
+				t.Errorf("FetchEmotes: %v", err)
+				return
+			}
+			if len(emotes) == 0 {
+				t.Errorf("expected global emotes, got none")
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/services/emote-service/go.mod
+++ b/services/emote-service/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/services/emote-service/go.sum
+++ b/services/emote-service/go.sum
@@ -107,8 +107,6 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
 github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.21.0 h1:jsV3tyMeJrEoc2f3EhNf7qoBW3NEZW7l/4ziT3M+OJI=

--- a/services/emote-service/handlers/emote.go
+++ b/services/emote-service/handlers/emote.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/caesar/all-chat/services/emote-service/cache"
+	"github.com/caesar/all-chat/services/emote-service/clients"
 	"github.com/caesar/all-chat/services/emote-service/models"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -163,10 +164,20 @@ func (h *EmoteHandler) GetChannelEmotes(c *gin.Context) {
 	allEmotes := make([]models.Emote, 0)
 	for res := range results {
 		if res.err != nil {
-			h.logger.Warn("Failed to fetch emotes from provider",
-				zap.String("provider", res.provider),
-				zap.String("channel", channel),
-				zap.Error(res.err))
+			// A "not found" is the normal case (channel has no emotes on this provider),
+			// not a failure — log it at Debug so it doesn't drown the logs or read as an
+			// incident. Only genuine failures (5xx/timeout/network) log at Warn.
+			if errors.Is(res.err, clients.ErrNotFound) {
+				h.logger.Debug("Provider has no emotes for channel",
+					zap.String("provider", res.provider),
+					zap.String("channel", channel),
+					zap.Error(res.err))
+			} else {
+				h.logger.Warn("Failed to fetch emotes from provider",
+					zap.String("provider", res.provider),
+					zap.String("channel", channel),
+					zap.Error(res.err))
+			}
 			continue
 		}
 		allEmotes = append(allEmotes, res.emotes...)
@@ -234,6 +245,24 @@ func (h *EmoteHandler) GetProviderEmotes(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// recordAPIResult increments the provider API-call counter, distinguishing a benign
+// "not_found" miss (the channel simply has no emotes on this provider — the norm for
+// BTTV/FFZ and unset 7TV channels) from a real "error" (5xx/timeout/network). Conflating
+// the two inflated the error rate and made a healthy service look like it was failing.
+func (h *EmoteHandler) recordAPIResult(provider string, err error) {
+	if h.apiCalls == nil {
+		return
+	}
+	result := "success"
+	if err != nil {
+		result = "error"
+		if errors.Is(err, clients.ErrNotFound) {
+			result = "not_found"
+		}
+	}
+	h.apiCalls.WithLabelValues("emote-service", provider, result).Inc()
+}
+
 // fetchWithCache attempts to fetch from cache first, then from API if cache miss
 func (h *EmoteHandler) fetchWithCache(ctx context.Context, client EmoteClient, provider, channel string) ([]models.Emote, error) {
 	// Try cache first
@@ -260,15 +289,10 @@ func (h *EmoteHandler) fetchWithCache(ctx context.Context, client EmoteClient, p
 
 	emotes, err = client.FetchEmotes(ctx, channel)
 	if err != nil {
-		if h.apiCalls != nil {
-			h.apiCalls.WithLabelValues("emote-service", provider, "error").Inc()
-		}
+		h.recordAPIResult(provider, err)
 		return nil, err
 	}
-
-	if h.apiCalls != nil {
-		h.apiCalls.WithLabelValues("emote-service", provider, "success").Inc()
-	}
+	h.recordAPIResult(provider, nil)
 
 	// Store in cache (best effort - don't fail if cache set fails)
 	if err := h.cache.Set(ctx, provider, channel, emotes); err != nil {
@@ -302,7 +326,20 @@ func (h *EmoteHandler) fetchWithCacheAndUser(ctx context.Context, client EmoteCl
 	useCombinedPath := supportsCombined && (userID != "" || isNonTwitchPlatform || seventvSetID != "")
 
 	if !useCombinedPath {
-		return h.fetchWithCache(ctx, client, provider, channel)
+		// BTTV/FFZ/Twitch are keyed by Twitch identity. On a non-Twitch platform the
+		// `channel` is a platform id (e.g. a YouTube channel id) those providers can't
+		// resolve, so use the linked twitch_channel hint — or skip entirely when there is
+		// no linked Twitch account, since a lookup with a platform id is a guaranteed 404
+		// and a wasted upstream call. Mirrors how the 7TV combined path already uses
+		// twitchChannel for non-Twitch platforms (ADR-0033 follow-up).
+		lookupChannel := channel
+		if isNonTwitchPlatform {
+			if twitchChannel == "" {
+				return nil, nil
+			}
+			lookupChannel = twitchChannel
+		}
+		return h.fetchWithCache(ctx, client, provider, lookupChannel)
 	}
 
 	// Build cache key that includes all parameters that vary the response
@@ -335,15 +372,10 @@ func (h *EmoteHandler) fetchWithCacheAndUser(ctx context.Context, client EmoteCl
 
 	emotes, err = combinedClient.FetchCombinedEmotes(ctx, channel, platform, userID, twitchChannel, seventvSetID)
 	if err != nil {
-		if h.apiCalls != nil {
-			h.apiCalls.WithLabelValues("emote-service", provider, "error").Inc()
-		}
+		h.recordAPIResult(provider, err)
 		return nil, err
 	}
-
-	if h.apiCalls != nil {
-		h.apiCalls.WithLabelValues("emote-service", provider, "success").Inc()
-	}
+	h.recordAPIResult(provider, nil)
 
 	// Store in cache (best effort - don't fail if cache set fails)
 	if err := h.cache.Set(ctx, provider, cacheKey, emotes); err != nil {

--- a/services/emote-service/handlers/emote_test.go
+++ b/services/emote-service/handlers/emote_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/caesar/all-chat/services/emote-service/cache"
@@ -47,8 +48,10 @@ func (m *mockEmoteClient) Provider() string {
 	return m.provider
 }
 
-// mockEmoteCache for testing
+// mockEmoteCache for testing. The handler fans provider fetches out across goroutines,
+// so this shared cache must be safe for concurrent Get/Set.
 type mockEmoteCache struct {
+	mu   sync.Mutex
 	data map[string][]models.Emote
 }
 
@@ -60,6 +63,8 @@ func newMockEmoteCache() *mockEmoteCache {
 
 func (m *mockEmoteCache) Get(ctx context.Context, provider, channel string) ([]models.Emote, error) {
 	key := provider + ":" + channel
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	emotes, ok := m.data[key]
 	if !ok {
 		return nil, cache.ErrCacheMiss
@@ -69,6 +74,8 @@ func (m *mockEmoteCache) Get(ctx context.Context, provider, channel string) ([]m
 
 func (m *mockEmoteCache) Set(ctx context.Context, provider, channel string, emotes []models.Emote) error {
 	key := provider + ":" + channel
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.data[key] = emotes
 	return nil
 }
@@ -346,19 +353,21 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
-		name           string
-		channel        string
-		platform       string
-		setupClients   func() map[string]EmoteClient
-		setupCache     func() EmoteCache
-		wantStatusCode int
-		wantEmoteCount int
+		name            string
+		channel         string
+		platform        string
+		twitchChannel   string
+		setupClients    func() map[string]EmoteClient
+		setupCache      func() EmoteCache
+		wantStatusCode  int
+		wantEmoteCount  int
 		hasTwitchGlobal bool
 	}{
 		{
-			name:     "YouTube channel includes Twitch global emotes",
-			channel:  "somechannel",
-			platform: "youtube",
+			name:          "YouTube channel with linked Twitch includes Twitch global + provider emotes",
+			channel:       "somechannel",
+			platform:      "youtube",
+			twitchChannel: "linkedtwitch",
 			setupClients: func() map[string]EmoteClient {
 				return map[string]EmoteClient{
 					"twitch": &mockEmoteClient{
@@ -376,15 +385,16 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 					},
 				}
 			},
-			setupCache:     func() EmoteCache { return newMockEmoteCache() },
-			wantStatusCode: http.StatusOK,
-			wantEmoteCount: 5, // 2 Twitch global + 2 regular Twitch (from mock) + 1 7TV = 5 total
+			setupCache:      func() EmoteCache { return newMockEmoteCache() },
+			wantStatusCode:  http.StatusOK,
+			wantEmoteCount:  5, // 2 Twitch global + 2 regular Twitch (from mock) + 1 7TV = 5 total
 			hasTwitchGlobal: true,
 		},
 		{
-			name:     "Kick channel includes Twitch global emotes",
-			channel:  "kickstreamer",
-			platform: "kick",
+			name:          "Kick channel with linked Twitch includes Twitch global + provider emotes",
+			channel:       "kickstreamer",
+			platform:      "kick",
+			twitchChannel: "linkedtwitch",
 			setupClients: func() map[string]EmoteClient {
 				return map[string]EmoteClient{
 					"twitch": &mockEmoteClient{
@@ -401,9 +411,41 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 					},
 				}
 			},
-			setupCache:     func() EmoteCache { return newMockEmoteCache() },
-			wantStatusCode: http.StatusOK,
-			wantEmoteCount: 3, // 1 Twitch global + 1 regular Twitch + 1 BTTV = 3 total
+			setupCache:      func() EmoteCache { return newMockEmoteCache() },
+			wantStatusCode:  http.StatusOK,
+			wantEmoteCount:  3, // 1 Twitch global + 1 regular Twitch (via linked channel) + 1 BTTV = 3 total
+			hasTwitchGlobal: true,
+		},
+		{
+			// ADR-0033 follow-up: with no linked twitch_channel, BTTV/FFZ/Twitch cannot
+			// resolve a non-Twitch (YouTube) channel id, so those Twitch-keyed providers
+			// are skipped entirely (no guaranteed-404 upstream calls). Only the Twitch
+			// GLOBAL emotes are added for the platform.
+			name:     "Non-Twitch channel without linked Twitch skips Twitch-keyed providers",
+			channel:  "someYtChannel",
+			platform: "youtube",
+			setupClients: func() map[string]EmoteClient {
+				return map[string]EmoteClient{
+					"twitch": &mockEmoteClient{
+						emotes: []models.Emote{
+							{Code: "Kappa", URL: "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0", Provider: "twitch", Channel: "global"},
+							{Code: "PogChamp", URL: "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/2.0", Provider: "twitch", Channel: "global"},
+						},
+						provider: "twitch",
+					},
+					"bttv": &mockEmoteClient{
+						emotes:   []models.Emote{{Code: "xqcL", URL: "https://bttv.net/1", Provider: "bttv", Channel: "someYtChannel"}},
+						provider: "bttv",
+					},
+					"ffz": &mockEmoteClient{
+						emotes:   []models.Emote{{Code: "ZULUL", URL: "https://ffz.net/1", Provider: "ffz", Channel: "someYtChannel"}},
+						provider: "ffz",
+					},
+				}
+			},
+			setupCache:      func() EmoteCache { return newMockEmoteCache() },
+			wantStatusCode:  http.StatusOK,
+			wantEmoteCount:  2, // only the 2 Twitch GLOBAL emotes; bttv/ffz/twitch-channel skipped
 			hasTwitchGlobal: true,
 		},
 		{
@@ -426,9 +468,9 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 					},
 				}
 			},
-			setupCache:     func() EmoteCache { return newMockEmoteCache() },
-			wantStatusCode: http.StatusOK,
-			wantEmoteCount: 2, // 1 Twitch + 1 7TV (no duplicate fetch of global)
+			setupCache:      func() EmoteCache { return newMockEmoteCache() },
+			wantStatusCode:  http.StatusOK,
+			wantEmoteCount:  2, // 1 Twitch + 1 7TV (no duplicate fetch of global)
 			hasTwitchGlobal: false,
 		},
 		{
@@ -445,9 +487,9 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 					},
 				}
 			},
-			setupCache:     func() EmoteCache { return newMockEmoteCache() },
-			wantStatusCode: http.StatusOK,
-			wantEmoteCount: 1, // Just regular Twitch emotes
+			setupCache:      func() EmoteCache { return newMockEmoteCache() },
+			wantStatusCode:  http.StatusOK,
+			wantEmoteCount:  1, // Just regular Twitch emotes
 			hasTwitchGlobal: false,
 		},
 	}
@@ -463,6 +505,13 @@ func TestEmoteHandler_GetChannelEmotes_WithTwitchGlobalForNonTwitchPlatform(t *t
 			url := "/emotes/channel/" + tt.channel
 			if tt.platform != "" {
 				url += "?platform=" + tt.platform
+			}
+			if tt.twitchChannel != "" {
+				sep := "?"
+				if tt.platform != "" {
+					sep = "&"
+				}
+				url += sep + "twitch_channel=" + tt.twitchChannel
 			}
 			req, _ := http.NewRequest("GET", url, nil)
 			w := httptest.NewRecorder()

--- a/services/emote-service/handlers/metrics_classification_test.go
+++ b/services/emote-service/handlers/metrics_classification_test.go
@@ -1,0 +1,61 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/caesar/all-chat/services/emote-service/clients"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestRecordAPIResult_Classification verifies the emote_api_calls_total metric separates
+// a benign "not_found" miss (channel has no emotes on this provider — the norm for
+// BTTV/FFZ and unset 7TV channels) from a real "error". Conflating them inflated the
+// error rate and made a healthy service look like it was failing during the 2026-07-17
+// investigation.
+func TestRecordAPIResult_Classification(t *testing.T) {
+	vec := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_emote_api_calls_total"},
+		[]string{"service", "provider", "result"},
+	)
+	h := &EmoteHandler{apiCalls: vec}
+
+	h.recordAPIResult("bttv", fmt.Errorf("bttv: no emotes: %w", clients.ErrNotFound))
+	h.recordAPIResult("7tv", errors.New("7tv api returned status 503"))
+	h.recordAPIResult("twitch", nil)
+
+	cases := []struct {
+		provider, result string
+		want             float64
+	}{
+		{"bttv", "not_found", 1}, // 404 classified as a benign miss
+		{"bttv", "error", 0},     // and NOT as an error
+		{"7tv", "error", 1},      // a real 5xx stays an error
+		{"7tv", "not_found", 0},  //
+		{"twitch", "success", 1}, // nil error is success
+	}
+	for _, tc := range cases {
+		got := testutil.ToFloat64(vec.WithLabelValues("emote-service", tc.provider, tc.result))
+		if got != tc.want {
+			t.Errorf("%s/%s = %v, want %v", tc.provider, tc.result, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Found while digging into the emote-service during the 2026-07-17 message-processor stream-lag investigation (#577). The emote-service was suspected of an upstream outage but was actually **healthy** — every request returned 200 with real emotes. Three real issues surfaced instead.

## P1 — 🔴 Concurrent-map crash (reliability)

`TwitchEmoteClient.fetchGlobal` wrote a shared `globalCache` map with no lock, while the handler fans provider fetches out across goroutines (one shared client, many concurrent requests). Under load this hit `fatal error: concurrent map writes` and **crashed a pod** (observed exit code 2 at 21:21 UTC).

The map was **dead state** — its only readers (`IsGlobalEmote`/`GetGlobalEmote`) have no callers anywhere in the repo — so it's removed entirely rather than mutex-guarded.

> This crash is made **more likely** by the message-processor concurrency change in #577 (ADR-0033), which raises concurrent emote-service requests from ~3 to as many as ~48 in-flight. Fixing it now closes that amplified risk. Locked with a `-race` reproduction test (red before, green after).

## P2 — 🟡 404s counted as errors (observability)

`emote_api_calls_total{result="error"}` counted a benign 404 (the channel simply has no emotes on that provider — the norm for BTTV/FFZ and unset 7TV channels) as an error. A healthy service therefore showed a large, alarming "error rate" that **misdirected this whole investigation**.

Providers now wrap a sentinel `clients.ErrNotFound` on 404; the handler records `result="not_found"` for those (only real 5xx/timeout/network failures are `"error"`) and logs them at `Debug` instead of `Warn` (they were log spam). See the new README **Observability** section.

## P3 — 🟢 Futile non-Twitch lookups (efficiency/correctness)

BTTV/FFZ/Twitch are keyed by Twitch identity, so a platform channel id (e.g. a YouTube channel id) can never resolve there — every such call was a guaranteed 404. For non-Twitch platforms the handler now uses the linked `twitch_channel` hint for those providers, and **skips them entirely when there's no linked Twitch account**. Mirrors how the 7TV combined path already uses `twitch_channel`. 7TV and global-Twitch behaviour is unchanged.

## Testing (TDD)

- `-race` reproduction of the concurrent-map crash (`clients`) — red before, green after.
- `errors_test.go`: each provider wraps `ErrNotFound` on 404 (`errors.Is`).
- `metrics_classification_test.go`: `not_found` vs `error` vs `success` classification, and that a 404 is **not** counted as an error.
- Updated the non-Twitch-platform handler test to pass `twitch_channel` (realistic multistream case) + a new case asserting Twitch-keyed providers are skipped without a linked account.
- Made the test `mockEmoteCache` concurrency-safe so the handler suite is `-race` clean (pre-existing test-helper race, exposed by the pre-existing concurrent fan-out).
- Full suite + `go vet` + `-short` + `-race` all green.

No behaviour change for Twitch channels; no ADR (bug fix + observability + routing refinement consistent with the existing linked-account model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)