### PR TITLE
fix(twitch): make chat subscriptions self-healing and share the dedup predicate

### DIFF
--- a/docs/adr/0046-twitch-chat-notices-via-chat-notification.md
+++ b/docs/adr/0046-twitch-chat-notices-via-chat-notification.md
@@ -100,13 +100,37 @@ subscription. It shares the chat condition (`broadcaster_user_id == user_id`) an
 authorization (`user:read:chat` + `user:bot`, broadcaster == chatter), so it joins
 the existing `subscribe_chat` / `unsubscribe_chat` bundle alongside the three
 moderation subscriptions. Creation is best-effort: a failure leaves chat working.
-Recovery is *not* a periodic retry — `reconcileChatLocked` only calls `subscribe_chat`
-on the `want && !ChatActive` transition, so a channel whose notice subscription
-failed or was revoked while chat stays active keeps working chat with no notices
-until demand cycles (the last overlay using it disconnects and reconnects) or the pod
-restarts. Acceptable because overlays disconnect routinely, but it means a
-continuously-connected overlay can sit without notices for a long time; a periodic
-reconcile of the companion subscriptions would close that gap.
+
+**Recovery is an explicit repair pass, not a hope.** `reconcileChatLocked` only acts
+on the `want ↔ ChatActive` *transition*, so once chat is active it never re-asserts
+anything. A subscription that failed at creation or was later revoked therefore stayed
+dead until demand cycled or the pod restarted — survivable for the chat subscription
+itself, whose absence is loud, but silent for the companions: a revoked
+`channel.chat.notification` meant watch streaks and announcements simply stopped
+arriving, with nothing in the logs and no recovery. Two mechanisms close that:
+
+1. **Revocation evicts the cache.** `SubscriptionManager.ForgetSubscription` drops the
+   cached id for *any* revoked type without calling Twitch (the subscription is
+   already gone; a DELETE on a stale id is a pointless 404). This matters because
+   `subscribeChatScoped`/`Subscribe` return early on a cache hit — a stale entry makes
+   every future re-subscribe a silent no-op, so eviction is what makes the
+   subscription recreatable at all. Wired into the webhook handler via
+   `SetSubscriptionForgetter` so the handler needs no dependency on the manager.
+2. **A periodic repair pass.** `reconcileChatSubscriptions` re-asserts the whole chat
+   subscription set for every `ChatActive` channel on its own coarse ticker
+   (`ChatSubscriptionReconcileInterval`, 5m — deliberately much slower than the sync
+   interval, since this is the only pass that can issue Twitch calls for a channel
+   whose demand never changed). Leader-gated, and cheap by construction: it consults
+   `HasSubscription` first, so a healthy channel costs a map lookup per type and zero
+   API calls. `HasSubscription` also lets the repair distinguish "still held" from
+   "genuinely recreated", which is what keeps the recreation logs honest instead of
+   claiming a repair on every pass.
+
+`subscribe_chat` and the repair action `ensure_chat` share one code path in `main.go`
+rather than duplicating the subscription list — the same anti-drift reasoning as the
+message-processor predicates below, and for the same reason: a duplicated list here
+already went stale once.
+
 Notice delivery also refreshes the EventSub chat
 ownership claim and the "connected" indicator, exactly as a chat message does — a
 delivered notice is equally proof the channel's chat is live.
@@ -170,15 +194,19 @@ and removes the assumption entirely.
 Deletion events are excluded and unaffected: they carry no `Tags` at all (the target
 id lives in `EventData.target_msg_id`).
 
-**The buffered-deletion drain is widened the same way**, and must be kept in lockstep
-with the dedup predicate above. A moderator can delete a watch-streak message or an
-announcement like any other message, and when the deletion races ahead of the message
-it is buffered and drained on the message's arrival. That drain was gated on plain
-chat only (`EventType == "" || "chat_message"`), so a notice — which arrives *with* an
-event type set — never drained its buffered deletion and the removed message stayed
-visible on every overlay until the buffer entry expired. Both predicates now read
-"any Twitch message that is not a deletion", and a regression test asserts the drain
-fires for `watch_streak`, `announcement` and plain chat alike.
+**The buffered-deletion drain shares the dedup's predicate.** A moderator can delete a
+watch-streak message or an announcement like any other message, and when the deletion
+races ahead of the message it is buffered and drained on the message's arrival. That
+drain was gated on plain chat only (`EventType == "" || "chat_message"`), so a notice —
+which arrives *with* an event type set — never drained its buffered deletion and the
+removed message stayed visible on every overlay until the buffer entry expired.
+
+Rather than fix the second condition to match the first, both call sites now go through
+a single `platformMessageID` helper. Keeping two copies in sync by discipline is exactly
+what failed: the dedup was widened for notices and its twin forty lines above was not.
+One function makes the class of bug unrepresentable. A regression test asserts the drain
+fires for `watch_streak`, `announcement` and plain chat alike, and a table test pins the
+predicate itself (deletions excluded, YouTube's InnerTube id as fallback, nil tags safe).
 
 ### Settings and rendering
 
@@ -247,11 +275,16 @@ Super Chats, channel-point redemptions), not just notices.
 ### Negative
 
 - One more EventSub subscription per chat-active channel (created with a user-scoped
-  condition, so no additional subscription cost, but more state to reconcile) — and
-  it recovers only on a demand cycle, as described above.
-- Two predicates in the message-processor (native-id dedup and the buffered-deletion
-  drain) must stay in lockstep. They already drifted once: widening only the first
-  left moderator-deleted notices stuck on screen.
+  condition, so no additional subscription cost, but more state to reconcile).
+- A new periodic pass that can talk to Twitch. It is bounded (leader-only,
+  `HasSubscription`-guarded, 5-minute ticker), but a channel whose subscription
+  permanently cannot be created — a scope the owner never granted — is retried once
+  per pass forever. The scope-error branch returns before the companions, so that
+  costs one call per channel per 5 minutes, not five.
+- `ForgetSubscription` deliberately does not verify against Twitch before evicting.
+  A spurious revocation notification would therefore cause one redundant re-create
+  (Twitch answers 409, which the existing reconcile path turns back into the live id),
+  which is strictly better than the alternative of never recovering.
 - The demote-to-chat path means the same raw message can render as an event on one
   overlay and as plain chat on another. That is correct per-overlay behaviour, but it
   is the first place where the event/chat distinction is not a property of the message

