### PR TITLE
feat(frontend): sound cue for new Activity items in the monitor view

### DIFF
--- a/frontend/src/app/overlay/[id]/view/__tests__/viewPrefs.test.ts
+++ b/frontend/src/app/overlay/[id]/view/__tests__/viewPrefs.test.ts
@@ -48,9 +48,20 @@ beforeEach(() => stubLocalStorage())
 afterEach(() => vi.unstubAllGlobals())
 
 describe('viewPrefs', () => {
-  it('returns all-on defaults when nothing is stored', () => {
+  it('returns defaults when nothing is stored: display toggles on, activity sound off', () => {
     expect(loadViewPrefs()).toEqual(DEFAULT_VIEW_PREFS)
-    expect(Object.values(DEFAULT_VIEW_PREFS).every((v) => v === true)).toBe(true)
+    // Display toggles default on so the readable monitor shows everything…
+    const displayToggles: Array<keyof MonitorViewPrefs> = [
+      'showAvatars',
+      'showBadges',
+      'showPronouns',
+      'showTimestamps',
+      'showPlatformGlyph',
+      'showModeration',
+    ]
+    expect(displayToggles.every((k) => DEFAULT_VIEW_PREFS[k] === true)).toBe(true)
+    // …but the activity sound is opt-in, so the dashboard is silent by default.
+    expect(DEFAULT_VIEW_PREFS.activitySoundEnabled).toBe(false)
   })
 
   it('merges a partial stored payload over the defaults', () => {
@@ -61,6 +72,40 @@ describe('viewPrefs', () => {
     expect(prefs.showBadges).toBe(true)
     expect(prefs.showModeration).toBe(true)
     expect(prefs.showTimestamps).toBe(true)
+  })
+
+  it('gives an older payload (no sound keys) the activity-sound defaults', () => {
+    // A payload saved before the activity sound existed has none of its keys.
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ showAvatars: false }))
+    const prefs = loadViewPrefs()
+    expect(prefs.activitySoundEnabled).toBe(DEFAULT_VIEW_PREFS.activitySoundEnabled)
+    expect(prefs.activitySoundVolume).toBe(DEFAULT_VIEW_PREFS.activitySoundVolume)
+    expect(prefs.activitySoundPreset).toBe(DEFAULT_VIEW_PREFS.activitySoundPreset)
+  })
+
+  it('preserves valid stored activity-sound settings', () => {
+    localStorage.setItem(
+      VIEW_PREFS_KEY,
+      JSON.stringify({ activitySoundEnabled: true, activitySoundVolume: 0.25, activitySoundPreset: 'pop' })
+    )
+    const prefs = loadViewPrefs()
+    expect(prefs.activitySoundEnabled).toBe(true)
+    expect(prefs.activitySoundVolume).toBe(0.25)
+    expect(prefs.activitySoundPreset).toBe('pop')
+  })
+
+  it('sanitizes an unknown preset back to the default', () => {
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ activitySoundPreset: 'airhorn' }))
+    expect(loadViewPrefs().activitySoundPreset).toBe(DEFAULT_VIEW_PREFS.activitySoundPreset)
+  })
+
+  it('clamps an out-of-range or non-numeric volume', () => {
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ activitySoundVolume: 5 }))
+    expect(loadViewPrefs().activitySoundVolume).toBe(1)
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ activitySoundVolume: -2 }))
+    expect(loadViewPrefs().activitySoundVolume).toBe(0)
+    localStorage.setItem(VIEW_PREFS_KEY, JSON.stringify({ activitySoundVolume: 'loud' }))
+    expect(loadViewPrefs().activitySoundVolume).toBe(DEFAULT_VIEW_PREFS.activitySoundVolume)
   })
 
   it('falls back to defaults on corrupt JSON', () => {
@@ -81,6 +126,9 @@ describe('viewPrefs', () => {
       showTimestamps: false,
       showPlatformGlyph: true,
       showModeration: false,
+      activitySoundEnabled: true,
+      activitySoundVolume: 0.8,
+      activitySoundPreset: 'chime',
     }
     saveViewPrefs(custom)
     expect(loadViewPrefs()).toEqual(custom)

--- a/frontend/src/app/overlay/[id]/view/page.tsx
+++ b/frontend/src/app/overlay/[id]/view/page.tsx
@@ -23,6 +23,8 @@
  * panel + Activity feed (pause-on-scroll scrollback and a click-a-username 1:1
  * chat filter live in ChatPanel), platform connection indicators, an
  * overlay-config summary, its own light/dark mode, view-local display toggles,
+ * an optional per-browser sound cue for new Activity items (distinct from the
+ * overlay's on-stream notification sounds; see viewPrefs `activitySound*`),
  * and per-message / per-user moderation controls for the overlay's owner. It
  * reuses the exact realtime pipeline the OBS overlay speaks (useOverlayStream)
  * but renders a readable, animation-free dashboard that ignores the overlay's
@@ -69,12 +71,14 @@ import type { EventSettings } from '@/lib/types/overlay'
 import {
   applyModerationMark,
   deletionSignature,
+  isAudienceEvent,
   mergeByAgg,
   partitionItems,
   toModEntry,
   type ModEntry,
   type ViewItem,
 } from '@/lib/utils/overlayViewModel'
+import { createSoundPlayer, type SoundPlayer, type SoundSettings } from '@/lib/utils/soundPlayer'
 
 import {
   DEFAULT_VIEW_LAYOUT,
@@ -93,6 +97,21 @@ import {
 const MAX_ITEMS = 500
 const MAX_MOD_LOG = 200
 const THEME_KEY = 'overlay-view-theme'
+
+// Gap between activity sounds. Longer than the overlay chat cooldown because a
+// single audience action can fan out into a burst (e.g. a mystery gift emits
+// many gift-sub events); one gentle ping per burst is what a moderator wants.
+const ACTIVITY_SOUND_COOLDOWN_MS = 1500
+
+/** Map the moderator's view prefs onto the shared sound-player settings. */
+function toActivitySoundSettings(prefs: MonitorViewPrefs): SoundSettings {
+  return {
+    enabled: prefs.activitySoundEnabled,
+    preset: prefs.activitySoundPreset,
+    volume: prefs.activitySoundVolume,
+    cooldownMs: ACTIVITY_SOUND_COOLDOWN_MS,
+  }
+}
 
 export default function OverlayMonitorView({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
@@ -120,11 +139,22 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
 
   // --- Stream callbacks ----------------------------------------------------
 
+  // Per-browser player for the activity sound. Created after mount (client
+  // only) and kept in sync with prefs by the effects below; onChat plays
+  // through it and the player itself gates on enabled/cooldown/volume, so
+  // onChat needs no prefs in its dependency list.
+  const activitySoundRef = useRef<SoundPlayer | null>(null)
+
   const onChat = useCallback((message: ChatMessage) => {
     setItems((prev) => [...prev, message].slice(-MAX_ITEMS))
     const type = message.event?.type
     if (type) {
       setObservedEventTypes((prev) => (prev.has(type) ? prev : new Set(prev).add(type)))
+    }
+    // Audible cue for easy-to-miss audience activity (channel points, gifts,
+    // follows, …). No-op unless the moderator enabled the activity sound.
+    if (isAudienceEvent(message)) {
+      activitySoundRef.current?.play()
     }
   }, [])
 
@@ -197,6 +227,33 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     setPrefs(next)
     saveViewPrefs(next)
   }, [])
+
+  // Build the activity-sound player once (client only), then keep its settings
+  // in lock-step with prefs. Split into create-once + sync so we never leak
+  // audio elements across re-renders.
+  useEffect(() => {
+    const player = createSoundPlayer(toActivitySoundSettings(DEFAULT_VIEW_PREFS))
+    activitySoundRef.current = player
+    return () => {
+      player.destroy()
+      activitySoundRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    activitySoundRef.current?.updateSettings(toActivitySoundSettings(prefs))
+  }, [prefs])
+
+  // Preview the activity sound. Bypasses the player's cooldown/enabled gate so
+  // "Test" always previews, and the click doubles as the user gesture browsers
+  // require before any programmatic audio may play in this tab.
+  const testActivitySound = useCallback(() => {
+    const el = new Audio(`/sounds/${prefs.activitySoundPreset}.mp3`)
+    el.volume = prefs.activitySoundVolume
+    el.play().catch(() => {
+      /* autoplay may still be blocked; the next attempt after a gesture works */
+    })
+  }, [prefs.activitySoundPreset, prefs.activitySoundVolume])
 
   // Restore the saved panel layout after mount (per-overlay; localStorage,
   // client only — guards against SSR hydration mismatch like the prefs/theme).
@@ -557,7 +614,11 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
             </button>
           )}
           <LayoutPicker layout={layout} onChange={updateLayout} />
-          <ViewSettingsBar prefs={prefs} onChange={updatePrefs} />
+          <ViewSettingsBar
+            prefs={prefs}
+            onChange={updatePrefs}
+            onTestActivitySound={testActivitySound}
+          />
           <OverlayViewThemeToggle light={light} onToggle={() => setLight((v) => !v)} />
           {isOwner && hasYouTubeSource && (
             <button

--- a/frontend/src/app/overlay/[id]/view/viewPrefs.ts
+++ b/frontend/src/app/overlay/[id]/view/viewPrefs.ts
@@ -26,6 +26,8 @@
  * `view/page.tsx`.
  */
 
+import { PRESET_NAMES, type PresetName } from '@/lib/utils/soundPlayer'
+
 export interface MonitorViewPrefs {
   showAvatars: boolean
   showBadges: boolean
@@ -33,6 +35,19 @@ export interface MonitorViewPrefs {
   showTimestamps: boolean
   showPlatformGlyph: boolean
   showModeration: boolean
+  /**
+   * Play a short sound in THIS browser when a new audience-activity item lands
+   * in the Activity & Events panel (channel-point redeems, gifts/roses, follows,
+   * subs, raids, …). This is a private aid for the moderator so easy-to-miss
+   * activity is noticed; it is entirely separate from the overlay's on-stream
+   * "Notification Sounds" and never plays on the public OBS overlay. Off by
+   * default so the dashboard stays silent until the moderator opts in.
+   */
+  activitySoundEnabled: boolean
+  /** Playback volume (0–1) for the activity sound. */
+  activitySoundVolume: number
+  /** Which built-in sound to play. Reuses the overlay sound presets. */
+  activitySoundPreset: PresetName
 }
 
 export const VIEW_PREFS_KEY = 'overlay-view-prefs'
@@ -44,6 +59,9 @@ export const DEFAULT_VIEW_PREFS: MonitorViewPrefs = {
   showTimestamps: true,
   showPlatformGlyph: true,
   showModeration: true,
+  activitySoundEnabled: false,
+  activitySoundVolume: 0.5,
+  activitySoundPreset: 'ping',
 }
 
 /**
@@ -57,7 +75,18 @@ export function loadViewPrefs(): MonitorViewPrefs {
     if (!raw) return { ...DEFAULT_VIEW_PREFS }
     const parsed = JSON.parse(raw) as Partial<MonitorViewPrefs>
     if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_VIEW_PREFS }
-    return { ...DEFAULT_VIEW_PREFS, ...parsed }
+    const merged = { ...DEFAULT_VIEW_PREFS, ...parsed }
+    // Sanitize the two fields that drive the audio element directly, so a
+    // corrupt payload can't request a missing sound file or an out-of-range gain.
+    if (!PRESET_NAMES.includes(merged.activitySoundPreset)) {
+      merged.activitySoundPreset = DEFAULT_VIEW_PREFS.activitySoundPreset
+    }
+    if (typeof merged.activitySoundVolume !== 'number' || !Number.isFinite(merged.activitySoundVolume)) {
+      merged.activitySoundVolume = DEFAULT_VIEW_PREFS.activitySoundVolume
+    } else {
+      merged.activitySoundVolume = Math.min(1, Math.max(0, merged.activitySoundVolume))
+    }
+    return merged
   } catch {
     return { ...DEFAULT_VIEW_PREFS }
   }

--- a/frontend/src/components/appearance/SoundGroup.tsx
+++ b/frontend/src/components/appearance/SoundGroup.tsx
@@ -50,6 +50,12 @@ export function SoundGroup({ displaySettings, onChange, isPremium, onPreview }: 
 
   return (
     <div className="space-y-4">
+      <p className="text-xs text-text-dim">
+        These sounds play on your public OBS overlay, for everyone watching your stream. Want a
+        private alert only you hear when new activity arrives (channel-point redeems, a TikTok Rose,
+        and so on)? Open the Monitor view and turn on Activity sound in its Display menu. That is a
+        separate setting and stays on that device.
+      </p>
       <ToggleSwitch
         label="Enable notification sounds"
         checked={enabled}

--- a/frontend/src/components/overlay/ViewSettingsBar.tsx
+++ b/frontend/src/components/overlay/ViewSettingsBar.tsx
@@ -22,16 +22,29 @@ import clsx from 'clsx'
 import { Settings } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 
+import { SliderControl } from '@/components/appearance/SliderControl'
 import { ToggleSwitch } from '@/components/appearance/ToggleSwitch'
 import type { MonitorViewPrefs } from '@/app/overlay/[id]/view/viewPrefs'
+import { PRESET_NAMES } from '@/lib/utils/soundPlayer'
 
 interface ViewSettingsBarProps {
   prefs: MonitorViewPrefs
   onChange: (prefs: MonitorViewPrefs) => void
+  /** Preview the activity sound (also satisfies the browser's autoplay gesture). */
+  onTestActivitySound?: () => void
 }
 
-/** Labels for each toggle, in the order they appear in the popover. */
-const TOGGLES: ReadonlyArray<{ key: keyof MonitorViewPrefs; label: string }> = [
+/** The boolean-valued keys of MonitorViewPrefs (the plain on/off toggles). */
+type BooleanPrefKey = {
+  [K in keyof MonitorViewPrefs]: MonitorViewPrefs[K] extends boolean ? K : never
+}[keyof MonitorViewPrefs]
+
+/**
+ * Display toggles, in the order they appear in the popover. Boolean-valued
+ * `MonitorViewPrefs` keys only; the activity-sound controls are rendered
+ * separately below because they carry volume/preset, not just on/off.
+ */
+const TOGGLES: ReadonlyArray<{ key: BooleanPrefKey; label: string }> = [
   { key: 'showAvatars', label: 'Avatars' },
   { key: 'showBadges', label: 'Badges' },
   { key: 'showPronouns', label: 'Pronouns' },
@@ -40,12 +53,16 @@ const TOGGLES: ReadonlyArray<{ key: keyof MonitorViewPrefs; label: string }> = [
   { key: 'showModeration', label: 'Moderation controls' },
 ]
 
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
 /**
  * Gear button + popover of view-local display toggles for the overlay monitor.
  * These are the moderator's personal preferences (persisted to localStorage by
  * the page) and never touch the overlay's saved visual settings.
  */
-export function ViewSettingsBar({ prefs, onChange }: ViewSettingsBarProps) {
+export function ViewSettingsBar({ prefs, onChange, onTestActivitySound }: ViewSettingsBarProps) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -79,7 +96,7 @@ export function ViewSettingsBar({ prefs, onChange }: ViewSettingsBarProps) {
       </button>
 
       {open && (
-        <div className="absolute right-0 z-50 mt-2 w-56 rounded-lg border border-border bg-surface p-3 shadow-lg">
+        <div className="absolute right-0 z-50 mt-2 w-64 rounded-lg border border-border bg-surface p-3 shadow-lg">
           <p className="mb-2 text-[10px] font-semibold tracking-wide text-text-dim uppercase">
             View settings
           </p>
@@ -92,6 +109,73 @@ export function ViewSettingsBar({ prefs, onChange }: ViewSettingsBarProps) {
                 onChange={(checked) => onChange({ ...prefs, [key]: checked })}
               />
             ))}
+          </div>
+
+          <div className="mt-3 border-t border-border pt-3">
+            <p className="mb-2 text-[10px] font-semibold tracking-wide text-text-dim uppercase">
+              Activity sound
+            </p>
+            <ToggleSwitch
+              label="Sound on new activity"
+              checked={prefs.activitySoundEnabled}
+              onChange={(checked) => onChange({ ...prefs, activitySoundEnabled: checked })}
+            />
+
+            {prefs.activitySoundEnabled && (
+              <div className="mt-2.5 flex flex-col gap-2.5">
+                <div>
+                  <label
+                    htmlFor="activity-sound-preset"
+                    className="mb-1 block text-sm text-text-sub"
+                  >
+                    Sound
+                  </label>
+                  <select
+                    id="activity-sound-preset"
+                    value={prefs.activitySoundPreset}
+                    onChange={(e) =>
+                      onChange({
+                        ...prefs,
+                        activitySoundPreset: e.target.value as MonitorViewPrefs['activitySoundPreset'],
+                      })
+                    }
+                    className="w-full rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text"
+                  >
+                    {PRESET_NAMES.map((name) => (
+                      <option key={name} value={name}>
+                        {capitalize(name)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <SliderControl
+                  label="Volume"
+                  value={prefs.activitySoundVolume}
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  unit=""
+                  onChange={(v) => onChange({ ...prefs, activitySoundVolume: v })}
+                />
+
+                {onTestActivitySound && (
+                  <button
+                    type="button"
+                    onClick={onTestActivitySound}
+                    className="self-start rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text hover:bg-surface-2 focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+                  >
+                    Test sound
+                  </button>
+                )}
+              </div>
+            )}
+
+            <p className="mt-2.5 text-xs text-text-dim">
+              Plays only here, in this browser, so you notice easy-to-miss activity like
+              channel-point redeems or a TikTok Rose. This is separate from your overlay&apos;s
+              on-stream notification sounds.
+            </p>
           </div>
         </div>
       )}

--- a/frontend/src/components/overlay/__tests__/ViewSettingsBar.test.tsx
+++ b/frontend/src/components/overlay/__tests__/ViewSettingsBar.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ViewSettingsBar } from '@/components/overlay/ViewSettingsBar'
+import { DEFAULT_VIEW_PREFS, type MonitorViewPrefs } from '@/app/overlay/[id]/view/viewPrefs'
+
+afterEach(() => cleanup())
+
+function setup(overrides: Partial<MonitorViewPrefs> = {}, onTest?: () => void) {
+  const prefs: MonitorViewPrefs = { ...DEFAULT_VIEW_PREFS, ...overrides }
+  const onChange = vi.fn()
+  const onTestActivitySound = onTest ?? vi.fn()
+  render(
+    <ViewSettingsBar prefs={prefs} onChange={onChange} onTestActivitySound={onTestActivitySound} />
+  )
+  // The controls live in a popover; open it via the gear button.
+  fireEvent.click(screen.getByRole('button', { name: 'Display settings' }))
+  return { onChange, onTestActivitySound }
+}
+
+describe('ViewSettingsBar activity sound', () => {
+  it('renders the activity-sound toggle and the separation note', () => {
+    setup()
+    expect(screen.getByRole('switch', { name: 'Sound on new activity' })).toBeInTheDocument()
+    expect(screen.getByText(/separate from your overlay's on-stream notification sounds/i)).toBeInTheDocument()
+  })
+
+  it('enabling the toggle calls onChange with activitySoundEnabled: true', () => {
+    const { onChange } = setup({ activitySoundEnabled: false })
+    fireEvent.click(screen.getByRole('switch', { name: 'Sound on new activity' }))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ activitySoundEnabled: true }))
+  })
+
+  it('hides sound/volume/test controls while the activity sound is off', () => {
+    setup({ activitySoundEnabled: false })
+    expect(screen.queryByLabelText('Sound')).toBeNull()
+    expect(screen.queryByText('Volume')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Test sound' })).toBeNull()
+  })
+
+  it('shows sound/volume/test controls when the activity sound is on', () => {
+    setup({ activitySoundEnabled: true, activitySoundPreset: 'pop', activitySoundVolume: 0.4 })
+    expect(screen.getByLabelText('Sound')).toBeInTheDocument()
+    expect(screen.getByText('Volume')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Test sound' })).toBeInTheDocument()
+  })
+
+  it('changing the preset calls onChange with the new preset', () => {
+    const { onChange } = setup({ activitySoundEnabled: true })
+    fireEvent.change(screen.getByLabelText('Sound'), { target: { value: 'pop' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ activitySoundPreset: 'pop' }))
+  })
+
+  it('moving the volume slider calls onChange with the new volume', () => {
+    const { onChange } = setup({ activitySoundEnabled: true, activitySoundVolume: 0.5 })
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '0.3' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ activitySoundVolume: 0.3 }))
+  })
+
+  it('clicking Test triggers the preview callback', () => {
+    const onTest = vi.fn()
+    setup({ activitySoundEnabled: true }, onTest)
+    fireEvent.click(screen.getByRole('button', { name: 'Test sound' }))
+    expect(onTest).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/utils/__tests__/overlayViewModel.test.ts
+++ b/frontend/src/lib/utils/__tests__/overlayViewModel.test.ts
@@ -22,6 +22,7 @@ import {
   applyModerationMark,
   countNewItems,
   deletionKind,
+  isAudienceEvent,
   isDeletionTarget,
   matchesUserFilter,
   mergeByAgg,
@@ -77,6 +78,38 @@ describe('partitionItems', () => {
     expect(chat).toHaveLength(0)
     expect(events).toHaveLength(0)
     expect(system).toHaveLength(0)
+  })
+})
+
+describe('isAudienceEvent', () => {
+  it('is true for audience activity (subs, gifts/roses, follows, likes)', () => {
+    expect(isAudienceEvent(item('m1', { eventType: 'subscription' }))).toBe(true)
+    expect(isAudienceEvent(item('m2', { eventType: 'gift' }))).toBe(true)
+    expect(isAudienceEvent(item('m3', { eventType: 'follow' }))).toBe(true)
+    expect(isAudienceEvent(item('m4', { eventType: 'channel_points' }))).toBe(true)
+    expect(isAudienceEvent(item('m5', { eventType: 'like_aggregate' }))).toBe(true)
+  })
+
+  it('is false for plain chat, system notices, and deletions', () => {
+    expect(isAudienceEvent(item('m1'))).toBe(false)
+    expect(isAudienceEvent(item('m2', { eventType: 'token_expiration_warning' }))).toBe(false)
+    expect(isAudienceEvent(item('m3', { eventType: 'source_permission_error' }))).toBe(false)
+    expect(isAudienceEvent(item('m4', { eventType: 'listener_deprecation_notice' }))).toBe(false)
+    expect(isAudienceEvent(item('m5', { eventType: 'message_deletion' }))).toBe(false)
+  })
+
+  it('matches partitionItems: it is true iff the item lands in the events pane', () => {
+    const samples: ViewItem[] = [
+      item('m1'),
+      item('m2', { eventType: 'subscription' }),
+      item('m3', { eventType: 'gift' }),
+      item('m4', { eventType: 'token_expiration_warning' }),
+      item('m5', { eventType: 'message_deletion' }),
+    ]
+    for (const s of samples) {
+      const inEventsPane = partitionItems([s]).events.length === 1
+      expect(isAudienceEvent(s)).toBe(inEventsPane)
+    }
   })
 })
 

--- a/frontend/src/lib/utils/overlayViewModel.ts
+++ b/frontend/src/lib/utils/overlayViewModel.ts
@@ -64,6 +64,19 @@ const SYSTEM_EVENT_TYPES: ReadonlySet<EventType> = new Set<EventType>([
 ])
 
 /**
+ * Whether an item is audience activity — i.e. it would land in the `events`
+ * pane of {@link partitionItems} (a sub, bit, raid, super chat, gift/rose,
+ * follow, …). Excludes plain chat, operational system notices, and deletions.
+ * Kept in lock-step with `partitionItems` so a sound plays exactly when a new
+ * row appears in the Activity & Events panel, and never otherwise.
+ */
+export function isAudienceEvent(item: ChatMessage): boolean {
+  const type = item.event?.type
+  if (!type) return false
+  return !SYSTEM_EVENT_TYPES.has(type) && type !== 'message_deletion'
+}
+
+/**
  * Split the held items into the three panes the view renders:
  *  - chat:   regular messages (no event)
  *  - events: audience activity (subs, bits, raids, super chats, gifts, follows, …)


### PR DESCRIPTION
## What

Adds an optional **sound cue** in the overlay **Monitor view** (`/overlay/[id]/view`) that plays a short sound whenever a new item lands in the **Activity & Events** panel: channel-point redeems, TikTok gifts/roses, follows, subs, raids, super chats, and so on.

It targets the easy-to-miss activity that has no on-stream sound of its own (a plain channel-point redeem, a single Rose), so the streamer can notice it and thank the viewer. It does **not** fire for plain chat, the moderator's own moderation actions, or operational system notices.

## Distinct from the overlay's "Notification Sounds"

This is intentionally a **different feature** from the existing overlay notification sounds:

- It is a moderator's **personal, per-browser** preference (localStorage). It never touches the overlay's `display_settings` and **never plays on the public OBS overlay**.
- The Monitor view's control carries a note: *"Plays only here, in this browser... separate from your overlay's on-stream notification sounds."*
- The overlay editor's **Notification Sounds** section now carries a reciprocal note pointing to the Monitor-view setting, so the distinction is clear from both sides.

## Controls

On/off, a choice of the three existing sounds (chime/pop/ping), a volume slider, and a **Test** button (which also satisfies the browser's autoplay-needs-a-gesture rule). A built-in 1.5s cooldown means a mystery-gift burst yields one gentle ping.

## Implementation

- **`viewPrefs.ts`** — new `activitySound{Enabled,Volume,Preset}` prefs (off by default) + load-time sanitization of preset/volume.
- **`overlayViewModel.ts`** — `isAudienceEvent()` helper, kept in lock-step with the Activity panel's partitioning so a cue plays exactly when a row appears.
- **`ViewSettingsBar.tsx`** — the new "Activity sound" controls + note.
- **`view/page.tsx`** — a pooled sound player (reused from the overlay engine) synced to prefs, playback in `onChat`, and the Test preview.
- **`SoundGroup.tsx`** — the clarifying note on the overlay settings.
- **Tests** — new `ViewSettingsBar` suite; extended `viewPrefs` and `overlayViewModel`.

## Scope / release notes

Ships **ungated (free)**: a private QoL/accessibility aid with no server cost and no on-stream effect, so the premium-toggle and onboarding-tour steps don't apply. Pure frontend, no backend changes. Remaining release step per project convention: a Patreon post once deployed.

## Verification

- `vitest`: affected suites pass (56 tests)
- `tsc --noEmit`: clean
- ESLint: clean on all touched files
