### PR TITLE
fix(emotes): adapt to 7TV API no longer embedding active emote set

### DIFF
--- a/services/emote-service/clients/seventv.go
+++ b/services/emote-service/clients/seventv.go
@@ -19,6 +19,7 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -44,7 +45,12 @@ type SevenTVClient struct {
 }
 
 type sevenTVUserResponse struct {
-	EmoteSet sevenTVEmoteSet `json:"emote_set"`
+	// EmoteSetID is the active emote-set ID. Since 2026-08-03 the
+	// /v3/users/{platform}/{platform_id} endpoint no longer embeds the full
+	// active set (emote_set is null), so this ID is what a follow-up
+	// /v3/emote-sets/{id} fetch must use.
+	EmoteSetID string           `json:"emote_set_id"`
+	EmoteSet   *sevenTVEmoteSet `json:"emote_set"`
 }
 
 type sevenTVEmoteSet struct {
@@ -197,7 +203,38 @@ func (c *SevenTVClient) fetchChannelEmotes(ctx context.Context, channel string) 
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return c.parseEmoteSet(apiResp.EmoteSet, channel), nil
+	return c.resolveConnectionEmotes(ctx, apiResp, channel)
+}
+
+// resolveConnectionEmotes turns a /v3/users/{platform}/{platform_id} response
+// into emotes. Since 2026-08-03 that endpoint returns emote_set as null and
+// only carries emote_set_id, so the set contents must be fetched separately
+// via /v3/emote-sets/{id}. When the embedded set is still populated the extra
+// round trip is skipped.
+func (c *SevenTVClient) resolveConnectionEmotes(ctx context.Context, apiResp sevenTVUserResponse, channel string) ([]models.Emote, error) {
+	if apiResp.EmoteSet != nil && len(apiResp.EmoteSet.Emotes) > 0 {
+		return c.parseEmoteSet(*apiResp.EmoteSet, channel), nil
+	}
+
+	setID := apiResp.EmoteSetID
+	if setID == "" && apiResp.EmoteSet != nil {
+		setID = apiResp.EmoteSet.ID
+	}
+	if setID == "" {
+		// User exists on 7TV but has no active emote set.
+		return []models.Emote{}, nil
+	}
+
+	emotes, err := c.fetchEmoteSetByID(ctx, setID, channel)
+	if errors.Is(err, ErrNotFound) {
+		// The connection references a set that no longer exists — treat as
+		// "no active set" rather than failing the whole emote fetch.
+		c.logger.Warn("7TV connection references a missing emote set",
+			zap.String("channel", channel),
+			zap.String("set_id", setID))
+		return []models.Emote{}, nil
+	}
+	return emotes, err
 }
 
 // FetchUserEmotes fetches a user's personal emote set from 7TV
@@ -250,7 +287,7 @@ func (c *SevenTVClient) FetchUserEmotes(ctx context.Context, platform, userID st
 	}
 
 	// Use a special marker for user emotes (will be used for cache key)
-	return c.parseEmoteSet(apiResp.EmoteSet, fmt.Sprintf("user:%s:%s", platform, userID)), nil
+	return c.resolveConnectionEmotes(ctx, apiResp, fmt.Sprintf("user:%s:%s", platform, userID))
 }
 
 // fetchEmotesForPlatform fetches 7TV emotes with platform awareness.
@@ -360,7 +397,7 @@ func (c *SevenTVClient) fetchPlatformConnectionEmotes(ctx context.Context, platf
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return c.parseEmoteSet(apiResp.EmoteSet, channel), nil
+	return c.resolveConnectionEmotes(ctx, apiResp, channel)
 }
 
 // mergeSevenTVEmotes merges two 7TV emote slices, with the second slice taking
@@ -449,8 +486,9 @@ func (c *SevenTVClient) FetchCombinedEmotes(ctx context.Context, channel, platfo
 }
 
 // fetchEmoteSetByID fetches a specific 7TV emote set by its ID (24-char hex
