### PR TITLE
fix(emote-service): negative-cache not-found lookups and cool down rate-limited providers

### DIFF
--- a/services/emote-service/cache/emote_cache.go
+++ b/services/emote-service/cache/emote_cache.go
@@ -43,21 +43,23 @@ type RedisClient interface {
 
 // EmoteCache handles caching of emotes in Redis
 type EmoteCache struct {
-	client    RedisClient
-	logger    *zap.Logger
-	ttl       time.Duration
-	globalTTL time.Duration
-	keyNS     string
+	client      RedisClient
+	logger      *zap.Logger
+	ttl         time.Duration
+	globalTTL   time.Duration
+	negativeTTL time.Duration
+	keyNS       string
 }
 
 // NewEmoteCache creates a new emote cache
 func NewEmoteCache(client RedisClient, logger *zap.Logger, ttl time.Duration) *EmoteCache {
 	return &EmoteCache{
-		client:    client,
-		logger:    logger,
-		ttl:       ttl,
-		globalTTL: 30 * 24 * time.Hour, // Global Twitch emotes cached for 30 days
-		keyNS:     cacheNamespace,
+		client:      client,
+		logger:      logger,
+		ttl:         ttl,
+		globalTTL:   30 * 24 * time.Hour, // Global Twitch emotes cached for 30 days
+		negativeTTL: 15 * time.Minute,
+		keyNS:       cacheNamespace,
 	}
 }
 
@@ -109,6 +111,31 @@ func (c *EmoteCache) Set(ctx context.Context, provider, channel string, emotes [
 		zap.Duration("ttl", ttl))
 
 	if err := c.client.Set(ctx, key, data, ttl).Err(); err != nil {
+		return fmt.Errorf("failed to set cache: %w", err)
+	}
+
+	return nil
+}
+
+// SetNegative caches an empty emote list for a provider/channel the provider answered
+// "not found" for. Not-found results were previously never cached, so every enrichment
+// request for a channel without a BTTV/FFZ/7TV set re-hit the provider — the dominant
+// share of upstream volume during a big-chat stream, and what tipped BTTV/FFZ into
+// rate-limiting us. The TTL is shorter than the positive one so a streamer's
+// newly-created emote set still shows up within minutes.
+func (c *EmoteCache) SetNegative(ctx context.Context, provider, channel string) error {
+	key := c.key(provider, channel)
+
+	data, err := json.Marshal([]models.Emote{})
+	if err != nil {
+		return fmt.Errorf("failed to marshal emotes: %w", err)
+	}
+
+	c.logger.Debug("Setting negative cache entry",
+		zap.String("key", key),
+		zap.Duration("ttl", c.negativeTTL))
+
+	if err := c.client.Set(ctx, key, data, c.negativeTTL).Err(); err != nil {
 		return fmt.Errorf("failed to set cache: %w", err)
 	}
 

--- a/services/emote-service/clients/bttv.go
+++ b/services/emote-service/clients/bttv.go
@@ -90,6 +90,9 @@ func (c *BTTVClient) FetchEmotes(ctx context.Context, channel string) ([]models.
 		// Channel has no BTTV emotes — the normal case for most channels, not a failure.
 		return nil, fmt.Errorf("bttv: no emotes for channel %q: %w", channel, ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("bttv", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}

--- a/services/emote-service/clients/errors.go
+++ b/services/emote-service/clients/errors.go
@@ -16,7 +16,13 @@
 
 package clients
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
 
 // ErrNotFound signals that a provider has no emotes for the requested channel — an HTTP
 // 404 / unknown-channel response. This is the NORMAL case for most channels on BTTV and
@@ -24,3 +30,38 @@ import "errors"
 // classify it as a benign "not_found" miss rather than a real API failure. Wrap it with
 // %w so callers can detect it via errors.Is.
 var ErrNotFound = errors.New("emotes not found for channel")
+
+// ErrRateLimited signals that a provider throttled us (HTTP 429). This is a transient,
+// provider-wide condition, not a per-channel fact: retrying the same request only keeps
+// the provider throttling, so the handler opens a short cooldown for the provider and
+// skips upstream fetches until it expires. Detect with errors.Is(err, ErrRateLimited);
+// the provider's Retry-After hint is available via errors.As with *RateLimitedError.
+var ErrRateLimited = errors.New("provider rate limited")
+
+// RateLimitedError wraps ErrRateLimited and carries the provider's Retry-After hint.
+// RetryAfter is zero when the provider sent no (or an unparseable) header.
+type RateLimitedError struct {
+	Provider   string
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitedError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("%s: rate limited (429), retry after %s", e.Provider, e.RetryAfter)
+	}
+	return fmt.Sprintf("%s: rate limited (429)", e.Provider)
+}
+
+func (e *RateLimitedError) Unwrap() error { return ErrRateLimited }
+
+// rateLimited builds the error for a 429 response, honoring a numeric Retry-After
+// header when present (the delta-seconds form; the rare HTTP-date form is ignored).
+func rateLimited(provider string, resp *http.Response) error {
+	var retryAfter time.Duration
+	if s := resp.Header.Get("Retry-After"); s != "" {
+		if secs, err := strconv.Atoi(s); err == nil && secs > 0 {
+			retryAfter = time.Duration(secs) * time.Second
+		}
+	}
+	return &RateLimitedError{Provider: provider, RetryAfter: retryAfter}
+}

--- a/services/emote-service/clients/ffz.go
+++ b/services/emote-service/clients/ffz.go
@@ -90,6 +90,9 @@ func (c *FFZClient) FetchEmotes(ctx context.Context, channel string) ([]models.E
 		// Channel has no FFZ room — the normal case for most channels, not a failure.
 		return nil, fmt.Errorf("ffz: no emotes for channel %q: %w", channel, ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("ffz", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}

--- a/services/emote-service/clients/seventv.go
+++ b/services/emote-service/clients/seventv.go
@@ -185,6 +185,9 @@ func (c *SevenTVClient) fetchChannelEmotes(ctx context.Context, channel string) 
 		// No 7TV set for this channel — a benign miss, not a failure.
 		return nil, fmt.Errorf("7tv: no emote set for channel: %w", ErrNotFound)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("7tv", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emotes: status code %d", resp.StatusCode)
 	}
@@ -234,6 +237,9 @@ func (c *SevenTVClient) FetchUserEmotes(ctx context.Context, platform, userID st
 		return []models.Emote{}, nil
 	}
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("7tv", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch user emotes: status code %d", resp.StatusCode)
 	}
@@ -341,6 +347,9 @@ func (c *SevenTVClient) fetchPlatformConnectionEmotes(ctx context.Context, platf
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("7TV %s connection not found for %s: %w", platform, channel, ErrNotFound)
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("7tv", resp)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("7TV %s connection returned status %d", platform, resp.StatusCode)
@@ -460,6 +469,9 @@ func (c *SevenTVClient) fetchEmoteSetByID(ctx context.Context, setID, channel st
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("override emote set %s not found", setID)
 	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("7tv", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("override emote set lookup returned status %d", resp.StatusCode)
 	}
@@ -498,6 +510,9 @@ func (c *SevenTVClient) fetchEmoteSet(ctx context.Context, setType, channel stri
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, rateLimited("7tv", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch emote set: status code %d", resp.StatusCode)
 	}

--- a/services/emote-service/clients/twitch.go
+++ b/services/emote-service/clients/twitch.go
@@ -249,6 +249,9 @@ func (c *TwitchClient) apiGet(ctx context.Context, path string, query url.Values
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return rateLimited("twitch", resp)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("twitch api %s returned status %d", path, resp.StatusCode)
 	}

--- a/services/emote-service/handlers/emote.go
+++ b/services/emote-service/handlers/emote.go
@@ -52,6 +52,9 @@ type CombinedEmoteClient interface {
 type EmoteCache interface {
 	Get(ctx context.Context, provider, channel string) ([]models.Emote, error)
 	Set(ctx context.Context, provider, channel string, emotes []models.Emote) error
+	// SetNegative caches a "this provider has no emotes here" answer (with a shorter
+	// TTL than positive entries) so a not-found is not re-checked on every request.
+	SetNegative(ctx context.Context, provider, channel string) error
 }
 
 // EmoteHandler handles emote-related HTTP requests
@@ -61,6 +64,13 @@ type EmoteHandler struct {
 	logger       *zap.Logger
 	fetchTimeout time.Duration
 	apiCalls     *prometheus.CounterVec
+
+	// rate-limit cooldown: after a provider 429s, skip its upstream fetches until the
+	// deadline passes instead of hammering an already-throttled API. Per-provider and
+	// in-process (each replica learns the 429 with at most one probe per window).
+	rateLimitCooldown time.Duration
+	cooldownMu        sync.Mutex
+	cooldownUntil     map[string]time.Time
 }
 
 // Allow human-readable channel names (letters, numbers, spaces, dash, dot, underscore)
@@ -70,11 +80,13 @@ var channelPattern = regexp.MustCompile(`^[A-Za-z0-9 _.-]+$`)
 // apiCalls is a counter tracking emote provider API calls (may be nil — skipped if nil).
 func NewEmoteHandler(clients map[string]EmoteClient, cache EmoteCache, logger *zap.Logger, apiCalls *prometheus.CounterVec) *EmoteHandler {
 	return &EmoteHandler{
-		clients:      clients,
-		cache:        cache,
-		logger:       logger,
-		fetchTimeout: 3 * time.Second,
-		apiCalls:     apiCalls,
+		clients:           clients,
+		cache:             cache,
+		logger:            logger,
+		fetchTimeout:      3 * time.Second,
+		apiCalls:          apiCalls,
+		rateLimitCooldown: time.Minute,
+		cooldownUntil:     make(map[string]time.Time),
 	}
 }
 
@@ -166,13 +178,21 @@ func (h *EmoteHandler) GetChannelEmotes(c *gin.Context) {
 		if res.err != nil {
 			// A "not found" is the normal case (channel has no emotes on this provider),
 			// not a failure — log it at Debug so it doesn't drown the logs or read as an
-			// incident. Only genuine failures (5xx/timeout/network) log at Warn.
-			if errors.Is(res.err, clients.ErrNotFound) {
+			// incident. Rate-limited results are also Debug: they occur once per message
+			// during a cooldown window, and the window itself is announced at Warn in
+			// startCooldown. Only genuine failures (5xx/timeout/network) log at Warn.
+			switch {
+			case errors.Is(res.err, clients.ErrNotFound):
 				h.logger.Debug("Provider has no emotes for channel",
 					zap.String("provider", res.provider),
 					zap.String("channel", channel),
 					zap.Error(res.err))
-			} else {
+			case errors.Is(res.err, clients.ErrRateLimited):
+				h.logger.Debug("Provider rate limited, emotes skipped",
+					zap.String("provider", res.provider),
+					zap.String("channel", channel),
+					zap.Error(res.err))
+			default:
 				h.logger.Warn("Failed to fetch emotes from provider",
 					zap.String("provider", res.provider),
 					zap.String("channel", channel),
@@ -247,20 +267,88 @@ func (h *EmoteHandler) GetProviderEmotes(c *gin.Context) {
 
 // recordAPIResult increments the provider API-call counter, distinguishing a benign
 // "not_found" miss (the channel simply has no emotes on this provider — the norm for
-// BTTV/FFZ and unset 7TV channels) from a real "error" (5xx/timeout/network). Conflating
-// the two inflated the error rate and made a healthy service look like it was failing.
+// BTTV/FFZ and unset 7TV channels) and a throttled "rate_limited" call from a real
+// "error" (5xx/timeout/network). Conflating them inflated the error rate and made a
+// healthy service look like it was failing.
 func (h *EmoteHandler) recordAPIResult(provider string, err error) {
 	if h.apiCalls == nil {
 		return
 	}
 	result := "success"
 	if err != nil {
-		result = "error"
-		if errors.Is(err, clients.ErrNotFound) {
+		switch {
+		case errors.Is(err, clients.ErrNotFound):
 			result = "not_found"
+		case errors.Is(err, clients.ErrRateLimited):
+			result = "rate_limited"
+		default:
+			result = "error"
 		}
 	}
 	h.apiCalls.WithLabelValues("emote-service", provider, result).Inc()
+}
+
+// providerInCooldown reports whether upstream fetches for the provider are currently
+// suppressed because it recently rate-limited us.
+func (h *EmoteHandler) providerInCooldown(provider string) bool {
+	h.cooldownMu.Lock()
+	defer h.cooldownMu.Unlock()
+	return time.Now().Before(h.cooldownUntil[provider])
+}
+
+// startCooldown suppresses upstream fetches for the provider after a 429, honoring the
+// provider's Retry-After hint when it exceeds the default window. Announced at Warn once
+// per window — the suppressed fetches themselves log at Debug, so a busy stream doesn't
+// re-create the log spam the cooldown exists to stop.
+func (h *EmoteHandler) startCooldown(provider string, err error) {
+	d := h.rateLimitCooldown
+	var rl *clients.RateLimitedError
+	if errors.As(err, &rl) && rl.RetryAfter > d {
+		d = rl.RetryAfter
+	}
+	until := time.Now().Add(d)
+
+	h.cooldownMu.Lock()
+	alreadyCooling := time.Now().Before(h.cooldownUntil[provider])
+	if until.After(h.cooldownUntil[provider]) {
+		h.cooldownUntil[provider] = until
+	}
+	h.cooldownMu.Unlock()
+
+	if !alreadyCooling {
+		h.logger.Warn("Provider rate limited, cooling down upstream fetches",
+			zap.String("provider", provider),
+			zap.Duration("cooldown", d))
+	}
+}
+
+// handleFetchError records the metric for a failed upstream fetch and applies the
+// failure policy: a 429 opens the provider cooldown; a not-found is negative-cached
+// under cacheKey so it isn't re-checked on every request. Other errors (5xx/timeout/
+// network) stay uncached — they're transient and retrying on the next request is fine.
+func (h *EmoteHandler) handleFetchError(ctx context.Context, provider, cacheKey string, err error) {
+	h.recordAPIResult(provider, err)
+	switch {
+	case errors.Is(err, clients.ErrRateLimited):
+		h.startCooldown(provider, err)
+	case errors.Is(err, clients.ErrNotFound):
+		setCtx, cancel := cacheWriteContext(ctx)
+		defer cancel()
+		if cacheErr := h.cache.SetNegative(setCtx, provider, cacheKey); cacheErr != nil {
+			h.logger.Warn("Failed to set negative cache",
+				zap.String("provider", provider),
+				zap.String("channel", cacheKey),
+				zap.Error(cacheErr))
+		}
+	}
+}
+
+// cacheWriteContext detaches a cache write from the request's lifecycle. After a slow
+// provider fetch the per-provider deadline is nearly spent, so writes issued on the
+// request context routinely died with "context deadline exceeded" — losing the entry
+// and re-triggering the same upstream fetch on the next message.
+func cacheWriteContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
 }
 
 // fetchWithCache attempts to fetch from cache first, then from API if cache miss
@@ -283,19 +371,28 @@ func (h *EmoteHandler) fetchWithCache(ctx context.Context, client EmoteClient, p
 			zap.Error(err))
 	}
 
+	if h.providerInCooldown(provider) {
+		h.logger.Debug("Provider in rate-limit cooldown, skipping upstream fetch",
+			zap.String("provider", provider),
+			zap.String("channel", channel))
+		return nil, &clients.RateLimitedError{Provider: provider}
+	}
+
 	h.logger.Debug("Cache miss, fetching from API",
 		zap.String("provider", provider),
 		zap.String("channel", channel))
 
 	emotes, err = client.FetchEmotes(ctx, channel)
 	if err != nil {
-		h.recordAPIResult(provider, err)
+		h.handleFetchError(ctx, provider, channel, err)
 		return nil, err
 	}
 	h.recordAPIResult(provider, nil)
 
 	// Store in cache (best effort - don't fail if cache set fails)
-	if err := h.cache.Set(ctx, provider, channel, emotes); err != nil {
+	setCtx, cancel := cacheWriteContext(ctx)
+	defer cancel()
+	if err := h.cache.Set(setCtx, provider, channel, emotes); err != nil {
 		h.logger.Warn("Failed to set cache",
 			zap.String("provider", provider),
 			zap.String("channel", channel),
@@ -365,6 +462,14 @@ func (h *EmoteHandler) fetchWithCacheAndUser(ctx context.Context, client EmoteCl
 			zap.Error(err))
 	}
 
+	if h.providerInCooldown(provider) {
+		h.logger.Debug("Provider in rate-limit cooldown, skipping upstream fetch",
+			zap.String("provider", provider),
+			zap.String("channel", channel),
+			zap.String("user_id", userID))
+		return nil, &clients.RateLimitedError{Provider: provider}
+	}
+
 	h.logger.Debug("Cache miss, fetching combined emotes from API",
 		zap.String("provider", provider),
 		zap.String("channel", channel),
@@ -372,13 +477,15 @@ func (h *EmoteHandler) fetchWithCacheAndUser(ctx context.Context, client EmoteCl
 
 	emotes, err = combinedClient.FetchCombinedEmotes(ctx, channel, platform, userID, twitchChannel, seventvSetID)
 	if err != nil {
-		h.recordAPIResult(provider, err)
+		h.handleFetchError(ctx, provider, cacheKey, err)
 		return nil, err
 	}
 	h.recordAPIResult(provider, nil)
 
 	// Store in cache (best effort - don't fail if cache set fails)
-	if err := h.cache.Set(ctx, provider, cacheKey, emotes); err != nil {
+	setCtx, cancel := cacheWriteContext(ctx)
+	defer cancel()
+	if err := h.cache.Set(setCtx, provider, cacheKey, emotes); err != nil {
 		h.logger.Warn("Failed to set cache",
 			zap.String("provider", provider),
 			zap.String("channel", channel),

--- a/services/emote-service/handlers/emote_test.go
+++ b/services/emote-service/handlers/emote_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/caesar/all-chat/services/emote-service/cache"
@@ -35,12 +36,14 @@ import (
 
 // mockEmoteClient for testing
 type mockEmoteClient struct {
-	emotes   []models.Emote
-	err      error
-	provider string
+	emotes     []models.Emote
+	err        error
+	provider   string
+	fetchCalls atomic.Int64
 }
 
 func (m *mockEmoteClient) FetchEmotes(ctx context.Context, channel string) ([]models.Emote, error) {
+	m.fetchCalls.Add(1)
 	return m.emotes, m.err
 }
 
@@ -51,8 +54,9 @@ func (m *mockEmoteClient) Provider() string {
 // mockEmoteCache for testing. The handler fans provider fetches out across goroutines,
 // so this shared cache must be safe for concurrent Get/Set.
 type mockEmoteCache struct {
-	mu   sync.Mutex
-	data map[string][]models.Emote
+	mu           sync.Mutex
+	data         map[string][]models.Emote
+	negativeKeys []string
 }
 
 func newMockEmoteCache() *mockEmoteCache {
@@ -77,6 +81,15 @@ func (m *mockEmoteCache) Set(ctx context.Context, provider, channel string, emot
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.data[key] = emotes
+	return nil
+}
+
+func (m *mockEmoteCache) SetNegative(ctx context.Context, provider, channel string) error {
+	key := provider + ":" + channel
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = []models.Emote{}
+	m.negativeKeys = append(m.negativeKeys, key)
 	return nil
 }
 

--- a/services/emote-service/handlers/metrics_classification_test.go
+++ b/services/emote-service/handlers/metrics_classification_test.go
@@ -41,16 +41,19 @@ func TestRecordAPIResult_Classification(t *testing.T) {
 	h.recordAPIResult("bttv", fmt.Errorf("bttv: no emotes: %w", clients.ErrNotFound))
 	h.recordAPIResult("7tv", errors.New("7tv api returned status 503"))
 	h.recordAPIResult("twitch", nil)
+	h.recordAPIResult("ffz", &clients.RateLimitedError{Provider: "ffz"})
 
 	cases := []struct {
 		provider, result string
 		want             float64
 	}{
-		{"bttv", "not_found", 1}, // 404 classified as a benign miss
-		{"bttv", "error", 0},     // and NOT as an error
-		{"7tv", "error", 1},      // a real 5xx stays an error
-		{"7tv", "not_found", 0},  //
-		{"twitch", "success", 1}, // nil error is success
+		{"bttv", "not_found", 1},   // 404 classified as a benign miss
+		{"bttv", "error", 0},       // and NOT as an error
+		{"7tv", "error", 1},        // a real 5xx stays an error
+		{"7tv", "not_found", 0},    //
+		{"twitch", "success", 1},   // nil error is success
+		{"ffz", "rate_limited", 1}, // 429 classified as throttling
+		{"ffz", "error", 0},        // and NOT as an error
 	}
 	for _, tc := range cases {
 		got := testutil.ToFloat64(vec.WithLabelValues("emote-service", tc.provider, tc.result))

--- a/services/emote-service/handlers/rate_limit_test.go
+++ b/services/emote-service/handlers/rate_limit_test.go
@@ -1,0 +1,132 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/emote-service/clients"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+// These tests lock in the failure policy added after the 2026-07-18/21 provider storms:
+// a channel with no emotes on a provider must not be re-checked upstream on every
+// request (negative caching), and a provider that 429s must not be hammered until its
+// cooldown passes.
+
+func doChannelRequest(t *testing.T, h *EmoteHandler, channel string) *httptest.ResponseRecorder {
+	t.Helper()
+	router := gin.New()
+	router.GET("/emotes/channel/:channel", h.GetChannelEmotes)
+	req, _ := http.NewRequest("GET", "/emotes/channel/"+channel, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestGetChannelEmotes_NotFoundIsNegativeCached(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	client := &mockEmoteClient{
+		err:      fmt.Errorf("bttv: no emotes for channel: %w", clients.ErrNotFound),
+		provider: "bttv",
+	}
+	mockCache := newMockEmoteCache()
+	h := NewEmoteHandler(map[string]EmoteClient{"bttv": client}, mockCache, zaptest.NewLogger(t), nil)
+
+	w := doChannelRequest(t, h, "ddg")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.EqualValues(t, 1, client.fetchCalls.Load(), "first request must hit the provider")
+	assert.Contains(t, mockCache.negativeKeys, "bttv:ddg", "not-found must be negative-cached")
+
+	w = doChannelRequest(t, h, "ddg")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.EqualValues(t, 1, client.fetchCalls.Load(),
+		"second request must be served from the negative cache, not the provider")
+}
+
+func TestGetChannelEmotes_RateLimitOpensCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	client := &mockEmoteClient{
+		err:      &clients.RateLimitedError{Provider: "bttv"},
+		provider: "bttv",
+	}
+	h := NewEmoteHandler(map[string]EmoteClient{"bttv": client}, newMockEmoteCache(), zaptest.NewLogger(t), nil)
+
+	w := doChannelRequest(t, h, "ddg")
+	assert.Equal(t, http.StatusOK, w.Code, "a rate-limited provider degrades, not fails, the aggregate response")
+	assert.EqualValues(t, 1, client.fetchCalls.Load())
+
+	// Different channel on the SAME provider: the cooldown is provider-wide, so no
+	// upstream call happens.
+	w = doChannelRequest(t, h, "otherchannel")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.EqualValues(t, 1, client.fetchCalls.Load(),
+		"requests during the cooldown must not hit the provider")
+}
+
+func TestGetChannelEmotes_CooldownExpires(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	client := &mockEmoteClient{
+		err:      &clients.RateLimitedError{Provider: "bttv"},
+		provider: "bttv",
+	}
+	h := NewEmoteHandler(map[string]EmoteClient{"bttv": client}, newMockEmoteCache(), zaptest.NewLogger(t), nil)
+	h.rateLimitCooldown = 10 * time.Millisecond
+
+	doChannelRequest(t, h, "ddg")
+	assert.EqualValues(t, 1, client.fetchCalls.Load())
+
+	time.Sleep(25 * time.Millisecond)
+
+	doChannelRequest(t, h, "ddg")
+	assert.EqualValues(t, 2, client.fetchCalls.Load(),
+		"after the cooldown expires the provider is probed again")
+}
+
+func TestStartCooldown_HonorsRetryAfter(t *testing.T) {
+	h := &EmoteHandler{
+		logger:            zaptest.NewLogger(t),
+		rateLimitCooldown: time.Minute,
+		cooldownUntil:     make(map[string]time.Time),
+	}
+
+	// Retry-After longer than the default extends the window.
+	h.startCooldown("bttv", &clients.RateLimitedError{Provider: "bttv", RetryAfter: 5 * time.Minute})
+	h.cooldownMu.Lock()
+	until := h.cooldownUntil["bttv"]
+	h.cooldownMu.Unlock()
+	assert.True(t, until.After(time.Now().Add(4*time.Minute)),
+		"Retry-After beyond the default must extend the cooldown")
+	assert.True(t, h.providerInCooldown("bttv"))
+	assert.False(t, h.providerInCooldown("ffz"), "cooldowns are per provider")
+
+	// A shorter/absent hint must never SHRINK an existing window.
+	h.startCooldown("bttv", &clients.RateLimitedError{Provider: "bttv"})
+	h.cooldownMu.Lock()
+	after := h.cooldownUntil["bttv"]
+	h.cooldownMu.Unlock()
+	assert.False(t, after.Before(until), "a later 429 with no hint must not shorten the cooldown")
+}


### PR DESCRIPTION
## Problem

During DDG-scale streams (Jul 17–21) the emote service made **~180k upstream calls per provider per day**; BTTV/FFZ throttled us with 429s for hours (~25k errors/provider on the worst day), so viewers' emotes rendered as plain text. `AllChatEmoteCacheEfficiencyDeclining` fired all week. Follow-up to #580, which fixed the crash + metric classification but not the retry storm.

Two compounding causes:

1. **Failed lookups were never cached.** A channel with no BTTV/FFZ/7TV set (the norm) 404s on every enrichment request, forever — the dominant share of upstream volume.
2. **429s were retried on the very next request**, keeping the provider throttling indefinitely (logs show the same channel re-fetched every 1–5 seconds during DDG's Jul 21 stream).

## Changes

- **Negative caching**: not-found results are cached as an empty set with a 15-minute TTL (vs 1h positive TTL, so a newly created emote set still appears within minutes). New `EmoteCache.SetNegative`.
- **Rate-limit cooldown**: clients map HTTP 429 to a `RateLimitedError` (new `ErrRateLimited` sentinel, honors numeric `Retry-After`); the handler opens a per-provider in-process cooldown (default 60s, extended by `Retry-After`) during which upstream fetches for that provider are skipped. Cooldown start = one Warn log; skips log at Debug.
- **Metrics**: upstream 429s are classified as `result="rate_limited"` in `emote_api_calls_total` (skipped fetches don't count — they're not API calls).
- **Detached cache writes**: cache Sets get their own 2s budget via `context.WithoutCancel` — they routinely died with "context deadline exceeded" after slow fetches, losing the entry and re-triggering the same upstream fetch.

## Testing

- New `handlers/rate_limit_test.go`: negative caching stops re-fetch, provider-wide cooldown, cooldown expiry, `Retry-After` extension (never shrinks an existing window).
- Extended `TestRecordAPIResult_Classification` with the `rate_limited` case.
- `go test ./... -race` green across the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjcuTZc8GWTEoQm6N4jH1K