### PR TITLE
fix(frontend): self-host Monaco so the CSS editor loads under CSP (ADR-0040)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ docs/overlay-themes/custom-fonts/
 # Exception: OG image font (required for build-time rendering)
 !frontend/public/fonts/Barlow-Bold.ttf
 
+# Vendored Monaco Editor assets (16 MB, regenerated from node_modules at build
+# time by frontend/scripts/copy-monaco.mjs — see ADR-0040)
+frontend/public/monaco/
+
 # Node modules (for frontend)
 node_modules/
 /web/node_modules/

--- a/docs/adr/0040-self-host-monaco-editor.md
+++ b/docs/adr/0040-self-host-monaco-editor.md
@@ -1,0 +1,93 @@
+# ADR-0040: Self-host the Monaco CSS editor (no third-party CDN)
+
+**Date**: 2026-07-19
+**Status**: Accepted
+**Deciders**: caesarakalaeii
+
+## Context and Problem Statement
+
+The overlay editor's Custom CSS field (`frontend/src/components/MonacoCSSEditor.tsx`,
+used from `overlays/[id]` and `overlays/[id]/credits`) is built on
+`@monaco-editor/react`. That wrapper delegates engine loading to
+`@monaco-editor/loader`, whose **default configuration fetches the Monaco
+engine from a public CDN**:
+
+```
+paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs' }
+```
+
+Our application CSP (`frontend/next.config.js`) deliberately enumerates every
+allowed script host and does **not** include `cdn.jsdelivr.net`:
+
+```
+script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at
+```
+
+So the browser blocked the loader script and the editor hung **forever on
+"Loading editor…"**. Reproduced in production via Playwright — the console
+showed:
+
+```
+Loading the script 'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs/loader.js'
+violates the following Content Security Policy directive:
+"script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at".
+The action has been blocked.
+→ Monaco initialization: error
+```
+
+Two ways to make the editor load again:
+
+1. **Add `cdn.jsdelivr.net` to `script-src`.** One line, but it (a) permanently
+   introduces a runtime dependency on a third-party CDN — a jsdelivr outage or
+   a corporate/geo block breaks the editor, and offline dev breaks; (b) widens
+   the script-execution surface to a large external origin, against the grain
+   of a CSP we otherwise keep tightly enumerated; and (c) does not by itself fix
+   Monaco's web workers (see below), so extra CSP relaxations are needed anyway.
+2. **Self-host Monaco from our own origin.** Vendor the engine into `public/`
+   and point the loader at it, so every request is same-origin `'self'`.
+
+## Decision
+
+**Self-host Monaco (option 2).**
+
+- `frontend/scripts/copy-monaco.mjs` copies `node_modules/monaco-editor/min/vs`
+  → `frontend/public/monaco/vs` at build time. `monaco-editor` is a peer
+  dependency of `@monaco-editor/react`, auto-installed and pinned in the
+  lockfile (0.55.1), so `npm ci` supplies it deterministically without a
+  separate direct-dependency entry (kept out to avoid npm-version lockfile
+  churn — see [[reference_frontend_npmci_lock_cache_masking]]). The output is
+  gitignored (16 MB) and regenerated via the `prebuild`/`predev` npm hooks; a
+  `.monaco-version` marker skips the copy when already current.
+- `frontend/src/lib/monaco.ts` calls `loader.config({ paths: { vs: '/monaco/vs' } })`
+  and is imported for its side effect at the top of `MonacoCSSEditor.tsx`,
+  before any `<Editor>` mounts.
+- **CSP: add `worker-src 'self' blob:`.** Monaco 0.55 runs its CSS language
+  services (validation, autocomplete) in Web Workers that it instantiates from
+  **same-origin `blob:` URLs** — this is independent of where the engine is
+  hosted. With no explicit `worker-src`, worker creation falls back to
+  `script-src` (no `blob:`) and is blocked, so the editor would render but its
+  language features silently die. `'self'` covers direct same-origin workers;
+  `blob:` covers Monaco's blob workers (blobs are built by same-origin script,
+  so this is far narrower than trusting an external script host, and the CSP
+  already trusts `blob:` in `media-src`). **No `script-src` change** — the
+  third-party CDN is never added.
+
+## Consequences
+
+- The CSS editor loads and its CSS validation/autocomplete work under the exact
+  production CSP. Verified end-to-end with Playwright: the real component
+  mounts (no "Loading editor…"), Monaco renders, and the CSS worker produces a
+  validation marker for a planted typo.
+- No third-party CDN in the runtime path: editor works offline, during a
+  jsdelivr outage, and in restricted networks; the script-execution surface
+  stays first-party.
+- Build produces a 16 MB `public/monaco/` (gitignored). The Docker builder runs
+  the copy via `prebuild`; the runner stage already copies `public/` into the
+  standalone image, so no Dockerfile change is required.
+- Upgrading `monaco-editor` (via a `@monaco-editor/react` bump) auto-refreshes
+  the vendored copy on the next build because `loader.config` is
+  version-agnostic (`/monaco/vs`) and the copy script keys off the installed
+  version.
+- The only CSP broadening is `worker-src 'self' blob:`, applied globally in
+  `cspBase`. Overlay/widget routes create no workers, so this does not
+  meaningfully weaken them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -499,6 +499,17 @@ All ADRs follow the **Markdown Any Decision Records (MADR)** template:
 
 ---
 