--- a/services/message-processor/consumer/native_dedup_test.go
+++ b/services/message-processor/consumer/native_dedup_test.go
@@ -135,6 +135,63 @@ func TestProcessMessage_NativeIDDedup_ChatNoticeVersusChatMessage(t *testing.T) 
 	}
 }
 
+// platformMessageID is the single predicate shared by the buffered-deletion drain and the native-id
+// dedup. They drifted once (ADR-0046) — widening one and not the other left moderator-deleted chat
+// notices stuck on overlays — so this pins the contract both now depend on.
+func TestPlatformMessageID(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  *models.RawChatMessage
+		want string
+	}{
+		{
+			name: "twitch plain chat uses the IRC id tag",
+			raw:  &models.RawChatMessage{Tags: map[string]string{"id": "native-1"}},
+			want: "native-1",
+		},
+		{
+			name: "twitch chat notice carries a native id despite having an event type",
+			raw:  &models.RawChatMessage{EventType: "watch_streak", Tags: map[string]string{"id": "native-2"}},
+			want: "native-2",
+		},
+		{
+			name: "announcement likewise",
+			raw:  &models.RawChatMessage{EventType: "announcement", Tags: map[string]string{"id": "native-3"}},
+			want: "native-3",
+		},
+		{
+			name: "youtube falls back to the InnerTube renderer id (#284)",
+			raw:  &models.RawChatMessage{Tags: map[string]string{"youtube_message_id": "yt-1"}},
+			want: "yt-1",
+		},
+		{
+			name: "deletions are excluded — their target lives in EventData",
+			raw: &models.RawChatMessage{
+				EventType: "message_deletion",
+				Tags:      map[string]string{"id": "should-be-ignored"},
+				EventData: map[string]interface{}{"target_msg_id": "native-4"},
+			},
+			want: "",
+		},
+		{
+			name: "events with no platform id (follow, raid) yield nothing",
+			raw:  &models.RawChatMessage{EventType: "follow"},
+			want: "",
+		},
+		{
+			name: "nil tags are safe",
+			raw:  &models.RawChatMessage{EventType: "subscription", Tags: nil},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, platformMessageID(tt.raw))
+		})
+	}
+}
+
 // A moderator can delete a watch-streak message or an announcement like any other message. When the
 // deletion races ahead of the message it is buffered and drained on arrival — but that drain used to
 // be gated on plain chat only, so a notice (which arrives with an event type set) never drained it

--- a/services/message-processor/consumer/stream_consumer.go
+++ b/services/message-processor/consumer/stream_consumer.go
@@ -56,6 +56,30 @@ const (
 // MessageHandler is called for each consumed message
 type MessageHandler func(ctx context.Context, msg *models.RawChatMessage) error
 
+// platformMessageID returns the platform-native message id of a message a moderator could later
+// remove, or "" when there is none.
+//
+// This is the single predicate behind BOTH the buffered-deletion drain and the native-id dedup in
+// processMessage. They must agree on which messages carry a native id: the drain resolves a pending
+// deletion against that id, and the dedup collapses duplicate deliveries of it. They previously
+// duplicated the condition and drifted — widening the dedup to cover Twitch chat notices while the
+// drain still tested for plain chat left a moderator-deleted watch streak visible on every overlay
+// (ADR-0046). Sharing one function makes that class of bug impossible.
+//
+// Deletions are excluded: they carry no Tags, and their target id lives in
+// EventData["target_msg_id"]. Twitch (IRC and EventSub) sets Tags["id"]; YouTube's InnerTube path
+// sets Tags["youtube_message_id"] instead, and without that fallback buffered deletions for YouTube
+// messages never drain (#284).
+func platformMessageID(raw *models.RawChatMessage) string {
+	if raw.EventType == "message_deletion" {
+		return ""
+	}
+	if id := raw.Tags["id"]; id != "" {
+		return id
+	}
+	return raw.Tags["youtube_message_id"]
+}
+
 // NativeDeduplicator drops messages whose platform-native id has already been processed. Both the
 // IRC and EventSub Twitch chat paths stamp the same native id into Tags["id"], so this makes the
 // brief IRC↔EventSub handoff overlap (and Twitch webhook retries) idempotent (ADR-0015).
@@ -324,21 +348,10 @@ func (c *StreamConsumer) processMessage(ctx context.Context, msg redis.XMessage)
 	}
 
 	// For any message a moderator could later remove, check whether its deletion already arrived
