### PR TITLE
fix(database): bound per-service pools to stop connection exhaustion (ADR-0039)

### DIFF
--- a/docs/adr/0039-database-connection-budget.md
+++ b/docs/adr/0039-database-connection-budget.md
@@ -1,0 +1,82 @@
+# ADR-0039: Database connection budget (bounded pools per service)
+
+**Date**: 2026-07-18
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+Every Go service builds its own PostgreSQL pool through the shared
+`shared/database.NewPostgresPool*` helpers. That helper hardcoded:
+
+```go
+config.MaxConns = 20   // per service instance
+config.MinConns = 5    // keep warm
+```
+
+`MinConns` is a floor the pool keeps open permanently. With ~40 service
+instances (≈18 services, several replicated) that is `40 × 5 = ~200`
+connections held **idle** at all times — and the shared CNPG cluster
+(`allchat-cluster`) was configured with `max_connections: "200"`.
+
+The result: Postgres sat pinned at its ceiling with ~197 idle connections and
+**zero headroom**. Running pods were fine (they already held their
+connections), but any event that started new pods — a node failure, a rolling
+deploy, or manual pod moves — made the new pool's connection attempts fail with:
+
+```
+FATAL: remaining connection slots are reserved for roles with the
+SUPERUSER attribute (SQLSTATE 53300)
+```
+
+so the pod hit a fatal DB-ping at startup and `CrashLoopBackOff`ed until older
+connections churned. This was observed on 2026-07-18 during the
+`caesar-control-3` OOM incident (ADR-0038 in caesar-deployment): the reschedule
+churn crashlooped `twitch-eventsub-listener` several times before it recovered.
+
+A secondary problem: all connections were opened with an empty
+`application_name`, so `pg_stat_activity` could not attribute connections to a
+service, making the leak impossible to diagnose from the database side.
+
+## Decision
+
+Treat database connections as a **budget**: `Σ(instances × MaxConns)` must stay
+comfortably under the cluster's `max_connections`. Concretely:
+
+1. **Shrink the pool defaults** in `shared/database`: `MaxConns 20 → 10`,
+   `MinConns 5 → 1`. This drops the permanent idle footprint from ~200 to ~40.
+2. **Make pool sizes env-configurable** via `DATABASE_MAX_CONNS` /
+   `DATABASE_MIN_CONNS`, so a genuinely DB-heavy service can be raised without a
+   code change (and the budget stays explicit).
+3. **Set `application_name`** on every connection, resolved from
+   `DATABASE_APP_NAME` → `OTEL_SERVICE_NAME` → `HOSTNAME` (the pod name is
+   always present), restoring per-service attribution in `pg_stat_activity`.
+4. **Raise `max_connections` 200 → 300** on the `allchat-cluster` CNPG cluster
+   (caesar-deployment) for headroom. This is memory-safe: the primary used
+   815Mi/2Gi at 200 connections and `work_mem` is only 2MB, so 300 stays well
+   under the 2Gi limit. The higher ceiling also gives a safe window to roll out
+   the smaller pools without hitting the ceiling mid-deploy.
+
+## Consequences
+
+Positive:
+- Steady-state DB connections drop from ~197 to ~40, and the ceiling rises to
+  300 — from **zero** headroom to ~260 slots. Mass restarts no longer crashloop.
+- `pg_stat_activity.application_name` now names the owning pod, so future pool
+  growth or leaks are diagnosable.
+- Pool sizing is tunable per service via env, no rebuild required.
+
+Negative / trade-offs:
+- `MinConns = 1` means a service that has been idle keeps only one warm
+  connection; the first concurrent query after a quiet period pays a
+  connection-open (~ms). Negligible for these workloads.
+- The budget is still additive: if the instance count grows enough that
+  `instances × MaxConns` again approaches `max_connections`, per-pool tuning
+  stops scaling.
+
+Follow-up:
+- If the service/replica count keeps growing, put a **PgBouncer** in front of
+  the cluster (CNPG `Pooler`, transaction mode) so client pool sizes are
+  decoupled from actual backend connections. Not done now because pgx defaults
+  to prepared statements (extended protocol), which needs care in transaction
+  mode; the pool-budget fix resolves the observed problem without that risk.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -488,6 +488,17 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0039: Database Connection Budget (bounded pools per service)
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-18
+**Problem**: The shared DB helper hardcoded `MinConns=5`/`MaxConns=20` per pool; across ~40 service instances that held ~197 permanently-idle connections against the cluster's `max_connections=200`, leaving zero headroom — any mass pod start (node failure, deploy) crashlooped new pods with `SQLSTATE 53300`. Connections were also anonymous (`application_name` empty), so the leak was undiagnosable from the DB
+**Decision**: Treat connections as a budget — `Σ(instances × MaxConns)` must stay under `max_connections`. Shrink shared defaults to `MinConns=1`/`MaxConns=10`, make both env-tunable (`DATABASE_MAX_CONNS`/`DATABASE_MIN_CONNS`), set `application_name` (from `DATABASE_APP_NAME`→`OTEL_SERVICE_NAME`→`HOSTNAME`), and raise `allchat-cluster` `max_connections` 200→300 (memory-safe: 815Mi/2Gi at 200 conns, `work_mem` 2MB)
+**Impact**: Steady-state DB connections drop ~197→~40 and headroom goes from 0 to ~260; mass restarts stop crashlooping; per-pod attribution restored. PgBouncer (CNPG `Pooler`, transaction mode) noted as the next step if instance count outgrows the additive budget. (ADR numbering shared with caesar-deployment, so this is 0039)
+**→ Read**: [0039-database-connection-budget.md](./0039-database-connection-budget.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number

--- a/shared/database/postgres.go
+++ b/shared/database/postgres.go
@@ -19,25 +19,62 @@ package database
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// NewPostgresPoolWithTracing creates a PostgreSQL pool with optional OpenTelemetry tracing
-func NewPostgresPoolWithTracing(connString string, tracingEnabled bool) (*pgxpool.Pool, error) {
+// Connection-pool defaults. Every service instance holds its own pool, so the
+// cluster-wide connection budget is (number of instances x MaxConns) and must
+// stay under the database's max_connections. These defaults are deliberately
+// small: a previous MinConns=5 across ~40 instances held ~200 permanently-idle
+// connections and pinned Postgres at its 200-connection ceiling, crashlooping
+// newly-starting pods with "remaining connection slots are reserved..."
+// (SQLSTATE 53300) on any mass restart. Raise per service with
+// DATABASE_MAX_CONNS / DATABASE_MIN_CONNS when a workload genuinely needs more.
+// See ADR-0039.
+const (
+	defaultMaxConns = 10
+	defaultMinConns = 1
+)
+
+// buildPoolConfig parses the connection string and applies the shared pool
+// tuning. It is separated from pool creation so it can be unit-tested without a
+// live database.
+func buildPoolConfig(connString string) (*pgxpool.Config, error) {
 	config, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
 
-	// Connection pool configuration
-	config.MaxConns = 20                       // Max connections per service instance
-	config.MinConns = 5                        // Keep warm connections
+	// Connection pool configuration (see the connection-budget note above).
+	config.MaxConns = int32(envInt("DATABASE_MAX_CONNS", defaultMaxConns))
+	config.MinConns = int32(envInt("DATABASE_MIN_CONNS", defaultMinConns))
 	config.MaxConnLifetime = 1 * time.Hour     // Recycle connections after 1 hour
-	config.MaxConnIdleTime = 10 * time.Minute  // Close idle connections
-	config.HealthCheckPeriod = 1 * time.Minute // Verify connections health
+	config.MaxConnIdleTime = 10 * time.Minute  // Close idle connections down to MinConns
+	config.HealthCheckPeriod = 1 * time.Minute // Verify connection health
+
+	// Tag connections so pg_stat_activity can attribute them to a service
+	// (they were previously anonymous, making pool leaks impossible to trace).
+	if name := applicationName(); name != "" {
+		if config.ConnConfig.RuntimeParams == nil {
+			config.ConnConfig.RuntimeParams = map[string]string{}
+		}
+		config.ConnConfig.RuntimeParams["application_name"] = name
+	}
+
+	return config, nil
+}
+
+// NewPostgresPoolWithTracing creates a PostgreSQL pool with optional OpenTelemetry tracing
+func NewPostgresPoolWithTracing(connString string, tracingEnabled bool) (*pgxpool.Pool, error) {
+	config, err := buildPoolConfig(connString)
+	if err != nil {
+		return nil, err
+	}
 
 	// Add OpenTelemetry tracer if enabled
 	if tracingEnabled {
@@ -72,4 +109,30 @@ func HealthCheck(pool *pgxpool.Pool) error {
 	defer cancel()
 
 	return pool.Ping(ctx)
+}
+
+// envInt returns the integer value of the named environment variable, or def
+// when it is unset, empty, non-numeric, or not positive.
+func envInt(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+// applicationName resolves a label for the connection's application_name,
+// preferring an explicit override, then the OTel service name, then the pod
+// hostname (always set in Kubernetes, giving per-service attribution for free).
+func applicationName() string {
+	for _, key := range []string{"DATABASE_APP_NAME", "OTEL_SERVICE_NAME", "HOSTNAME"} {
+		if v := os.Getenv(key); v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/shared/database/postgres_test.go
+++ b/shared/database/postgres_test.go
@@ -1,0 +1,118 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package database
+
+import "testing"
+
+const testDSN = "postgres://user:pass@localhost:5432/db"
+
+func TestEnvInt(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		def  int
+		want int
+	}{
+		{"unset uses default", false, "", 10, 10},
+		{"valid override", true, "5", 10, 5},
+		{"empty uses default", true, "", 10, 10},
+		{"non-numeric uses default", true, "abc", 10, 10},
+		{"zero rejected", true, "0", 10, 10},
+		{"negative rejected", true, "-3", 10, 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("TEST_ENV_INT", tc.val)
+			}
+			if got := envInt("TEST_ENV_INT_UNSET_"+tc.name, tc.def); !tc.set && got != tc.want {
+				t.Fatalf("envInt(unset) = %d, want %d", got, tc.want)
+			}
+			if tc.set {
+				if got := envInt("TEST_ENV_INT", tc.def); got != tc.want {
+					t.Fatalf("envInt(%q) = %d, want %d", tc.val, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPoolConfigDefaults(t *testing.T) {
+	// Ensure a clean environment.
+	t.Setenv("DATABASE_MAX_CONNS", "")
+	t.Setenv("DATABASE_MIN_CONNS", "")
+
+	cfg, err := buildPoolConfig(testDSN)
+	if err != nil {
+		t.Fatalf("buildPoolConfig: %v", err)
+	}
+	if cfg.MaxConns != defaultMaxConns {
+		t.Errorf("MaxConns = %d, want %d", cfg.MaxConns, defaultMaxConns)
+	}
+	if cfg.MinConns != defaultMinConns {
+		t.Errorf("MinConns = %d, want %d", cfg.MinConns, defaultMinConns)
+	}
+	// Connection-budget guard: the default must stay small so that
+	// (instances x MaxConns) fits under the cluster max_connections (ADR-0039).
+	if cfg.MaxConns > 10 {
+		t.Errorf("default MaxConns %d is too high for the shared connection budget", cfg.MaxConns)
+	}
+	if cfg.MinConns > 2 {
+		t.Errorf("default MinConns %d holds too many idle connections per instance", cfg.MinConns)
+	}
+}
+
+func TestBuildPoolConfigEnvOverride(t *testing.T) {
+	t.Setenv("DATABASE_MAX_CONNS", "6")
+	t.Setenv("DATABASE_MIN_CONNS", "2")
+
+	cfg, err := buildPoolConfig(testDSN)
+	if err != nil {
+		t.Fatalf("buildPoolConfig: %v", err)
+	}
+	if cfg.MaxConns != 6 {
+		t.Errorf("MaxConns = %d, want 6", cfg.MaxConns)
+	}
+	if cfg.MinConns != 2 {
+		t.Errorf("MinConns = %d, want 2", cfg.MinConns)
+	}
+}
+
+func TestBuildPoolConfigApplicationName(t *testing.T) {
+	t.Setenv("DATABASE_APP_NAME", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("HOSTNAME", "twitch-eventsub-listener-abc123")
+
+	cfg, err := buildPoolConfig(testDSN)
+	if err != nil {
+		t.Fatalf("buildPoolConfig: %v", err)
+	}
+	if got := cfg.ConnConfig.RuntimeParams["application_name"]; got != "twitch-eventsub-listener-abc123" {
+		t.Errorf("application_name = %q, want the hostname fallback", got)
+	}
+}
+
+func TestApplicationNamePrecedence(t *testing.T) {
+	t.Setenv("HOSTNAME", "pod-xyz")
+	t.Setenv("OTEL_SERVICE_NAME", "otel-name")
+	t.Setenv("DATABASE_APP_NAME", "explicit-name")
+
+	if got := applicationName(); got != "explicit-name" {
+		t.Errorf("applicationName() = %q, want the explicit override to win", got)
+	}
+}


### PR DESCRIPTION
## Why

During the 2026-07-18 `caesar-control-3` OOM incident, `twitch-eventsub-listener` crashlooped with:

```
FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute (SQLSTATE 53300)
```

Root cause: the shared pool helper hardcoded `MinConns=5` / `MaxConns=20`. `MinConns` is a floor kept open permanently, so across ~40 service instances that's **~197 idle connections** held against the CNPG cluster's `max_connections=200` — **zero headroom**. Running pods are fine, but any event that starts new pods (node failure, deploy, reschedule) makes the new pool's connection attempts fail, and the pod fatals at startup → `CrashLoopBackOff`. Connections were also opened with an empty `application_name`, so the pileup was invisible in `pg_stat_activity`.

## What

- `MinConns 5 → 1`, `MaxConns 20 → 10` — drops the permanent idle footprint from ~197 to ~40.
- Both env-tunable via `DATABASE_MAX_CONNS` / `DATABASE_MIN_CONNS` for genuinely DB-heavy services.
- Set `application_name` from `DATABASE_APP_NAME` → `OTEL_SERVICE_NAME` → `HOSTNAME` (pod name is always present) — restores per-service attribution.
- Extracted `buildPoolConfig()` so the tuning is unit-testable without a live DB; added tests (env parsing, defaults, overrides, application_name precedence, connection-budget guard).
- **ADR-0039** documents the connection-budget invariant: `Σ(instances × MaxConns)` must stay under `max_connections`.

## Paired change (must merge first)

caesar-deployment: raise `allchat-cluster` `max_connections` 200 → 300 for rollout headroom (memory-safe: primary was 815Mi/2Gi at 200 conns, `work_mem` 2MB). **Merge the DB-headroom PR and let CNPG apply it before this deploys**, so the rolling deploy of the smaller pools doesn't hit the ceiling mid-flight.

## Follow-up

If instance count keeps growing, front the cluster with PgBouncer (CNPG `Pooler`, transaction mode). Deferred here because pgx defaults to prepared statements (extended protocol), which needs care in transaction mode — the pool-budget fix resolves the observed problem without that risk.

## Test

`cd shared && GOTOOLCHAIN=go1.25.7 go test ./database/` → `ok`. Vet clean, full `shared` module builds.