+### ADR-0040: Self-host the Monaco CSS editor (no third-party CDN)
+
+**Status**: ✅ Accepted
+**Date**: 2026-07-19
+**Problem**: The overlay editor's Custom CSS field uses `@monaco-editor/react`, whose loader fetches the Monaco engine from `cdn.jsdelivr.net` by default. The app CSP `script-src` enumerates allowed hosts and excludes jsdelivr, so the loader script was blocked and the editor hung forever on "Loading editor…" (reproduced in prod via Playwright: CSP violation → `Monaco initialization: error`)
+**Decision**: Self-host instead of punching a CSP hole to a CDN. A build-time script (`scripts/copy-monaco.mjs`, wired via `prebuild`/`predev`) vendors `monaco-editor/min/vs` → `public/monaco/vs` (gitignored, 16 MB; `monaco-editor` stays a lockfile-pinned peer dep to avoid npm-version lockfile churn), and `src/lib/monaco.ts` points the loader at same-origin `/monaco/vs`. Add `worker-src 'self' blob:` to the CSP — Monaco runs its CSS language services in same-origin `blob:` workers regardless of engine host; without it the editor loads but validation/autocomplete silently die. No `script-src` change; no third-party CDN in the runtime path
+**Impact**: The CSS editor loads and its CSS language features work under the exact production CSP (verified end-to-end with Playwright); the editor works offline / during a jsdelivr outage and the script-execution surface stays first-party. The only CSP broadening is `worker-src 'self' blob:` (already trusted in `media-src`). (ADR numbering shared with caesar-deployment, so this is 0040)
+**→ Read**: [0040-self-host-monaco-editor.md](./0040-self-host-monaco-editor.md)
+
+---
+
 ## How to Create a New ADR
 
 ### Step 1: Determine ADR Number

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -73,6 +73,16 @@ const nextConfig = {
       // (components/Analytics.tsx); without it the tracker script is CSP-blocked
       // and no page views or custom events are recorded.
       "script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at",
+      // worker-src governs Web Worker/SharedWorker creation. The overlay
+      // editor's self-hosted Monaco (/monaco/vs, ADR-0040) runs its CSS
+      // language services — validation, autocomplete — in workers that Monaco
+      // instantiates from same-origin blob: URLs. Without an explicit
+      // worker-src these fall back to script-src (no blob:) and are blocked,
+      // so the editor loads but its language features silently die. 'self'
+      // covers direct same-origin workers; blob: covers Monaco's blob workers
+      // (blobs are built by same-origin script, so this is far narrower than a
+      // third-party script-src host).
+      "worker-src 'self' blob:",
       "style-src 'self' 'unsafe-inline'",
       "connect-src 'self' wss: ws: https:",
       // media-src governs <video>/<audio> sources. Chat message video attachments

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "npm run copy:monaco",
     "dev": "next dev -p 3000",
     "generate:themes": "node scripts/generate-bundled-themes.mjs",
+    "copy:monaco": "node scripts/copy-monaco.mjs",
+    "prebuild": "npm run copy:monaco",
     "build": "next build",
     "start": "next start -p 3000",
     "lint": "next lint",

--- a/frontend/scripts/copy-monaco.mjs
+++ b/frontend/scripts/copy-monaco.mjs
@@ -1,0 +1,77 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Vendor Monaco Editor into public/ so the CSS editor loads it from our own
+ * origin instead of cdn.jsdelivr.net.
+ *
+ * WHY: @monaco-editor/react defaults to fetching the Monaco engine from
+ * https://cdn.jsdelivr.net/npm/monaco-editor@<ver>/min/vs. The app CSP
+ * script-src allows only 'self' (+ a couple of named hosts), so that CDN
+ * script is blocked and the editor hangs forever on "Loading editor...".
+ * Serving Monaco from /monaco/vs keeps every request same-origin — no CSP
+ * hole for a third-party CDN, and Monaco's web workers load under
+ * default-src 'self' with no worker-src/blob relaxation. See ADR-0040.
+ *
+ * Source: node_modules/monaco-editor/min/vs. monaco-editor is a peer
+ * dependency of @monaco-editor/react — npm auto-installs it and the lockfile
+ * pins it (0.55.1), so `npm ci` provides it deterministically without a
+ * separate direct-dependency entry (kept out to avoid lockfile churn).
+ * Output: public/monaco/vs. The output is gitignored (16 MB, regenerated
+ * from node_modules) and produced at build time via the `prebuild`/`predev`
+ * npm hooks.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+
+const MONACO_VERSION = require('monaco-editor/package.json').version
+const SRC_VS = join(dirname(require.resolve('monaco-editor/package.json')), 'min', 'vs')
+const DEST_DIR = join(__dirname, '..', 'public', 'monaco')
+const DEST_VS = join(DEST_DIR, 'vs')
+const VERSION_MARKER = join(DEST_DIR, '.monaco-version')
+
+// Skip the copy when public/monaco already holds this exact monaco-editor
+// version — keeps `npm run dev`/`build` startup fast. A version bump (or a
+// missing marker) forces a fresh copy so the vendored assets never go stale.
+const alreadyCurrent =
+  existsSync(VERSION_MARKER) &&
+  existsSync(join(DEST_VS, 'loader.js')) &&
+  readFileSync(VERSION_MARKER, 'utf8').trim() === MONACO_VERSION
+
+if (alreadyCurrent) {
+  console.log(`[copy-monaco] public/monaco already at ${MONACO_VERSION}, skipping`)
+  process.exit(0)
+}
+
+if (!existsSync(SRC_VS)) {
+  console.error(
+    `[copy-monaco] source not found: ${SRC_VS}\n  Is monaco-editor installed? Run \`npm install\`.`
+  )
+  process.exit(1)
+}
+
+mkdirSync(DEST_DIR, { recursive: true })
+cpSync(SRC_VS, DEST_VS, { recursive: true })
+writeFileSync(VERSION_MARKER, MONACO_VERSION + '\n')
+console.log(`[copy-monaco] copied monaco-editor@${MONACO_VERSION} -> public/monaco/vs`)

--- a/frontend/src/app/__tests__/security-headers.test.ts
+++ b/frontend/src/app/__tests__/security-headers.test.ts
@@ -118,4 +118,18 @@ describe('next.config framing policy', () => {
     expect(ruleFor(all, '/overlay/:id/participate')).toBeUndefined()
     expect(ruleFor(all, '/overlay/:id/view')).toBeUndefined()
   })
+
+  it('allows Monaco editor blob workers so the CSS editor language services load (ADR-0040)', async () => {
+    const all = await rules()
+    // The overlay editor's self-hosted Monaco (/monaco/vs) runs its CSS
+    // language services in same-origin blob: workers. Without an explicit
+    // worker-src these fall back to script-src (no blob:) and are blocked, so
+    // the editor loads but validation/autocomplete silently die. This must
+    // hold on the app routes AND survive the last-wins full-CSP replacement on
+    // the embeddable widget routes.
+    expect(csp(ruleFor(all, '/:path*'))).toContain("worker-src 'self' blob:")
+    for (const source of WIDGET_SOURCES) {
+      expect(csp(ruleFor(all, source)), source).toContain("worker-src 'self' blob:")
+    }
+  })
 })