-	// and was buffered. Scoped the same way as the native-id dedup below — every non-deletion
-	// message carrying a platform message id — because Twitch chat notices (watch streaks,
-	// announcements) are deletable chat that arrives with an event type set (ADR-0046). Gating this
-	// on plain chat alone meant a deletion that raced ahead of its notice never drained, leaving a
-	// moderator-removed watch streak visible on the overlay until the buffer entry expired.
-	// Messages without a platform id fall through harmlessly (the inner check no-ops).
-	if rawMsg.EventType != "message_deletion" {
-		// Extract platform message ID from tags. Twitch sets Tags["id"] (IRC tag),
-		// YouTube sets Tags["youtube_message_id"] (InnerTube renderer ID); without
-		// the YouTube fallback, buffered deletions for YouTube messages would
-		// never drain (#284).
-		platformMsgID := rawMsg.Tags["id"]
-		if platformMsgID == "" {
-			platformMsgID = rawMsg.Tags["youtube_message_id"]
-		}
+	// and was buffered. Uses the SAME predicate as the native-id dedup below — see
+	// platformMessageID, which exists so these two cannot drift apart again (ADR-0046).
+	{
+		platformMsgID := platformMessageID(rawMsg)
 		if platformMsgID != "" {
 			// NOTE: registry.Add() happens in twitch-listener per user decision (CONTEXT.md)
 			// We only CHECK the buffer here for pending deletions
@@ -374,15 +387,15 @@ func (c *StreamConsumer) processMessage(ctx context.Context, msg redis.XMessage)
 	// webhook retry) can present the same message twice. Drop the second copy before enrichment so
 	// viewers never see doubled chat.
 	//
-	// Scoped to any Twitch message carrying Tags["id"] — the native, globally-unique message id.
-	// That deliberately includes chat notices (watch streaks, announcements), which arrive on
+	// Scoped via the SAME platformMessageID predicate as the buffered-deletion drain above, so the
+	// two can never disagree about which messages carry a native id (ADR-0046). That deliberately
+	// includes chat notices (watch streaks, announcements), which arrive on
 	// channel.chat.notification stamped with the same native id the corresponding
 	// channel.chat.message would carry, so the two collapse to one rendered message in whichever
-	// order they arrive (ADR-0046). Twitch documents the two subscriptions as disjoint, so in
-	// practice only one is sent; keying on the native id makes that an assumption we cannot get
-	// wrong. Deletion events carry no Tags and other platforms are unaffected.
-	if c.nativeDedup != nil && rawMsg.Platform == "twitch" && rawMsg.EventType != "message_deletion" {
-		if nativeID := rawMsg.Tags["id"]; nativeID != "" {
+	// order they arrive. Twitch documents the two subscriptions as disjoint, so in practice only one
+	// is sent; keying on the native id makes that an assumption we cannot get wrong.
+	if c.nativeDedup != nil && rawMsg.Platform == "twitch" {
+		if nativeID := platformMessageID(rawMsg); nativeID != "" {
 			if dup, derr := c.nativeDedup.IsDuplicateNativeID(ctx, rawMsg.Platform, nativeID); derr == nil && dup {
 				c.logger.Debug("Dropping duplicate Twitch message by native id",
 					zap.String("native_id", nativeID),

--- a/services/twitch-eventsub-listener/README.md
+++ b/services/twitch-eventsub-listener/README.md
@@ -76,6 +76,15 @@ notice refreshes the ownership claim and the connected indicator, exactly like a
 (but a *revoked* notification subscription does not release the claim — losing notices does not mean
 chat is dead).
 
+**Self-healing.** `reconcileChat` only fires on the demand transition, so a subscription that failed
+at creation or was later revoked used to stay dead until demand cycled or the pod restarted — silent
+for the companions, since nothing logs "no watch streaks arriving". Two mechanisms fix that: a
+revocation evicts the cached subscription id (`ForgetSubscription`, without calling Twitch — the
+subscription is already gone, and a stale cache entry would make every re-subscribe a silent no-op),
+and a leader-gated repair pass (`ensure_chat`, every `ChatSubscriptionReconcileInterval` = 5m)
+re-asserts the set for every chat-active channel. The pass checks `HasSubscription` first, so a
+healthy channel costs a map lookup and no API call, and only genuine recreations are logged.
+
 Notices are routed by `notice_type` (any `shared_chat_` prefix is stripped first, since the payload
 arrives under a prefixed key too):
 

--- a/services/twitch-eventsub-listener/channels/manager.go
+++ b/services/twitch-eventsub-listener/channels/manager.go
@@ -43,14 +43,22 @@ type Channel struct {
 }
 
 // SubscriptionCallback is invoked by the manager to create/delete subscriptions. action is one of:
-//   - "subscribe":       create the event subscriptions (points, subs, raids, …) for the channel
-//   - "subscribe_chat":   create the channel.chat.message subscription
-//   - "unsubscribe_chat": delete only the channel.chat.message subscription
+//   - "subscribe":        create the event subscriptions (points, subs, raids, …) for the channel
+//   - "subscribe_chat":   create the chat subscription and its companions
+//   - "ensure_chat":      re-assert the chat subscription set for an already-chat-active channel
+//     (idempotent; a no-op for every subscription the manager still holds)
+//   - "unsubscribe_chat": delete the chat subscription and its companions
 //   - "unsubscribe":      delete ALL subscriptions for the channel
 //
 // Event subscriptions are created for every active channel; the chat subscription is gated on
 // chat scope AND live-overlay demand (see reconcileChatLocked), so it uses the *_chat actions.
 type SubscriptionCallback func(broadcasterID string, accessToken string, action string) error
+
+// ChatSubscriptionReconcileInterval is how often a chat-active channel's subscription set is
+// re-asserted. Deliberately much coarser than the sync interval: for a healthy channel every
+// re-assert is an in-memory cache hit costing nothing, but a channel whose subscription genuinely
+// went missing does one Twitch API call per pass, so this bounds that repair traffic.
+const ChatSubscriptionReconcileInterval = 5 * time.Minute
 
 // UserIDResolver resolves Twitch usernames to user IDs
 type UserIDResolver interface {
@@ -110,6 +118,10 @@ type Manager struct {
 	stopChan     chan struct{}
 	wg           sync.WaitGroup
 	syncInterval time.Duration
+
+	// chatReconcileInterval drives reconcileChatSubscriptions. Defaults to
+	// ChatSubscriptionReconcileInterval; tests shorten it via SetChatReconcileInterval.
+	chatReconcileInterval time.Duration
 }
 
 // compile-time assertion: Manager must satisfy listener.ChannelManager
@@ -128,6 +140,16 @@ func NewManager(db *pgxpool.Pool, logger *zap.Logger, resolver UserIDResolver, c
 		syncSignal:   make(chan struct{}, 1),
 		stopChan:     make(chan struct{}),
 		syncInterval: syncInterval,
+
+		chatReconcileInterval: ChatSubscriptionReconcileInterval,
+	}
+}
+
+// SetChatReconcileInterval overrides how often the chat subscription set is re-asserted. Values <= 0
+// are ignored so a misconfiguration can never turn the repair pass into a busy loop.
+func (m *Manager) SetChatReconcileInterval(d time.Duration) {
+	if d > 0 {
+		m.chatReconcileInterval = d
 	}
 }
 
@@ -405,6 +427,57 @@ func (m *Manager) releaseClaim(login string) {
 	}
 }
 
+// reconcileChatSubscriptions re-asserts the chat subscription set for every channel this pod
+// currently serves chat for, healing subscriptions that went missing without the channel's
+// demand state changing.
+//
+// Why this is needed: reconcileChatLocked only acts on the want↔ChatActive *transition*. Once
+// ChatActive is true it never calls subscribe_chat again, so a subscription that failed at creation
+// time or was later revoked by Twitch stayed dead until demand cycled (the last overlay disconnects
+// and reconnects) or the pod restarted. That was survivable for the chat subscription itself, whose
+// absence is loud, but silent for the companions — a revoked channel.chat.notification meant watch
+// streaks and announcements simply stopped arriving with nothing in the logs and no recovery
+// (ADR-0046). Revocations now also evict the subscription-manager cache entry, so this pass sees the
+// gap and recreates it.
+//
+// Leader-gated, and cheap by construction: the subscription manager returns early on a cache hit, so
+// a healthy channel costs a map lookup per type and no API call. Channels are snapshotted under the
+// read lock; callbacks run outside it so a slow Twitch API never blocks syncing.
+func (m *Manager) reconcileChatSubscriptions(ctx context.Context) {
+	if m.callback == nil || !m.leads() {
+		return
+	}
+
+	type target struct{ broadcasterID, accessToken string }
+	m.mu.RLock()
+	pending := make([]target, 0, len(m.channels))
+	for broadcasterID, ch := range m.channels {
+		if ch.ChatActive {
+			pending = append(pending, target{broadcasterID, ch.AccessToken})
+		}
+	}
+	m.mu.RUnlock()
+
+	if len(pending) == 0 {
+		return
+	}
+
+	for _, t := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := m.callback(t.broadcasterID, t.accessToken, "ensure_chat"); err != nil {
+			// Non-fatal: chat itself keeps flowing, and the next pass retries. Logged at Warn
+			// because a persistent failure here is exactly the silent-loss case this pass exists
+			// to surface.
+			m.logger.Warn("Failed to re-assert chat subscription set",
+				zap.String("broadcaster_id", t.broadcasterID),
+				zap.Error(err),
+			)
+		}
+	}
+}
+
 // reconcileChatLocked creates or deletes channel.chat.message subscriptions so that a chat
 // subscription exists exactly for channels that (a) have the chat scope and (b) have live
 // overlay demand. Must be called with m.mu held. Only the leader's callback performs real
@@ -457,6 +530,12 @@ func (m *Manager) Start(ctx context.Context) error {
 		ticker := time.NewTicker(m.syncInterval)
 		defer ticker.Stop()
 
+		// Separate, much coarser ticker: re-asserting subscriptions is repair work, not steady-state
+		// syncing, and it is the only pass that can issue Twitch API calls for a channel whose
+		// demand never changed. See ChatSubscriptionReconcileInterval.
+		reconcileTicker := time.NewTicker(m.chatReconcileInterval)
+		defer reconcileTicker.Stop()
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -475,6 +554,8 @@ func (m *Manager) Start(ctx context.Context) error {
 				}
 				m.refreshClaims(ctx)
 				m.heartbeatActiveSources(ctx)
+			case <-reconcileTicker.C:
+				m.reconcileChatSubscriptions(ctx)
 			}
 		}
 	}()

--- a/services/twitch-eventsub-listener/channels/manager_chatreconcile_test.go
+++ b/services/twitch-eventsub-listener/channels/manager_chatreconcile_test.go
@@ -1,0 +1,144 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package channels
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// reconcileChatSubscriptions re-asserts the subscription set for chat-active channels. It exists
+// because reconcileChatLocked only fires on the want↔ChatActive transition, so a subscription that
+// was revoked or failed to create while chat stayed active was never retried — silently killing the
+// chat-notice feed for the pod's lifetime (ADR-0046).
+func TestReconcileChatSubscriptions_EnsuresOnlyChatActiveChannels(t *testing.T) {
+	cb := &recordingCallback{}
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetLeaderFunc(func() bool { return true })
+
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "serving", ChatActive: true}
+	m.channels["222"] = &Channel{BroadcasterID: "222", BroadcasterName: "nodemand", ChatActive: false}
+
+	m.reconcileChatSubscriptions(context.Background())
+
+	got := cb.snapshot()
+	if len(got) != 1 || got[0] != "ensure_chat:111" {
+		t.Fatalf("calls = %v, want exactly [ensure_chat:111] — a channel with no chat subscription has nothing to repair", got)
+	}
+}
+
+// Only the pod holding the subscriptions may recreate them; a standby recreating subscriptions would
+// duplicate the leader's and leak them.
+func TestReconcileChatSubscriptions_StandbyDoesNothing(t *testing.T) {
+	cb := &recordingCallback{}
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetLeaderFunc(func() bool { return false })
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "serving", ChatActive: true}
+
+	m.reconcileChatSubscriptions(context.Background())
+
+	if got := cb.snapshot(); len(got) != 0 {
+		t.Fatalf("standby issued %v, want no subscription calls", got)
+	}
+}
+
+// A failing channel must not stop the others from being repaired, and must not propagate an error
+// that would look like a sync failure.
+func TestReconcileChatSubscriptions_ContinuesPastFailures(t *testing.T) {
+	cb := &recordingCallback{err: errors.New("twitch 500")}
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetLeaderFunc(func() bool { return true })
+	m.channels["111"] = &Channel{BroadcasterID: "111", BroadcasterName: "a", ChatActive: true}
+	m.channels["222"] = &Channel{BroadcasterID: "222", BroadcasterName: "b", ChatActive: true}
+	m.channels["333"] = &Channel{BroadcasterID: "333", BroadcasterName: "c", ChatActive: true}
+
+	m.reconcileChatSubscriptions(context.Background())
+
+	if got := cb.snapshot(); len(got) != 3 {
+		t.Fatalf("attempted %d channels, want all 3 even though every call failed", len(got))
+	}
+}
+
+// A cancelled context must stop the pass promptly rather than walking every channel during shutdown.
+func TestReconcileChatSubscriptions_StopsOnCancelledContext(t *testing.T) {
+	cb := &recordingCallback{}
+
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetSubscriptionCallback(cb.fn)
+	m.SetLeaderFunc(func() bool { return true })
+	for _, id := range []string{"111", "222", "333"} {
+		m.channels[id] = &Channel{BroadcasterID: id, BroadcasterName: "ch" + id, ChatActive: true}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	m.reconcileChatSubscriptions(ctx)
+
+	if got := cb.snapshot(); len(got) != 0 {
+		t.Fatalf("issued %v after cancellation, want none", got)
+	}
+}
+
+// No callback wired (or no channels) must be a safe no-op, not a nil-deref.
+func TestReconcileChatSubscriptions_NilSafe(t *testing.T) {
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m.SetLeaderFunc(func() bool { return true })
+	m.channels["111"] = &Channel{BroadcasterID: "111", ChatActive: true}
+
+	m.reconcileChatSubscriptions(context.Background()) // no callback set
+
+	cb := &recordingCallback{}
+	m2 := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	m2.SetSubscriptionCallback(cb.fn)
+	m2.SetLeaderFunc(func() bool { return true })
+	m2.reconcileChatSubscriptions(context.Background()) // no channels
+
+	if got := cb.snapshot(); len(got) != 0 {
+		t.Fatalf("expected no calls with zero channels, got %v", got)
+	}
+}
+
+// The repair interval must default to the documented constant, and a non-positive override must be
+// ignored so a misconfiguration can never turn the repair pass into a busy loop hammering Twitch.
+func TestSetChatReconcileInterval(t *testing.T) {
+	m := NewManager(nil, zap.NewNop(), &countingResolver{}, nil, time.Minute)
+	if m.chatReconcileInterval != ChatSubscriptionReconcileInterval {
+		t.Fatalf("default = %v, want %v", m.chatReconcileInterval, ChatSubscriptionReconcileInterval)
+	}
+
+	m.SetChatReconcileInterval(30 * time.Second)
+	if m.chatReconcileInterval != 30*time.Second {
+		t.Fatalf("override = %v, want 30s", m.chatReconcileInterval)
+	}
+
+	for _, bad := range []time.Duration{0, -time.Second} {
+		m.SetChatReconcileInterval(bad)
+		if m.chatReconcileInterval != 30*time.Second {
+			t.Fatalf("interval %v was accepted; non-positive values must be ignored", bad)
+		}
+	}
+}

--- a/services/twitch-eventsub-listener/channels/manager_test.go
+++ b/services/twitch-eventsub-listener/channels/manager_test.go
@@ -33,16 +33,18 @@ import (
 )
 
 // recordingCallback records the (broadcasterID, action) pairs the manager invokes, in order.
+// err, when set, is returned from every call so tests can exercise failure handling.
 type recordingCallback struct {
 	mu      sync.Mutex
 	actions []string // "action:broadcasterID"
+	err     error
 }
 
 func (r *recordingCallback) fn(broadcasterID, _ string, action string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.actions = append(r.actions, action+":"+broadcasterID)
-	return nil
+	return r.err
 }
 
 func (r *recordingCallback) snapshot() []string {

--- a/services/twitch-eventsub-listener/cmd/main.go
+++ b/services/twitch-eventsub-listener/cmd/main.go
@@ -226,6 +226,11 @@ func main() {
 	// Create webhook handler
 	webhookHandler := webhooks.NewHandler(webhookSecret, redisClient, db, streamPublisher, listenerMetrics, statusPublisher, chatClaims, msgRegistry, log)
 
+	// A revocation makes the cached subscription id stale; evicting it is what lets the channel
+	// manager's periodic repair pass recreate the subscription instead of short-circuiting on a
+	// cache hit forever (ADR-0046).
+	webhookHandler.SetSubscriptionForgetter(subscriptionMgr.ForgetSubscription)
+
 	// Set up channel manager callback. Actions: "subscribe" creates the event subscriptions
 	// for every active channel; "subscribe_chat"/"unsubscribe_chat" manage the
 	// channel.chat.message subscription, which the manager gates on chat scope AND live-overlay
@@ -415,24 +420,43 @@ func main() {
 			}
 			return fmt.Errorf("all subscriptions failed for broadcaster %s", broadcasterID)
 
-		} else if action == "subscribe_chat" {
-			// Create the chat subscription. A scope error is non-fatal: return nil so the
-			// manager marks chat active and doesn't retry-spam; that channel just won't get
-			// EventSub chat (it stays on IRC unless/until the owner grants the missing scope).
-			if _, err := subscriptionMgr.SubscribeToChatMessages(ctx, broadcasterID); err != nil {
-				if strings.Contains(err.Error(), "subscription already exists") {
-					// Already subscribed — fall through to ensure deletion subs also exist.
-				} else if isScopeError(err) {
-					log.Info("Chat message subscription requires user:read:chat + user:bot scopes",
+		} else if action == "subscribe_chat" || action == "ensure_chat" {
+			// Both actions assert the same subscription set; they differ only in intent.
+			// "subscribe_chat" fires on the transition into chat-active, "ensure_chat" is the
+			// periodic repair pass that re-asserts it for a channel already chat-active (ADR-0046).
+			// Sharing one branch is deliberate: two copies of this list drifted once already and
+			// left a subscription silently absent. Every call is idempotent — the subscription
+			// manager returns early on a cache hit, so a healthy channel costs no API calls.
+			repairing := action == "ensure_chat"
+
+			// On the repair pass, skip what this pod still holds. Re-calling Subscribe would
+			// succeed either way (cache hit returns the stored id), so checking first is what makes
+			// "created" distinguishable from "no-op" — otherwise every pass would claim to have
+			// recreated every subscription.
+			if !repairing || !subscriptionMgr.HasSubscription(broadcasterID, "channel.chat.message") {
+				// A scope error is non-fatal: return nil so the manager marks chat active and
+				// doesn't retry-spam; that channel just won't get EventSub chat (it stays on IRC
+				// unless/until the owner grants the missing scope).
+				if _, err := subscriptionMgr.SubscribeToChatMessages(ctx, broadcasterID); err != nil {
+					if strings.Contains(err.Error(), "subscription already exists") {
+						// Already subscribed — fall through to ensure the companions exist too.
+					} else if isScopeError(err) {
+						if !repairing {
+							log.Info("Chat message subscription requires user:read:chat + user:bot scopes",
+								zap.String("broadcaster_id", broadcasterID))
+						}
+						// No chat sub → the companions (same scope) would fail too. The channel
+						// stays on IRC, which still handles its deletions.
+						return nil
+					} else {
+						return err
+					}
+				} else if repairing {
+					log.Info("Recreated missing chat subscription",
 						zap.String("broadcaster_id", broadcasterID))
-					// No chat sub → the deletion subs (same scope) would fail too. The channel
-					// stays on IRC, which still handles its deletions.
-					return nil
 				} else {
-					return err
+					log.Info("Subscribed to chat messages", zap.String("broadcaster_id", broadcasterID))
 				}
-			} else {
-				log.Info("Subscribed to chat messages", zap.String("broadcaster_id", broadcasterID))
 			}
 
 			// Companion chat subscriptions: the chat-notice feed (watch streaks, announcements —
@@ -440,7 +464,7 @@ func main() {
 			// single message, of a user's messages (timeout/ban), and full chat clears. They all
 			// share user:read:chat and the chat condition, so they live with the chat subscription.
 			// Best-effort — a failure here doesn't undo the chat subscription (the channel still
-			// reads chat, just may miss notices or a deletion type until the next sync re-attempts).
+			// reads chat, just may miss notices or a deletion type until the next repair pass).
 			for _, sub := range []struct {
 				name string
 				fn   func(context.Context, string) (string, error)
@@ -450,14 +474,22 @@ func main() {
 				{"channel.chat.clear_user_messages", subscriptionMgr.SubscribeToChatClearUserMessages},
 				{"channel.chat.clear", subscriptionMgr.SubscribeToChatClear},
 			} {
+				if repairing && subscriptionMgr.HasSubscription(broadcasterID, sub.name) {
+					continue // still held; nothing to repair
+				}
 				if _, err := sub.fn(ctx, broadcasterID); err != nil {
 					if strings.Contains(err.Error(), "subscription already exists") || isScopeError(err) {
 						continue
 					}
-					log.Warn("Failed to subscribe to chat moderation event",
+					log.Warn("Failed to subscribe to companion chat subscription",
 						zap.String("broadcaster_id", broadcasterID),
 						zap.String("type", sub.name),
+						zap.Bool("repairing", repairing),
 						zap.Error(err))
+				} else if repairing {
+					log.Info("Recreated missing companion chat subscription",
+						zap.String("broadcaster_id", broadcasterID),
+						zap.String("type", sub.name))
 				}
 			}
 			return nil

--- a/services/twitch-eventsub-listener/eventsub/subscription_manager.go
+++ b/services/twitch-eventsub-listener/eventsub/subscription_manager.go
@@ -336,6 +336,49 @@ func (sm *SubscriptionManager) subscribeChatScoped(ctx context.Context, subType,
 	return sm.subscribeWithCondition(ctx, subType, broadcasterID, token, "1", condition, cacheKey)
 }
 
+// HasSubscription reports whether this pod still holds a subscription of the given type for the
+// broadcaster. Used by the periodic repair pass to tell "still held" from "genuinely missing" —
+// re-calling Subscribe would succeed either way (it returns the cached id on a hit), so without this
+// the repair could not distinguish a no-op from an actual recreation.
+func (sm *SubscriptionManager) HasSubscription(broadcasterID, subType string) bool {
+	if broadcasterID == "" || subType == "" {
+		return false
+	}
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+	_, exists := sm.subscriptions[broadcasterID+":"+subType]
+	return exists
+}
+
+// ForgetSubscription drops one cached subscription id WITHOUT calling Twitch, reporting whether an
+// entry was actually removed.
+//
+// Used when Twitch tells us a subscription is already gone (a revocation webhook). The cached id is
+// stale from that moment on, and because subscribeChatScoped/Subscribe return early on a cache hit,
+// leaving it in place makes every future re-subscribe attempt a silent no-op — the subscription can
+// then never be recreated for the lifetime of the pod. Evicting the entry lets the periodic
+// reconcile (channels.Manager) create a fresh one. Deleting from Twitch would be wrong here: the
+// subscription no longer exists, and DELETE on a stale id is a pointless 404.
+func (sm *SubscriptionManager) ForgetSubscription(broadcasterID, subType string) bool {
+	if broadcasterID == "" || subType == "" {
+		return false
+	}
+	cacheKey := broadcasterID + ":" + subType
+
+	sm.mu.Lock()
+	_, existed := sm.subscriptions[cacheKey]
+	delete(sm.subscriptions, cacheKey)
+	sm.mu.Unlock()
+
+	if existed {
+		sm.logger.Info("Dropped revoked EventSub subscription from cache so it can be recreated",
+			zap.String("broadcaster_id", broadcasterID),
+			zap.String("type", subType),
+		)
+	}
+	return existed
+}
+
 // Unsubscribe deletes ALL EventSub subscriptions for a broadcaster.
 //
 // Every subscription is cached under "broadcasterID:type" (see subscribeWithCondition),

--- a/services/twitch-eventsub-listener/eventsub/subscription_manager_test.go
+++ b/services/twitch-eventsub-listener/eventsub/subscription_manager_test.go
@@ -173,3 +173,58 @@ func Test409GetExistingFails(t *testing.T) {
 	sm.mu.RUnlock()
 	require.False(t, cached, "cache must not be populated when reconciliation GET fails")
 }
+
+// ForgetSubscription drops a revoked subscription's cached id WITHOUT calling Twitch. This is what
+// makes a revocation recoverable: subscribeChatScoped/Subscribe return early on a cache hit, so a
+// stale entry turns every future re-subscribe into a silent no-op and the subscription can never
+// come back while the pod lives (ADR-0046).
+func TestForgetSubscription(t *testing.T) {
+	log := zap.NewNop()
+
+	var deleteCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleteCalls++
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	sm := NewSubscriptionManager("client-id", "client-secret", "webhook-secret", "https://example.com/callback", log)
+	sm.apiURL = server.URL + "/helix/eventsub/subscriptions"
+	sm.tokenURL = server.URL + "/oauth2/token"
+
+	sm.mu.Lock()
+	sm.subscriptions["b-1:channel.chat.notification"] = "sub-abc"
+	sm.mu.Unlock()
+
+	require.True(t, sm.HasSubscription("b-1", "channel.chat.notification"))
+
+	require.True(t, sm.ForgetSubscription("b-1", "channel.chat.notification"),
+		"forgetting a cached subscription must report that an entry was removed")
+	require.False(t, sm.HasSubscription("b-1", "channel.chat.notification"),
+		"the cache entry must be gone so the repair pass can recreate the subscription")
+	require.Equal(t, 0, deleteCalls,
+		"a revoked subscription no longer exists on Twitch — ForgetSubscription must not issue a DELETE")
+
+	// Idempotent, and never invents entries for unknown keys.
+	require.False(t, sm.ForgetSubscription("b-1", "channel.chat.notification"))
+	require.False(t, sm.ForgetSubscription("", "channel.chat.notification"))
+	require.False(t, sm.ForgetSubscription("b-1", ""))
+	require.False(t, sm.HasSubscription("b-1", ""))
+	require.False(t, sm.HasSubscription("", ""))
+}
+
+// HasSubscription must be scoped per (broadcaster, type) so repairing one channel's notice feed
+// never masks another channel's missing one.
+func TestHasSubscriptionIsScopedPerBroadcasterAndType(t *testing.T) {
+	sm := NewSubscriptionManager("client-id", "client-secret", "webhook-secret", "https://example.com/callback", zap.NewNop())
+
+	sm.mu.Lock()
+	sm.subscriptions["b-1:channel.chat.message"] = "sub-1"
+	sm.mu.Unlock()
+
+	require.True(t, sm.HasSubscription("b-1", "channel.chat.message"))
+	require.False(t, sm.HasSubscription("b-1", "channel.chat.notification"), "different type")
+	require.False(t, sm.HasSubscription("b-2", "channel.chat.message"), "different broadcaster")
+}

--- a/services/twitch-eventsub-listener/webhooks/handler.go
+++ b/services/twitch-eventsub-listener/webhooks/handler.go
@@ -74,6 +74,11 @@ type Handler struct {
 	registry        registry.MessageIDRegistry // native→internal-UUID map for single-message deletions (nil-safe)
 	logger          *zap.Logger
 
+	// forgetSubscription drops a revoked subscription from the subscription manager's cache so the
+	// periodic reconcile can recreate it (nil-safe). Injected via SetSubscriptionForgetter rather
+	// than passed to NewHandler to avoid the handler depending on the subscription manager.
+	forgetSubscription func(broadcasterID, subType string) bool
+
 	// claimRefreshedAt throttles per-channel claim refreshes (one Redis write per channel per
 	// twitchchat.ClaimRefreshInterval) so high chat volume does not amplify into Redis writes.
 	claimMu          sync.Mutex
@@ -103,6 +108,14 @@ func NewHandler(secret string, redis *redis.Client, db *pgxpool.Pool, publisher 
 		claimRefreshedAt:  make(map[string]time.Time),
 		statusPublishedAt: make(map[string]time.Time),
 	}
+}
+
+// SetSubscriptionForgetter injects the callback that drops a revoked subscription from the
+// subscription manager's cache. Without it a revocation leaves a stale cached id behind, every
+// re-subscribe attempt short-circuits on the cache hit, and that subscription stays dead until the
+// pod restarts (ADR-0046). Safe to leave unset — revocations are then only logged.
+func (h *Handler) SetSubscriptionForgetter(f func(broadcasterID, subType string) bool) {
+	h.forgetSubscription = f
 }
 
 // HandleEventSubWebhook processes incoming EventSub webhook notifications
@@ -304,13 +317,21 @@ func (h *Handler) handleRevocation(c *gin.Context, body []byte) {
 		zap.String("status", revocation.Subscription.Status),
 	)
 
-	// A revoked chat subscription stops delivering chat. Release the ownership claim so the IRC
+	bid := conditionBroadcasterID(revocation.Subscription.Condition)
+
+	// Drop the revoked subscription from the cache. This applies to EVERY type, not just chat: the
+	// cached id is stale the moment Twitch revokes it, and a cache hit makes every subsequent
+	// re-subscribe a silent no-op, so without eviction the subscription can never come back while
+	// this pod lives. Eviction lets the channel manager's periodic reconcile recreate it (ADR-0046).
+	if bid != "" && h.forgetSubscription != nil {
+		h.forgetSubscription(bid, revocation.Subscription.Type)
+	}
+
+	// A revoked chat subscription also stops delivering chat. Release the ownership claim so the IRC
 	// listener resumes this channel immediately (ADR-0015) instead of waiting for the claim TTL,
 	// and clear the channel's indicator.
-	if revocation.Subscription.Type == "channel.chat.message" {
-		if bid := conditionBroadcasterID(revocation.Subscription.Condition); bid != "" {
-			go h.handleChatSubRevoked(bid)
-		}
+	if revocation.Subscription.Type == "channel.chat.message" && bid != "" {
+		go h.handleChatSubRevoked(bid)
 	}
 
 	c.Status(http.StatusNoContent)
@@ -333,7 +354,10 @@ func conditionBroadcasterID(condition map[string]interface{}) string {
 // broadcaster is not a registered all-chat Twitch user. The webhook may land on any pod, so this
 // always reads the DB rather than an in-memory channel map.
 func (h *Handler) resolveLogin(broadcasterID string) string {
-	if broadcasterID == "" {
+	// db may be nil (the other optional collaborators already are). Without this guard a revocation
+	// nil-derefs on QueryRow — and because handleChatSubRevoked runs in its own goroutine, that
+	// panic takes down the whole process rather than failing one request.
+	if broadcasterID == "" || h.db == nil {
 		return ""
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/services/twitch-eventsub-listener/webhooks/handler_revocation_test.go
+++ b/services/twitch-eventsub-listener/webhooks/handler_revocation_test.go
@@ -1,0 +1,156 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package webhooks
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// revocationBody builds the payload Twitch sends when it revokes a subscription.
+func revocationBody(t *testing.T, subType, broadcasterID string) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]interface{}{
+		"subscription": map[string]interface{}{
+			"id":      "sub-1",
+			"type":    subType,
+			"status":  "authorization_revoked",
+			"version": "1",
+			"condition": map[string]interface{}{
+				"broadcaster_user_id": broadcasterID,
+				"user_id":             broadcasterID,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+type forgetRecorder struct {
+	mu    sync.Mutex
+	calls []string // "broadcasterID:subType"
+}
+
+func (f *forgetRecorder) forget(broadcasterID, subType string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, broadcasterID+":"+subType)
+	return true
+}
+
+func (f *forgetRecorder) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// A revocation must evict the cached subscription id for EVERY type. The cached id is stale the
+// moment Twitch revokes it, and because the subscribe path returns early on a cache hit, leaving it
+// behind makes every future re-subscribe a silent no-op — the subscription then stays dead for the
+// pod's lifetime. Eviction is what lets the channel manager's repair pass recreate it (ADR-0046).
+func TestHandleRevocation_EvictsCachedSubscription(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, subType := range []string{
+		"channel.chat.notification",
+		"channel.chat.message_delete",
+		"channel.chat.clear_user_messages",
+		"channel.chat.clear",
+		"channel.chat.message",
+		"channel.follow",
+	} {
+		t.Run(subType, func(t *testing.T) {
+			_, _, h := newStatusTestHandler(t)
+			rec := &forgetRecorder{}
+			h.SetSubscriptionForgetter(rec.forget)
+
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			h.handleRevocation(c, revocationBody(t, subType, "12345"))
+
+			got := rec.snapshot()
+			if len(got) != 1 || got[0] != "12345:"+subType {
+				t.Fatalf("forget calls = %v, want [12345:%s]", got, subType)
+			}
+		})
+	}
+}
+
+// Without a broadcaster id in the condition there is no cache key to evict; the handler must not
+// invent one (a "" key would evict nothing and hide the real problem).
+func TestHandleRevocation_NoBroadcasterIDDoesNotEvict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, _, h := newStatusTestHandler(t)
+	rec := &forgetRecorder{}
+	h.SetSubscriptionForgetter(rec.forget)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"subscription": map[string]interface{}{
+			"id":        "sub-1",
+			"type":      "channel.chat.notification",
+			"status":    "authorization_revoked",
+			"condition": map[string]interface{}{}, // no broadcaster_user_id
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	h.handleRevocation(c, body)
+
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("forget calls = %v, want none", got)
+	}
+}
+
+// The forgetter is optional; a handler without one must still process revocations rather than panic.
+func TestHandleRevocation_NilForgetterIsSafe(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, _, h := newStatusTestHandler(t) // no SetSubscriptionForgetter
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	h.handleRevocation(c, revocationBody(t, "channel.chat.notification", "12345"))
+
+	if w.Code >= 500 {
+		t.Fatalf("status = %d, want a non-5xx response", w.Code)
+	}
+}
+
+// A malformed revocation body must not reach the forgetter (nothing reliable to evict) and must not
+// panic — Twitch retries on 5xx, and a revocation storm answered with 5xx risks further revocations.
+func TestHandleRevocation_MalformedBodyIsSafe(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, _, h := newStatusTestHandler(t)
+	rec := &forgetRecorder{}
+	h.SetSubscriptionForgetter(rec.forget)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	h.handleRevocation(c, []byte("{not json"))
+
+	if got := rec.snapshot(); len(got) != 0 {
+		t.Fatalf("forget calls = %v, want none for an unparseable body", got)
+	}
+}


### PR DESCRIPTION
Closes the two gaps [ADR-0046](./docs/adr/0046-twitch-chat-notices-via-chat-notification.md) documented but did not fix (raised in the review of #644/#645).

## 1. A revoked or failed chat subscription could stay dead for the pod's lifetime

`reconcileChatLocked` only acts on the `want ↔ ChatActive` **transition**, so once chat is active nothing re-asserts the subscription set. A subscription that failed at creation or was later revoked by Twitch was never retried — recovery required a demand cycle (last overlay disconnects and reconnects) or a pod restart.

That was survivable for `channel.chat.message`, whose absence is loud. It was **silent** for the companions: a revoked `channel.chat.notification` meant watch streaks and announcements simply stopped arriving, with nothing in the logs and no recovery path. Exactly the failure mode #644 set out to eliminate, reachable a different way.

**Two mechanisms fix it:**

**`ForgetSubscription`** drops the cached id for any revoked type without calling Twitch (the subscription is already gone; a DELETE on a stale id is a pointless 404). This is the load-bearing part — `subscribeChatScoped`/`Subscribe` return early on a cache hit, so a stale entry makes every future re-subscribe a silent no-op and the subscription can *never* come back. Wired in via `SetSubscriptionForgetter`, so the webhook handler gains no dependency on the subscription manager. Applies to every subscription type, not just chat.

**`reconcileChatSubscriptions`** re-asserts the whole set for every `ChatActive` channel on its own coarse ticker (`ChatSubscriptionReconcileInterval` = 5m, deliberately much slower than the sync interval since this is the only pass that can issue Twitch calls for a channel whose demand never changed). Leader-gated, continues past per-channel failures, stops on context cancellation.

**`HasSubscription`** makes the pass cheap *and* honest. A healthy channel costs a map lookup per type and **zero API calls**. And because a re-`Subscribe` would succeed either way on a cache hit, checking first is what lets the logs distinguish a real recreation from a no-op — otherwise every pass would claim to have repaired every subscription every 5 minutes.

`subscribe_chat` and the new `ensure_chat` action **share one branch** in `main.go` rather than duplicating the subscription list. Same reasoning as (2) — and this is precisely the list that went stale once already.

## 2. The two message-processor predicates can no longer drift

The native-id dedup and the buffered-deletion drain must agree on which messages carry a platform-native id. They were separate copies of the condition, and they *did* drift: #644 widened the dedup for chat notices and left its twin forty lines above testing for plain chat, so a moderator-deleted watch streak stayed visible on every overlay until the buffer entry expired (fixed in #645).

Both call sites now go through a single `platformMessageID` helper. Keeping two copies in sync by discipline is what already failed once; one function makes the class of bug **unrepresentable** rather than merely fixed. A table test pins the contract: deletions excluded (their target lives in `EventData`), YouTube's InnerTube id as fallback (#284), nil tags safe.

## Also: a latent crash, found while testing (1)

`resolveLogin` dereferenced `h.db` with no nil check. Since `handleChatSubRevoked` runs in its own goroutine, that panic would take down the **whole process** rather than fail one request. `db` is now guarded like the handler's other optional collaborators — which is also what made the revocation path testable at all.

## Testing

- `reconcileChatSubscriptions`: ensures only `ChatActive` channels, standby does nothing, continues past failures, stops on cancelled context, nil-safe with no callback / no channels
- `SetChatReconcileInterval`: defaults to the documented constant and **ignores non-positive values**, so a misconfiguration can't turn the repair into a busy loop hammering Twitch
- `ForgetSubscription`: evicts, is idempotent, never invents entries for empty keys, and asserts **no DELETE is issued**; `HasSubscription` scoped per (broadcaster, type)
- `handleRevocation`: evicts for all six subscription types, doesn't evict without a broadcaster id, nil-forgetter safe, malformed body safe (no 5xx — a revocation storm answered with 5xx risks further revocations)
- `platformMessageID`: table test over chat / notice / announcement / YouTube / deletion / event-without-id / nil tags

Full sweep green on the current main (`060af092`): build, vet and tests for twitch-eventsub-listener and message-processor.

## Costs, documented in the ADR rather than glossed

- A channel whose subscription **permanently** can't be created (a scope the owner never granted) is retried once per pass forever. The scope-error branch returns before the companions, so that's one call per channel per 5 minutes, not five.
- `ForgetSubscription` doesn't verify against Twitch before evicting, so a spurious revocation costs one redundant re-create — Twitch answers 409, which the existing reconcile path turns back into the live id. Strictly better than never recovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)