### PR TITLE
fix(auth-service): non-premium viewer cosmetics 500 + surface real OAuth errors

### DIFF
--- a/frontend/src/app/chat/auth-error/page.tsx
+++ b/frontend/src/app/chat/auth-error/page.tsx
@@ -31,9 +31,28 @@ import { Suspense } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 
+// Map the backend `platform` query param to a display name. Falls back to a
+// platform-neutral label so the page never misnames the provider that failed
+// (it used to hardcode "Twitch" for every platform).
+const PLATFORM_LABELS: Record<string, string> = {
+  twitch: 'Twitch',
+  youtube: 'YouTube',
+  kick: 'Kick',
+  tiktok: 'TikTok',
+  discord: 'Discord',
+}
+
 function AuthErrorContent() {
   const searchParams = useSearchParams()
   const error = searchParams.get('error') || 'Authentication failed'
+  const platform = searchParams.get('platform') ?? ''
+  // Read the label defensively: indexing a plain object with an attacker-supplied
+  // query value (e.g. ?platform=toString) can resolve to an inherited Object
+  // prototype member, so require the resolved value to actually be one of our
+  // string labels before using it — otherwise fall back to a neutral label.
+  const platformLabel = PLATFORM_LABELS[platform]
+  const accountLabel =
+    typeof platformLabel === 'string' ? `${platformLabel} account` : 'streaming account'
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-bg">
@@ -42,7 +61,7 @@ function AuthErrorContent() {
         <h1 className="mb-4 text-3xl font-bold text-text">Authentication Failed</h1>
         <p className="mb-6 text-lg text-youtube">{error}</p>
         <p className="mb-8 text-text-sub">
-          There was an error authenticating with your Twitch account. Please try again or contact
+          There was an error authenticating with your {accountLabel}. Please try again or contact
           support if the problem persists.
         </p>
         <div className="space-y-4">

--- a/services/auth-service/handlers/viewer_auth.go
+++ b/services/auth-service/handlers/viewer_auth.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -264,8 +265,18 @@ func (h *ViewerAuthHandler) HandleTwitchLogin(c *gin.Context) {
 
 // HandleTwitchCallback handles the OAuth callback for Twitch viewers
 func (h *ViewerAuthHandler) HandleTwitchCallback(c *gin.Context) {
+	c.Set("auth_platform", "twitch")
 	code := c.Query("code")
 	state := c.Query("state")
+
+	if raw, userMsg := oauthErrorMessage(c); userMsg != "" {
+		h.logger.Warn("OAuth provider returned an error on viewer callback",
+			zap.String("platform", "twitch"),
+			zap.String("error", raw),
+		)
+		h.redirectToFrontendWithError(c, userMsg)
+		return
+	}
 
 	if code == "" || state == "" {
 		h.redirectToFrontendWithError(c, "Missing code or state parameter")
@@ -602,9 +613,63 @@ func (h *ViewerAuthHandler) generateViewerJWT(session *models.ViewerSession, vie
 	return sharedAuth.GenerateViewerJWTWithKid(h.userKeyChain.LatestKid(), claims, string(h.userKeyChain.LatestSecret()))
 }
 
-// redirectToFrontendWithError redirects to frontend with error message
+// safeOAuthErrorMessages maps recognized provider error codes/messages to safe,
+// user-facing text. The auth-error page shows ONLY these curated strings (or the
+// generic fallback), never the raw provider ?error= value verbatim: that value is
+// attacker-influenceable (anyone can craft a callback URL) and rendering it on our
+// own domain would be a content-spoofing / phishing surface. The raw value is still
+// logged by each callback so operators can diagnose (e.g. Kick's "invalid redirect
+// uri" when a callback URL is unregistered).
+var safeOAuthErrorMessages = map[string]string{
+	"access_denied":           "You declined the authorization request.",
+	"invalid_scope":           "The requested permissions were not granted.",
+	"invalid_request":         "The authorization request was invalid. Please try again.",
+	"server_error":            "The provider reported a server error. Please try again.",
+	"temporarily_unavailable": "The provider is temporarily unavailable. Please try again.",
+	"invalid redirect uri":    "This app is not configured correctly with the provider. Please contact support.",
+	"redirect_uri_mismatch":   "This app is not configured correctly with the provider. Please contact support.",
+}
+
+// genericOAuthErrorMessage is shown for any provider error code we don't have a
+// curated message for — bounding page output to a safe, fixed set of strings.
+const genericOAuthErrorMessage = "The provider reported an error during sign-in. Please try again or contact support."
+
+// oauthErrorMessage inspects the OAuth callback for a provider error redirect
+// (?error=...&error_description=...). It returns the raw provider value (for
+// logging only) and a SAFE, bounded user-facing message (for display). userMsg is
+// "" only when the provider reported no error.
+//
+// Providers redirect back to our callback with an error and no code — e.g. Kick
+// sends ?error=invalid+redirect+uri when the callback URL is not registered — which
+// beats the misleading generic "Missing code or state parameter" the callbacks used
+// to report for every no-code redirect. See safeOAuthErrorMessages for why the raw
+// value is not surfaced directly.
+func oauthErrorMessage(c *gin.Context) (raw, userMsg string) {
+	code := c.Query("error")
+	if code == "" {
+		return "", ""
+	}
+	raw = code
+	if desc := c.Query("error_description"); desc != "" {
+		raw = code + ": " + desc
+	}
+	if msg, ok := safeOAuthErrorMessages[strings.ToLower(strings.TrimSpace(code))]; ok {
+		return raw, msg
+	}
+	return raw, genericOAuthErrorMessage
+}
+
+// redirectToFrontendWithError redirects to the frontend auth-error page with the
+// error message and, when set on the context via "auth_platform", the platform
+// that failed so the page can name the correct provider instead of hardcoding
+// "Twitch". Both values are query-escaped.
 func (h *ViewerAuthHandler) redirectToFrontendWithError(c *gin.Context, errorMsg string) {
-	redirectURL := fmt.Sprintf("%s/chat/auth-error?error=%s", h.frontendURL, errorMsg)
+	redirectURL := fmt.Sprintf("%s/chat/auth-error?error=%s", h.frontendURL, url.QueryEscape(errorMsg))
+	if p, ok := c.Get("auth_platform"); ok {
+		if platform, ok := p.(string); ok && platform != "" {
+			redirectURL += "&platform=" + url.QueryEscape(platform)
+		}
+	}
 	c.Redirect(http.StatusFound, redirectURL)
 }
 
@@ -676,8 +741,18 @@ func (h *ViewerAuthHandler) HandleYouTubeLogin(c *gin.Context) {
 
 // HandleYouTubeCallback handles the OAuth callback for YouTube viewers
 func (h *ViewerAuthHandler) HandleYouTubeCallback(c *gin.Context) {
+	c.Set("auth_platform", "youtube")
 	code := c.Query("code")
 	state := c.Query("state")
+
+	if raw, userMsg := oauthErrorMessage(c); userMsg != "" {
+		h.logger.Warn("OAuth provider returned an error on viewer callback",
+			zap.String("platform", "youtube"),
+			zap.String("error", raw),
+		)
+		h.redirectToFrontendWithError(c, userMsg)
+		return
+	}
 
 	if code == "" || state == "" {
 		h.redirectToFrontendWithError(c, "Missing code or state parameter")
@@ -903,8 +978,18 @@ func (h *ViewerAuthHandler) HandleKickLogin(c *gin.Context) {
 
 // HandleKickCallback handles the OAuth callback for Kick viewers
 func (h *ViewerAuthHandler) HandleKickCallback(c *gin.Context) {
+	c.Set("auth_platform", "kick")
 	code := c.Query("code")
 	state := c.Query("state")
+
+	if raw, userMsg := oauthErrorMessage(c); userMsg != "" {
+		h.logger.Warn("OAuth provider returned an error on viewer callback",
+			zap.String("platform", "kick"),
+			zap.String("error", raw),
+		)
+		h.redirectToFrontendWithError(c, userMsg)
+		return
+	}
 
 	if code == "" || state == "" {
 		h.redirectToFrontendWithError(c, "Missing code or state parameter")

--- a/services/auth-service/handlers/viewer_auth_test.go
+++ b/services/auth-service/handlers/viewer_auth_test.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -173,5 +174,82 @@ func TestViewerCallbackTombstone_NoTombstoneFallsThrough(t *testing.T) {
 	}
 	if w.Code != http.StatusOK {
 		t.Fatalf("want no redirect (200 default), got %d", w.Code)
+	}
+}
+
+// TestOAuthErrorMessage verifies the callback maps a provider error to a SAFE,
+// bounded user-facing message (never reflecting raw provider text to the page)
+// while returning the raw value for logging, and yields "" when there is no error.
+func TestOAuthErrorMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name        string
+		query       string
+		wantRaw     string
+		wantUserMsg string
+	}{
+		{"no error", "code=abc&state=xyz", "", ""},
+		{"known code (kick)", "error=invalid+redirect+uri&state=xyz", "invalid redirect uri", safeOAuthErrorMessages["invalid redirect uri"]},
+		{"known code with description", "error=access_denied&error_description=user+said+no", "access_denied: user said no", safeOAuthErrorMessages["access_denied"]},
+		{"unknown code falls back to generic", "error=weird_provider_thing", "weird_provider_thing", genericOAuthErrorMessage},
+		{"attacker text does not reach the page", "error=Sign+in+at+evil.example", "Sign in at evil.example", genericOAuthErrorMessage},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/callback?"+tt.query, nil)
+			raw, userMsg := oauthErrorMessage(c)
+			if raw != tt.wantRaw {
+				t.Errorf("raw = %q, want %q", raw, tt.wantRaw)
+			}
+			if userMsg != tt.wantUserMsg {
+				t.Errorf("userMsg = %q, want %q", userMsg, tt.wantUserMsg)
+			}
+		})
+	}
+}
+
+// TestRedirectToFrontendWithError_IncludesPlatform verifies the error redirect
+// query-escapes the message and appends the failing platform (set via
+// auth_platform) so the auth-error page names the correct provider instead of
+// hardcoding "Twitch".
+func TestRedirectToFrontendWithError_IncludesPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &ViewerAuthHandler{logger: zap.NewNop(), frontendURL: "https://app.test"}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/callback", nil)
+	c.Set("auth_platform", "kick")
+
+	h.redirectToFrontendWithError(c, "invalid redirect uri")
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("want 302, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if !strings.Contains(loc, "platform=kick") {
+		t.Errorf("redirect Location %q missing platform=kick", loc)
+	}
+	if !strings.Contains(loc, "error=invalid+redirect+uri") {
+		t.Errorf("redirect Location %q missing escaped error message", loc)
+	}
+}
+
+// TestRedirectToFrontendWithError_NoPlatform verifies the redirect omits the
+// platform param when none was set (so the page falls back to a neutral label).
+func TestRedirectToFrontendWithError_NoPlatform(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &ViewerAuthHandler{logger: zap.NewNop(), frontendURL: "https://app.test"}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/callback", nil)
+
+	h.redirectToFrontendWithError(c, "boom")
+
+	if loc := w.Header().Get("Location"); strings.Contains(loc, "platform=") {
+		t.Errorf("redirect Location %q should not contain platform param", loc)
 	}
 }

--- a/services/auth-service/handlers/viewer_cosmetics.go
+++ b/services/auth-service/handlers/viewer_cosmetics.go
@@ -77,31 +77,7 @@ func (h *ViewerCosmeticsHandler) HandleGetCosmetics(c *gin.Context) {
 		return
 	}
 
-	if cosmetics == nil {
-		c.JSON(http.StatusOK, gin.H{
-			"name_color":      nil,
-			"name_gradient":   nil,
-			"avatar_frame_id": nil,
-			"avatar_flair_id": nil,
-		})
-		return
-	}
-
-	// Parse name_gradient from raw JSON for the response
-	var gradientResponse interface{}
-	if len(cosmetics.NameGradient) > 0 && string(cosmetics.NameGradient) != "null" {
-		var g interface{}
-		if json.Unmarshal(cosmetics.NameGradient, &g) == nil {
-			gradientResponse = g
-		}
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"name_color":      cosmetics.NameColor,
-		"name_gradient":   gradientResponse,
-		"avatar_frame_id": cosmetics.AvatarFrameID,
-		"avatar_flair_id": cosmetics.AvatarFlairID,
-	})
+	c.JSON(http.StatusOK, cosmeticsResponse(cosmetics))
 }
 
 // HandlePatchCosmetics handles PATCH /viewer/cosmetics.
@@ -113,7 +89,7 @@ func (h *ViewerCosmeticsHandler) HandleGetCosmetics(c *gin.Context) {
 // Request body: {"name_color": "#rrggbb"} or {"name_gradient": {...}} (mutually exclusive)
 // Response:     {"name_color": ..., "name_gradient": ...}
 func (h *ViewerCosmeticsHandler) HandlePatchCosmetics(c *gin.Context) {
-	handlePatchCosmeticsLogic(c, h.identityRepo)
+	handlePatchCosmeticsLogic(c, h.identityRepo, h.logger)
 
 	// Invalidate Redis identity cache on success.
 	// The cache is keyed per platform (viewer:identity:{platform}:{platform_user_id}), so
@@ -151,10 +127,34 @@ func (h *ViewerCosmeticsHandler) HandlePatchCosmetics(c *gin.Context) {
 // cosmeticsUpsertRepo is the minimal interface for the cosmetics handler's DB access.
 // This enables unit testing with mock implementations.
 type cosmeticsUpsertRepo interface {
-	UpsertViewerCosmetics(ctx context.Context, viewerID uuid.UUID, nameColor *string, nameGradient []byte, avatarFrameID *uuid.UUID, avatarFlairID *uuid.UUID) error
-	// UpsertAvatarCosmetics updates only avatar_frame_id and avatar_flair_id, leaving
-	// name_color and name_gradient untouched. Used for avatar-only PATCH requests.
-	UpsertAvatarCosmetics(ctx context.Context, viewerID uuid.UUID, avatarFrameID *uuid.UUID, avatarFlairID *uuid.UUID) error
+	// UpsertViewerCosmetics applies a per-column partial update and returns the full
+	// persisted row (so the response reflects stored state without a separate read).
+	UpsertViewerCosmetics(ctx context.Context, viewerID uuid.UUID, update repository.CosmeticsUpdate) (*repository.ViewerCosmetics, error)
+	// GetFullCosmetics reads the current persisted cosmetics — used only for the
+	// no-op case (an empty PATCH that writes nothing).
+	GetFullCosmetics(ctx context.Context, viewerID uuid.UUID) (*repository.ViewerCosmetics, error)
+}
+
+// cosmeticsResponse builds the JSON body describing a viewer's persisted cosmetics.
+// Shared by GET and PATCH so both report identical, accurate state. name_gradient is
+// parsed from its raw JSON; a nil row yields all-null fields.
+func cosmeticsResponse(c *repository.ViewerCosmetics) gin.H {
+	if c == nil {
+		return gin.H{"name_color": nil, "name_gradient": nil, "avatar_frame_id": nil, "avatar_flair_id": nil}
+	}
+	var gradient interface{}
+	if len(c.NameGradient) > 0 && string(c.NameGradient) != "null" {
+		var g interface{}
+		if json.Unmarshal(c.NameGradient, &g) == nil {
+			gradient = g
+		}
+	}
+	return gin.H{
+		"name_color":      c.NameColor,
+		"name_gradient":   gradient,
+		"avatar_frame_id": c.AvatarFrameID,
+		"avatar_flair_id": c.AvatarFlairID,
+	}
 }
 
 // linkedPlatformsGetter abstracts the GetLinkedPlatforms DB call for testability.
@@ -195,9 +195,25 @@ type patchCosmeticsRequest struct {
 	avatarFlairIDPresent bool
 }
 
+// normalizeClearUUID maps a pointer to the zero UUID to a nil pointer.
+//
+// A nil *uuid.UUID is encoded by pgx as SQL NULL, which clears the column and
+// satisfies the avatar_frame_id / avatar_flair_id foreign keys. A non-nil
+// pointer to uuid.Nil is instead encoded as the literal '00000000-...-000000000000'
+// value, which has no matching cosmetic_frames / cosmetic_flairs row and therefore
+// violates the foreign key (SQLSTATE 23503) — surfacing as a 500. The zero UUID is
+// never a real catalog id (PKs default to gen_random_uuid), so treating it as
+// "clear the selection" is always correct.
+func normalizeClearUUID(id *uuid.UUID) *uuid.UUID {
+	if id != nil && *id == uuid.Nil {
+		return nil
+	}
+	return id
+}
+
 // handlePatchCosmeticsLogic contains the core business logic for PATCH cosmetics.
 // Extracted to allow unit testing with a mock repository.
-func handlePatchCosmeticsLogic(c *gin.Context, repo cosmeticsUpsertRepo) {
+func handlePatchCosmeticsLogic(c *gin.Context, repo cosmeticsUpsertRepo, logger *zap.Logger) {
 	// Step 1: Extract viewer_id from JWT claims (set by middleware)
 	viewerIDVal, exists := c.Get("viewer_id")
 	if !exists {
@@ -367,48 +383,69 @@ func handlePatchCosmeticsLogic(c *gin.Context, repo cosmeticsUpsertRepo) {
 			return
 		}
 		// Downgrade enforcement: always clear frame/flair for non-premium viewers,
-		// regardless of whether they sent these fields. Pass &uuid.Nil as the
-		// "clear" sentinel so the UPSERT writes NULL to the DB.
-		nilUUID := uuid.Nil
-		avatarFrameID = &nilUUID
-		avatarFlairID = &nilUUID
+		// regardless of whether they sent these fields. Leave both as nil pointers
+		// so the UPSERT writes SQL NULL. A pointer to uuid.Nil would be encoded as
+		// the literal zero UUID and violate the avatar FK constraints (see
+		// normalizeClearUUID) — that bug 500'd every non-premium cosmetics save.
+		avatarFrameID = nil
+		avatarFlairID = nil
 	} else {
-		// Premium viewer: pass through whatever was sent.
-		// nil pointer = field absent in request body = UPSERT overwrites with NULL (v1.4 behavior).
-		// &uuid.Nil = explicit clear sent as JSON null.
-		// &<real UUID> = set to that frame/flair.
-		avatarFrameID = req.AvatarFrameID
-		avatarFlairID = req.AvatarFlairID
+		// Premium viewer: pass through whatever was sent, but map a zero-UUID
+		// selection to nil (clear) so it writes SQL NULL instead of tripping the
+		// avatar FK. nil pointer = field absent/null = UPSERT overwrites with NULL.
+		avatarFrameID = normalizeClearUUID(req.AvatarFrameID)
+		avatarFlairID = normalizeClearUUID(req.AvatarFlairID)
 	}
 
-	// Step 6: Upsert cosmetics in DB.
-	// When the request explicitly includes name_color or name_gradient fields (even as null),
-	// use the full upsert that can overwrite all four columns.
-	// When only avatar fields are present (name_color and name_gradient both absent from the
-	// JSON body), use a targeted UPDATE that leaves name_color and name_gradient untouched.
-	// This prevents avatar-only saves from NULLing out a previously saved name color.
-	nameFieldsProvided := req.nameColorPresent || req.nameGradientPresent
-	if nameFieldsProvided {
-		if err := repo.UpsertViewerCosmetics(c.Request.Context(), viewerID, req.NameColor, nameGradientBytes, avatarFrameID, avatarFlairID); err != nil {
+	// Step 6: Persist only the column groups the request actually addressed (PATCH is
+	// a partial update) and report the persisted result. Writing untouched columns
+	// would clobber cosmetics the request never referenced:
+	//   - setName:  a name_color or name_gradient field was present (the two move
+	//     together — mutual exclusion is enforced above).
+	//   - setFrame / setFlair: that avatar field was present, OR the viewer is
+	//     non-premium — non-premium saves always re-clear the avatar (downgrade
+	//     enforcement), with avatarFrameID/avatarFlairID already forced to nil above.
+	ctx := c.Request.Context()
+	setName := req.nameColorPresent || req.nameGradientPresent
+	setFrame := req.avatarFrameIDPresent || !hasAccess
+	setFlair := req.avatarFlairIDPresent || !hasAccess
+
+	// No-op PATCH (nothing addressed): report current state without a pointless write.
+	if !setName && !setFrame && !setFlair {
+		full, err := repo.GetFullCosmetics(ctx, viewerID)
+		if err != nil {
+			if logger != nil {
+				logger.Error("Failed to read viewer cosmetics", zap.String("viewer_id", viewerID.String()), zap.Error(err))
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update cosmetics"})
 			return
 		}
-	} else {
-		if err := repo.UpsertAvatarCosmetics(c.Request.Context(), viewerID, avatarFrameID, avatarFlairID); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update cosmetics"})
-			return
-		}
+		c.JSON(http.StatusOK, cosmeticsResponse(full))
+		return
 	}
 
-	// Step 7: Return updated values
-	var gradientResponse interface{}
-	if req.NameGradient != nil {
-		gradientResponse = req.NameGradient
-	}
-	c.JSON(http.StatusOK, gin.H{
-		"name_color":     req.NameColor,
-		"name_gradient":  gradientResponse,
-		"avatar_frame_id": req.AvatarFrameID,
-		"avatar_flair_id": req.AvatarFlairID,
+	persisted, err := repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{
+		SetName:       setName,
+		NameColor:     req.NameColor,
+		NameGradient:  nameGradientBytes,
+		SetFrame:      setFrame,
+		AvatarFrameID: avatarFrameID,
+		SetFlair:      setFlair,
+		AvatarFlairID: avatarFlairID,
 	})
+	if err != nil {
+		if logger != nil {
+			logger.Error("Failed to upsert viewer cosmetics",
+				zap.String("viewer_id", viewerID.String()),
+				zap.Error(err),
+			)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update cosmetics"})
+		return
+	}
+
+	// Step 7: Report the actual persisted state returned by the upsert, so the
+	// response never diverges from what was stored (untouched columns, or a zero-UUID
+	// normalized to NULL).
+	c.JSON(http.StatusOK, cosmeticsResponse(persisted))
 }

--- a/services/auth-service/handlers/viewer_cosmetics_test.go
+++ b/services/auth-service/handlers/viewer_cosmetics_test.go
@@ -34,53 +34,73 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
-// mockCosmeticsUpsertRepo implements cosmeticsUpsertRepo for testing.
+// mockCosmeticsUpsertRepo implements cosmeticsUpsertRepo for testing. It records
+// each partial-update call AND maintains an in-memory `stored` row that applies the
+// same per-column semantics as the real UPSERT — so the handler's response (built
+// from the returned row) reflects exactly what a column-selective write persists.
 type mockCosmeticsUpsertRepo struct {
 	upsertCalls []struct {
-		viewerID      uuid.UUID
-		nameColor     *string
-		nameGradient  []byte
-		avatarFrameID *uuid.UUID
-		avatarFlairID *uuid.UUID
-	}
-	avatarUpsertCalls []struct {
-		viewerID      uuid.UUID
-		avatarFrameID *uuid.UUID
-		avatarFlairID *uuid.UUID
+		viewerID uuid.UUID
+		update   repository.CosmeticsUpdate
 	}
 	upsertErr error
+	getErr    error
+	stored    *repository.ViewerCosmetics // simulates the persisted row (nil = no row)
 }
 
-func (m *mockCosmeticsUpsertRepo) UpsertViewerCosmetics(ctx context.Context, viewerID uuid.UUID, nameColor *string, nameGradient []byte, avatarFrameID *uuid.UUID, avatarFlairID *uuid.UUID) error {
+func (m *mockCosmeticsUpsertRepo) UpsertViewerCosmetics(ctx context.Context, viewerID uuid.UUID, u repository.CosmeticsUpdate) (*repository.ViewerCosmetics, error) {
 	m.upsertCalls = append(m.upsertCalls, struct {
-		viewerID      uuid.UUID
-		nameColor     *string
-		nameGradient  []byte
-		avatarFrameID *uuid.UUID
-		avatarFlairID *uuid.UUID
-	}{viewerID, nameColor, nameGradient, avatarFrameID, avatarFlairID})
-	return m.upsertErr
+		viewerID uuid.UUID
+		update   repository.CosmeticsUpdate
+	}{viewerID, u})
+	if m.upsertErr != nil {
+		return nil, m.upsertErr
+	}
+	if m.stored == nil {
+		m.stored = &repository.ViewerCosmetics{}
+	}
+	// Apply only the addressed column groups (mirrors the SQL CASE-per-flag).
+	if u.SetName {
+		m.stored.NameColor = u.NameColor
+		m.stored.NameGradient = u.NameGradient
+	}
+	if u.SetFrame {
+		m.stored.AvatarFrameID = u.AvatarFrameID
+	}
+	if u.SetFlair {
+		m.stored.AvatarFlairID = u.AvatarFlairID
+	}
+	cp := *m.stored // return a copy, as RETURNING yields a snapshot
+	return &cp, nil
 }
 
-func (m *mockCosmeticsUpsertRepo) UpsertAvatarCosmetics(ctx context.Context, viewerID uuid.UUID, avatarFrameID *uuid.UUID, avatarFlairID *uuid.UUID) error {
-	m.avatarUpsertCalls = append(m.avatarUpsertCalls, struct {
-		viewerID      uuid.UUID
-		avatarFrameID *uuid.UUID
-		avatarFlairID *uuid.UUID
-	}{viewerID, avatarFrameID, avatarFlairID})
-	return m.upsertErr
+func (m *mockCosmeticsUpsertRepo) GetFullCosmetics(ctx context.Context, viewerID uuid.UUID) (*repository.ViewerCosmetics, error) {
+	return m.stored, m.getErr
+}
+
+// lastUpdate returns the CosmeticsUpdate from the single recorded upsert call,
+// failing the test if the number of calls is not exactly one.
+func (m *mockCosmeticsUpsertRepo) lastUpdate(t *testing.T) repository.CosmeticsUpdate {
+	t.Helper()
+	if len(m.upsertCalls) != 1 {
+		t.Fatalf("expected exactly 1 upsert call, got %d", len(m.upsertCalls))
+	}
+	return m.upsertCalls[0].update
 }
 
 // testCosmeticsHandler wraps handlePatchCosmeticsLogic with a mock repo for unit testing.
 type testCosmeticsHandler struct {
-	repo cosmeticsUpsertRepo
+	repo   cosmeticsUpsertRepo
+	logger *zap.Logger
 }
 
 func (h *testCosmeticsHandler) Handle(c *gin.Context) {
-	handlePatchCosmeticsLogic(c, h.repo)
+	handlePatchCosmeticsLogic(c, h.repo, h.logger)
 }
 
 // setupCosmeticsTest creates a gin router that simulates the JWT middleware setting claims.
@@ -92,11 +112,10 @@ func setupCosmeticsTest(t *testing.T, viewerIDStr, platform, platformUserID stri
 // setupCosmeticsTestWithPremium creates a gin router with configurable is_premium flag.
 func setupCosmeticsTestWithPremium(t *testing.T, viewerIDStr, platform, platformUserID string, isPremium bool) (*gin.Engine, *mockCosmeticsUpsertRepo) {
 	t.Helper()
-	_ = zaptest.NewLogger(t) // ensure logger is available
 	gin.SetMode(gin.TestMode)
 
 	mock := &mockCosmeticsUpsertRepo{}
-	h := &testCosmeticsHandler{repo: mock}
+	h := &testCosmeticsHandler{repo: mock, logger: zaptest.NewLogger(t)}
 
 	router := gin.New()
 	router.PATCH("/viewer/cosmetics", func(c *gin.Context) {
@@ -115,37 +134,42 @@ func setupCosmeticsTestWithPremium(t *testing.T, viewerIDStr, platform, platform
 	return router, mock
 }
 
-func TestPatchCosmetics_ValidColor(t *testing.T) {
-	viewerID := uuid.New()
-	router, mock := setupCosmeticsTest(t, viewerID.String(), "twitch", "12345")
-
-	body := `{"name_color":"#ff6600"}`
+func doPatch(t *testing.T, router *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
 	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
+	return w
+}
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d body=%s", w.Code, w.Body.String())
-	}
-
+func parseBody(t *testing.T, w *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
 	var resp map[string]interface{}
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if resp["name_color"] != "#ff6600" {
+	return resp
+}
+
+func TestPatchCosmetics_ValidColor(t *testing.T) {
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTest(t, viewerID.String(), "twitch", "12345")
+
+	w := doPatch(t, router, `{"name_color":"#ff6600"}`)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if resp := parseBody(t, w); resp["name_color"] != "#ff6600" {
 		t.Errorf("name_color = %v, want #ff6600", resp["name_color"])
 	}
 
-	// Verify DB was called with correct args
-	if len(mock.upsertCalls) != 1 {
-		t.Fatalf("expected 1 upsert call, got %d", len(mock.upsertCalls))
-	}
 	if mock.upsertCalls[0].viewerID != viewerID {
 		t.Errorf("upsert called with wrong viewerID")
 	}
-	if mock.upsertCalls[0].nameColor == nil || *mock.upsertCalls[0].nameColor != "#ff6600" {
-		t.Errorf("upsert called with wrong nameColor")
+	u := mock.lastUpdate(t)
+	if !u.SetName || u.NameColor == nil || *u.NameColor != "#ff6600" {
+		t.Errorf("expected SetName with nameColor #ff6600, got %+v", u)
 	}
 }
 
@@ -153,45 +177,22 @@ func TestPatchCosmetics_NullColor(t *testing.T) {
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTest(t, viewerID.String(), "twitch", "12345")
 
-	body := `{"name_color":null}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_color":null}`)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-
-	var resp map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
+	if resp := parseBody(t, w); resp["name_color"] != nil {
+		t.Errorf("expected name_color null, got %v", resp["name_color"])
 	}
-	// name_color should be null
-	if val, exists := resp["name_color"]; exists && val != nil {
-		t.Errorf("expected name_color to be null, got %v", val)
-	}
-
-	// Verify DB was called with nil nameColor
-	if len(mock.upsertCalls) != 1 {
-		t.Fatalf("expected 1 upsert call, got %d", len(mock.upsertCalls))
-	}
-	if mock.upsertCalls[0].nameColor != nil {
-		t.Errorf("expected nil nameColor for null input, got %v", *mock.upsertCalls[0].nameColor)
+	if u := mock.lastUpdate(t); !u.SetName || u.NameColor != nil {
+		t.Errorf("expected SetName with nil nameColor, got %+v", u)
 	}
 }
 
 func TestPatchCosmetics_InvalidHex(t *testing.T) {
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTest(t, viewerID.String(), "twitch", "12345")
-
-	body := `{"name_color":"notahex"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusBadRequest {
+	if w := doPatch(t, router, `{"name_color":"notahex"}`); w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for invalid hex, got %d body=%s", w.Code, w.Body.String())
 	}
 }
@@ -199,29 +200,14 @@ func TestPatchCosmetics_InvalidHex(t *testing.T) {
 func TestPatchCosmetics_MissingViewerID(t *testing.T) {
 	// Empty viewer_id simulates a pre-Phase-28 token (old token without viewer_id claim)
 	router, _ := setupCosmeticsTest(t, "", "twitch", "12345")
-
-	body := `{"name_color":"#ff6600"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
+	if w := doPatch(t, router, `{"name_color":"#ff6600"}`); w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for missing viewer_id, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_InvalidViewerIDFormat(t *testing.T) {
-	// Non-UUID viewer_id value
 	router, _ := setupCosmeticsTest(t, "not-a-uuid", "twitch", "12345")
-
-	body := `{"name_color":"#ff6600"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusUnauthorized {
+	if w := doPatch(t, router, `{"name_color":"#ff6600"}`); w.Code != http.StatusUnauthorized {
 		t.Errorf("expected 401 for invalid viewer_id format, got %d body=%s", w.Code, w.Body.String())
 	}
 }
@@ -229,243 +215,304 @@ func TestPatchCosmetics_InvalidViewerIDFormat(t *testing.T) {
 // Phase 29: gradient tests
 
 func TestPatchCosmetics_GradientAccepted(t *testing.T) {
-	// Premium viewer with a valid gradient should get 200.
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
 
-	body := `{"name_gradient":{"type":"linear","colors":["#ff0000","#0000ff"],"angle":90}}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_gradient":{"type":"linear","colors":["#ff0000","#0000ff"],"angle":90}}`)
 	if w.Code != http.StatusOK {
 		t.Errorf("expected 200 for premium gradient, got %d body=%s", w.Code, w.Body.String())
 	}
-
-	if len(mock.upsertCalls) != 1 {
-		t.Fatalf("expected 1 upsert call, got %d", len(mock.upsertCalls))
+	u := mock.lastUpdate(t)
+	// A gradient-only PATCH addresses only the name group; avatar columns are untouched.
+	if !u.SetName || u.SetFrame || u.SetFlair {
+		t.Errorf("expected SetName only, got %+v", u)
 	}
-	if mock.upsertCalls[0].nameColor != nil {
+	if u.NameColor != nil {
 		t.Errorf("name_color should be nil when gradient is set (mutual exclusion)")
 	}
-	if mock.upsertCalls[0].nameGradient == nil {
+	if u.NameGradient == nil {
 		t.Errorf("expected nameGradient bytes to be set")
 	}
 }
 
 func TestPatchCosmetics_GradientRejectedNonPremium(t *testing.T) {
-	// Non-premium viewer attempting to set gradient should get 403.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", false)
-
-	body := `{"name_gradient":{"type":"linear","colors":["#ff0000","#0000ff"],"angle":90}}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_gradient":{"type":"linear","colors":["#ff0000","#0000ff"],"angle":90}}`)
 	if w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for non-premium gradient attempt, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_GradientValidation(t *testing.T) {
-	// Invalid gradient (1 color, angle 400) should return 400.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
-
-	// Only 1 color — invalid
-	body := `{"name_gradient":{"type":"linear","colors":["#ff0000"],"angle":400}}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_gradient":{"type":"linear","colors":["#ff0000"],"angle":400}}`)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for invalid gradient (1 color), got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_GradientValidation_BadAngle(t *testing.T) {
-	// Valid colors but angle out of range should return 400.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
-
-	body := `{"name_gradient":{"type":"linear","colors":["#ff0000","#00ff00"],"angle":400}}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_gradient":{"type":"linear","colors":["#ff0000","#00ff00"],"angle":400}}`)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for angle 400, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_MutualExclusion(t *testing.T) {
-	// Gradient PATCH should nullify name_color in the DB call.
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
 
-	// Send gradient only — name_color should be nil in upsert call
-	body := `{"name_gradient":{"type":"linear","colors":["#aabbcc","#112233"],"angle":45}}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_gradient":{"type":"linear","colors":["#aabbcc","#112233"],"angle":45}}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-
-	if len(mock.upsertCalls) != 1 {
-		t.Fatalf("expected 1 upsert call, got %d", len(mock.upsertCalls))
+	if u := mock.lastUpdate(t); u.NameColor != nil {
+		t.Errorf("mutual exclusion: name_color should be nil when gradient is set, got %v", *u.NameColor)
 	}
-	if mock.upsertCalls[0].nameColor != nil {
-		t.Errorf("mutual exclusion: name_color should be nil when gradient is set, got %v", *mock.upsertCalls[0].nameColor)
-	}
-
-	// Response should have null name_color
-	var resp map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-	if val, exists := resp["name_color"]; exists && val != nil {
-		t.Errorf("response name_color should be null when gradient is set, got %v", val)
+	if resp := parseBody(t, w); resp["name_color"] != nil {
+		t.Errorf("response name_color should be null when gradient is set, got %v", resp["name_color"])
 	}
 }
 
 // Phase 30: avatar frame / flair tests
 
 func TestPatchCosmetics_AvatarFrameID_PremiumAccepted(t *testing.T) {
-	// Premium viewer with a valid avatar_frame_id should get 200.
-	// Since name_color and name_gradient are absent from the body, the handler
-	// routes to UpsertAvatarCosmetics to avoid NULLing out saved name color.
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
 
 	frameID := uuid.New()
-	body := `{"avatar_frame_id":"` + frameID.String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"avatar_frame_id":"`+frameID.String()+`"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for premium avatar_frame_id, got %d body=%s", w.Code, w.Body.String())
 	}
-	// Avatar-only PATCH routes to UpsertAvatarCosmetics, not UpsertViewerCosmetics.
-	if len(mock.upsertCalls) != 0 {
-		t.Fatalf("expected 0 full upsert calls for avatar-only PATCH, got %d", len(mock.upsertCalls))
+	u := mock.lastUpdate(t)
+	// Frame-only PATCH addresses only the frame; name and flair stay untouched.
+	if u.SetName || u.SetFlair || !u.SetFrame {
+		t.Errorf("expected SetFrame only, got %+v", u)
 	}
-	if len(mock.avatarUpsertCalls) != 1 {
-		t.Fatalf("expected 1 avatar upsert call, got %d", len(mock.avatarUpsertCalls))
-	}
-	if mock.avatarUpsertCalls[0].avatarFrameID == nil {
-		t.Error("expected avatarFrameID to be non-nil in avatar upsert call")
-	} else if *mock.avatarUpsertCalls[0].avatarFrameID != frameID {
-		t.Errorf("expected avatarFrameID=%v, got %v", frameID, *mock.avatarUpsertCalls[0].avatarFrameID)
+	if u.AvatarFrameID == nil || *u.AvatarFrameID != frameID {
+		t.Errorf("expected avatarFrameID=%v, got %v", frameID, u.AvatarFrameID)
 	}
 }
 
 func TestPatchCosmetics_AvatarFrameID_NonPremiumRejected(t *testing.T) {
-	// Non-premium viewer attempting to set avatar_frame_id should get 403.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", false)
-
 	frameID := uuid.New()
-	body := `{"avatar_frame_id":"` + frameID.String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusForbidden {
+	if w := doPatch(t, router, `{"avatar_frame_id":"`+frameID.String()+`"}`); w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for non-premium avatar_frame_id, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_AvatarFlairID_NonPremiumRejected(t *testing.T) {
-	// Non-premium viewer attempting to set avatar_flair_id should get 403.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", false)
-
 	flairID := uuid.New()
-	body := `{"avatar_flair_id":"` + flairID.String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusForbidden {
+	if w := doPatch(t, router, `{"avatar_flair_id":"`+flairID.String()+`"}`); w.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for non-premium avatar_flair_id, got %d body=%s", w.Code, w.Body.String())
 	}
 }
 
 func TestPatchCosmetics_NonPremium_DowngradeClears(t *testing.T) {
-	// Non-premium viewer sending only name_color: DB call should pass nil, nil for frame/flair
-	// AND the frame/flair clear UPDATE should fire (avatarFrameID = &uuid.Nil in upsert).
+	// Non-premium viewer sending only name_color: the avatar columns must be cleared
+	// with NIL POINTERS (→ SQL NULL), NOT &uuid.Nil. A pointer to the zero UUID is
+	// encoded as the literal '00000000-...' value, which violates the avatar FKs and
+	// 500s the request against a real database (prod bug reported 2026-07-17).
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", false)
 
-	body := `{"name_color":"#00ff00"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"name_color":"#00ff00"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-	if len(mock.upsertCalls) != 1 {
-		t.Fatalf("expected 1 upsert call, got %d", len(mock.upsertCalls))
+	u := mock.lastUpdate(t)
+	// Downgrade enforcement: non-premium forces both avatar columns cleared to nil.
+	if !u.SetFrame || u.AvatarFrameID != nil {
+		t.Errorf("expected SetFrame with nil avatarFrameID (→ SQL NULL), got %+v", u)
 	}
-	// Downgrade enforcement: avatarFrameID should be &uuid.Nil (clear sentinel)
-	if mock.upsertCalls[0].avatarFrameID == nil {
-		t.Error("expected avatarFrameID=&uuid.Nil for downgrade clear, got nil pointer")
-	} else if *mock.upsertCalls[0].avatarFrameID != uuid.Nil {
-		t.Errorf("expected avatarFrameID=uuid.Nil, got %v", *mock.upsertCalls[0].avatarFrameID)
+	if !u.SetFlair || u.AvatarFlairID != nil {
+		t.Errorf("expected SetFlair with nil avatarFlairID (→ SQL NULL), got %+v", u)
 	}
-	if mock.upsertCalls[0].avatarFlairID == nil {
-		t.Error("expected avatarFlairID=&uuid.Nil for downgrade clear, got nil pointer")
-	} else if *mock.upsertCalls[0].avatarFlairID != uuid.Nil {
-		t.Errorf("expected avatarFlairID=uuid.Nil, got %v", *mock.upsertCalls[0].avatarFlairID)
+}
+
+func TestPatchCosmetics_NonPremium_AvatarOnlyClearsWithNil(t *testing.T) {
+	// The frontend avatar card sends {"avatar_frame_id":null,"avatar_flair_id":null}
+	// for "None". For a non-premium viewer this must pass nil pointers (→ SQL NULL),
+	// not &uuid.Nil. This is the exact avatar-save path that 500'd in prod.
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", false)
+
+	w := doPatch(t, router, `{"avatar_frame_id":null,"avatar_flair_id":null}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	u := mock.lastUpdate(t)
+	if !u.SetFrame || u.AvatarFrameID != nil || !u.SetFlair || u.AvatarFlairID != nil {
+		t.Errorf("expected both avatar columns cleared to nil, got %+v", u)
+	}
+}
+
+func TestPatchCosmetics_Premium_ZeroUUIDNormalizedToNil(t *testing.T) {
+	// Defensive: even a premium viewer sending the literal zero UUID must have it
+	// normalized to nil (→ SQL NULL) so it clears the slot rather than tripping the FK.
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
+
+	w := doPatch(t, router, `{"avatar_frame_id":"00000000-0000-0000-0000-000000000000","avatar_flair_id":"00000000-0000-0000-0000-000000000000"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if u := mock.lastUpdate(t); u.AvatarFrameID != nil || u.AvatarFlairID != nil {
+		t.Errorf("expected zero-UUID avatar ids normalized to nil, got %+v", u)
+	}
+}
+
+func TestPatchCosmetics_UpsertError_Returns500AndLogs(t *testing.T) {
+	// When the repository upsert fails, the handler must return 500 AND log the
+	// underlying error (previously it swallowed the error, leaving only the
+	// middleware access log — impossible to diagnose in prod).
+	viewerID := uuid.New()
+	gin.SetMode(gin.TestMode)
+
+	core, logs := observer.New(zap.ErrorLevel)
+	mock := &mockCosmeticsUpsertRepo{upsertErr: fmt.Errorf("boom: FK violation")}
+	h := &testCosmeticsHandler{repo: mock, logger: zap.New(core)}
+
+	router := gin.New()
+	router.PATCH("/viewer/cosmetics", func(c *gin.Context) {
+		c.Set("viewer_id", viewerID.String())
+		c.Set("is_premium", false)
+		c.Next()
+	}, h.Handle)
+
+	if w := doPatch(t, router, `{"name_color":"#00ff00"}`); w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d body=%s", w.Code, w.Body.String())
+	}
+	if logs.Len() == 0 {
+		t.Error("expected the upsert failure to be logged, got no error logs")
+	}
+}
+
+func TestPatchCosmetics_Premium_NameOnly_PreservesAvatar(t *testing.T) {
+	// Regression ([0]): a name-color/gradient-only PATCH must NOT clear a premium
+	// viewer's saved avatar frame/flair. It addresses only the name group, so the
+	// avatar columns are left untouched and reported unchanged.
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
+
+	savedFrame := uuid.New()
+	mock.stored = &repository.ViewerCosmetics{AvatarFrameID: &savedFrame}
+
+	w := doPatch(t, router, `{"name_color":"#00ff00","name_gradient":null}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if u := mock.lastUpdate(t); !u.SetName || u.SetFrame || u.SetFlair {
+		t.Errorf("name-only PATCH must address only the name group, got %+v", u)
+	}
+	resp := parseBody(t, w)
+	if resp["avatar_frame_id"] != savedFrame.String() {
+		t.Errorf("expected preserved avatar_frame_id=%s, got %v", savedFrame, resp["avatar_frame_id"])
+	}
+	if resp["name_color"] != "#00ff00" {
+		t.Errorf("expected name_color=#00ff00, got %v", resp["name_color"])
+	}
+}
+
+func TestPatchCosmetics_Premium_FlairOnly_PreservesFrame(t *testing.T) {
+	// Regression (re-review): a PATCH touching only one avatar column must not clear
+	// the sibling column. Here a flair-only change must preserve the saved frame.
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
+
+	savedFrame := uuid.New()
+	mock.stored = &repository.ViewerCosmetics{AvatarFrameID: &savedFrame}
+
+	newFlair := uuid.New()
+	w := doPatch(t, router, `{"avatar_flair_id":"`+newFlair.String()+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if u := mock.lastUpdate(t); u.SetFrame || !u.SetFlair {
+		t.Errorf("flair-only PATCH must set flair and leave frame untouched, got %+v", u)
+	}
+	resp := parseBody(t, w)
+	if resp["avatar_frame_id"] != savedFrame.String() {
+		t.Errorf("expected preserved avatar_frame_id=%s, got %v", savedFrame, resp["avatar_frame_id"])
+	}
+	if resp["avatar_flair_id"] != newFlair.String() {
+		t.Errorf("expected avatar_flair_id=%s, got %v", newFlair, resp["avatar_flair_id"])
+	}
+}
+
+func TestPatchCosmetics_AvatarOnly_ResponseReflectsPreservedName(t *testing.T) {
+	// Regression ([4]): an avatar-only PATCH preserves the stored name color, and the
+	// response must report that preserved value — not echo null from the (absent)
+	// request name field.
+	viewerID := uuid.New()
+	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
+
+	savedColor := "#ff0000"
+	mock.stored = &repository.ViewerCosmetics{NameColor: &savedColor}
+
+	frameID := uuid.New()
+	w := doPatch(t, router, `{"avatar_frame_id":"`+frameID.String()+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w)
+	if resp["name_color"] != savedColor {
+		t.Errorf("avatar-only PATCH must report preserved name_color=%s, got %v", savedColor, resp["name_color"])
+	}
+	if resp["avatar_frame_id"] != frameID.String() {
+		t.Errorf("expected avatar_frame_id=%s, got %v", frameID, resp["avatar_frame_id"])
+	}
+}
+
+func TestPatchCosmetics_Premium_ZeroUUID_ResponseShowsNull(t *testing.T) {
+	// Regression ([7]): a zero-UUID avatar selection is normalized to NULL before the
+	// write, so the response must report null — not echo the zero UUID.
+	viewerID := uuid.New()
+	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
+
+	w := doPatch(t, router, `{"avatar_frame_id":"00000000-0000-0000-0000-000000000000","avatar_flair_id":"00000000-0000-0000-0000-000000000000"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	resp := parseBody(t, w)
+	if resp["avatar_frame_id"] != nil {
+		t.Errorf("expected avatar_frame_id null (zero-UUID normalized), got %v", resp["avatar_frame_id"])
+	}
+	if resp["avatar_flair_id"] != nil {
+		t.Errorf("expected avatar_flair_id null (zero-UUID normalized), got %v", resp["avatar_flair_id"])
 	}
 }
 
 func TestPatchCosmetics_AvatarOnly_DoesNotClearNameColor(t *testing.T) {
 	// Regression test: saving avatar cosmetics (no name_color/name_gradient in body)
-	// must NOT call UpsertViewerCosmetics (which would NULL out the stored name color).
-	// It must call UpsertAvatarCosmetics instead, leaving name cosmetics untouched.
+	// must not address the name group (which would NULL a stored name color).
 	viewerID := uuid.New()
 	router, mock := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
 
 	frameID := uuid.New()
 	flairID := uuid.New()
-	body := `{"avatar_frame_id":"` + frameID.String() + `","avatar_flair_id":"` + flairID.String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"avatar_frame_id":"`+frameID.String()+`","avatar_flair_id":"`+flairID.String()+`"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-	// Full upsert must NOT be called — it would clear name_color.
-	if len(mock.upsertCalls) != 0 {
-		t.Fatalf("avatar-only PATCH must not call UpsertViewerCosmetics, got %d call(s)", len(mock.upsertCalls))
+	u := mock.lastUpdate(t)
+	if u.SetName {
+		t.Errorf("avatar-only PATCH must not address the name group, got %+v", u)
 	}
-	// Avatar-targeted upsert must be called.
-	if len(mock.avatarUpsertCalls) != 1 {
-		t.Fatalf("expected 1 UpsertAvatarCosmetics call, got %d", len(mock.avatarUpsertCalls))
+	if u.AvatarFrameID == nil || *u.AvatarFrameID != frameID {
+		t.Errorf("expected avatarFrameID=%v, got %v", frameID, u.AvatarFrameID)
 	}
-	c := mock.avatarUpsertCalls[0]
-	if c.avatarFrameID == nil || *c.avatarFrameID != frameID {
-		t.Errorf("expected avatarFrameID=%v, got %v", frameID, c.avatarFrameID)
-	}
-	if c.avatarFlairID == nil || *c.avatarFlairID != flairID {
-		t.Errorf("expected avatarFlairID=%v, got %v", flairID, c.avatarFlairID)
+	if u.AvatarFlairID == nil || *u.AvatarFlairID != flairID {
+		t.Errorf("expected avatarFlairID=%v, got %v", flairID, u.AvatarFlairID)
 	}
 }
 
@@ -498,7 +545,6 @@ func TestPatchCosmetics_CacheInvalidation_AllLinkedPlatforms(t *testing.T) {
 	kickUserID := "kick-user-789"
 
 	// Seed Redis with identity cache entries for all three platforms.
-	// These simulate cached entries that were created when each platform first saw a message.
 	gradientJSON := `{"type":"linear","colors":["#ff0000","#0000ff"],"angle":90}`
 	cachedWithGradient := fmt.Sprintf(`{"viewer_id":"%s","name_color":null,"name_gradient":%s}`, viewerID, gradientJSON)
 	nullSentinel := "null"
@@ -506,7 +552,6 @@ func TestPatchCosmetics_CacheInvalidation_AllLinkedPlatforms(t *testing.T) {
 	redisClient.Set(context.Background(), fmt.Sprintf("viewer:identity:youtube:%s", youtubeUserID), nullSentinel, 0)
 	redisClient.Set(context.Background(), fmt.Sprintf("viewer:identity:kick:%s", kickUserID), nullSentinel, 0)
 
-	// Build handler with mock linked platforms getter that returns all three platforms.
 	mockRepo := &mockCosmeticsUpsertRepo{}
 	mockLinked := &mockLinkedPlatformsGetter{
 		platforms: []repository.LinkedPlatform{
@@ -533,12 +578,9 @@ func TestPatchCosmetics_CacheInvalidation_AllLinkedPlatforms(t *testing.T) {
 		c.Set("platform_user_id", twitchUserID)
 		c.Next()
 	}, func(c *gin.Context) {
-		handlePatchCosmeticsLogic(c, mockRepo)
+		handlePatchCosmeticsLogic(c, mockRepo, logger)
 	}, func(c *gin.Context) {
 		// Simulate the cache invalidation portion of HandlePatchCosmetics.
-		// We call it as a separate step here since we can't use h.HandlePatchCosmetics
-		// (which calls handlePatchCosmeticsLogic internally — we used the separate approach
-		// to avoid double-calling). Instead we test the invalidation step directly.
 		if c.Writer.Status() == http.StatusOK {
 			vidVal, _ := c.Get("viewer_id")
 			vidStr := vidVal.(string)
@@ -551,17 +593,10 @@ func TestPatchCosmetics_CacheInvalidation_AllLinkedPlatforms(t *testing.T) {
 		}
 	})
 
-	body := `{"name_color":"#aabbcc"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
+	if w := doPatch(t, router, `{"name_color":"#aabbcc"}`); w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
 
-	// All three cache keys must be gone.
 	for _, tc := range []struct {
 		platform string
 		userID   string
@@ -571,32 +606,23 @@ func TestPatchCosmetics_CacheInvalidation_AllLinkedPlatforms(t *testing.T) {
 		{"kick", kickUserID},
 	} {
 		key := fmt.Sprintf("viewer:identity:%s:%s", tc.platform, tc.userID)
-		exists := mr.Exists(key)
-		if exists {
+		if mr.Exists(key) {
 			t.Errorf("cache key %q should have been deleted but still exists", key)
 		}
 	}
 }
 
 func TestPatchCosmetics_AvatarFrameID_ResponseIncludes(t *testing.T) {
-	// Response JSON must include avatar_frame_id field.
+	// Response JSON must include avatar_frame_id and avatar_flair_id fields.
 	viewerID := uuid.New()
 	router, _ := setupCosmeticsTestWithPremium(t, viewerID.String(), "twitch", "12345", true)
 
 	frameID := uuid.New()
-	body := `{"avatar_frame_id":"` + frameID.String() + `"}`
-	req := httptest.NewRequest(http.MethodPatch, "/viewer/cosmetics", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
-
+	w := doPatch(t, router, `{"avatar_frame_id":"`+frameID.String()+`"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
-	var resp map[string]interface{}
-	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
+	resp := parseBody(t, w)
 	if _, exists := resp["avatar_frame_id"]; !exists {
 		t.Error("response missing avatar_frame_id field")
 	}

--- a/services/auth-service/repository/viewer_identity_repository.go
+++ b/services/auth-service/repository/viewer_identity_repository.go
@@ -150,59 +150,59 @@ func (r *ViewerIdentityRepository) GetFullCosmetics(ctx context.Context, viewerI
 	return &c, nil
 }
 
-// UpsertViewerCosmetics sets name_color, name_gradient, avatar_frame_id, and avatar_flair_id for a viewer.
-// Pass nil for nameColor to clear it; pass nil for nameGradient to clear it.
-// Pass nil for avatarFrameID or avatarFlairID to clear the respective selection.
-// Gradient and color are stored independently — the caller is responsible for
-// enforcing mutual exclusion before calling this method.
-func (r *ViewerIdentityRepository) UpsertViewerCosmetics(
-	ctx context.Context,
-	viewerID uuid.UUID,
-	nameColor *string,
-	nameGradient []byte,
-	avatarFrameID *uuid.UUID, // nil = clear selection
-	avatarFlairID *uuid.UUID, // nil = clear selection
-) error {
-	_, err := r.db.Exec(ctx,
+// CosmeticsUpdate describes a partial update to a viewer's cosmetics. Each Set*
+// flag selects whether that column group is written; groups whose flag is false are
+// left exactly as they were (or NULL on first insert). name_color and name_gradient
+// move together under SetName because they are mutually exclusive (setting one
+// clears the other); avatar_frame_id and avatar_flair_id are independent and have
+// their own flags, so changing one never disturbs the other.
+//
+// To CLEAR a set column, pass a nil pointer (→ SQL NULL) with the Set flag true.
+// Never pass a pointer to uuid.Nil for an avatar column: it would be encoded as the
+// literal '00000000-...' value and violate the avatar foreign keys.
+type CosmeticsUpdate struct {
+	SetName      bool
+	NameColor    *string
+	NameGradient []byte
+
+	SetFrame      bool
+	AvatarFrameID *uuid.UUID
+
+	SetFlair      bool
+	AvatarFlairID *uuid.UUID
+}
+
+// UpsertViewerCosmetics applies a partial cosmetics update and returns the full
+// persisted row. It is a true per-column PATCH: only the column groups whose Set*
+// flag is true are written, so e.g. changing a name color never clears a saved
+// avatar frame, and setting a flair never clears the frame. The RETURNING clause
+// yields the authoritative post-write state in the same round-trip, so callers
+// never need a separate (racy, fallible) read-back to report what was stored.
+// Callers MUST pass a nil value for any group whose Set flag is false (the handler
+// does: absent request fields decode to nil). This keeps the INSERT branch's VALUES
+// unwrapped so the JSONB/UUID columns get their parameters directly (wrapping a param
+// in CASE would lose the column's type context and break inference); the per-group
+// gating that preserves an existing row's untouched columns lives in the typed
+// ON CONFLICT branch, where both CASE arms are already column-typed.
+func (r *ViewerIdentityRepository) UpsertViewerCosmetics(ctx context.Context, viewerID uuid.UUID, u CosmeticsUpdate) (*ViewerCosmetics, error) {
+	var c ViewerCosmetics
+	err := r.db.QueryRow(ctx,
 		`INSERT INTO viewer_cosmetics (viewer_id, name_color, name_gradient, avatar_frame_id, avatar_flair_id, updated_at)
 		 VALUES ($1, $2, $3, $4, $5, NOW())
 		 ON CONFLICT (viewer_id) DO UPDATE SET
-		     name_color = EXCLUDED.name_color,
-		     name_gradient = EXCLUDED.name_gradient,
-		     avatar_frame_id = EXCLUDED.avatar_frame_id,
-		     avatar_flair_id = EXCLUDED.avatar_flair_id,
-		     updated_at = NOW()`,
-		viewerID, nameColor, nameGradient, avatarFrameID, avatarFlairID,
-	)
+		     name_color      = CASE WHEN $6 THEN EXCLUDED.name_color      ELSE viewer_cosmetics.name_color      END,
+		     name_gradient   = CASE WHEN $6 THEN EXCLUDED.name_gradient   ELSE viewer_cosmetics.name_gradient   END,
+		     avatar_frame_id = CASE WHEN $7 THEN EXCLUDED.avatar_frame_id ELSE viewer_cosmetics.avatar_frame_id END,
+		     avatar_flair_id = CASE WHEN $8 THEN EXCLUDED.avatar_flair_id ELSE viewer_cosmetics.avatar_flair_id END,
+		     updated_at = NOW()
+		 RETURNING name_color, name_gradient, avatar_frame_id, avatar_flair_id`,
+		viewerID, u.NameColor, u.NameGradient, u.AvatarFrameID, u.AvatarFlairID,
+		u.SetName, u.SetFrame, u.SetFlair,
+	).Scan(&c.NameColor, &c.NameGradient, &c.AvatarFrameID, &c.AvatarFlairID)
 	if err != nil {
-		return fmt.Errorf("failed to upsert viewer cosmetics: %w", err)
+		return nil, fmt.Errorf("failed to upsert viewer cosmetics: %w", err)
 	}
-	return nil
-}
-
-// UpsertAvatarCosmetics updates only the avatar_frame_id and avatar_flair_id columns,
-// leaving name_color and name_gradient untouched. This prevents avatar-only PATCH
-// requests from accidentally NULLing out a previously saved name color/gradient.
-// Pass nil for avatarFrameID or avatarFlairID to clear the respective selection.
-func (r *ViewerIdentityRepository) UpsertAvatarCosmetics(
-	ctx context.Context,
-	viewerID uuid.UUID,
-	avatarFrameID *uuid.UUID, // nil = clear selection
-	avatarFlairID *uuid.UUID, // nil = clear selection
-) error {
-	_, err := r.db.Exec(ctx,
-		`INSERT INTO viewer_cosmetics (viewer_id, avatar_frame_id, avatar_flair_id, updated_at)
-		 VALUES ($1, $2, $3, NOW())
-		 ON CONFLICT (viewer_id) DO UPDATE SET
-		     avatar_frame_id = EXCLUDED.avatar_frame_id,
-		     avatar_flair_id = EXCLUDED.avatar_flair_id,
-		     updated_at = NOW()`,
-		viewerID, avatarFrameID, avatarFlairID,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to upsert avatar cosmetics: %w", err)
-	}
-	return nil
+	return &c, nil
 }
 
 // LinkViewerToUser links a viewer session to a streamer user account and recomputes

--- a/services/auth-service/repository/viewer_identity_repository_test.go
+++ b/services/auth-service/repository/viewer_identity_repository_test.go
@@ -23,10 +23,12 @@ import (
 	"testing"
 
 	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/caesar/all-chat/shared/premium"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 // newTestDB returns a pgxpool connected to the local test database.
@@ -60,7 +62,7 @@ func cleanupViewer(t *testing.T, pool *pgxpool.Pool, platform, platformUserID st
 
 func TestGetOrCreateViewerByPlatform_NewViewer(t *testing.T) {
 	pool := newTestDB(t)
-	repo := repository.NewViewerIdentityRepository(pool)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
 	ctx := context.Background()
 
 	platform := "twitch"
@@ -74,7 +76,7 @@ func TestGetOrCreateViewerByPlatform_NewViewer(t *testing.T) {
 
 func TestGetOrCreateViewerByPlatform_Existing(t *testing.T) {
 	pool := newTestDB(t)
-	repo := repository.NewViewerIdentityRepository(pool)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
 	ctx := context.Background()
 
 	platform := "twitch"
@@ -92,7 +94,7 @@ func TestGetOrCreateViewerByPlatform_Existing(t *testing.T) {
 
 func TestGetViewerCosmetics_NotFound(t *testing.T) {
 	pool := newTestDB(t)
-	repo := repository.NewViewerIdentityRepository(pool)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
 	ctx := context.Background()
 
 	// Use a random UUID that has no cosmetics row
@@ -105,7 +107,7 @@ func TestGetViewerCosmetics_NotFound(t *testing.T) {
 
 func TestUpsertViewerCosmetics(t *testing.T) {
 	pool := newTestDB(t)
-	repo := repository.NewViewerIdentityRepository(pool)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
 	ctx := context.Background()
 
 	platform := "twitch"
@@ -116,11 +118,84 @@ func TestUpsertViewerCosmetics(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedColor := "#ff6600"
-	err = repo.UpsertViewerCosmetics(ctx, viewerID, &expectedColor, nil, nil, nil)
+	_, err = repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{SetName: true, NameColor: &expectedColor})
 	require.NoError(t, err)
 
 	color, err := repo.GetViewerCosmetics(ctx, viewerID)
 	require.NoError(t, err)
 	require.NotNil(t, color)
 	assert.Equal(t, expectedColor, *color)
+}
+
+// TestUpsertViewerCosmetics_ZeroUUIDViolatesAvatarFK is the DB-layer regression
+// guard for the prod bug (reported 2026-07-17) where the cosmetics handler passed
+// a pointer to uuid.Nil as a "clear" sentinel. pgx encodes a non-nil pointer as
+// the literal '00000000-...' value, which has no cosmetic_frames / cosmetic_flairs
+// row and violates the avatar FK constraints (SQLSTATE 23503) — 500'ing every
+// non-premium save. Passing nil (→ SQL NULL) must succeed. This asserts both.
+func TestUpsertViewerCosmetics_ZeroUUIDViolatesAvatarFK(t *testing.T) {
+	pool := newTestDB(t)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
+	ctx := context.Background()
+
+	platform := "twitch"
+	platformUserID := "user_cosmetics_fk_test"
+	defer cleanupViewer(t, pool, platform, platformUserID)
+
+	viewerID, err := repo.GetOrCreateViewerByPlatform(ctx, platform, platformUserID)
+	require.NoError(t, err)
+
+	color := "#00ff00"
+
+	// nil avatar pointers → SQL NULL → satisfies the FK → succeeds (the fix).
+	_, err = repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{
+		SetName: true, NameColor: &color,
+		SetFrame: true, AvatarFrameID: nil,
+		SetFlair: true, AvatarFlairID: nil,
+	})
+	require.NoError(t, err, "nil avatar pointers should write SQL NULL and satisfy the FK")
+
+	// A pointer to the zero UUID → literal '00000000-...' → FK violation (the bug).
+	zero := uuid.Nil
+	_, err = repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{
+		SetFrame: true, AvatarFrameID: &zero,
+		SetFlair: true, AvatarFlairID: &zero,
+	})
+	require.Error(t, err, "zero-UUID avatar ids must violate the avatar FK constraint")
+}
+
+// TestUpsertViewerCosmetics_PartialUpdatePreservesUntouchedColumns verifies the
+// per-column PATCH semantics against a real database: a name-only update must not
+// disturb a saved avatar frame (the ON CONFLICT CASE gating), and the RETURNING
+// clause must report the full merged row.
+func TestUpsertViewerCosmetics_PartialUpdatePreservesUntouchedColumns(t *testing.T) {
+	pool := newTestDB(t)
+	repo := repository.NewViewerIdentityRepository(pool, premium.NewRecomputer(pool, zap.NewNop()))
+	ctx := context.Background()
+
+	platform := "twitch"
+	platformUserID := "user_cosmetics_partial_test"
+	defer cleanupViewer(t, pool, platform, platformUserID)
+
+	viewerID, err := repo.GetOrCreateViewerByPlatform(ctx, platform, platformUserID)
+	require.NoError(t, err)
+
+	// Seed a catalog frame so a valid avatar_frame_id can be set.
+	var frameID uuid.UUID
+	err = pool.QueryRow(ctx, `INSERT INTO cosmetic_frames (name, image_url) VALUES ('itest', 'itest') RETURNING id`).Scan(&frameID)
+	require.NoError(t, err)
+	defer pool.Exec(ctx, `DELETE FROM cosmetic_frames WHERE id = $1`, frameID)
+
+	// Set the avatar frame.
+	_, err = repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{SetFrame: true, AvatarFrameID: &frameID})
+	require.NoError(t, err)
+
+	// A name-only update must preserve the frame and return the merged row.
+	color := "#123456"
+	res, err := repo.UpsertViewerCosmetics(ctx, viewerID, repository.CosmeticsUpdate{SetName: true, NameColor: &color})
+	require.NoError(t, err)
+	require.NotNil(t, res.NameColor)
+	assert.Equal(t, color, *res.NameColor)
+	require.NotNil(t, res.AvatarFrameID, "name-only update must preserve the saved avatar frame")
+	assert.Equal(t, frameID, *res.AvatarFrameID)
 }


### PR DESCRIPTION
## What & why

From a viewer bug report while trying out allch.at: saving viewer appearance failed with `{"error":"Failed to update cosmetics"}`, and a failed Kick connect showed a generic "Missing code or state parameter" on a page that said "Twitch".

### 1. Non-premium cosmetics save always 500'd (the reported crash)
`PATCH /viewer/cosmetics` returned 500 for **every non-premium viewer**. The downgrade-enforcement path passed `&uuid.Nil` for `avatar_frame_id`/`avatar_flair_id` intending SQL NULL, but pgx encodes a non-nil pointer as the literal zero UUID `00000000-…`, which violates the FKs to `cosmetic_frames`/`cosmetic_flairs` (both empty in prod) → FK violation (23503). Confirmed against the prod schema + Loki (a burst of `PATCH /viewer/cosmetics → 500`).

- Pass `nil` (→ SQL NULL) to clear.
- Rework the handler into a **true per-column partial update**: one column-selective `UpsertViewerCosmetics` (`INSERT … ON CONFLICT` with per-flag `CASE` gating + `RETURNING`). A name save no longer clears a saved avatar frame; a flair change no longer clears the frame; the response reflects persisted state (no read-back/echo).
- The 500 path now logs the underlying error (previously it logged nothing — only the middleware access log showed the 500).

This shipped green because the unit test asserted the buggy `&uuid.Nil` contract against a mock that never hits a DB. Tests were rewritten to assert the correct contract, plus a real-Postgres integration guard.

### 2. OAuth error UX
- Viewer OAuth callbacks now surface the provider's `?error=` (e.g. Kick's "invalid redirect uri") through a **safe curated mapping** with a generic fallback — the raw value is logged only, never reflected verbatim to the page (avoids a content-spoofing surface).
- `/chat/auth-error` names the **actual** failing platform (Kick/YouTube/…) instead of hardcoding "Twitch", falling back to a neutral "streaming account" label.

> The "invalid redirect uri" root cause itself was an ops fix (the Kick OAuth app was missing the viewer callback URL) and is already resolved on the Kick dashboard.

## Testing
- Unit: full auth-service suite green (`-short`).
- Integration: exercised the real `RETURNING`/`CASE` SQL + FK behavior against Postgres 16 — nil → NULL succeeds, zero-UUID → FK violation, and a partial update preserves untouched columns.
- Frontend: lint clean; page typechecks.
- Reviewed by two adversarial code-review passes; all confirmed findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVWTdrmKUsfJtBjqjioGH1
