### PR TITLE
fix(frontend): correct per-platform moderation capability copy

### DIFF
--- a/frontend/src/app/__tests__/moderation-copy.test.ts
+++ b/frontend/src/app/__tests__/moderation-copy.test.ts
@@ -1,0 +1,63 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Moderation-capability copy honesty gate.
+ *
+ * The moderation-service (ADR-0017) does NOT support the same actions on every
+ * platform: Twitch + Discord do delete/timeout/ban/unban, Kick has no
+ * single-message delete, YouTube is ban-only, TikTok is unsupported. Marketing
+ * and docs copy previously claimed a blanket "delete, timeout and ban across
+ * Twitch, YouTube, Kick and Discord", which is false. This test locks the copy
+ * so that overstatement cannot silently return.
+ *
+ * Source of truth: services/moderation-service/README.md capability matrix.
+ * Parses source as text (repo convention, see token-contrast.test.ts).
+ */
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const read = (rel: string) => readFileSync(join(__dirname, '..', rel), 'utf-8')
+
+describe('moderation copy is honest per-platform (ADR-0017)', () => {
+  const upgrade = read('upgrade/page.tsx')
+  const onboarding = readFileSync(
+    join(__dirname, '..', '..', 'components', 'onboarding', 'OnboardingChecklist.tsx'),
+    'utf-8',
+  )
+  const docs = read('docs/page.tsx')
+
+  it('no surface makes the false blanket "ban across Twitch, YouTube, Kick, and Discord" claim', () => {
+    for (const src of [upgrade, onboarding, docs]) {
+      expect(src).not.toMatch(/across Twitch, YouTube, Kick,? and Discord/)
+    }
+  })
+
+  it('the upgrade page states YouTube is ban-only and TikTok is unsupported', () => {
+    expect(upgrade).toMatch(/ban on YouTube/i)
+    expect(upgrade).toMatch(/TikTok has no moderation API/i)
+  })
+
+  it('the docs page spells out the real Kick and YouTube limits', () => {
+    expect(docs).toMatch(/Kick does timeout,\s+ban and unban/)
+    expect(docs).toMatch(/no single-message\s+delete/)
+    expect(docs).toMatch(/YouTube is ban-only/)
+  })
+})

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -312,8 +312,9 @@ export default function DocsPage() {
                 With <strong>Moderation controls</strong> on in the monitor, hover a message to{' '}
                 <strong>Delete</strong> it, or open a chatter to <strong>Timeout</strong>,{' '}
                 <strong>Ban</strong> or <strong>Unban</strong> them — applied on the source
-                platform. What&apos;s available depends on the platform (Twitch does delete, timeout
-                and ban; YouTube is ban-only; TikTok has no moderation API).
+                platform: Twitch and Discord do delete, timeout, ban and unban; Kick does timeout,
+                ban and unban (no single-message delete); YouTube is ban-only; TikTok has no
+                moderation API.
               </p>
               <p>
                 The first time, use <strong>Enable moderation &amp; chat sending</strong> to grant

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -44,7 +44,7 @@ const features: PremiumFeature[] = [
     icon: ShieldCheck,
     title: 'Moderate from your overlay',
     description:
-      'Delete, timeout, and ban across Twitch, YouTube, Kick, and Discord straight from the monitor view — no second dashboard.',
+      'Moderate straight from the monitor view — no second dashboard. Delete, timeout, ban and unban on Twitch and Discord; timeout, ban and unban on Kick; ban on YouTube. (TikTok has no moderation API.)',
   },
   {
     icon: Volume2,

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -316,8 +316,9 @@ export function OnboardingChecklist({
                 <li>
                   <span className="font-medium text-text">Moderate from your overlay</span>
                   <p className="text-xs text-text-sub">
-                    Delete, timeout, and ban straight from the Monitor View button at the top of the
-                    editor. (Premium)
+                    Delete, timeout, ban and unban from the Monitor View button at the top of the
+                    editor. Full controls on Twitch and Discord; Kick has no single-message delete;
+                    YouTube is ban-only. (Premium)
                   </p>
                 </li>
                 <li>


### PR DESCRIPTION
## What

Fixes user-facing copy that overstated cross-platform moderation. Per the moderation-service capability matrix (ADR-0017, `services/moderation-service/README.md`):

| Platform | Actions |
|---|---|
| Twitch | delete, timeout, ban, unban |
| Discord | delete, timeout, ban, unban |
| Kick | timeout, ban, unban (**no single-message delete**) |
| YouTube | **ban only** |
| TikTok | unsupported |

Three surfaces were wrong and disagreed with each other:
- **`/upgrade`** and **onboarding** claimed "delete, timeout, and ban across Twitch, YouTube, Kick, and Discord" (overstated).
- **`/docs`** under-stated it (only named Twitch + YouTube + TikTok; omitted Kick and Discord and unban).

All three now carry one honest per-platform line.

## Testing

- New `moderation-copy.test.ts` (vitest) locks the copy against the false blanket claim and asserts the real Kick/YouTube limits. Red before, green after.
- `tsc --noEmit` clean.

## Note

There is a pre-existing `react-hooks/set-state-in-effect` eslint error in `OnboardingChecklist.tsx` (line ~136, in an analytics effect) that predates this change and is unrelated to it, left untouched to keep this PR scoped to the copy fix.