-// legacy ObjectID or 26-char ULID). channel is only used to populate the
-// Channel field on the parsed emotes.
+// legacy ObjectID or 26-char ULID). Used for per-overlay override sets and for
+// resolving connection emote_set_id references. channel is only used to
+// populate the Channel field on the parsed emotes.
 func (c *SevenTVClient) fetchEmoteSetByID(ctx context.Context, setID, channel string) ([]models.Emote, error) {
 	urlPath := fmt.Sprintf("%s/v3/emote-sets/%s", c.baseURL, setID)
 
@@ -462,23 +500,23 @@ func (c *SevenTVClient) fetchEmoteSetByID(ctx context.Context, setID, channel st
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch override emote set: %w", err)
+		return nil, fmt.Errorf("failed to fetch emote set: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("override emote set %s not found", setID)
+		return nil, fmt.Errorf("emote set %s not found: %w", setID, ErrNotFound)
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		return nil, rateLimited("7tv", resp)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("override emote set lookup returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("emote set lookup returned status %d", resp.StatusCode)
 	}
 
 	var emoteSet sevenTVEmoteSet
 	if err := json.NewDecoder(resp.Body).Decode(&emoteSet); err != nil {
-		return nil, fmt.Errorf("failed to decode override response: %w", err)
+		return nil, fmt.Errorf("failed to decode emote set response: %w", err)
 	}
 
 	return c.parseEmoteSet(emoteSet, channel), nil

--- a/services/emote-service/clients/seventv_test.go
+++ b/services/emote-service/clients/seventv_test.go
@@ -280,6 +280,165 @@ func TestSevenTVClient_FetchEmotes(t *testing.T) {
 	}
 }
 
+func TestSevenTVClient_FetchEmotes_NullEmoteSet(t *testing.T) {
+	// Since 2026-08-03, /v3/users/{platform}/{platform_id} returns emote_set as
+	// null and only carries emote_set_id; the set contents must be fetched via
+	// a follow-up /v3/emote-sets/{id} call.
+	connectionResponse := `{
+		"id": "71092938",
+		"platform": "TWITCH",
+		"username": "xqc",
+		"emote_set_id": "set-123",
+		"emote_set": null
+	}`
+
+	setResponse := `{
+		"id": "set-123",
+		"name": "Cool Emotes",
+		"emotes": [
+			{
+				"id": "60ae7316f7c927fad14e6ca2",
+				"name": "xqcL",
+				"data": {
+					"host": {
+						"url": "//cdn.7tv.app/emote/60ae7316f7c927fad14e6ca2",
+						"files": [{"name": "1x.webp", "width": 28}]
+					}
+				}
+			}
+		]
+	}`
+
+	globalResponse := `{
+		"id": "global-set",
+		"name": "Global Emotes",
+		"emotes": [
+			{
+				"id": "603cac391cd55c0014d989be",
+				"name": "Stare",
+				"data": {
+					"host": {
+						"url": "//cdn.7tv.app/emote/603cac391cd55c0014d989be",
+						"files": [{"name": "1x.webp", "width": 28}]
+					}
+				}
+			}
+		]
+	}`
+
+	tests := []struct {
+		name               string
+		connectionResponse string
+		setStatusCode      int
+		setResponse        string
+		wantEmotes         []string
+		wantMissingEmotes  []string
+		wantSetFetch       bool
+	}{
+		{
+			name:               "null emote_set resolves via emote_set_id follow-up fetch",
+			connectionResponse: connectionResponse,
+			setStatusCode:      http.StatusOK,
+			setResponse:        setResponse,
+			wantEmotes:         []string{"xqcL", "Stare"},
+			wantSetFetch:       true,
+		},
+		{
+			name:               "null emote_set and null emote_set_id yields globals only",
+			connectionResponse: `{"id": "71092938", "platform": "TWITCH", "username": "xqc", "emote_set_id": null, "emote_set": null}`,
+			wantEmotes:         []string{"Stare"},
+			wantMissingEmotes:  []string{"xqcL"},
+		},
+		{
+			name:               "dangling emote_set_id (set deleted) degrades to globals only",
+			connectionResponse: connectionResponse,
+			setStatusCode:      http.StatusNotFound,
+			wantEmotes:         []string{"Stare"},
+			wantMissingEmotes:  []string{"xqcL"},
+			wantSetFetch:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sawSetFetch := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/v3/emote-sets/global"):
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(globalResponse))
+				case strings.Contains(r.URL.Path, "/v3/emote-sets/set-123"):
+					sawSetFetch = true
+					w.WriteHeader(tt.setStatusCode)
+					if tt.setResponse != "" {
+						w.Write([]byte(tt.setResponse))
+					}
+				case strings.Contains(r.URL.Path, "/v3/users/twitch/"):
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(tt.connectionResponse))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			logger := zaptest.NewLogger(t)
+			client := NewSevenTVClient(logger, &mockTwitchLookup{id: "71092938"}, &mockKickLookup{id: "0"})
+			client.baseURL = server.URL
+
+			emotes, err := client.FetchEmotes(context.Background(), "xqc")
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSetFetch, sawSetFetch, "emote-set follow-up fetch expectation")
+
+			emoteMap := make(map[string]models.Emote)
+			for _, e := range emotes {
+				emoteMap[e.Code] = e
+			}
+			for _, code := range tt.wantEmotes {
+				assert.Contains(t, emoteMap, code)
+			}
+			for _, code := range tt.wantMissingEmotes {
+				assert.NotContains(t, emoteMap, code)
+			}
+		})
+	}
+}
+
+func TestSevenTVClient_FetchUserEmotes_NullEmoteSet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/v3/emote-sets/personal-set"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{
+				"id": "personal-set",
+				"name": "Personal Emotes",
+				"emotes": [{
+					"id": "emote-1",
+					"name": "myEmote",
+					"data": {"host": {"url": "//cdn.7tv.app/emote/emote-1", "files": [{"name": "1x.webp", "width": 28}]}}
+				}]
+			}`))
+		case strings.Contains(r.URL.Path, "/v3/users/twitch/"):
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": "123", "platform": "TWITCH", "emote_set_id": "personal-set", "emote_set": null}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	logger := zaptest.NewLogger(t)
+	client := NewSevenTVClient(logger, &mockTwitchLookup{id: "123"}, &mockKickLookup{id: "0"})
+	client.baseURL = server.URL
+
+	emotes, err := client.FetchUserEmotes(context.Background(), "twitch", "123")
+
+	require.NoError(t, err)
+	require.Len(t, emotes, 1)
+	assert.Equal(t, "myEmote", emotes[0].Code)
+}
+
 func TestSevenTVClient_Provider(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 	client := NewSevenTVClient(logger, &mockTwitchLookup{id: "1"}, &mockKickLookup{id: "0"})

--- a/services/message-processor/seventv/manager.go
+++ b/services/message-processor/seventv/manager.go
@@ -39,10 +39,23 @@ type UserResponse struct {
 	ID       string `json:"id"`
 	Platform string `json:"platform"`
 	Username string `json:"username"`
-	EmoteSet struct {
+	// EmoteSetID is the active emote-set ID. Since 2026-08-03 the
+	// /v3/users/{platform}/{platform_id} endpoint returns emote_set as null,
+	// so this top-level ID is the reliable source.
+	EmoteSetID string `json:"emote_set_id"`
+	EmoteSet   struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"emote_set"`
+}
+
+// ActiveEmoteSetID returns the user's active emote-set ID, preferring the
+// top-level emote_set_id over the (possibly null) embedded emote_set object.
+func (u *UserResponse) ActiveEmoteSetID() string {
+	if u.EmoteSetID != "" {
+		return u.EmoteSetID
+	}
+	return u.EmoteSet.ID
 }
 
 // Manager manages 7TV event subscriptions and cache invalidation
