### PR TITLE
feat(frontend): keyword-led SEO metadata, expanded sitemap, docs JSON-LD

### DIFF
--- a/frontend/src/app/__tests__/seo-metadata.test.ts
+++ b/frontend/src/app/__tests__/seo-metadata.test.ts
@@ -1,0 +1,98 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * SEO metadata & structured-data guarantees (search-visibility CI gate).
+ *
+ * Locks the on-page SEO signals we rely on so a refactor cannot silently drop
+ * them: the keyword-led homepage title, the crawlable content pages in the
+ * sitemap, Discord + "OBS chat overlay" in the site description, and the
+ * HowTo / TechArticle / BreadcrumbList JSON-LD on the docs pages.
+ *
+ * Follows the repo convention (see token-contrast.test.ts) of parsing source
+ * as text rather than importing the page modules, which pull in client
+ * components and next/font and do not load cleanly under vitest. The sitemap
+ * is a pure module, so it is exercised functionally.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import sitemap from '../sitemap'
+
+const read = (rel: string) => readFileSync(join(__dirname, '..', rel), 'utf-8')
+
+describe('sitemap', () => {
+  const urls = sitemap().map((entry) => entry.url)
+
+  it('lists the homepage', () => {
+    expect(urls).toContain('https://allch.at')
+  })
+
+  it('includes the docs, developer API and upgrade pages', () => {
+    expect(urls).toContain('https://allch.at/docs')
+    expect(urls).toContain('https://allch.at/docs/api')
+    expect(urls).toContain('https://allch.at/upgrade')
+  })
+
+  it('keeps the legal pages indexable', () => {
+    expect(urls).toContain('https://allch.at/legal/privacy')
+  })
+})
+
+describe('homepage metadata (page.tsx)', () => {
+  const src = read('page.tsx')
+
+  it('sets a keyword-led absolute title', () => {
+    expect(src).toMatch(/absolute:\s*['"]Multi-Platform Chat Overlay/)
+  })
+
+  it('leads the homepage description with the search phrase and all five platforms', () => {
+    // Distinctive phrases from the new homepage description, so this cannot
+    // pass on the pre-existing JSON-LD featureList that also mentions OBS.
+    expect(src).toContain('multi-platform chat overlay for OBS')
+    expect(src).toMatch(/Kick, TikTok, and Discord chat/)
+  })
+})
+
+describe('site description (layout.tsx)', () => {
+  const src = read('layout.tsx')
+
+  it('names all five platforms including Discord in the description', () => {
+    // Precise phrase; guards against passing on the DISCORD_INVITE_URL import.
+    expect(src).toMatch(/Kick, TikTok, and Discord chat/)
+  })
+
+  it('describes an "OBS chat overlay" (the primary search term)', () => {
+    expect(src).toContain('one OBS chat overlay')
+  })
+})
+
+describe('docs structured data (JSON-LD)', () => {
+  it('the streamer guide emits HowTo + BreadcrumbList', () => {
+    const src = read('docs/page.tsx')
+    expect(src).toContain("'HowTo'")
+    expect(src).toContain("'BreadcrumbList'")
+  })
+
+  it('the developer API page emits TechArticle + BreadcrumbList', () => {
+    const src = read('docs/api/page.tsx')
+    expect(src).toContain("'TechArticle'")
+    expect(src).toContain("'BreadcrumbList'")
+  })
+})

--- a/frontend/src/app/docs/api/page.tsx
+++ b/frontend/src/app/docs/api/page.tsx
@@ -19,12 +19,41 @@
 import Link from 'next/link'
 import { AppNav } from '@/components/AppNav'
 import { Code, Pre, FieldTable } from '@/components/docs/prose'
+import { JsonLd } from '@/components/JsonLd'
 
 export const metadata = {
   title: 'Developer API',
   description:
     'Connect third-party tools to the All-Chat unified chat WebSocket stream: message format, platform events, status messages and reconnection (Twitch, YouTube, Kick, TikTok, Discord).',
   alternates: { canonical: '/docs/api' },
+}
+
+// Structured data: a technical reference page maps to schema.org TechArticle,
+// plus a Home > Documentation > Developer API breadcrumb trail. Emitted server
+// side so both are in the initial HTML for crawlers.
+const techArticleLd = {
+  '@context': 'https://schema.org',
+  '@type': 'TechArticle',
+  headline: 'All-Chat Developer API reference',
+  description:
+    'Read the All-Chat unified chat WebSocket stream: message format, platform events, status messages and reconnection for Twitch, YouTube, Kick, TikTok and Discord.',
+  url: 'https://allch.at/docs/api',
+  about: 'All-Chat unified chat WebSocket API',
+}
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://allch.at' },
+    { '@type': 'ListItem', position: 2, name: 'Documentation', item: 'https://allch.at/docs' },
+    {
+      '@type': 'ListItem',
+      position: 3,
+      name: 'Developer API',
+      item: 'https://allch.at/docs/api',
+    },
+  ],
 }
 
 const TEST_OVERLAY_ID = '00000000-0000-4000-8000-000000000a11'
