### PR TITLE
fix(legal): align legal pages with current German law, localize avatar fallbacks

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -30,7 +30,6 @@ const nextConfig = {
       'cdn.betterttv.net', // BTTV emotes
       'cdn.frankerfacez.com', // FFZ emotes
       'files.kick.com', // Kick emotes
-      'ui-avatars.com', // Generated avatar fallbacks
       'cdn.discordapp.com', // Discord guild icons
     ],
   },
@@ -66,7 +65,7 @@ const nextConfig = {
   async headers() {
     const cspBase = [
       "default-src 'self'",
-      "img-src 'self' data: https: static-cdn.jtvnw.net yt3.ggpht.com cdn.7tv.app cdn.betterttv.net cdn.frankerfacez.com files.kick.com ui-avatars.com cdn.discordapp.com",
+      "img-src 'self' data: https: static-cdn.jtvnw.net yt3.ggpht.com cdn.7tv.app cdn.betterttv.net cdn.frankerfacez.com files.kick.com cdn.discordapp.com",
       // embed.twitch.tv hosts the Twitch Embed SDK used by the credits/clips
       // overlay route (audit #3); without it the SDK script is CSP-blocked and
       // clips never play. analytics.allch.at hosts the self-hosted Umami tracker

--- a/frontend/src/app/legal/impressum/page.tsx
+++ b/frontend/src/app/legal/impressum/page.tsx
@@ -23,7 +23,7 @@ export const dynamic = 'force-dynamic'
 
 export const metadata = {
   title: 'Impressum | All-Chat',
-  description: 'Legal notice (Impressum) as required by TMG 5.',
+  description: 'Legal notice (Impressum) as required by § 5 DDG.',
   alternates: { canonical: '/legal/impressum' },
 }
 

--- a/frontend/src/app/legal/privacy/page.tsx
+++ b/frontend/src/app/legal/privacy/page.tsx
@@ -29,7 +29,7 @@ const listClasses = 'list-disc pl-6 space-y-1 text-text-sub'
 
 export default function PrivacyPolicyPage() {
   return (
-    <LegalLayout title="Privacy Policy (Datenschutzerkl&auml;rung)" lastUpdated="June 8, 2026">
+    <LegalLayout title="Privacy Policy (Datenschutzerkl&auml;rung)" lastUpdated="July 30, 2026">
       <div className="space-y-4">
         <div className="rounded-xl border border-twitch/20 bg-twitch/5 p-5 text-text-sub">
           <strong className="text-text">TL;DR:</strong> All-Chat only collects the information we
@@ -160,6 +160,42 @@ export default function PrivacyPolicyPage() {
             security and availability.
           </p>
         </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-text">2.6 Premium Membership (Patreon)</h3>
+          <p>
+            Premium features are unlocked through a paid membership on Patreon. If you connect your
+            Patreon account to All-Chat, we store:
+          </p>
+          <ul className={listClasses}>
+            <li>Your Patreon user ID</li>
+            <li>Encrypted OAuth access and refresh tokens for the Patreon API</li>
+            <li>
+              Your membership state for our campaign (status, tier, pledge amount, renewal date)
+            </li>
+          </ul>
+          <p className="text-sm text-text-dim">
+            We do <strong className="text-text">not</strong> receive or store your payment details;
+            payments are processed entirely by Patreon. Patreon notifies us via webhooks when your
+            membership changes, and a periodic reconciliation keeps the state current. Disconnecting
+            Patreon in the Settings page deletes the stored tokens and revokes subscription-derived
+            premium.
+          </p>
+          <p className="text-sm text-text-dim">
+            Legal basis: Art.&nbsp;6(1)(b) DSGVO &ndash; providing the premium features you
+            subscribed to. For the data you provide on patreon.com itself, Patreon, Inc. (US) is an
+            independent controller; see the{' '}
+            <a
+              href="https://www.patreon.com/policy/legal"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-twitch underline decoration-twitch/30 underline-offset-4"
+            >
+              Patreon Privacy Policy
+            </a>
+            .
+          </p>
+        </div>
       </section>
 
       {/* --- How We Use --- */}
@@ -182,6 +218,10 @@ export default function PrivacyPolicyPage() {
         <ul className={listClasses}>
           <li>PostgreSQL for account data, overlays, and encrypted OAuth tokens</li>
           <li>Redis for ephemeral sessions, message fan-out, and rate limiting</li>
+          <li>
+            All of the above runs on our own infrastructure on servers located in{' '}
+            <strong className="text-text">Germany</strong> (hosting provider: Hetzner Online GmbH)
+          </li>
         </ul>
         <h3 className="text-lg font-semibold text-text">4.2 Safeguards</h3>
         <ul className={listClasses}>
@@ -207,7 +247,7 @@ export default function PrivacyPolicyPage() {
         <h3 className="text-lg font-semibold text-text">5.1 Streaming Platform APIs</h3>
         <p>We connect to the following services to deliver the core product:</p>
         <ul className={listClasses}>
-          <li>Twitch IRC and Helix APIs</li>
+          <li>Twitch EventSub and Helix APIs</li>
           <li>YouTube Live Chat and OAuth APIs</li>
           <li>TikTok Live APIs and Kick APIs</li>
           <li>Discord Gateway API</li>
@@ -246,10 +286,6 @@ export default function PrivacyPolicyPage() {
         </p>
         <ul className={listClasses}>
           <li>
-            <strong className="text-text">UI Avatars</strong> (ui-avatars.com) &ndash; generates
-            fallback avatar images from display names when a platform avatar is unavailable
-          </li>
-          <li>
             <strong className="text-text">GitHub API</strong> (api.github.com) &ndash; fetches
             community themes from our public repository in the theme marketplace
           </li>
@@ -257,7 +293,8 @@ export default function PrivacyPolicyPage() {
         <p className="text-sm text-text-dim">
           Legal basis: Art.&nbsp;6(1)(f) DSGVO &ndash; legitimate interest in providing a functional
           and visually complete overlay experience. You can avoid loading these by not opening the
-          theme marketplace and by providing a custom avatar URL.
+          theme marketplace. Fallback avatars (shown when a platform avatar is unavailable) are
+          generated locally in your browser and involve no external request.
         </p>
 
         <h3 className="text-lg font-semibold text-text">5.4 YouTube-Specific Notice</h3>
@@ -318,7 +355,7 @@ export default function PrivacyPolicyPage() {
         </p>
         <p className="text-sm text-text-dim">
           Because the tracker stores no information on, and reads none from, your device, it does
-          not require consent under &sect;&nbsp;25 TTDSG; the processing of the resulting data rests
+          not require consent under &sect;&nbsp;25 TDDDG; the processing of the resulting data rests
           on Art.&nbsp;6(1)(f) DSGVO &ndash; our legitimate interest in measuring and improving the
           service.
         </p>
@@ -400,6 +437,10 @@ export default function PrivacyPolicyPage() {
           or use the Settings page. You also have the right to lodge a complaint with your
           supervisory authority (Aufsichtsbeh&ouml;rde).
         </p>
+        <p className="text-sm text-text-dim">
+          We do not use automated decision-making or profiling within the meaning of Art.&nbsp;22
+          DSGVO.
+        </p>
         <p className="font-semibold text-text">
           For YouTube Data: You can revoke All-Chat&apos;s access to your YouTube data via the{' '}
           <a
@@ -432,9 +473,8 @@ export default function PrivacyPolicyPage() {
           <strong className="text-text">privacy-friendly, cookieless usage analytics</strong>{' '}
           (self-hosted Umami) &ndash; it sets nothing on your device and stores no personal
           identifier; see Section&nbsp;5.6 for the full description. Fonts are self-hosted
-          (Section&nbsp;5.2) and do not set cookies. The third-party resources listed in
-          Section&nbsp;5.3 (UI Avatars, GitHub API) may cause the respective providers to set their
-          own cookies when loaded.
+          (Section&nbsp;5.2) and do not set cookies. The GitHub API (Section&nbsp;5.3) may cause
+          GitHub to set its own cookies when the theme marketplace is loaded.
         </p>
       </section>
 
@@ -452,11 +492,18 @@ export default function PrivacyPolicyPage() {
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">10. International Data Transfers</h2>
         <p>
-          When you use streaming platform integrations, data is transferred to servers operated by
-          Twitch (Amazon, US), Google/YouTube (US), TikTok (various), and Kick (AU). These transfers
-          are necessary to perform the service you requested (Art.&nbsp;49(1)(b) DSGVO). The GitHub
-          API (theme marketplace) may also involve transfers to the US. Fonts are self-hosted on our
-          infrastructure and therefore do not involve any third-country transfer when loaded.
+          All-Chat itself is hosted on servers located in Germany (see Section&nbsp;4.1). However,
+          when you use streaming platform integrations, data is transferred to servers operated by
+          Twitch (Amazon, US), Google/YouTube (US), TikTok (various), and Kick (AU). If you connect
+          a Patreon membership, data is exchanged with Patreon, Inc. (US). The GitHub API (theme
+          marketplace) may also involve transfers to the US.
+        </p>
+        <p className="text-sm text-text-dim">
+          Where a provider is certified under the EU&ndash;US Data Privacy Framework, the transfer
+          rests on the EU Commission&apos;s adequacy decision (Art.&nbsp;45 DSGVO). Otherwise, the
+          transfer is necessary to perform the service you requested (Art.&nbsp;49(1)(b) DSGVO).
+          Fonts are self-hosted on our infrastructure and therefore do not involve any third-country
+          transfer when loaded.
         </p>
       </section>
 
@@ -499,8 +546,8 @@ export default function PrivacyPolicyPage() {
 
         <h3 className="text-lg font-semibold text-text">Twitch</h3>
         <p>
-          We connect to Twitch IRC to receive chat messages. We do not access channel analytics,
-          subscriber information, or payment data.
+          We connect to Twitch EventSub to receive chat messages. We do not access channel
+          analytics, subscriber information, or payment data.
         </p>
 
         <h3 className="text-lg font-semibold text-text">YouTube</h3>

--- a/frontend/src/app/legal/terms/page.tsx
+++ b/frontend/src/app/legal/terms/page.tsx
@@ -29,7 +29,7 @@ const listClasses = 'list-disc pl-6 space-y-1 text-text-sub'
 
 export default function TermsOfServicePage() {
   return (
-    <LegalLayout title="Terms of Service (Nutzungsbedingungen)" lastUpdated="June 8, 2026">
+    <LegalLayout title="Terms of Service (Nutzungsbedingungen)" lastUpdated="July 30, 2026">
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">1. Acceptance of Terms</h2>
         <p>
@@ -180,26 +180,58 @@ export default function TermsOfServicePage() {
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">9. Limitation of Liability</h2>
         <p>
-          To the fullest extent permitted by law, All-Chat is not liable for indirect, incidental,
-          special, or consequential damages arising from your use of the Service.
+          We are liable without limitation for damages caused intentionally or by gross negligence,
+          for injury to life, body, or health, and under the German Product Liability Act
+          (Produkthaftungsgesetz).
+        </p>
+        <p>
+          In cases of slight negligence, we are liable only for the breach of essential contractual
+          obligations (Kardinalpflichten): obligations whose fulfilment makes the proper performance
+          of the contract possible in the first place and on whose fulfilment you may regularly
+          rely. In such cases, our liability is limited to the damage that is foreseeable and
+          typical for this type of service. Any further liability is excluded.
+        </p>
+        <p>
+          These limitations also apply in favour of our legal representatives and vicarious agents
+          (Erf&uuml;llungsgehilfen).
         </p>
       </section>
 
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">10. Indemnification</h2>
         <p>
-          You agree to indemnify All-Chat against claims, damages, losses, and expenses arising from
-          your use of the Service, violation of these Terms, or infringement of another party&apos;s
-          rights.
+          You agree to indemnify All-Chat against third-party claims, including the reasonable costs
+          of legal defence, arising from your culpable violation of these Terms, applicable law, or
+          the rights of others. This does not apply to the extent you are not responsible for the
+          violation.
         </p>
       </section>
 
       <section className="space-y-4">
-        <h2 className="text-2xl font-semibold text-text">11. Right of Withdrawal (Widerrufsrecht)</h2>
+        <h2 className="text-2xl font-semibold text-text">
+          11. Premium Subscriptions &amp; Right of Withdrawal (Widerrufsrecht)
+        </h2>
         <p>
-          As All-Chat is a free service, there is no contract requiring a formal withdrawal period.
-          You may stop using the service and delete your account at any time via the Settings page.
-          Upon deletion, all your personal data is removed as described in our Privacy Policy.
+          The core All-Chat service is free of charge. Premium features are unlocked through a paid
+          membership on{' '}
+          <a
+            href="https://www.patreon.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-twitch underline decoration-twitch/30 underline-offset-4"
+          >
+            Patreon
+          </a>
+          : you subscribe to our campaign on patreon.com and then connect your Patreon account to
+          All-Chat. The subscription contract, billing, cancellation, and any statutory right of
+          withdrawal for the paid membership are handled by Patreon under Patreon&apos;s own terms.
+          All-Chat itself does not charge you and does not process payments.
+        </p>
+        <p>
+          You may stop using All-Chat and delete your account at any time via the Settings page.
+          Upon deletion, your personal data is removed as described in our Privacy Policy. Note that
+          deleting your All-Chat account does not cancel a Patreon membership; cancel it directly on
+          Patreon.
         </p>
       </section>
 
@@ -223,9 +255,12 @@ export default function TermsOfServicePage() {
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold text-text">14. Governing Law &amp; Jurisdiction</h2>
         <p>
-          These Terms are governed by the laws of the Federal Republic of Germany. The courts at the
-          domicile of the operator shall have jurisdiction, unless mandatory consumer protection
-          rules provide otherwise.
+          These Terms are governed by the laws of the Federal Republic of Germany, excluding the UN
+          Convention on Contracts for the International Sale of Goods (CISG). If you are a consumer,
+          the mandatory consumer protection provisions of the country in which you habitually reside
+          remain unaffected. If you are a merchant (Kaufmann), a legal entity under public law, or a
+          special fund under public law, the exclusive place of jurisdiction is the domicile of the
+          operator.
         </p>
       </section>
 

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -52,6 +52,7 @@ import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
 import { AllChatBadge } from '@/components/AllChatBadge'
+import { UserAvatar } from '@/components/UserAvatar'
 import { PremiumBadge } from '@/components/PremiumBadge'
 import { EventContent } from '@/components/overlay/EventContent'
 import { MessageAttachments } from '@/components/overlay/MessageAttachments'
@@ -756,25 +757,14 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                   >
                     <div className="flex items-start gap-3">
                       {/* Avatar */}
-                      <div className="flex-shrink-0">
-                        {message.user.avatar_url ? (
-                          <Image
-                            src={message.user.avatar_url}
-                            alt={message.user.display_name}
-                            width={40}
-                            height={40}
-                            className="h-10 w-10 rounded-full object-cover"
-                            onError={(e) => {
-                              e.currentTarget.src = `https://ui-avatars.com/api/?name=${encodeURIComponent(
-                                message.user.display_name
-                              )}&background=6b7280&color=fff&size=40`
-                            }}
-                          />
-                        ) : (
-                          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-700 font-semibold text-white">
-                            {message.user.display_name?.slice(0, 2).toUpperCase() || '?'}
-                          </div>
-                        )}
+                      <div className="flex-shrink-0" style={{ overflow: 'visible' }}>
+                        <UserAvatar
+                          avatarUrl={message.user.avatar_url}
+                          frameUrl={message.user.avatar_frame_url}
+                          flairUrl={message.user.avatar_flair_url}
+                          size={40}
+                          displayName={message.user.display_name}
+                        />
                       </div>
 
                       {/* Message Content */}


### PR DESCRIPTION
## Summary

Legal-compliance pass over the Impressum, Terms of Service, and Privacy Policy against current German law, plus removal of the last third-party avatar dependency (ui-avatars.com).

### Statute references (were outdated)
- **§ 5 TMG → § 5 DDG**: the TMG was repealed in May 2024 by the Digitale-Dienste-Gesetz (impressum meta description here; the Impressum HTML itself lives in the caesar-deployment ConfigMap, companion PR there)
- **§ 25 TTDSG → § 25 TDDDG**: same 2024 reform renamed the TTDSG (privacy policy, Umami section)

### Terms of Service
- **Liability clause rewritten** to be valid under German AGB law: the old blanket exclusion violated § 309 Nr. 7 BGB (liability for injury to life/body/health and gross negligence cannot be excluded), which would have voided the clause entirely
- **Indemnification narrowed** to culpable violations (§ 307 BGB risk)
- **§ 11 corrected**: the page claimed "All-Chat is a free service", but premium exists. It now accurately describes the Patreon membership flow; billing/cancellation/withdrawal are handled by Patreon
- **Jurisdiction clause** restricted to merchants (§ 38 ZPO allows forum agreements only between merchants), CISG excluded

### Privacy Policy
- **New Section 2.6**: discloses the Patreon integration (Patreon user ID, encrypted OAuth tokens, membership status/tier/pledge/renewal via webhooks + reconcile), which was previously undisclosed (Art. 13 DSGVO gap). Stored fields verified against migration 063 and the payment-service README
- **Hosting disclosed**: all data on servers in Germany (Hetzner)
- **Transfers (Section 10)**: now lists Patreon, bases transfers on the EU-US Data Privacy Framework adequacy decision where certified, Art. 49(1)(b) fallback
- **Art. 22 statement** (no automated decision-making) added
- **Twitch IRC → EventSub** (ADR-0026 factual drift)

### ui-avatars.com removal
The preview embed page swapped broken avatars for `ui-avatars.com` images, transmitting viewer IPs to a third party (§ 25 TDDDG gray zone). It now uses the same local `UserAvatar` initials fallback as the live overlay (better preview parity, includes frames/flairs). Domain dropped from the image allowlist and CSP `img-src`; disclosure removed from the privacy policy.

Both pages' "Last updated" bumped to July 30, 2026.

## Companion change

The Impressum ConfigMap fix (§ 5 DDG, § 18 Abs. 2 MStV) is in caesar-deployment.

## Verification
- `tsc --noEmit` clean, ESLint clean (one pre-existing warning), Prettier conformant
- Parity, security-headers, and UserAvatar test suites pass (27 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)