@@ -116,7 +129,7 @@ func (m *Manager) TrackChannel(ctx context.Context, platform, channelID string) 
 			return nil
 		}
 
-		emoteSetID = user.EmoteSet.ID
+		emoteSetID = user.ActiveEmoteSetID()
 		if emoteSetID == "" {
 			m.logger.Debug("Channel has no emote set on 7TV",
 				zap.String("channel_id", channelID),
@@ -191,7 +204,7 @@ func (m *Manager) TrackUser(ctx context.Context, platform, userID string) error 
 			return nil
 		}
 
-		emoteSetID = user.EmoteSet.ID
+		emoteSetID = user.ActiveEmoteSetID()
 		if emoteSetID == "" {
 			m.logger.Debug("User has no emote set on 7TV",
 				zap.String("user_id", userID),

--- a/services/message-processor/seventv/manager_test.go
+++ b/services/message-processor/seventv/manager_test.go
@@ -1,0 +1,65 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package seventv
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUserResponse_ActiveEmoteSetID(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			// Post-2026-08-03 shape: emote_set is null, only emote_set_id is set.
+			name: "null emote_set with top-level emote_set_id",
+			body: `{"id": "u1", "platform": "TWITCH", "username": "xqc", "emote_set_id": "01FE9DRF000009TR6M9N941CYW", "emote_set": null}`,
+			want: "01FE9DRF000009TR6M9N941CYW",
+		},
+		{
+			// Legacy shape: embedded emote_set only.
+			name: "embedded emote_set without top-level id",
+			body: `{"id": "u1", "platform": "TWITCH", "username": "xqc", "emote_set": {"id": "legacy-set", "name": "Emotes"}}`,
+			want: "legacy-set",
+		},
+		{
+			name: "top-level id preferred over embedded set",
+			body: `{"emote_set_id": "top-level", "emote_set": {"id": "embedded"}}`,
+			want: "top-level",
+		},
+		{
+			name: "no emote set at all",
+			body: `{"id": "u1", "platform": "TWITCH", "emote_set_id": null, "emote_set": null}`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var user UserResponse
+			if err := json.Unmarshal([]byte(tt.body), &user); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+			if got := user.ActiveEmoteSetID(); got != tt.want {
+				t.Errorf("ActiveEmoteSetID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

7TV announced a v3 API change effective **Monday, 3 August 2026, 17:00**: `/v3/users/{platform}/{platform_id}` will return `emote_set: null` instead of embedding the full active emote set. Only `emote_set_id` (and `user.emote_sets`) remain.

Without this change, on cutover day:

- **emote-service** decodes the null `emote_set` to an empty struct with no error, so all 7TV channel emotes, personal emote sets, and YouTube/Kick connection emotes silently resolve to empty and get cached empty (only globals via `/v3/emote-sets/global` survive).
- **message-processor** reads `emote_set.id` to subscribe to 7TV EventAPI updates; it would silently skip every channel, so emote-set changes would stop invalidating the emote cache.

Already safe, no changes needed: overlay-manager's `seventv_resolver.go` (already prefers `emote_set_id`), the EventAPI WebSocket client, and the frontend (no direct 7TV calls).

## What

- **emote-service**: new `resolveConnectionEmotes` helper used by all three connection call sites (Twitch channel, personal user set, YouTube/Kick connection). It uses the embedded set while 7TV still sends it (no extra round trip pre-cutover), otherwise fetches `/v3/emote-sets/{emote_set_id}` via the existing set-by-ID helper. A dangling set ID (deleted set) degrades to "no channel emotes" instead of failing the whole fetch; no active set returns empty as before.
- **message-processor**: `UserResponse` gains `emote_set_id` and `ActiveEmoteSetID()` (top-level ID preferred, embedded `emote_set.id` as fallback) for EventAPI subscription mapping.
- Tests cover the post-cutover shape: null set resolved via follow-up fetch, null set with no ID (globals only), dangling set ID, and the manager decode of both old and new shapes.

Verified against the live 7TV API: the connection response carries top-level `emote_set_id`, and `/v3/emote-sets/{id}` returns exactly the shape the existing parser handles.

## Notes

- After cutover, a channel emote fetch costs two 7TV calls instead of one; the emote cache plus the negative-cache/cooldown from #595 absorb this.
- Should be merged and rolled out before **2026-08-03 17:00**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)