### PR TITLE
docs: correct stale allchat.io references to allch.at

### DIFF
--- a/docs/architecture/02-DEPLOYMENT.md
+++ b/docs/architecture/02-DEPLOYMENT.md
@@ -745,11 +745,11 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - api.allchat.io
-        - overlays.allchat.io
+        - api.allch.at
+        - overlays.allch.at
       secretName: allchat-tls
   rules:
-    - host: api.allchat.io
+    - host: api.allch.at
       http:
         paths:
           - path: /
@@ -759,7 +759,7 @@ spec:
                 name: api-gateway
                 port:
                   number: 8080
-    - host: overlays.allchat.io
+    - host: overlays.allch.at
       http:
         paths:
           - path: /ws
@@ -808,13 +808,13 @@ data:
   emote_service_url: "http://emote-service:8083"
 
   # Frontend URL (used for OAuth redirect generation)
-  frontend_url: "https://app.allchat.io"
+  frontend_url: "https://app.allch.at"
 
   # Logging
   log_level: "info"
 
   # WebSocket Overlay Security
-  websocket_allowed_origins: "https://app.allchat.io,https://studio.allchat.io"
+  websocket_allowed_origins: "https://app.allch.at,https://studio.allch.at"
 ```
 
 > **API Gateway runtime knobs**

--- a/docs/architecture/05-SECURITY.md
+++ b/docs/architecture/05-SECURITY.md
@@ -350,7 +350,7 @@ func (rl *RateLimiter) Limit() gin.HandlerFunc {
 // pkg/middleware/cors.go
 func CORS() gin.HandlerFunc {
     return cors.New(cors.Config{
-        AllowOrigins:     []string{"https://allchat.io", "https://*.allchat.io"},
+        AllowOrigins:     []string{"https://allch.at", "https://*.allch.at"},
         AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
         AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
         ExposeHeaders:    []string{"Content-Length", "X-RateLimit-Limit"},
@@ -430,7 +430,7 @@ func (r *PostgresOverlayRepository) GetByID(ctx context.Context, id string) (*do
 spec:
   tls:
     - hosts:
-        - api.allchat.io
+        - api.allch.at
       secretName: allchat-tls  # Let's Encrypt certificate
 ```
 