@@ -42,6 +71,8 @@ const toc = [
 export default function DeveloperDocsPage() {
   return (
     <div className="min-h-screen bg-bg transition-colors duration-300">
+      <JsonLd data={techArticleLd} />
+      <JsonLd data={breadcrumbLd} />
       <AppNav />
       <div className="mx-auto max-w-4xl px-4 py-12">
         <div className="rounded-xl border border-border bg-surface p-8 transition-colors duration-300 md:p-12">

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { AppNav } from '@/components/AppNav'
 import { Code, Pre } from '@/components/docs/prose'
+import { JsonLd } from '@/components/JsonLd'
 import { DISCORD_INVITE_URL } from '@/lib/constants'
 
 export const metadata = {
@@ -27,6 +28,47 @@ export const metadata = {
   description:
     'Get your All-Chat overlay live in OBS, pick from 16 built-in themes, and make it your own — no CSS required to start, full CSS control when you want it.',
   alternates: { canonical: '/docs' },
+}
+
+// Structured data: the "Get your overlay live" section is a genuine step-by-step
+// procedure, so it maps to schema.org HowTo (rich-result eligible). Breadcrumbs
+// give Google the Home > Documentation trail. Emitted from this server page, so
+// both land in the initial HTML for crawlers.
+const howToLd = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  name: 'Get your All-Chat overlay live in OBS',
+  description:
+    'Set up a multi-platform chat overlay in OBS with All-Chat, combining Twitch, YouTube, Kick, TikTok and Discord chat into one browser source.',
+  step: [
+    {
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Sign in',
+      text: 'Sign in at allch.at with your Twitch, YouTube, or Kick account.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 2,
+      name: 'Create an overlay and connect your platforms',
+      text: 'In the dashboard, create an overlay and connect the platforms you stream on. Each connected platform becomes a chat source on that overlay.',
+    },
+    {
+      '@type': 'HowToStep',
+      position: 3,
+      name: 'Add the overlay to OBS',
+      text: 'Copy the overlay browser-source URL and add it to OBS as a Browser Source. Chat appears the moment the overlay connects.',
+    },
+  ],
+}
+
+const breadcrumbLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://allch.at' },
+    { '@type': 'ListItem', position: 2, name: 'Documentation', item: 'https://allch.at/docs' },
+  ],
 }
 
 /** A "variable / default / effect" row table for the CSS custom properties. */
@@ -122,6 +164,8 @@ const toc = [
 export default function DocsPage() {
   return (
     <div className="min-h-screen bg-bg transition-colors duration-300">
+      <JsonLd data={howToLd} />
+      <JsonLd data={breadcrumbLd} />
       <AppNav />
       <main id="main-content" tabIndex={-1} className="mx-auto max-w-4xl px-4 py-12">
         <div className="rounded-xl border border-border bg-surface p-8 transition-colors duration-300 md:p-12">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -61,14 +61,18 @@ export const metadata: Metadata = {
     template: '%s | All-Chat',
   },
   description:
-    'See all your Twitch, YouTube, Kick, and TikTok chat in one overlay. Drop it into OBS and go. 7TV, BTTV, and FFZ emotes built in. Free and open source.',
+    'See all your Twitch, YouTube, Kick, TikTok, and Discord chat in one OBS chat overlay. Drop it into OBS and go. 7TV, BTTV, and FFZ emotes built in. Free and open source.',
   keywords: [
     'twitch chat',
     'youtube chat',
     'kick chat',
     'tiktok chat',
+    'discord chat',
     'chat overlay',
     'obs overlay',
+    'obs chat overlay',
+    'multichat',
+    'streamelements alternative',
     'streaming',
     'multistream',
     'chat aggregator',
@@ -87,13 +91,13 @@ export const metadata: Metadata = {
     siteName: 'All-Chat',
     title: 'All-Chat — Every chat. One overlay.',
     description:
-      'All your Twitch, YouTube, Kick, and TikTok chat in one overlay. 7TV, BTTV, and FFZ emotes built in.',
+      'All your Twitch, YouTube, Kick, TikTok, and Discord chat in one OBS overlay. 7TV, BTTV, and FFZ emotes built in.',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'All-Chat — Every chat. One overlay.',
     description:
-      'All your Twitch, YouTube, Kick, and TikTok chat in one overlay. 7TV, BTTV, and FFZ emotes built in.',
+      'All your Twitch, YouTube, Kick, TikTok, and Discord chat in one OBS overlay. 7TV, BTTV, and FFZ emotes built in.',
   },
   robots: {
     index: true,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -30,6 +30,15 @@ import { JsonLd } from '@/components/JsonLd'
 import { FAQ_ITEMS } from '@/lib/faq'
 
 export const metadata: Metadata = {
+  // The homepage targets the category search intent, not just the brand.
+  // `absolute` overrides the layout title template ("%s | All-Chat") so the
+  // query terms lead the <title>, and a keyword-led description overrides the
+  // layout default for this page specifically.
+  title: {
+    absolute: 'Multi-Platform Chat Overlay for Twitch, YouTube, Kick & TikTok | All-Chat',
+  },
+  description:
+    'Free multi-platform chat overlay for OBS. Merge your Twitch, YouTube, Kick, TikTok, and Discord chat into one overlay, with 7TV, BTTV, and FFZ emotes built in. Open source, no install.',
   alternates: { canonical: '/' },
 }
 

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -28,6 +28,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 1,
     },
+    // Content pages. These are live, indexable and keyword-relevant but were
+    // previously absent from the sitemap, so they were under-crawled.
+    {
+      url: `${baseUrl}/docs`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/docs/api`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/upgrade`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
     {
       url: `${baseUrl}/legal/privacy`,
       lastModified: new Date(),


### PR DESCRIPTION
## What

Ships the low-risk, high-value SEO quick wins from the growth audit. All changes are invisible to users (metadata, sitemap, structured data) and improve how crawlers see the site.

- **Homepage** (`page.tsx`): keyword-led `<title>` (`Multi-Platform Chat Overlay for Twitch, YouTube, Kick & TikTok | All-Chat`) and a keyword-led description naming all five platforms + OBS, overriding the brand-only defaults for the homepage.
- **Site description** (`layout.tsx`): added **Discord** (previously omitted) and the phrase "OBS chat overlay" to the meta/OG/Twitter descriptions; added a few keywords.
- **Sitemap** (`sitemap.ts`): added `/docs`, `/docs/api`, `/upgrade` — live, indexable content pages that were previously absent from the sitemap and under-crawled (Google's cached snippet was stale).
- **Docs structured data**: `HowTo` + `BreadcrumbList` on the streamer guide, `TechArticle` + `BreadcrumbList` on the developer API page (rich-result eligible), server-rendered.

## Why

The audit found our rendering + existing schema are already good; we rank poorly because the indexable surface is tiny and titles/descriptions targeted the brand, not search intent. This closes the cheapest gaps.

## Testing

- New `seo-metadata.test.ts` (vitest) locks the sitemap entries, the keyword title, the Discord/OBS description, and the docs JSON-LD types.
- `tsc --noEmit` clean; eslint clean on changed files (1 unrelated pre-existing warning).
- **Production build verified end-to-end**: prerendered homepage `<title>`/description, `docs.html` + `docs/api.html` JSON-LD, and `sitemap.xml` all contain the new content.

## Not in this PR (follow-ups from the audit)

Landing/comparison/per-platform pages (the durable ranking wins), homepage H1 copy + body internal-links (brand-visible, wants a human eye), and off-repo items (GitHub repo metadata, Search Console, directory submissions, the Cloudflare AI-crawler decision).