### PR TITLE
ci: report required test checks on docs-only PRs

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -14,11 +14,13 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'services/**'
-      - 'frontend/**'
-      - 'shared/**'
-      - '.github/workflows/**'
+    # No `paths:` filter here on purpose. Required status checks (`test (*)`,
+    # `test-node`) live in this workflow; if a `paths:` filter skipped the whole
+    # workflow for docs-only PRs, those required checks would never report and the
+    # PR would be stuck in "Expected — Waiting for status to be reported" forever.
+    # Instead the workflow always triggers and the individual jobs skip cheaply via
+    # a job-level `if:` on detect-changes.outputs.code. A job skipped by a
+    # conditional reports "Success", which satisfies branch protection.
   workflow_dispatch:
 
 env:
@@ -53,6 +55,7 @@ jobs:
       frontend: ${{ steps.changes.outputs.frontend }}
       shared: ${{ steps.changes.outputs.shared }}
       migrations: ${{ steps.changes.outputs.migrations }}
+      code: ${{ steps.changes.outputs.code }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -131,6 +134,16 @@ jobs:
             migrations:
               - 'migrations/**'
               - 'scripts/run-migrations.sh'
+            # Aggregate "any test-relevant code changed" signal. Gates the test
+            # jobs so docs-only PRs skip them (and thus report Success) instead of
+            # running the full Go/Node suites.
+            code:
+              - 'services/**'
+              - 'frontend/**'
+              - 'shared/**'
+              - 'migrations/**'
+              - 'scripts/**'
+              - '.github/workflows/**'
 
   build-and-push:
     runs-on: ubuntu-latest
@@ -269,7 +282,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.code == 'true'
     strategy:
       matrix:
         service:
@@ -306,7 +320,8 @@ jobs:
 
   test-node:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v7
 
@@ -328,7 +343,8 @@ jobs:
   # migrations applied, so they run in a dedicated job (they would t.Skipf without a DB).
   test-engagement-integration:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.code == 'true'
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -283,7 +283,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.code == 'true'
+    # Keep this job RUNNING on every PR (do not gate it at the job level) so the
+    # matrix expands and each `test (<service>)` required context is created and
+    # reports. A matrix job skipped via job-level `if:` collapses to a single
+    # `test` check, which would leave the per-leg required contexts unreported and
+    # block docs-only PRs. The expensive step is gated instead (see below).
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         service:
@@ -313,6 +318,9 @@ jobs:
           go-version: '1.25.12'
 
       - name: Run tests for ${{ matrix.service }}
+        # Skip the actual suite on docs-only PRs. The job still succeeds, so the
+        # required `test (<service>)` context reports Success without running Go.
+        if: needs.detect-changes.outputs.code == 'true'
         run: |
           cd services/${{ matrix.service }}
           go mod download


### PR DESCRIPTION
## Problem

PR #604 (docs-only) was stuck with `mergeStateStatus: BLOCKED` and had to be admin-merged. Nothing was actually running — the required backend checks never reported.

Branch protection on `main` requires these contexts:

- `test (auth-service)` … `test (discord-listener)` and `test-node`

They are produced by `build-and-push.yml`, whose `pull_request` trigger had a `paths:` filter (`services/**`, `frontend/**`, `shared/**`, `.github/workflows/**`). A docs-only PR touches none of those, so the **whole workflow is skipped by path filtering** and those required contexts stay in *"Expected — Waiting for status to be reported"* forever → the PR can never merge without an admin bypass.

(The Frontend A11y Gate already avoids this: it runs a `changes` job on every PR and emits `SKIPPED` conclusions, which satisfy branch protection.)

## Fix

GitHub's rule: a workflow skipped by a **path filter** leaves required checks pending, but a job/step skipped by a **conditional** reports **Success**. So:

- **Remove the `pull_request` `paths:` filter** — the workflow now triggers on every PR to `main`.
- Add an aggregate `code` output to the existing `detect-changes` job (matches all test-relevant paths).
- **`test` (matrix job):** keep it **running** on every PR and gate only the `go test` **step** on `code == 'true'`. This is deliberate — a *matrix job* skipped at the job level collapses to a single `test` check and would **not** emit the per-leg `test (<service>)` required contexts. Keeping the job running lets the matrix expand so each required context is created and reports **Success**; the step skip just avoids running Go on docs-only PRs.
- **`test-node` / `test-engagement-integration` (single-context jobs):** gated at the **job** level. A skipped single job reports its own context as `SKIPPED`, which branch protection counts as a pass (same mechanism the a11y gate already relies on).

## Result

- **Docs-only PR:** workflow triggers; `test` legs run (checkout only, no Go) → each `test (<service>)` reports **Success**; `test-node` skips → **pass**. PR is mergeable normally, no admin bypass.
- **Code PR:** unchanged — full Go matrix + node + integration run exactly as before.
- **Push events:** unchanged — `build-and-push` still `if: github.event_name != 'pull_request'`; the `push` `paths:` filter is untouched.

## Verification

This PR touches `.github/workflows/**`, so `code == true` and the full required suite runs here — confirming the code-PR path still works end-to-end.