--- a/docs/phase-reports/KUBERNETES_CONTROLLER_ANALYSIS.md
+++ b/docs/phase-reports/KUBERNETES_CONTROLLER_ANALYSIS.md
@@ -155,7 +155,7 @@ data:
 
 ```yaml
 ---
-apiVersion: allchat.io/v1alpha1
+apiVersion: allch.at/v1alpha1
 kind: Overlay
 metadata:
   name: streamer-xqc-main
@@ -179,13 +179,13 @@ status:
   phase: "Active"
 
 ---
-apiVersion: allchat.io/v1alpha1
+apiVersion: allch.at/v1alpha1
 kind: ChatSource
 metadata:
   name: xqc-twitch
   namespace: allchat
   ownerReferences:
-    - apiVersion: allchat.io/v1alpha1
+    - apiVersion: allch.at/v1alpha1
       kind: Overlay
       name: streamer-xqc-main
 spec:

--- a/docs/phase-reports/LIMITS_ALERTS_MONITORING.md
+++ b/docs/phase-reports/LIMITS_ALERTS_MONITORING.md
@@ -292,7 +292,7 @@ groups:
         annotations:
           summary: "{{ $labels.pod }} is down"
           description: "Service {{ $labels.app }} ({{ $labels.pod }}) has been down for >2 minutes"
-          runbook: "https://docs.allchat.io/runbooks/service-down"
+          runbook: "https://docs.allch.at/runbooks/service-down"
 
       # Error rate
       - alert: HighErrorRate
@@ -309,7 +309,7 @@ groups:
         annotations:
           summary: "High error rate on {{ $labels.service }}"
           description: "Error rate: {{ $value | humanizePercentage }} (threshold: 5%)"
-          runbook: "https://docs.allchat.io/runbooks/high-error-rate"
+          runbook: "https://docs.allch.at/runbooks/high-error-rate"
 
       # Database connections
       - alert: DatabaseConnectionPoolExhausted
@@ -324,7 +324,7 @@ groups:
         annotations:
           summary: "Database pool exhausted on {{ $labels.service }}"
           description: "Active: {{ $value }}, Max: {{ $labels.max_conns }}"
-          runbook: "https://docs.allchat.io/runbooks/db-pool-exhausted"
+          runbook: "https://docs.allch.at/runbooks/db-pool-exhausted"
 
       # Redis availability
       - alert: RedisDown
@@ -336,7 +336,7 @@ groups:
         annotations:
           summary: "Redis is down"
           description: "All message processing will stop"
-          runbook: "https://docs.allchat.io/runbooks/redis-down"
+          runbook: "https://docs.allch.at/runbooks/redis-down"
 
       # CNPG health
       - alert: CNPGClusterDegraded
@@ -348,7 +348,7 @@ groups:
         annotations:
           summary: "CNPG cluster has < 2 ready instances"
           description: "Ready instances: {{ $value }}/3"
-          runbook: "https://docs.allchat.io/runbooks/cnpg-degraded"
+          runbook: "https://docs.allch.at/runbooks/cnpg-degraded"
 
       # WebSocket capacity
       - alert: WebSocketCapacityHigh
@@ -360,7 +360,7 @@ groups:
         annotations:
           summary: "API Gateway approaching WebSocket capacity"
           description: "Connections: {{ $value }}/2500 limit"
-          runbook: "https://docs.allchat.io/runbooks/websocket-capacity"
+          runbook: "https://docs.allch.at/runbooks/websocket-capacity"
 
       # YouTube quota
       - alert: YouTubeQuotaExhausted
@@ -372,7 +372,7 @@ groups:
         annotations:
           summary: "YouTube API quota nearly exhausted"
           description: "Used: {{ $value }}/10000 units"
-          runbook: "https://docs.allchat.io/runbooks/youtube-quota"
+          runbook: "https://docs.allch.at/runbooks/youtube-quota"
 
   - name: warning
     interval: 1m
@@ -401,7 +401,7 @@ groups:
         annotations:
           summary: "High message backlog in Redis Stream"
           description: "Pending messages: {{ $value }}"
-          runbook: "https://docs.allchat.io/runbooks/message-backlog"
+          runbook: "https://docs.allch.at/runbooks/message-backlog"
 
       # CPU usage
       - alert: HighCPUUsage

--- a/docs/phase-reports/SCALING_PERFORMANCE.md
+++ b/docs/phase-reports/SCALING_PERFORMANCE.md
@@ -581,7 +581,7 @@ artillery run test/load/websocket-surge.yaml
 ```yaml
 # test/load/websocket-surge.yaml
 config:
-  target: "wss://overlays.allchat.io"
+  target: "wss://overlays.allch.at"
   phases:
     - duration: 60
       arrivalRate: 100  # 100 connections/second


### PR DESCRIPTION
## What

Swaps every `allchat.io` reference in the docs to the real production domain `allch.at`.

## Why

The production domain is **`allch.at`**, served at the apex (app, API and WebSocket all route under it; confirmed via `frontend/src/app/layout.tsx` `metadataBase`, `shared/middleware/cors.go` defaults, and the `caesar-deployment` repo which has zero `allchat.io`). A few architecture and phase-report docs used fake `allchat.io` per-service subdomains (`api.` / `overlays.` / `app.` / `docs.allchat.io`) as placeholders. When grepping the repo for our domain, those read like the real thing and are actively misleading.

## Scope

Doc-only, 5 files, 20 occurrences. No behavioural change, these are illustrative example manifests; the real manifests live in `caesar-deployment`.

- `docs/architecture/02-DEPLOYMENT.md`
- `docs/architecture/05-SECURITY.md`
- `docs/phase-reports/KUBERNETES_CONTROLLER_ANALYSIS.md`
- `docs/phase-reports/LIMITS_ALERTS_MONITORING.md`
- `docs/phase-reports/SCALING_PERFORMANCE.md`