--- a/frontend/src/components/MonacoCSSEditor.tsx
+++ b/frontend/src/components/MonacoCSSEditor.tsx
@@ -25,6 +25,11 @@
 
 'use client'
 
+// Side-effect import: points the Monaco loader at our self-hosted /monaco/vs
+// (see src/lib/monaco.ts + ADR-0040). MUST run before <Editor> mounts, so it
+// stays the first import; otherwise the loader falls back to cdn.jsdelivr.net,
+// which the app CSP blocks — leaving the editor stuck on "Loading editor...".
+import '@/lib/monaco'
 import { Editor, OnMount } from '@monaco-editor/react'
 import { useRef, useEffect } from 'react'
 

--- a/frontend/src/lib/monaco.ts
+++ b/frontend/src/lib/monaco.ts
@@ -1,0 +1,41 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Monaco loader configuration (self-hosted).
+ *
+ * @monaco-editor/react loads the Monaco engine from cdn.jsdelivr.net by
+ * default. The app CSP (see next.config.js) restricts script-src to 'self'
+ * plus a couple of named hosts, so the CDN loader is blocked and the editor
+ * hangs on "Loading editor..." forever. Pointing the loader at our own
+ * /monaco/vs (vendored into public/ by scripts/copy-monaco.mjs) keeps every
+ * request same-origin — no third-party CDN in the CSP, and Monaco's web
+ * workers load under default-src 'self' with no blob/worker-src relaxation.
+ *
+ * Import this module for its side effect BEFORE any <Editor> mounts. It is
+ * safe to import more than once; loader.config only takes effect until the
+ * first loader.init(), and every editor entry point routes through here.
+ *
+ * See ADR-0040.
+ */
+
+import { loader } from '@monaco-editor/react'
+
+loader.config({ paths: { vs: '/monaco/vs' } })
+
+export { loader }


