### PR TITLE
fix(api-gateway): keep overlay connection status when session enrichment fails

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -389,7 +389,7 @@ func main() {
 	healthHandler := handlers.NewHealthHandler(registry)
 	badgeHandler := handlers.NewTwitchBadgeHandler(log, twitchClientID, twitchClientSecret)
 	avatarProxyHandler := handlers.NewAvatarProxyHandler(redisClient, log)
-	statsHandler := handlers.NewStatsHandler(redisClient)
+	statsHandler := handlers.NewStatsHandler(redisClient, log)
 	wsHandler := handlers.NewWebSocketHandler(wsManager, subscriber, subRepo, statusSubscriber, userKeyChain, replayBuffer, chatReplayBuffer, redisClient, log)
 
 	// Create viewer WebSocket handler (same origin policy as owner handler)

--- a/services/api-gateway/handlers/stats.go
+++ b/services/api-gateway/handlers/stats.go
@@ -23,16 +23,21 @@ import (
 	"github.com/caesar/all-chat/services/api-gateway/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
 )
 
 // StatsHandler serves public platform statistics.
 type StatsHandler struct {
-	redis *redis.Client
+	redis  *redis.Client
+	logger *zap.Logger
 }
 
 // NewStatsHandler creates a StatsHandler.
-func NewStatsHandler(redis *redis.Client) *StatsHandler {
-	return &StatsHandler{redis: redis}
+func NewStatsHandler(redis *redis.Client, logger *zap.Logger) *StatsHandler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &StatsHandler{redis: redis, logger: logger}
 }
 
 // GetPlatformStats returns message counts per platform for the last 7 days.
@@ -125,12 +130,19 @@ func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 	for i, id := range activeIDs {
 		startedCmds[i] = pipe.HGet(ctx, sessions.SessionKeyPrefix+id, "started_at")
 	}
-	// Exec reports redis.Nil when a session hash is simply missing (an expected
-	// state, handled per-command below); any other error is a real Redis failure
-	// and should surface as 500 rather than silently dropping every timestamp.
+	// started_at is an OPTIONAL enrichment ("connected for X"); the overlay:connected
+	// SCAN above is the authoritative "which overlays are live" answer. A failure here
+	// must NOT discard that answer — returning 500 made the admin UI (which silently
+	// ignores a non-OK response) render every overlay as "not connected" even while
+	// live, whenever this pipeline hit a transient blip or a single stray/mistyped
+	// session key. Degrade instead: log and return connection status without durations.
+	// redis.Nil merely means some session hashes are missing (expected, handled
+	// per-command below); on any other error each command carries that error, so its
+	// Result() call below fails and connected_since is simply omitted.
 	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load overlay sessions"})
-		return
+		h.logger.Warn("failed to load overlay session start times; returning connection status without durations",
+			zap.Error(err),
+		)
 	}
 
 	for i, id := range activeIDs {

--- a/services/api-gateway/handlers/stats_test.go
+++ b/services/api-gateway/handlers/stats_test.go
@@ -41,7 +41,7 @@ func setupStatsTestRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
 func TestGetActiveOverlays_Empty(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, _ := setupStatsTestRedis(t)
-	handler := NewStatsHandler(client)
+	handler := NewStatsHandler(client, nil)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -60,7 +60,7 @@ func TestGetActiveOverlays_Empty(t *testing.T) {
 func TestGetActiveOverlays_ReturnsConnectedIDs(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, mr := setupStatsTestRedis(t)
-	handler := NewStatsHandler(client)
+	handler := NewStatsHandler(client, nil)
 
 	// Simulate active overlays in Redis
 	mr.Set("overlay:connected:abc-123", "1")
@@ -94,7 +94,7 @@ func TestGetActiveOverlays_ReturnsConnectedIDs(t *testing.T) {
 func TestGetActiveOverlays_IncludesConnectedSince(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, mr := setupStatsTestRedis(t)
-	handler := NewStatsHandler(client)
+	handler := NewStatsHandler(client, nil)
 
 	// Overlay with a session hash carrying a start time.
 	startedAt := time.Now().UTC().Add(-90 * time.Minute).Truncate(time.Second)
@@ -130,4 +130,35 @@ func TestGetActiveOverlays_IncludesConnectedSince(t *testing.T) {
 	noSession, ok := byID["no-session"]
 	require.True(t, ok)
 	assert.Nil(t, noSession.ConnectedSince)
+}
+
+// TestGetActiveOverlays_EnrichmentFailureStillReturnsStatus guards the regression
+// where a failure of the optional started_at enrichment discarded the entire
+// connection-status answer: the endpoint 500'd and the admin UI (which silently
+// ignores non-OK responses) showed every overlay as "not connected" even while
+// live. A stray/mistyped session key (here a plain string where a hash is
+// expected) makes the pipelined HGET return WRONGTYPE, which must degrade to
+// "status without durations", not fail the whole request.
+func TestGetActiveOverlays_EnrichmentFailureStillReturnsStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client, mr := setupStatsTestRedis(t)
+	handler := NewStatsHandler(client, nil)
+
+	mr.Set("overlay:connected:live-overlay", "1")
+	mr.SetTTL("overlay:connected:live-overlay", 10*time.Minute)
+	// Wrong type for the session key: HGET session:active:live-overlay -> WRONGTYPE.
+	mr.Set("session:active:live-overlay", "not-a-hash")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/admin/overlays/active", nil)
+
+	handler.GetActiveOverlays(c)
+
+	assert.Equal(t, http.StatusOK, w.Code, "enrichment failure must not 500 the connection status")
+	var overlays []ActiveOverlay
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &overlays))
+	require.Len(t, overlays, 1)
+	assert.Equal(t, "live-overlay", overlays[0].OverlayID)
+	assert.Nil(t, overlays[0].ConnectedSince, "duration is dropped, but the overlay is still reported connected")
 }


### PR DESCRIPTION
## Problem

The admin overlays view showed every overlay as **"not connected" even while live**, intermittently. Root cause is in `services/api-gateway/handlers/stats.go` `GetActiveOverlays`, introduced by the connected-duration refactor (#557).

The handler does two things:
1. **Authoritative:** `SCAN overlay:connected:*` — the set of overlays with a live WebSocket. This *is* the connection-status answer.
2. **Optional enrichment:** a pipelined `HGET session:active:{id} started_at` — the "connected for X" duration.

A failure of step 2 returned `500` for the whole endpoint, discarding the status already computed in step 1. The admin page ignores a non-OK response, so the connected set went empty and everything rendered "not connected". The enrichment pipeline can fail independently of a healthy SCAN (a `WRONGTYPE` on a stray `session:active:*` key, or a transient blip / context-deadline between the SCAN loop and `Exec`), hence the intermittency.

## Fix

Degrade gracefully: the optional duration enrichment can no longer nuke the status. On pipeline error we log and return the connected overlay IDs **without** timestamps (the per-command result loop already omits `connected_since` for commands that errored). Genuine status-endpoint failures (SCAN error) still `500`, which the frontend surfaces as the "status unavailable" banner added in #579.

The two fixes compose:
- Enrichment-only failure → `200` with connected IDs, no durations → overlays shown connected, no banner.
- Total failure (Redis/SCAN down) → `500` → frontend banner.

## Changes
- `stats.go`: graceful degradation on pipeline error; add a `*zap.Logger` to `StatsHandler` (nil-guarded) for observability.
- `cmd/main.go`: pass the logger to `NewStatsHandler`.
- `stats_test.go`: regression test — a `WRONGTYPE` session key now returns `200` with the overlay still reported connected (fails against old code).

## Test
`go build ./...`, `go vet ./handlers/`, and `go test ./handlers/ -run TestGetActiveOverlays` all pass.