### PR TITLE
fix(tiktok-listener): stop double-publishing streakable gift events

### DIFF
--- a/services/tiktok-listener/CHANGELOG.md
+++ b/services/tiktok-listener/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - Resource Optimization & Message Deduplication
 
 ### Fixed
+- **Duplicated gift events**: Streakable gifts (`gift.type === 1`) fire the `GIFT` event repeatedly while the combo is in progress; only the final frame carries the full `repeatCount`. The handler now skips intermediate frames (`repeatEnd` falsy) so a single streakable gift is published once instead of twice.
 - **Timestamp Issue**: Messages now use TikTok's native `createTime` timestamp instead of generating new ones on receipt
   - Prevents messages from appearing "fresh" when they're actually old/replayed
   - Properly preserves message chronology during reconnects

--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -212,7 +212,7 @@ interface TikTokChatData {
 interface TikTokGift {
   id?: string;
   name?: string;
-  type?: number; // gift type: 1 = normal, 2 = streakable (was top-level `giftType`)
+  type?: number; // gift type: 1 = streakable (combo), other = non-streakable (was top-level `giftType`)
   diamondCount?: number;
 }
 
@@ -221,6 +221,7 @@ interface TikTokGiftData {
   user?: TikTokUser;
   giftId?: string; // now top-level (was `gift.giftId`)
   repeatCount?: number;
+  repeatEnd?: number; // 1 once a streakable gift's combo has finished; intermediate frames are 0
   gift?: TikTokGift;
 }
 
@@ -1144,6 +1145,14 @@ class TikTokListenerService {
   private async handleGift(username: string, overlayId: string, data: TikTokGiftData): Promise<void> {
     try {
       this.heartbeatMonitor.recordMessage(username);
+
+      // Streakable gifts (gift.type === 1) fire GIFT repeatedly while the combo
+      // is in progress; only the final frame (repeatEnd) carries the complete
+      // repeatCount. Publishing the intermediate frames would show the same gift
+      // multiple times (e.g. a single Rose renders twice). Skip until the streak ends.
+      if (data.gift?.type === 1 && !data.repeatEnd) {
+        return;
+      }
 
       const msgId = data.common?.msgId || randomUUID();
       const createTime = data.common?.createTime;


### PR DESCRIPTION
## Problem

Reported by streamer **lejoe**: *"the gift on tiktok was double."*

TikTok's modern `WebcastEvent.GIFT` fires **repeatedly** while a streakable/combo gift (`gift.type === 1`, e.g. a Rose) is in progress. Only the final frame carries `repeatEnd` and the complete `repeatCount`. `handleGift` published on **every** frame, so a single streakable gift emitted a streak-begin frame *and* a streak-end frame and rendered **twice** on the overlay.

This surfaced now because the TikTok connect-button fix (#601) finally lets TikTok connect, so gift events actually flow through.

## Fix

Skip intermediate streak frames and publish once the combo ends:

```ts
if (data.gift?.type === 1 && !data.repeatEnd) {
  return; // streak still in progress
}
```

- Adds `repeatEnd?: number` to `TikTokGiftData`.
- Non-streakable gifts are unaffected (guard is false → published immediately).
- Safe fallback: if `gift.type` is ever absent, the guard is false and we publish — a real gift is never silently dropped.
- `repeatCount` / `diamond_count` already reflect the final combo total, so counts stay correct.
- Corrects the backwards interface comment (`type === 1` is the *streakable* type).

## Verification

- `tsc --noEmit`: clean
- `vitest run`: 49/49 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)