### PR TITLE
fix(api-gateway): retry the startup database connection with backoff

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -100,8 +100,26 @@ func main() {
 	connString := fmt.Sprintf("postgres://%s:%s@%s:%s/%s",
 		dbUser, dbPassword, dbHost, dbPort, dbName)
 
-	db, err := database.NewPostgresPool(connString)
+	// A single startup context, cancelled by SIGINT/SIGTERM, so both the database
+	// and Redis connect-with-retry loops abort promptly on shutdown instead of
+	// blocking termination while a dependency is unavailable. Released once both
+	// dependencies are connected so the normal server signal handling takes over.
+	startupCtx, stopStartup := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+
+	// Connect to PostgreSQL, retrying with backoff so a transient outage (e.g. a
+	// CNPG primary failover or the pod being rescheduled) does not crash-loop this
+	// service on startup — it stays alive reporting not-ready until the DB returns.
+	db, err := database.NewPostgresPoolWithRetry(startupCtx, connString, false,
+		database.DefaultRetryOptions(),
+		func(attempt int, err error, backoff time.Duration) {
+			log.Warn("Database not reachable, retrying with backoff",
+				zap.Int("attempt", attempt),
+				zap.Duration("backoff", backoff),
+				zap.Error(err),
+			)
+		})
 	if err != nil {
+		stopStartup()
 		log.Fatal("Failed to connect to database", zap.Error(err))
 	}
 	defer db.Close()
@@ -117,7 +135,6 @@ func main() {
 	redisPort := getEnvOrDefault("REDIS_PORT", "6379")
 	redisAddr := sharedredis.BuildDSN(redisHost, redisPort)
 
-	startupCtx, stopStartup := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	redisClient, err := sharedredis.NewClientWithRetry(startupCtx, redisAddr, getEnvOrDefault("REDIS_PASSWORD", ""), tracingEnabled,
 		sharedredis.DefaultRetryOptions(),
 		func(attempt int, err error, backoff time.Duration) {

--- a/shared/database/postgres.go
+++ b/shared/database/postgres.go
@@ -103,6 +103,75 @@ func NewPostgresPool(connString string) (*pgxpool.Pool, error) {
 	return NewPostgresPoolWithTracing(connString, false)
 }
 
+// RetryOptions configures startup connection retry with exponential backoff.
+// Mirrors shared/redis.RetryOptions so services connect to Postgres and Redis
+// with the same resilience semantics.
+type RetryOptions struct {
+	// MaxAttempts is the maximum number of connection attempts. A value <= 0
+	// means retry until the supplied context is cancelled.
+	MaxAttempts int
+	// InitialBackoff is the wait before the second attempt. Defaults to 1s.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the backoff between attempts. Defaults to 30s.
+	MaxBackoff time.Duration
+}
+
+// DefaultRetryOptions returns sensible startup-retry defaults: retry indefinitely
+// (bounded only by the caller's context) with backoff growing from 1s to 30s.
+// This keeps a service alive — reporting not-ready via its readiness probe —
+// while PostgreSQL is briefly unavailable (e.g. a CNPG primary failover or the
+// pod being rescheduled), instead of crash-looping on a fatal connection error.
+func DefaultRetryOptions() RetryOptions {
+	return RetryOptions{
+		MaxAttempts:    0,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+}
+
+// NewPostgresPoolWithRetry behaves like NewPostgresPoolWithTracing but retries the
+// initial connection (pool create + ping) with exponential backoff instead of
+// returning on the first failure. It stops and returns an error when MaxAttempts
+// is exhausted or ctx is cancelled. onRetry, if non-nil, is invoked after each
+// failed attempt (before the backoff sleep) so callers can log progress.
+func NewPostgresPoolWithRetry(ctx context.Context, connString string, tracingEnabled bool, opts RetryOptions, onRetry func(attempt int, err error, backoff time.Duration)) (*pgxpool.Pool, error) {
+	if opts.InitialBackoff <= 0 {
+		opts.InitialBackoff = 1 * time.Second
+	}
+	if opts.MaxBackoff <= 0 {
+		opts.MaxBackoff = 30 * time.Second
+	}
+
+	backoff := opts.InitialBackoff
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		pool, err := NewPostgresPoolWithTracing(connString, tracingEnabled)
+		if err == nil {
+			return pool, nil
+		}
+		lastErr = err
+
+		if opts.MaxAttempts > 0 && attempt >= opts.MaxAttempts {
+			return nil, fmt.Errorf("database connection failed after %d attempts: %w", attempt, lastErr)
+		}
+
+		if onRetry != nil {
+			onRetry(attempt, err, backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("database connection aborted after %d attempts (%v): %w", attempt, ctx.Err(), lastErr)
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > opts.MaxBackoff {
+			backoff = opts.MaxBackoff
+		}
+	}
+}
+
 // HealthCheck verifies the database connection is healthy
 func HealthCheck(pool *pgxpool.Pool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/shared/database/postgres_test.go
+++ b/shared/database/postgres_test.go
@@ -16,7 +16,11 @@
 
 package database
 
-import "testing"
+import (
+	"context"
+	"testing"
+	"time"
+)
 
 const testDSN = "postgres://user:pass@localhost:5432/db"
 
@@ -114,5 +118,55 @@ func TestApplicationNamePrecedence(t *testing.T) {
 
 	if got := applicationName(); got != "explicit-name" {
 		t.Errorf("applicationName() = %q, want the explicit override to win", got)
+	}
+}
+
+// fastRetryOpts returns retry options with millisecond backoffs so tests don't sleep.
+func fastRetryOpts(maxAttempts int) RetryOptions {
+	return RetryOptions{
+		MaxAttempts:    maxAttempts,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     5 * time.Millisecond,
+	}
+}
+
+// unreachableDSN points at a port that refuses connections immediately, so each
+// attempt fails fast without waiting for the ping timeout.
+const unreachableDSN = "postgres://u:p@127.0.0.1:1/db"
+
+func TestNewPostgresPoolWithRetry_RetriesThenFails(t *testing.T) {
+	retries := 0
+	pool, err := NewPostgresPoolWithRetry(context.Background(), unreachableDSN, false, fastRetryOpts(3),
+		func(attempt int, err error, backoff time.Duration) { retries++ })
+	if err == nil {
+		pool.Close()
+		t.Fatal("expected error after exhausting attempts, got nil")
+	}
+	// With MaxAttempts=3, onRetry fires after attempts 1 and 2; attempt 3 returns the error.
+	if retries != 2 {
+		t.Errorf("expected 2 retry callbacks before giving up, got %d", retries)
+	}
+}
+
+func TestNewPostgresPoolWithRetry_AbortsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	// MaxAttempts=0 means retry forever; only the cancelled context stops it.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pool, err := NewPostgresPoolWithRetry(ctx, unreachableDSN, false, fastRetryOpts(0),
+			func(attempt int, err error, backoff time.Duration) {})
+		if err == nil {
+			pool.Close()
+			t.Error("expected error when context is cancelled, got nil")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("NewPostgresPoolWithRetry did not abort on context cancellation")
 	}
 }


### PR DESCRIPTION
## Problem

api-gateway called `log.Fatal` on the **first** failed DB ping (`cmd/main.go`), so every rollout produced a one-time crash + restart per pod whenever the CNPG primary (`allchat-cluster-rw`) had any brief blip at the instant the pod booted.

Observed directly on the #590 rollout — all three new pods exited 1 within seconds of starting:

```
level":"fatal" ... msg":"Failed to connect to database"
error":"failed to ping database: ... allchat-cluster-rw...:5432: connect: connection refused"
```

…then came up clean on the automatic restart. Harmless but noisy, and it briefly drops capacity on every deploy.

## Fix

Mirror the startup-retry the service **already** uses for Redis (`sharedredis.NewClientWithRetry`):

- Add `database.NewPostgresPoolWithRetry` (exponential backoff, cancellable via `context`) + `RetryOptions` / `DefaultRetryOptions`, structurally identical to the Redis helper. Lives in `shared/database` so any service can adopt it.
- Wire it into api-gateway with a **single** `SIGINT`/`SIGTERM`-cancellable startup context shared by the DB and Redis connects.

The pod now stays alive reporting **not-ready** (readiness probe checks DB+Redis) until the DB returns, instead of crash-looping — while `SIGTERM` still aborts startup promptly so shutdown isn't blocked.

Behavior preserved: pool tuning is unchanged (still goes through `NewPostgresPoolWithTracing` → the ADR-0039 `buildPoolConfig`), and tracing stays off for this pool as before.

## Scope
Only api-gateway is wired up here (that's where the restart was seen). The helper is reusable, so other services can switch from `NewPostgresPool` to `NewPostgresPoolWithRetry` in follow-ups.

## Test
- `shared/database`: added `TestNewPostgresPoolWithRetry_RetriesThenFails` and `_AbortsOnContextCancel` (unreachable DSN + cancelled context; no live DB needed). All `shared/database` tests + `go vet` pass.
- `services/api-gateway`: `go build ./...` and `go vet ./cmd/` pass (no `lostcancel`).