### PR TITLE
feat(frontend): selectable entry animations for overlay chat messages

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -81,7 +81,11 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      JWT_SECRET: ${JWT_SECRET:-frontend-dev-secret-12345}
+      JWT_SECRET: frontend-dev-secret-12345-padded-to-32b
+      # Versioned key chain (shared/auth): services fatal without _V1 since the
+      # JWT key-rotation migration
+      JWT_SECRET_V1: frontend-dev-secret-12345-padded-to-32b
+      SERVICE_JWT_SECRET_V1: frontend-dev-service-secret-padded-32b
       TWITCH_CLIENT_ID: ${TWITCH_CLIENT_ID}
       TWITCH_CLIENT_SECRET: ${TWITCH_CLIENT_SECRET}
       MESSAGE_PROCESSOR_URL: http://message-processor:8087
@@ -90,6 +94,7 @@ services:
       # docker-compose.yml fallback so `make frontend-dev` works without an .env.
       # Override for local key-rotation testing: TOKEN_ENCRYPTION_KEY=$(openssl rand -base64 32)
       TOKEN_ENCRYPTION_KEY: ${TOKEN_ENCRYPTION_KEY:-0123456789abcdef0123456789abcdef}
+      TOKEN_ENCRYPTION_KEY_V1: ${TOKEN_ENCRYPTION_KEY_V1:-0123456789abcdef0123456789abcdef}
       OVERLAY_PUBLIC_BASE_URL: ${OVERLAY_PUBLIC_BASE_URL:-http://localhost:3000}
     ports:
       - "127.0.0.1:8082:8082"
@@ -150,7 +155,11 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      JWT_SECRET: ${JWT_SECRET:-frontend-dev-secret-12345}
+      JWT_SECRET: frontend-dev-secret-12345-padded-to-32b
+      # Versioned key chain (shared/auth): services fatal without _V1 since the
+      # JWT key-rotation migration
+      JWT_SECRET_V1: frontend-dev-secret-12345-padded-to-32b
+      SERVICE_JWT_SECRET_V1: frontend-dev-service-secret-padded-32b
       API_GATEWAY_URL: http://api-gateway:8080
     ports:
       - "127.0.0.1:8090:8090"
@@ -184,10 +193,15 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: "6379"
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      JWT_SECRET: ${JWT_SECRET:-frontend-dev-secret-12345}
+      JWT_SECRET: frontend-dev-secret-12345-padded-to-32b
+      # Versioned key chain (shared/auth): services fatal without _V1 since the
+      # JWT key-rotation migration
+      JWT_SECRET_V1: frontend-dev-secret-12345-padded-to-32b
+      SERVICE_JWT_SECRET_V1: frontend-dev-service-secret-padded-32b
       TWITCH_CLIENT_ID: ${TWITCH_CLIENT_ID}
       TWITCH_CLIENT_SECRET: ${TWITCH_CLIENT_SECRET}
-      CORS_ORIGIN: "*"  # Allow all origins for frontend dev
+      # Wildcard is rejected when AllowCredentials is on (H3 cookie auth)
+      CORS_ORIGIN: "http://localhost:3000"
       WEBSOCKET_ALLOWED_ORIGINS: "*"
     ports:
       - "127.0.0.1:8080:8080"

--- a/docs/frontend/FRONTEND_DEV_SETUP.md
+++ b/docs/frontend/FRONTEND_DEV_SETUP.md
@@ -68,13 +68,15 @@ No secrets required! All services use development defaults:
 ```bash
 # Database
 DB_PASSWORD=dev_password_123
-JWT_SECRET=frontend-dev-secret-12345
+# JWT key chain (shared/auth) — dev values are hardcoded in
+# docker-compose.frontend.yml (JWT_SECRET, JWT_SECRET_V1, SERVICE_JWT_SECRET_V1;
+# secrets must be at least 32 bytes)
 
 # API Keys
 MESSAGE_PROCESSOR_API_KEY=dev-frontend-key
 
 # CORS
-CORS_ORIGIN=*  # All origins allowed
+CORS_ORIGIN=http://localhost:3000  # wildcard is rejected with cookie auth
 ```
 
 ### Message Generator Options

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -204,6 +204,94 @@
 }
 
 /* ============================================================
+   MESSAGE ENTRY ANIMATIONS — how a new chat message appears on the overlay.
+   Document scope (same rationale as ring-spin) and BEFORE the reduced-motion
+   gate below, so the gate collapses these to their end state.
+   Applied as .msg-anim-* on the chat bubble by the live overlay page and the
+   editor's embed preview when visual_settings.messageAnimation is set; the
+   class list lives in lib/types/visual-settings.ts (MESSAGE_ANIMATIONS).
+   Bundled themes / custom CSS can override: these are single unlayered class
+   rules, and theme <style> blocks are injected later in the document.
+   ============================================================ */
+
+/* Fly-in variants start outside the overlay edge; clip the horizontal
+   overshoot at the message container so no horizontal scroll area appears
+   (OBS browser sources and the editor preview iframe). */
+.msg-anim-container {
+  overflow-x: clip;
+}
+
+.msg-anim-fly-left {
+  animation: msg-anim-fly-left 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes msg-anim-fly-left {
+  from { transform: translateX(-115%); }
+  to   { transform: none; }
+}
+
+.msg-anim-fly-right {
+  animation: msg-anim-fly-right 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes msg-anim-fly-right {
+  from { transform: translateX(115%); }
+  to   { transform: none; }
+}
+
+.msg-anim-fly-spring {
+  animation: msg-anim-fly-spring 550ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes msg-anim-fly-spring {
+  from { opacity: 0; transform: translateX(-70%); }
+  to   { opacity: 1; transform: none; }
+}
+
+.msg-anim-pop {
+  transform-origin: 18% 100%;
+  animation: msg-anim-pop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes msg-anim-pop {
+  from { opacity: 0; transform: scale(0.5); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+.msg-anim-bounce {
+  animation: msg-anim-bounce 600ms linear both;
+}
+@keyframes msg-anim-bounce {
+  0%   { opacity: 0; transform: translateY(110%); }
+  55%  { opacity: 1; transform: translateY(-7%); }
+  75%  { transform: translateY(4%); }
+  90%  { transform: translateY(-2%); }
+  100% { transform: none; }
+}
+
+.msg-anim-flip {
+  transform-origin: 50% 100%;
+  animation: msg-anim-flip 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes msg-anim-flip {
+  from { opacity: 0; transform: perspective(600px) rotateX(-75deg); }
+  to   { opacity: 1; transform: perspective(600px) rotateX(0deg); }
+}
+
+.msg-anim-swoosh {
+  animation: msg-anim-swoosh 450ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes msg-anim-swoosh {
+  0%   { opacity: 0; transform: translateX(-45%) skewX(8deg); filter: blur(6px); }
+  60%  { opacity: 1; transform: translateX(2%) skewX(-2deg); filter: blur(0); }
+  100% { transform: none; }
+}
+
+.msg-anim-soft-focus {
+  animation: msg-anim-soft-focus 400ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+@keyframes msg-anim-soft-focus {
+  from { opacity: 0; transform: scale(0.96); filter: blur(12px); }
+  to   { opacity: 1; transform: none; filter: blur(0); }
+}
+
+/* ============================================================
    REDUCED MOTION — global gate (WCAG 2.3.3 / supports 2.2.2)
    Document scope, after the layered styles, so it wins everywhere in the app
    chrome: decorative animation (logo ring-spin, fade-ins, slide-up, spinners)

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -52,7 +52,12 @@ import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
 import { isDisplayVisible } from '@/lib/utils/displayVisibility'
-import type { VisualSettings } from '@/lib/types/visual-settings'
+import {
+  isMessageAnimation,
+  MESSAGE_ANIMATION_CLASS,
+  type MessageAnimation,
+  type VisualSettings,
+} from '@/lib/types/visual-settings'
 import { shouldFilterMessage } from '@/lib/utils/filterMessage'
 import type { FilterSettings } from '@/lib/types/overlay'
 import { createSoundPlayer } from '@/lib/utils/soundPlayer'
@@ -136,6 +141,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   const [bubbleStyle, setBubbleStyle] = useState<React.CSSProperties>({})
   const [platformBadgePosition, setPlatformBadgePosition] = useState<'before' | 'after'>('before')
   const [platformBadgeStyle, setPlatformBadgeStyle] = useState<'text' | 'icon'>('text')
+  // Entry animation for new chat bubbles; null keeps the default fade + slide-up
+  const [messageAnimation, setMessageAnimation] = useState<MessageAnimation | null>(null)
   const [showPlatformBadge, setShowPlatformBadge] = useState(true)
   const [showPlatformIndicators, setShowPlatformIndicators] = useState(true)
   // Visibility toggles whose CSS rules are scoped to `.overlay-preview-body`
@@ -366,6 +373,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       if (vs.platformBadgeStyle !== undefined) {
         setPlatformBadgeStyle(vs.platformBadgeStyle)
       }
+      // Unconditional so clearing the setting restores the default on reload
+      setMessageAnimation(isMessageAnimation(vs.messageAnimation) ? vs.messageAnimation : null)
       if (vs.showPlatformIndicators !== undefined) {
         setShowPlatformIndicators(vs.showPlatformIndicators !== 'none')
       }
@@ -670,7 +679,7 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       {/* text-shadow inherits to every text node below; the var is injected by
           visualSettingsToCss and gradient usernames force it off locally */}
       <div
-        className="overlay-live-body space-y-3"
+        className={clsx('overlay-live-body space-y-3', messageAnimation && 'msg-anim-container')}
         style={{ textShadow: 'var(--chat-text-shadow, none)', ...containerStyle }}
       >
         {invertMessageOrder && <div ref={messagesEndRef} className="scroll-anchor" />}
@@ -691,7 +700,10 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                 isEvent
                   ? ['event-message', eventTierClass, eventTypeClass]
                   : [
-                      'chat-message animate-in rounded-lg p-3 shadow-lg backdrop-blur-sm duration-300 slide-in-from-bottom-2',
+                      'chat-message rounded-lg p-3 shadow-lg backdrop-blur-sm',
+                      messageAnimation
+                        ? MESSAGE_ANIMATION_CLASS[messageAnimation]
+                        : 'animate-in duration-300 slide-in-from-bottom-2',
                       isSharedChat
                         ? 'border-2 border-purple-500/50 bg-purple-900/40'
                         : 'bg-slate-900/90',

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -66,7 +66,11 @@ import type {
 } from '@/lib/types/overlay'
 import type { ChatMessage } from '@/lib/types/message'
 import type { AcceptedShare } from '@/lib/types/share'
-import type { VisualSettings } from '@/lib/types/visual-settings'
+import {
+  isMessageAnimation,
+  type MessageAnimation,
+  type VisualSettings,
+} from '@/lib/types/visual-settings'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
 import { useNotificationSocket } from '@/hooks/useNotificationSocket'
 import { parseCssToVisualSettings } from '@/lib/utils/theme-css-parser'
@@ -140,6 +144,20 @@ const PLATFORM_BORDER: Record<string, string> = {
 // Last-active settings section (ADR-0042); replaces the retired per-drawer
 // open/closed maps (editor-panel-sections-v1 / appearance-panel-sections-v1).
 const ACTIVE_SECTION_STORAGE_KEY = 'editor-active-section-v1'
+
+// Entry-animation choices for new chat messages ('' = default fade + slide up).
+// Values map to .msg-anim-* classes in globals.css via visual_settings.
+const ENTRY_ANIMATION_OPTIONS: ReadonlyArray<{ value: MessageAnimation | ''; label: string }> = [
+  { value: '', label: 'Fade + slide up (default)' },
+  { value: 'fly-left', label: 'Fly in from left' },
+  { value: 'fly-right', label: 'Fly in from right' },
+  { value: 'fly-spring', label: 'Fly in with overshoot' },
+  { value: 'pop', label: 'Pop in' },
+  { value: 'bounce', label: 'Bounce up' },
+  { value: 'flip', label: 'Flip in' },
+  { value: 'swoosh', label: 'Swoosh' },
+  { value: 'soft-focus', label: 'Soft focus' },
+]
 
 // Maps onboarding spotlight targets to left-nav sections (ADR-0042). The
 // guide's 'appearance' target predates the flat nav; Typography is the first
@@ -1607,6 +1625,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   const panelRef = useRef<HTMLDivElement>(null)
 
   // --- Customization state ---
+  const entryAnimationSelectId = useId()
   const [maxMessages, setMaxMessages] = useState(50)
   const [messageDuration, setMessageDuration] = useState(15)
   const [disableMessageFade, setDisableMessageFade] = useState(false)
@@ -1886,6 +1905,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           platformBadgeStyle: settings.platformBadgeStyle,
           showPlatformBadge: settings.showPlatformBadge,
           showPlatformIndicators: settings.showPlatformIndicators,
+          messageAnimation: settings.messageAnimation,
         },
       },
       '*'
@@ -3354,6 +3374,37 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                         </label>
                         <p className="mt-1 ml-5 text-xs text-text-sub">
                           Show newest messages at the top instead of the bottom
+                        </p>
+                      </div>
+
+                      {/* Entry Animation */}
+                      <div data-setting-anchor="entryAnimation">
+                        <label
+                          htmlFor={entryAnimationSelectId}
+                          className="mb-1 block text-xs text-text-sub"
+                        >
+                          Entry Animation
+                        </label>
+                        <select
+                          id={entryAnimationSelectId}
+                          value={visualSettings.messageAnimation ?? ''}
+                          onChange={(e) =>
+                            handleVisualSettingsChange({
+                              messageAnimation: isMessageAnimation(e.target.value)
+                                ? e.target.value
+                                : undefined,
+                            })
+                          }
+                          className="w-full rounded-lg border border-border bg-surface px-3 py-1.5 text-xs text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+                        >
+                          {ENTRY_ANIMATION_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                              {opt.label}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="mt-1 text-xs text-text-sub">
+                          How new messages appear on the overlay
                         </p>
                       </div>
 

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -43,6 +43,11 @@ import { renderMessageContent } from '@/lib/renderMessage'
 import { resolveTwitchBadgeIcons } from '@/lib/twitchBadges'
 import { sortMessageBadges } from '@/lib/badgeOrder'
 import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import {
+  isMessageAnimation,
+  MESSAGE_ANIMATION_CLASS,
+  type MessageAnimation,
+} from '@/lib/types/visual-settings'
 import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
@@ -216,6 +221,8 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
   const [platformBadgePosition, setPlatformBadgePosition] = useState<'before' | 'after'>('before')
   const [platformBadgeStyle, setPlatformBadgeStyle] = useState<'text' | 'icon'>('text')
   const [showPlatformBadge, setShowPlatformBadge] = useState(true)
+  // Entry animation for new chat bubbles; null keeps the default fade + slide-up
+  const [messageAnimation, setMessageAnimation] = useState<MessageAnimation | null>(null)
 
   // Phase 11: Filter settings state
   const [filterSettings, setFilterSettings] = useState<FilterSettings>({})
@@ -316,6 +323,8 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         if (s.showPlatformBadge !== undefined) {
           setShowPlatformBadge(s.showPlatformBadge !== 'none')
         }
+        // Unconditional so switching back to the default clears the class live
+        setMessageAnimation(isMessageAnimation(s.messageAnimation) ? s.messageAnimation : null)
         return
       }
       // Live custom/theme CSS from the editor (theme apply, or typing in the
@@ -455,6 +464,9 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         }
         if (vs.platformBadgeStyle === 'text' || vs.platformBadgeStyle === 'icon') {
           setPlatformBadgeStyle(vs.platformBadgeStyle)
+        }
+        if (isMessageAnimation(vs.messageAnimation)) {
+          setMessageAnimation(vs.messageAnimation)
         }
         // Phase 11: Load filter settings from config
         if (config.filter_settings) {
@@ -683,7 +695,10 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         )}
       >
         <div
-          className="overlay-preview-body h-full space-y-3 overflow-y-auto p-4"
+          className={clsx(
+            'overlay-preview-body h-full space-y-3 overflow-y-auto p-4',
+            messageAnimation && 'msg-anim-container'
+          )}
           style={{
             scrollbarWidth: 'thin',
             scrollbarColor: '#374151 transparent',
@@ -728,7 +743,14 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                     className={
                       isEvent
                         ? clsx('event-message', eventTierClass, eventTypeClass)
-                        : 'rounded-lg bg-slate-900/90 p-3 shadow-lg backdrop-blur-sm'
+                        : clsx(
+                            'rounded-lg bg-slate-900/90 p-3 shadow-lg backdrop-blur-sm',
+                            // Mirror the live overlay's entry animation so the
+                            // editor preview is a faithful pick-and-compare
+                            messageAnimation
+                              ? MESSAGE_ANIMATION_CLASS[messageAnimation]
+                              : 'animate-in duration-300 slide-in-from-bottom-2'
+                          )
                     }
                     style={isEvent ? undefined : bubbleStyle}
                   >

--- a/frontend/src/components/editor/sectionRegistry.ts
+++ b/frontend/src/components/editor/sectionRegistry.ts
@@ -279,7 +279,7 @@ export const EDITOR_SECTIONS: EditorSection[] = [
     id: 'messages',
     group: 'behavior',
     title: 'Messages',
-    description: 'How many messages show, and how long they stay.',
+    description: 'How messages appear, how many show, and how long they stay.',
     keywords: 'behavior chat flow',
     entries: [
       { label: 'Max Messages', keywords: 'limit count maximum', anchorId: 'maxMessages' },
@@ -297,6 +297,11 @@ export const EDITOR_SECTIONS: EditorSection[] = [
         label: 'Invert Message Order',
         keywords: 'newest top reverse direction bottom',
         anchorId: 'invertOrder',
+      },
+      {
+        label: 'Entry Animation',
+        keywords: 'animation animate fly slide bounce pop flip swoosh blur appear motion effect',
+        anchorId: 'entryAnimation',
       },
       {
         label: 'Emote Providers',

--- a/frontend/src/lib/types/visual-settings.ts
+++ b/frontend/src/lib/types/visual-settings.ts
@@ -17,6 +17,47 @@
  */
 
 /**
+ * Message entry animations — how a new chat message appears on the overlay.
+ *
+ * Each value maps to a `.msg-anim-<value>` class defined in globals.css
+ * (document scope, so bundled themes and custom CSS can override it).
+ * `undefined` keeps the default tailwindcss-animate fade + slide-up.
+ */
+export const MESSAGE_ANIMATIONS = [
+  'fly-left',
+  'fly-right',
+  'fly-spring',
+  'pop',
+  'bounce',
+  'flip',
+  'swoosh',
+  'soft-focus',
+] as const
+
+export type MessageAnimation = (typeof MESSAGE_ANIMATIONS)[number]
+
+export function isMessageAnimation(value: unknown): value is MessageAnimation {
+  return (
+    typeof value === 'string' && (MESSAGE_ANIMATIONS as readonly string[]).includes(value)
+  )
+}
+
+/**
+ * Static value → class map (no runtime string building; className strings must
+ * be statically greppable, see DESIGN_SYSTEM.md). Classes live in globals.css.
+ */
+export const MESSAGE_ANIMATION_CLASS: Record<MessageAnimation, string> = {
+  'fly-left': 'msg-anim-fly-left',
+  'fly-right': 'msg-anim-fly-right',
+  'fly-spring': 'msg-anim-fly-spring',
+  pop: 'msg-anim-pop',
+  bounce: 'msg-anim-bounce',
+  flip: 'msg-anim-flip',
+  swoosh: 'msg-anim-swoosh',
+  'soft-focus': 'msg-anim-soft-focus',
+}
+
+/**
  * VisualSettings — structured CSS properties for the visual-customizer cascade layer.
  *
  * Each field maps to a CSS custom property on :root.
@@ -73,6 +114,10 @@ export interface VisualSettings {
   // Platform badge options (not CSS-driven, stored for settings persistence)
   platformBadgePosition?: 'before' | 'after'
   platformBadgeStyle?: 'text' | 'icon'
+
+  // Message entry animation (not CSS-driven, stored for settings persistence;
+  // applied as a .msg-anim-* class on the chat bubble)
+  messageAnimation?: MessageAnimation
 
   // Phase 9: Pronoun display
   showPronouns?: 'inline' | 'none'      // --chat-show-pronouns

--- a/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
+++ b/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
@@ -98,6 +98,8 @@ describe('visualSettingsToCss', () => {
       membershipGiftSizeModifier: '1.2',
       platformBadgePosition: 'before',
       platformBadgeStyle: 'text',
+      // Message entry animation (not CSS-driven, not emitted as CSS properties)
+      messageAnimation: 'fly-left',
       // Phase 9: Pronoun display (not CSS-driven, not emitted as CSS properties)
       showPronouns: 'inline',
       pronounPosition: 'after',
@@ -116,6 +118,9 @@ describe('visualSettingsToCss', () => {
     // platformBadgePosition and platformBadgeStyle are not CSS properties, so not emitted
     expect(result).not.toContain('platformBadgePosition')
     expect(result).not.toContain('platformBadgeStyle')
+    // messageAnimation is applied as a .msg-anim-* class, never as a CSS property
+    expect(result).not.toContain('messageAnimation')
+    expect(result).not.toContain('fly-left')
     // All 52 CSS properties present (excludes non-CSS fields)
     expect((result.match(/--chat-|--platform-/g) ?? []).length).toBe(52)
   })

--- a/migrations/init/053_overlay_seventv_override.sql
+++ b/migrations/init/053_overlay_seventv_override.sql
@@ -1,0 +1,13 @@
+-- 053: per-overlay 7TV emote set override.
+--
+-- Lets a streamer attach a 7TV emote set to an overlay independently of the
+-- platform sources. Useful when no Twitch source exists (so the platform
+-- connection lookup misses) or when the streamer wants emotes from a different
+-- 7TV identity than the one linked to their Twitch/YouTube/Kick account.
+--
+-- Stores the resolved canonical emote-set ID. The overlay-manager handler
+-- accepts user input as raw IDs, 7tv.app emote-set URLs, or profile URLs and
+-- resolves to this canonical form on save.
+
+ALTER TABLE overlay_configs
+    ADD COLUMN IF NOT EXISTS seventv_emote_set_id VARCHAR(24);

--- a/scripts/generate-test-messages.sh
+++ b/scripts/generate-test-messages.sh
@@ -71,20 +71,17 @@ if ! command -v curl &> /dev/null; then
     exit 1
 fi
 
-# Check if redis-cli is available
-if ! command -v redis-cli &> /dev/null; then
-    echo -e "${RED}Error: redis-cli is required but not installed${NC}"
-    exit 1
+# Redis check is a nicety only (messages go through the processor's HTTP API);
+# don't hard-require redis-cli on the host.
+if command -v redis-cli &> /dev/null; then
+    echo -e "${YELLOW}Testing Redis connection...${NC}"
+    if redis-cli -h $REDIS_HOST -p $REDIS_PORT ping > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ Redis connection OK${NC}"
+    else
+        echo -e "${YELLOW}⚠ Cannot reach Redis at $REDIS_HOST:$REDIS_PORT (continuing; the processor connects to Redis itself)${NC}"
+    fi
+    echo ""
 fi
-
-# Test Redis connection
-echo -e "${YELLOW}Testing Redis connection...${NC}"
-if ! redis-cli -h $REDIS_HOST -p $REDIS_PORT ping > /dev/null 2>&1; then
-    echo -e "${RED}Error: Cannot connect to Redis at $REDIS_HOST:$REDIS_PORT${NC}"
-    exit 1
-fi
-echo -e "${GREEN}✓ Redis connection OK${NC}"
-echo ""
 
 # Test Message Processor connection
 echo -e "${YELLOW}Testing Message Processor connection...${NC}"
@@ -98,37 +95,30 @@ echo ""
 
 # Function to generate a random message
 generate_message() {
-    local message_id=$1
     local platform=${PLATFORMS[$RANDOM % ${#PLATFORMS[@]}]}
     local username=${USERNAMES[$RANDOM % ${#USERNAMES[@]}]}
     local message_text=${MESSAGES[$RANDOM % ${#MESSAGES[@]}]}
-    local timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-    # Create JSON payload
+    # Create JSON payload (schema: mockMessageRequest in
+    # services/message-processor/cmd/main.go — overlay_id + text required)
     local json_payload=$(cat <<EOF
 {
     "overlay_id": "$TEST_OVERLAY_ID",
     "platform": "$platform",
     "channel_id": "test_channel_123",
-    "message_id": "test_msg_$message_id",
     "user_id": "user_$(($RANDOM % 1000))",
     "username": "$username",
     "display_name": "$username",
-    "message": "$message_text",
-    "timestamp": "$timestamp",
-    "is_moderator": $([ $(($RANDOM % 10)) -eq 0 ] && echo "true" || echo "false"),
-    "is_subscriber": $([ $(($RANDOM % 3)) -eq 0 ] && echo "true" || echo "false"),
-    "is_vip": $([ $(($RANDOM % 5)) -eq 0 ] && echo "true" || echo "false"),
-    "color": "#$(printf '%06X' $(($RANDOM % 16777216)))",
-    "emotes": []
+    "text": "$message_text",
+    "color": "#$(printf '%06X' $(($RANDOM % 16777216)))"
 }
 EOF
 )
 
     # Send to Message Processor mock endpoint
-    local response=$(curl -s -X POST "$MESSAGE_PROCESSOR_URL/api/mock/message" \
+    local response=$(curl -s -X POST "$MESSAGE_PROCESSOR_URL/internal/mock-messages" \
         -H "Content-Type: application/json" \
-        -H "X-API-Key: $API_KEY" \
+        -H "X-Internal-Token: $API_KEY" \
         -d "$json_payload" \
         -w "\n%{http_code}")
 


### PR DESCRIPTION
## What

Users asked for more animations for appearing messages (fly-in was named explicitly). This adds a per-overlay **Entry Animation** setting with nine options:

| Option | Motion |
|---|---|
| Fade + slide up (default) | current production behavior, unchanged |
| Fly in from left / right | slides in from outside the overlay edge, 420ms decelerate |
| Fly in with overshoot | spring easing, lands past the target and settles |
| Pop in | scales up out of the corner |
| Bounce up | rises from below with a bounce, the loudest option |
| Flip in | tips up from the baseline with a hint of 3D |
| Swoosh | fly-in with skew + motion blur |
| Soft focus | blurs into focus, the quietest option |

Interactive mock the options were picked from: the nine-panel comparison artifact (same keyframes as shipped here).

## How

- `visual_settings.messageAnimation` (persisted like `platformBadgePosition`; no backend change needed, `visual_settings` is a pass-through JSONB blob)
- Applied as a `.msg-anim-*` class on the chat bubble; keyframes live in `globals.css` at document scope, **before** the global `prefers-reduced-motion` gate, so reduced-motion users get the end state
- `.msg-anim-container` sets `overflow-x: clip` on the message container so fly-in variants never create a horizontal scroll area (OBS browser sources, preview iframe)
- Themes/custom CSS can override: single unlayered class rules, theme `<style>` blocks are injected later in the document
- Editor: dropdown in the **Messages** section, registered in the settings-search registry, and wired through the preview `VISUAL_SETTINGS_UPDATE` postMessage channel
- The editor embed preview now also plays the default fade/slide-up (previously preview cards appeared with no animation), so picking an option is a faithful comparison

Not premium-gated (decided with Malte): no resource cost, treated like the free overlay themes.

## Dev-stack repairs (second commit)

Verifying this end-to-end surfaced that `make frontend-dev` was broken by config drift; fixed along the way:

- JWT key chain: services fatal without `JWT_SECRET_V1`/`SERVICE_JWT_SECRET_V1` (≥32 bytes); dev values hardcoded in `docker-compose.frontend.yml`
- `TOKEN_ENCRYPTION_KEY_V1` for overlay-manager
- `CORS_ORIGIN=*` is rejected with cookie auth → pinned to `http://localhost:3000`
- `generate-test-messages.sh`: moved to the current `/internal/mock-messages` endpoint (`X-Internal-Token`, `text` field), host `redis-cli` no longer required
- `migrations/init`: mirrored 053 (`seventv_emote_set_id`) — fresh dev volumes 404ed every overlay config fetch without it

## Verification

- `tsc --noEmit`, ESLint on touched files, vitest (44 tests incl. sectionRegistry/SettingsSearch/overlay suites) all green
- End-to-end against the local dev stack: set `messageAnimation` on the seeded overlay, pumped mock messages, confirmed in-browser that the bubble runs `msg-anim-fly-left` (420ms) resp. `msg-anim-bounce` (600ms) and the container clips horizontal overshoot; default behavior verified unchanged when the setting is absent

## Release steps

- Feature gate: intentionally none (free feature)
- Patreon post: draft after deploy (announce the nine animations)