### PR DESCRIPTION
## Problem

The overlay editor's **Custom CSS field** (Monaco, via `@monaco-editor/react`) hangs forever on **"Loading editor…"**.

`@monaco-editor/loader` fetches the Monaco engine from `cdn.jsdelivr.net` by default, but the app CSP `script-src` only allows `'self'`, `embed.twitch.tv`, and `analytics.allch.at`. The loader script is CSP-blocked, so the editor never mounts.

Reproduced live on `allch.at` with Playwright — console:

```
Loading the script 'https://cdn.jsdelivr.net/npm/monaco-editor@0.55.1/min/vs/loader.js'
violates the following Content Security Policy directive:
"script-src 'self' 'unsafe-inline' https://embed.twitch.tv https://analytics.allch.at".
The action has been blocked.
→ Monaco initialization: error
```

## Fix — self-host Monaco (don't punch a CSP hole to a third-party CDN)

- **`frontend/scripts/copy-monaco.mjs`** vendors `monaco-editor/min/vs` → `public/monaco/vs` at build time (gitignored 16 MB; wired via `prebuild`/`predev`; `.monaco-version` marker skips redundant copies). The Docker runner already copies `public/` into the standalone image, so no Dockerfile change is needed. `monaco-editor` stays a lockfile-pinned **peer dep** — a direct-dep entry caused npm-12-vs-11 lockfile churn.
- **`frontend/src/lib/monaco.ts`** points the loader at same-origin `/monaco/vs`, side-effect-imported first in `MonacoCSSEditor.tsx`.
- **`worker-src 'self' blob:`** added to the CSP. Monaco 0.55 runs its CSS language services (validation/autocomplete) in same-origin **blob: workers** regardless of engine host; without an explicit `worker-src` they fall back to `script-src` (no `blob:`) and are blocked, so the editor would render but its language features silently die. `blob:` is already trusted in `media-src`; **no `script-src` change**, no third-party CDN in the runtime path.

See **ADR-0040** for the full rationale and the CDN-allowlist alternative that was rejected.

## Verification (Playwright, under the exact production CSP)

- **Before:** real editor stuck on "Loading editor…", `.monaco-editor` never mounts.
- **After:** the real `MonacoCSSEditor` component mounts and renders; the CSS worker flags a planted typo (`markerCount: 1`); no worker CSP violations remain.
- App compiles successfully; changed files are type-clean + pass ESLint/Prettier.
- CSP contract test (`security-headers.test.ts`) passes with a new assertion pinning `worker-src` (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)