### PR TITLE
fix(overlay-manager): bind Discord sources to a guild the owner connected

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,10 @@ TIKTOK_MAX_ERROR_BACKOFF_MS=300000     # Max: 5 minutes for errors
 
 # Discord Bot Token (Required for Discord bot)
 # Create bot at: https://discord.com/developers/applications
+# Also consumed by discord-listener, moderation-service and overlay-manager. In
+# overlay-manager it is required to add/reconfigure a Discord chat source: the shared bot is
+# the principal Discord authorizes, so overlay-manager must itself bind each channel to a
+# guild the requesting user has connected (ADR-0048). Unset ⇒ Discord source add fails closed.
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
 
 # Discord Channel ID where quota updates will be posted (Required)

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -1170,8 +1170,15 @@ function AddSourceForm({
       onSourceAdded?.()
       trackEvent('source_configured', { platform: 'discord' })
       toastManager.add({ title: 'Discord source added', type: 'success' })
-    } catch {
-      toastManager.add({ title: 'Failed to add Discord source', type: 'error' })
+    } catch (err) {
+      // Surface the server's reason: the Discord source guard (ADR-0048) refuses channels in
+      // servers the user has not connected and explains what to do, which a generic failure
+      // toast would throw away.
+      toastManager.add({
+        title: 'Failed to add Discord source',
+        description: err instanceof ApiError ? err.message : undefined,
+        type: 'error',
+      })
     } finally {
       setIsAddingDiscord(false)
     }

--- a/services/overlay-manager/README.md
+++ b/services/overlay-manager/README.md
@@ -84,6 +84,14 @@ OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 # Application
 APP_VERSION=dev
 ENVIRONMENT=development
+
+# Discord source guard (ADR-0048) — the same shared bot token discord-listener uses.
+# Required to ADD or RECONFIGURE a Discord chat source: every Discord channel is acted on by
+# the shared bot, so Discord authorizes the bot rather than the requesting user and will not
+# refuse a channel the user has no claim to. overlay-manager resolves each channel's guild via
+# GET /channels/{id} and requires a matching discord_guilds row for the overlay owner.
+# When unset, Discord source add/patch fails closed with 503 (other platforms are unaffected).
+DISCORD_BOT_TOKEN=your_discord_bot_token_here
 ```
 
 ---

--- a/services/overlay-manager/clients/discord.go
+++ b/services/overlay-manager/clients/discord.go
@@ -1,0 +1,121 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const defaultDiscordAPIBase = "https://discord.com/api/v10"
+
+// Sentinel errors from the Discord REST calls. They are distinguished because the caller's
+// response differs: a missing channel is a client mistake, a forbidden one means the bot
+// needs re-inviting, and anything else must fail closed as a transient error.
+var (
+	ErrDiscordChannelNotFound = errors.New("discord: channel not found")
+	ErrDiscordForbidden       = errors.New("discord: forbidden")
+	ErrDiscordUnauthorized    = errors.New("discord: bot token rejected")
+	ErrDiscordNoGuild         = errors.New("discord: channel belongs to no guild")
+)
+
+// DiscordClient performs the minimal bot-authenticated reads overlay-manager needs to
+// validate that a Discord channel may be attached to an overlay.
+//
+// It deliberately holds only read capability: overlay-manager must be able to answer
+// "which guild does this channel belong to" without gaining any ability to write to Discord.
+type DiscordClient struct {
+	botToken   string
+	baseURL    string
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewDiscordClient creates a Discord REST client authenticated as the shared bot.
+func NewDiscordClient(botToken string, logger *zap.Logger) *DiscordClient {
+	return &DiscordClient{
+		botToken:   botToken,
+		baseURL:    defaultDiscordAPIBase,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		logger:     logger,
+	}
+}
+
+// WithBaseURL overrides the API base (tests).
+func (d *DiscordClient) WithBaseURL(base string) *DiscordClient {
+	d.baseURL = base
+	return d
+}
+
+// GuildIDForChannel resolves the guild a channel belongs to, as Discord itself reports it.
+//
+// This is the authoritative binding: it must never be replaced by a client-supplied
+// guild_id, because the whole point is to stop a caller from pairing a channel they do not
+// control with a guild they do.
+func (d *DiscordClient) GuildIDForChannel(ctx context.Context, channelID string) (string, error) {
+	endpoint := fmt.Sprintf("%s/channels/%s", d.baseURL, url.PathEscape(channelID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("discord: build channel request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+d.botToken)
+	req.Header.Set("User-Agent", "AllChat (https://allch.at, 1.0)")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("discord: channel request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through to decode
+	case http.StatusNotFound:
+		return "", ErrDiscordChannelNotFound
+	case http.StatusForbidden:
+		return "", ErrDiscordForbidden
+	case http.StatusUnauthorized:
+		return "", ErrDiscordUnauthorized
+	default:
+		return "", fmt.Errorf("discord: unexpected status %d resolving channel", resp.StatusCode)
+	}
+
+	var body struct {
+		ID      string `json:"id"`
+		GuildID string `json:"guild_id"`
+		Type    int    `json:"type"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("discord: decode channel: %w", err)
+	}
+
+	// DMs and group DMs carry no guild_id. Returning "" here would hand an empty guild id to
+	// an ownership check that could match nothing (or, worse, a row with an empty guild_id).
+	if body.GuildID == "" {
+		return "", ErrDiscordNoGuild
+	}
+
+	return body.GuildID, nil
+}

--- a/services/overlay-manager/clients/discord_test.go
+++ b/services/overlay-manager/clients/discord_test.go
@@ -1,0 +1,114 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestDiscordClient_GuildIDForChannel_Success asserts the happy path: the bot token is
+// sent as an Authorization header and the guild_id is read off the channel object.
+func TestDiscordClient_GuildIDForChannel_Success(t *testing.T) {
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chan-1","guild_id":"guild-9","type":0}`))
+	}))
+	defer srv.Close()
+
+	c := NewDiscordClient("bot-secret", zap.NewNop()).WithBaseURL(srv.URL)
+
+	guildID, err := c.GuildIDForChannel(context.Background(), "chan-1")
+	require.NoError(t, err)
+	assert.Equal(t, "guild-9", guildID)
+	assert.Equal(t, "/channels/chan-1", gotPath)
+	assert.Equal(t, "Bot bot-secret", gotAuth,
+		"must authenticate as the bot, not with a user token")
+}
+
+// TestDiscordClient_GuildIDForChannel_NotFound maps Discord's 404 to a distinct error so
+// the caller can answer "that channel does not exist / the bot cannot see it" rather than
+// treating it as a transient failure.
+func TestDiscordClient_GuildIDForChannel_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Unknown Channel","code":10003}`))
+	}))
+	defer srv.Close()
+
+	c := NewDiscordClient("bot-secret", zap.NewNop()).WithBaseURL(srv.URL)
+
+	_, err := c.GuildIDForChannel(context.Background(), "nope")
+	assert.ErrorIs(t, err, ErrDiscordChannelNotFound)
+}
+
+// TestDiscordClient_GuildIDForChannel_Forbidden covers a channel in a guild the bot is in
+// but cannot view. It must NOT be reported as "not found" — the distinction drives whether
+// the user is told to re-invite the bot.
+func TestDiscordClient_GuildIDForChannel_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewDiscordClient("bot-secret", zap.NewNop()).WithBaseURL(srv.URL)
+
+	_, err := c.GuildIDForChannel(context.Background(), "chan-1")
+	assert.ErrorIs(t, err, ErrDiscordForbidden)
+}
+
+// TestDiscordClient_GuildIDForChannel_DMHasNoGuild guards the case that would otherwise
+// return an empty guild id and let an empty-string ownership check through: DM and group-DM
+// channels carry no guild_id at all.
+func TestDiscordClient_GuildIDForChannel_DMHasNoGuild(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"dm-1","type":1}`))
+	}))
+	defer srv.Close()
+
+	c := NewDiscordClient("bot-secret", zap.NewNop()).WithBaseURL(srv.URL)
+
+	_, err := c.GuildIDForChannel(context.Background(), "dm-1")
+	assert.ErrorIs(t, err, ErrDiscordNoGuild)
+}
+
+// TestDiscordClient_GuildIDForChannel_ServerError must surface a non-sentinel error so the
+// caller fails closed rather than mistaking it for "unowned".
+func TestDiscordClient_GuildIDForChannel_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewDiscordClient("bot-secret", zap.NewNop()).WithBaseURL(srv.URL)
+
+	_, err := c.GuildIDForChannel(context.Background(), "chan-1")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrDiscordChannelNotFound))
+	assert.False(t, errors.Is(err, ErrDiscordForbidden))
+}

--- a/services/overlay-manager/cmd/main.go
+++ b/services/overlay-manager/cmd/main.go
@@ -215,6 +215,20 @@ func main() {
 	seventvResolver := clients.NewSevenTVResolver(log)
 	configHandler := handlers.NewConfigHandler(configRepo, overlayRepo, sourceRepo, seventvResolver)
 	sourcesHandler := handlers.NewSourcesHandler(sourceRepo, overlayRepo, dbPool, log, redisClient, bm, tokenCipher)
+
+	// Discord source guard (ADR-0048): a Discord source is acted on by the SHARED bot, so
+	// Discord authorizes the bot rather than the caller and will not refuse a channel the
+	// caller has no claim to. Bind every Discord channel to a guild the user has connected.
+	// Without the bot token there is no way to resolve a channel's guild — Discord chat cannot
+	// work at all in that case, and adding a source fails closed rather than unvalidated.
+	if config.DiscordBotToken != "" {
+		sourcesHandler.SetDiscordGuard(
+			clients.NewDiscordClient(config.DiscordBotToken, log),
+			repository.NewDiscordGuildRepository(dbPool),
+		)
+	} else {
+		log.Warn("DISCORD_BOT_TOKEN not set — Discord sources cannot be validated and will be refused")
+	}
 	mockHandler := handlers.NewMockMessageHandler(overlayRepo, sourceRepo, mpClient, log)
 	healthHandler := handlers.NewHealthHandler(dbPool, redisClient)
 	adminHandler := handlers.NewAdminHandler(overlayRepo, sourceRepo, log)
@@ -408,6 +422,7 @@ type Config struct {
 	MessageProcessorAPIKey string
 	TwitchClientID         string
 	TwitchClientSecret     string
+	DiscordBotToken        string
 }
 
 // loadConfig loads configuration from environment variables
@@ -426,6 +441,7 @@ func loadConfig() *Config {
 		MessageProcessorAPIKey: getEnv("MESSAGE_PROCESSOR_API_KEY", ""),
 		TwitchClientID:         getEnv("TWITCH_CLIENT_ID", ""),
 		TwitchClientSecret:     getEnv("TWITCH_CLIENT_SECRET", ""),
+		DiscordBotToken:        getEnv("DISCORD_BOT_TOKEN", ""),
 	}
 }
 

--- a/services/overlay-manager/handlers/sources.go
+++ b/services/overlay-manager/handlers/sources.go
@@ -19,10 +19,12 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/caesar/all-chat/services/overlay-manager/clients"
 	"github.com/caesar/all-chat/services/overlay-manager/models"
 	"github.com/caesar/all-chat/shared/encryption"
 	"github.com/caesar/all-chat/shared/metrics"
@@ -43,6 +45,19 @@ type SourceRepository interface {
 	UpdateConfig(ctx context.Context, id string, config map[string]interface{}) error
 }
 
+// discordChannelGuildResolver reports which guild a Discord channel belongs to, as Discord
+// itself sees it. A client-supplied guild id is never a substitute: the whole point is to stop
+// a caller pairing a channel they do not control with a guild they do.
+type discordChannelGuildResolver interface {
+	GuildIDForChannel(ctx context.Context, channelID string) (string, error)
+}
+
+// discordGuildOwnership reports whether a user has connected a guild — i.e. invited the
+// shared bot to it, which Discord only offers to members holding Manage Server.
+type discordGuildOwnership interface {
+	UserOwnsGuild(ctx context.Context, userID, guildID string) (bool, error)
+}
+
 // SourcesHandler handles HTTP requests for overlay chat sources
 type SourcesHandler struct {
 	sourceRepo  SourceRepository
@@ -52,6 +67,19 @@ type SourcesHandler struct {
 	logger      *zap.Logger
 	bm          *metrics.BusinessMetrics
 	cipher      *encryption.MultiKeyEncryptor // Encrypts kick_oauth_tokens on write (D-16; nil = no encryption)
+
+	// Discord source guard (ADR-0048). Both nil means Discord sources cannot be validated,
+	// and adding one fails closed.
+	discordChannels discordChannelGuildResolver
+	discordGuilds   discordGuildOwnership
+}
+
+// SetDiscordGuard wires the Discord source guard. Injected separately from the constructor
+// because it is optional configuration (DISCORD_BOT_TOKEN): when it is absent, Discord chat
+// cannot work at all, and Discord sources must be refused rather than accepted unvalidated.
+func (h *SourcesHandler) SetDiscordGuard(channels discordChannelGuildResolver, guilds discordGuildOwnership) {
+	h.discordChannels = channels
+	h.discordGuilds = guilds
 }
 
 // discordChannelEntry is the JSON value stored at discord:channels:{channel_id}.
@@ -76,6 +104,98 @@ func NewSourcesHandler(sourceRepo SourceRepository, overlayRepo OverlayRepositor
 		bm:          bm,
 		cipher:      cipher,
 	}
+}
+
+// discordConfigChannelKeys are the config fields that name a Discord channel All-Chat will
+// act on. Each is attacker-controlled and each is exercised by the SHARED bot, so Discord
+// authorizes the bot and never the caller:
+//   - inbound_channel_id is the discord:channels:{id} registry key that routes a guild's chat
+//     into an overlay (a read capability over that channel).
+//   - relay_channel_id is an outbound webhook target that discord-listener provisions and
+//     posts chat into (a write capability).
+//
+// channel_id itself is checked alongside these, since it is what the moderation write-path
+// acts on.
+var discordConfigChannelKeys = []string{"inbound_channel_id", "relay_channel_id"}
+
+// authorizeDiscordChannels verifies that every Discord channel a request would put to work
+// belongs to a guild the user has connected. It returns (0, "") when the request is allowed,
+// or an HTTP status plus message when it must be refused.
+//
+// It fails closed on every uncertainty: an unconfigured guard, a Discord API error and a
+// database error all refuse, because "cannot verify" must never read as "allowed". A guild id
+// supplied in config is not trusted as the binding — Discord's own answer for the channel is
+// authoritative — but a value that contradicts it is refused rather than stored, since a
+// mislabelled source would misinform the owner about what they attached. (ADR-0048.)
+//
+// channelID is the source's primary channel, and is validated (and used for the guild_id
+// claim check) only when non-empty. Reconfiguring an existing source passes "" so that a
+// primary channel deleted on Discord's side cannot strand the owner: they must still be able
+// to turn a relay off, and the stored channel is not what this request changes.
+func (h *SourcesHandler) authorizeDiscordChannels(ctx context.Context, userID, channelID string, config map[string]interface{}) (int, string) {
+	if h.discordChannels == nil || h.discordGuilds == nil {
+		h.logger.Error("Discord source guard unconfigured — refusing Discord source",
+			zap.String("user_id", userID))
+		return http.StatusServiceUnavailable, "Discord source validation is unavailable, please try again later"
+	}
+
+	// channel_id first: its resolved guild is also what a supplied guild_id must match.
+	var candidates []string
+	if channelID != "" {
+		candidates = append(candidates, channelID)
+	}
+	for _, key := range discordConfigChannelKeys {
+		if v, ok := config[key].(string); ok && v != "" && v != channelID {
+			candidates = append(candidates, v)
+		}
+	}
+
+	claimedGuild, _ := config["guild_id"].(string)
+	if channelID == "" {
+		claimedGuild = "" // no primary channel to compare a claim against
+	}
+	seen := make(map[string]bool, len(candidates))
+
+	for i, candidate := range candidates {
+		if seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+
+		guildID, err := h.discordChannels.GuildIDForChannel(ctx, candidate)
+		switch {
+		case errors.Is(err, clients.ErrDiscordChannelNotFound), errors.Is(err, clients.ErrDiscordNoGuild):
+			return http.StatusBadRequest, fmt.Sprintf("Discord channel '%s' does not exist or is not a server channel", candidate)
+		case errors.Is(err, clients.ErrDiscordForbidden):
+			return http.StatusBadRequest, fmt.Sprintf("All-Chat's bot cannot see Discord channel '%s' — re-invite the bot with access to it", candidate)
+		case err != nil:
+			h.logger.Error("Failed to resolve Discord channel guild",
+				zap.String("channel_id", candidate), zap.Error(err))
+			return http.StatusServiceUnavailable, "Could not verify the Discord channel right now, please try again"
+		}
+
+		// Only the primary channel_id's guild is compared against the claim; the other fields
+		// are validated by ownership alone (they may legitimately sit in the same guild).
+		if i == 0 && claimedGuild != "" && claimedGuild != guildID {
+			return http.StatusBadRequest, "The Discord server does not match the selected channel"
+		}
+
+		owns, err := h.discordGuilds.UserOwnsGuild(ctx, userID, guildID)
+		if err != nil {
+			h.logger.Error("Failed to check Discord guild ownership",
+				zap.String("user_id", userID), zap.String("guild_id", guildID), zap.Error(err))
+			return http.StatusServiceUnavailable, "Could not verify the Discord server right now, please try again"
+		}
+		if !owns {
+			h.logger.Warn("Refused Discord channel in a guild the user has not connected",
+				zap.String("user_id", userID),
+				zap.String("channel_id", candidate),
+				zap.String("guild_id", guildID))
+			return http.StatusForbidden, "You have not connected that Discord server to All-Chat"
+		}
+	}
+
+	return 0, ""
 }
 
 // setDiscordChannelRegistry writes the channel registry Redis key and publishes an invalidation event.
@@ -449,6 +569,16 @@ func (h *SourcesHandler) HandleAddSource(c *gin.Context) {
 		// If fetch fails, channelName retains the fallback value (channel_id) — acceptable
 	}
 
+	// Discord sources are acted on by the shared bot, which Discord authorizes instead of the
+	// caller — so nothing upstream refuses a channel the caller has no claim to. Verify guild
+	// ownership here, fail closed. (ADR-0048.)
+	if req.Platform == "discord" {
+		if status, msg := h.authorizeDiscordChannels(c.Request.Context(), userID.(string), channelID, req.Config); status != 0 {
+			c.JSON(status, gin.H{"error": msg})
+			return
+		}
+	}
+
 	var channelHandle *string
 	if req.ChannelHandle != "" {
 		channelHandle = &req.ChannelHandle
@@ -623,6 +753,24 @@ func (h *SourcesHandler) HandleUpdateSourceConfig(c *gin.Context) {
 		return
 	}
 
+	// Owning the overlay in the path is not enough: UpdateConfig is keyed on source_id alone,
+	// so without this the caller could patch a source belonging to someone else's overlay.
+	source, err := h.sourceRepo.GetByID(c.Request.Context(), sourceID)
+	if err != nil || source == nil || source.OverlayID != overlayID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "source not found on this overlay"})
+		return
+	}
+
+	// A Discord relay/inbound target can be introduced by PATCH just as easily as at create
+	// time, so it needs the same ownership guard. Only the channels named in THIS request are
+	// validated — the stored primary channel was checked when the source was created. (ADR-0048.)
+	if source.Platform == "discord" {
+		if status, msg := h.authorizeDiscordChannels(c.Request.Context(), userID.(string), "", req.Config); status != 0 {
+			c.JSON(status, gin.H{"error": msg})
+			return
+		}
+	}
+
 	// Validate stream_select if present (YouTube stream selection strategy)
 	if strategy, ok := req.Config["stream_select"].(string); ok && strategy != "" {
 		validStrategies := map[string]bool{
@@ -733,6 +881,15 @@ func (h *SourcesHandler) HandleAddSourceAuto(c *gin.Context) {
 			})
 			return
 		}
+	}
+
+	// This endpoint serves the OAuth callback (twitch/youtube/kick) and has no legitimate
+	// Discord caller — Discord connects through auth-service's bot-invite flow, which writes
+	// discord_guilds rather than overlay sources. A source row alone is enough to make a
+	// channel moderatable, so refuse outright instead of running an add-source guard here.
+	if req.Platform == "discord" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "discord sources cannot be added through this endpoint"})
+		return
 	}
 
 	var channelHandle *string

--- a/services/overlay-manager/handlers/sources_discord_test.go
+++ b/services/overlay-manager/handlers/sources_discord_test.go
@@ -1,0 +1,424 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caesar/all-chat/services/overlay-manager/clients"
+	"github.com/caesar/all-chat/services/overlay-manager/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// The Discord source guard closes a cross-tenant escalation: before it existed, any
+// authenticated user could attach an arbitrary Discord channel id to their own overlay.
+// Because the shared bot is the actor for every Discord read (channel registry → the
+// attacker's overlay receives that guild's chat), every moderation write (delete/timeout/ban
+// bounded only by the bot's guild permissions), and every relay write (a provisioned webhook
+// posting into the channel), the only thing binding a source to its rightful owner is this
+// check. See ADR-0048.
+
+type mockDiscordChannelResolver struct {
+	guilds map[string]string // channelID → guildID
+	err    error
+}
+
+func (m *mockDiscordChannelResolver) GuildIDForChannel(_ context.Context, channelID string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	g, ok := m.guilds[channelID]
+	if !ok {
+		return "", clients.ErrDiscordChannelNotFound
+	}
+	return g, nil
+}
+
+type mockDiscordGuildOwnership struct {
+	owned map[string]bool // userID|guildID → true
+	err   error
+}
+
+func (m *mockDiscordGuildOwnership) UserOwnsGuild(_ context.Context, userID, guildID string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.owned[userID+"|"+guildID], nil
+}
+
+// discordTestHandler builds a SourcesHandler with the Discord guard wired and a capture hook
+// on Create. db stays nil: the guard must never need it.
+func discordTestHandler(resolver discordChannelGuildResolver, ownership discordGuildOwnership, captured **models.ChatSource) *SourcesHandler {
+	h := &SourcesHandler{
+		sourceRepo: &mockSourceRepository{
+			createFunc: func(_ context.Context, s *models.ChatSource) error {
+				if captured != nil {
+					*captured = s
+				}
+				return nil
+			},
+		},
+		overlayRepo: &mockOverlayRepository{
+			getByIDAndUserIDFunc: func(_ context.Context, id, userID string) (*models.Overlay, error) {
+				return &models.Overlay{ID: id, UserID: userID, Name: "Test Overlay"}, nil
+			},
+		},
+		db:     nil,
+		logger: zap.NewNop(),
+	}
+	h.SetDiscordGuard(resolver, ownership)
+	return h
+}
+
+func postDiscordSource(h *SourcesHandler, body map[string]interface{}) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/overlays/:id/sources", func(c *gin.Context) {
+		c.Set("user_id", "attacker")
+		h.HandleAddSource(c)
+	})
+	bodyBytes, _ := json.Marshal(body)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/overlays/overlay-id/sources", bytes.NewBuffer(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// A channel in a guild the caller never connected must be refused. This is the core of the
+// vulnerability: the bot can see the guild, so without this check the source works.
+func TestHandleAddSource_Discord_RejectsChannelInUnconnectedGuild(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{"victim-chan": "victim-guild"}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "victim-chan",
+		"config":     map[string]interface{}{"guild_id": "victim-guild"},
+	})
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a channel in a guild the caller has not connected must be refused")
+	assert.Nil(t, captured, "no source row may be created for an unowned guild")
+}
+
+// The legitimate flow must keep working: the frontend only offers channels from guilds the
+// user connected, so the resolved guild is one they own.
+func TestHandleAddSource_Discord_AllowsChannelInConnectedGuild(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{"my-chan": "attacker-guild"}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "my-chan",
+		"config": map[string]interface{}{
+			"guild_id":           "attacker-guild",
+			"inbound_channel_id": "my-chan",
+		},
+	})
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	if assert.NotNil(t, captured) {
+		assert.Equal(t, "discord", captured.Platform)
+	}
+}
+
+// A guard that cannot run must refuse, not pass. Without the bot token there is no way to
+// resolve the channel's guild, so Discord sources cannot be validated at all.
+func TestHandleAddSource_Discord_FailsClosedWithoutGuard(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(nil, nil, &captured)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "any-chan",
+	})
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code,
+		"an unconfigured guard must fail closed, never allow")
+	assert.Nil(t, captured)
+}
+
+// A transient Discord outage must not be mistaken for "unowned" (403) or let the source
+// through — it is a 503 so the caller retries.
+func TestHandleAddSource_Discord_FailsClosedOnResolverError(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{err: errors.New("discord: unexpected status 500")},
+		&mockDiscordGuildOwnership{},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "any-chan",
+	})
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Nil(t, captured)
+}
+
+// Likewise a database failure on the ownership lookup must fail closed.
+func TestHandleAddSource_Discord_FailsClosedOnOwnershipError(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{"c": "g"}},
+		&mockDiscordGuildOwnership{err: errors.New("db down")},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "c",
+	})
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Nil(t, captured)
+}
+
+// An unknown channel id is a client error, distinguishable from "you do not own it".
+func TestHandleAddSource_Discord_RejectsUnknownChannel(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{}},
+		&mockDiscordGuildOwnership{},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "does-not-exist",
+	})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Nil(t, captured)
+}
+
+// The client-supplied guild_id is never trusted as the binding, but if it contradicts what
+// Discord reports, the request is a mistake (or an attempt) and is refused rather than
+// silently stored — a wrong guild_id would mislabel the source in the UI.
+func TestHandleAddSource_Discord_RejectsGuildIDMismatch(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{"my-chan": "attacker-guild"}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "my-chan",
+		"config":     map[string]interface{}{"guild_id": "some-other-guild"},
+	})
+
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"a config guild_id that disagrees with Discord must be refused")
+	assert.Nil(t, captured)
+}
+
+// inbound_channel_id is what actually gets written to the discord:channels:{id} registry, so
+// it is the read-path target and must be validated even when channel_id is legitimate.
+func TestHandleAddSource_Discord_ValidatesInboundChannelID(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{
+			"my-chan":     "attacker-guild",
+			"victim-chan": "victim-guild",
+		}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "my-chan",
+		"config": map[string]interface{}{
+			"guild_id":           "attacker-guild",
+			"inbound_channel_id": "victim-chan",
+		},
+	})
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"inbound_channel_id is the registry key and must be owned too")
+	assert.Nil(t, captured)
+}
+
+// relay_channel_id is an outbound write target: discord-listener provisions a webhook and
+// posts chat into it, so an unowned value turns All-Chat into a spam relay.
+func TestHandleAddSource_Discord_ValidatesRelayChannelID(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{
+			"my-chan":     "attacker-guild",
+			"victim-chan": "victim-guild",
+		}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		&captured,
+	)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "my-chan",
+		"config": map[string]interface{}{
+			"guild_id":         "attacker-guild",
+			"relay_enabled":    true,
+			"relay_channel_id": "victim-chan",
+		},
+	})
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"relay_channel_id is an outbound write target and must be owned")
+	assert.Nil(t, captured)
+}
+
+// Non-Discord platforms must be unaffected by the guard, including when it is unconfigured.
+func TestHandleAddSource_NonDiscord_UnaffectedByGuard(t *testing.T) {
+	var captured *models.ChatSource
+	h := discordTestHandler(nil, nil, &captured)
+
+	w := postDiscordSource(h, map[string]interface{}{
+		"platform":   "twitch",
+		"channel_id": "xqc",
+	})
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.NotNil(t, captured)
+}
+
+// The internal auto-add endpoint exists for the OAuth callback (twitch/youtube/kick) and has
+// no legitimate Discord caller. It writes no registry key, but a row alone is enough to make
+// a channel moderatable, so it must refuse Discord outright.
+func TestHandleAddSourceAuto_RejectsDiscord(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var captured *models.ChatSource
+	h := discordTestHandler(nil, nil, &captured)
+
+	router := gin.New()
+	router.POST("/internal/overlays/:id/sources/auto", func(c *gin.Context) {
+		c.Set("user_id", "attacker")
+		h.HandleAddSourceAuto(c)
+	})
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"platform":   "discord",
+		"channel_id": "victim-chan",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/internal/overlays/overlay-id/sources/auto", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code,
+		"the auto endpoint must not create Discord sources")
+	assert.Nil(t, captured)
+}
+
+// patchConfig drives HandleUpdateSourceConfig with a given stored source.
+func patchConfig(h *SourcesHandler, stored *models.ChatSource, config map[string]interface{}) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	h.sourceRepo = &mockSourceRepository{
+		getByIDFunc: func(_ context.Context, _ string) (*models.ChatSource, error) {
+			return stored, nil
+		},
+	}
+	router := gin.New()
+	router.PATCH("/overlays/:id/sources/:source_id/config", func(c *gin.Context) {
+		c.Set("user_id", "attacker")
+		h.HandleUpdateSourceConfig(c)
+	})
+	body, _ := json.Marshal(map[string]interface{}{"config": config})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/overlays/overlay-id/sources/source-id/config", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// The relay target can also be set after the fact, so the PATCH path needs the same guard.
+func TestHandleUpdateSourceConfig_Discord_ValidatesRelayChannel(t *testing.T) {
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{guilds: map[string]string{
+			"my-chan":     "attacker-guild",
+			"victim-chan": "victim-guild",
+		}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		nil,
+	)
+
+	w := patchConfig(h, &models.ChatSource{
+		ID: "source-id", OverlayID: "overlay-id", Platform: "discord", ChannelID: "my-chan",
+	}, map[string]interface{}{
+		"relay_enabled":    true,
+		"relay_channel_id": "victim-chan",
+	})
+
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a relay target added by PATCH must be validated like one added at create time")
+}
+
+// A primary channel deleted on Discord's side must not strand the owner: reconfiguring the
+// source (e.g. turning a relay off) validates only the channels named in the request.
+func TestHandleUpdateSourceConfig_Discord_AllowsWhenStoredChannelIsGone(t *testing.T) {
+	h := discordTestHandler(
+		// "gone-chan" is absent from the resolver, i.e. deleted on Discord.
+		&mockDiscordChannelResolver{guilds: map[string]string{"my-chan": "attacker-guild"}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"attacker|attacker-guild": true}},
+		nil,
+	)
+
+	w := patchConfig(h, &models.ChatSource{
+		ID: "source-id", OverlayID: "overlay-id", Platform: "discord", ChannelID: "gone-chan",
+	}, map[string]interface{}{
+		"relay_enabled": false,
+	})
+
+	assert.Equal(t, http.StatusOK, w.Code,
+		"a deleted primary channel must not block turning a relay off")
+}
+
+// A source id from someone else's overlay must not be patchable just because the caller owns
+// the overlay named in the path — UpdateConfig was previously keyed on source_id alone.
+func TestHandleUpdateSourceConfig_RejectsSourceFromAnotherOverlay(t *testing.T) {
+	h := discordTestHandler(
+		&mockDiscordChannelResolver{},
+		&mockDiscordGuildOwnership{},
+		nil,
+	)
+
+	w := patchConfig(h, &models.ChatSource{
+		ID: "source-id", OverlayID: "someone-elses-overlay", Platform: "twitch", ChannelID: "xqc",
+	}, map[string]interface{}{"stream_select": "first_found"})
+
+	assert.Equal(t, http.StatusNotFound, w.Code,
+		"the source must belong to the overlay in the path")
+}

--- a/services/overlay-manager/handlers/sources_patch_test.go
+++ b/services/overlay-manager/handlers/sources_patch_test.go
@@ -112,6 +112,10 @@ func setupPatchRouter(h *SourcesHandler) *gin.Engine {
 
 // TestHandleUpdateSourceConfig_Success verifies that a valid PATCH request with
 // ownership and config returns 200 with "config updated" message.
+//
+// Since ADR-0048 the handler also requires the source to exist on the overlay named in the
+// path, and — for a Discord source — that every channel in the config sits in a guild the
+// caller has connected. The stored source and the approving guard below satisfy both.
 func TestHandleUpdateSourceConfig_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -120,6 +124,14 @@ func TestHandleUpdateSourceConfig_Success(t *testing.T) {
 
 	h := buildPatchHandler(
 		&mockSourceRepositoryWithConfig{
+			getByIDFunc: func(_ context.Context, id string) (*models.ChatSource, error) {
+				return &models.ChatSource{
+					ID:        id,
+					OverlayID: "overlay-id",
+					Platform:  "discord",
+					ChannelID: "987654321",
+				}, nil
+			},
 			updateConfigFunc: func(_ context.Context, id string, cfg map[string]interface{}) error {
 				capturedID = id
 				capturedConfig = cfg
@@ -131,6 +143,10 @@ func TestHandleUpdateSourceConfig_Success(t *testing.T) {
 				return &models.Overlay{ID: id, UserID: userID, Name: "Test"}, nil
 			},
 		},
+	)
+	h.SetDiscordGuard(
+		&mockDiscordChannelResolver{guilds: map[string]string{"987654321": "123456789"}},
+		&mockDiscordGuildOwnership{owned: map[string]bool{"test-user-id|123456789": true}},
 	)
 
 	router := setupPatchRouter(h)

--- a/services/overlay-manager/repository/discord_guild_repo.go
+++ b/services/overlay-manager/repository/discord_guild_repo.go
@@ -1,0 +1,56 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// DiscordGuildRepository reads the discord_guilds connections written by auth-service's
+// bot-invite callback (migration 035).
+type DiscordGuildRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewDiscordGuildRepository creates a repository over an existing pool.
+func NewDiscordGuildRepository(pool *pgxpool.Pool) *DiscordGuildRepository {
+	return &DiscordGuildRepository{pool: pool}
+}
+
+// UserOwnsGuild reports whether the user has connected this guild to All-Chat.
+//
+// A row exists only for the user who completed the bot-invite flow for that guild, and
+// Discord offers that flow only to members holding Manage Server — so the row is the closest
+// available proof that the user administers the guild. It is the authorization anchor for
+// every Discord source, because Discord itself authorizes the shared bot rather than the
+// caller and will not refuse a channel the caller has no claim to (ADR-0048).
+func (r *DiscordGuildRepository) UserOwnsGuild(ctx context.Context, userID, guildID string) (bool, error) {
+	const query = `
+		SELECT EXISTS(
+			SELECT 1 FROM discord_guilds
+			WHERE user_id = $1 AND guild_id = $2
+		)`
+
+	var exists bool
+	if err := r.pool.QueryRow(ctx, query, userID, guildID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("check discord guild ownership: %w", err)
+	}
+	return exists, nil
+}

--- a/services/overlay-manager/repository/discord_guild_repo_test.go
+++ b/services/overlay-manager/repository/discord_guild_repo_test.go
@@ -1,0 +1,116 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupDiscordGuildTestDatabase starts PostgreSQL and creates discord_guilds as migration 035
+// defines it, so the ownership query is exercised against the real column names and the
+// UNIQUE(user_id, guild_id) shape it relies on.
+func setupDiscordGuildTestDatabase(t *testing.T) (*DiscordGuildRepository, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	require.NoError(t, err)
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS discord_guilds (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL,
+			guild_id VARCHAR(32) NOT NULL,
+			guild_name VARCHAR(200),
+			guild_icon TEXT,
+			connected_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			UNIQUE (user_id, guild_id)
+		)`)
+	require.NoError(t, err)
+
+	return NewDiscordGuildRepository(pool), func() {
+		pool.Close()
+		_ = pgContainer.Terminate(ctx)
+	}
+}
+
+// TestUserOwnsGuild verifies the authorization anchor for every Discord source: the row must
+// belong to the asking user, and another user's connection to the same guild must not count.
+func TestUserOwnsGuild(t *testing.T) {
+	repo, cleanup := setupDiscordGuildTestDatabase(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	owner := uuid.New().String()
+	stranger := uuid.New().String()
+
+	_, err := repo.pool.Exec(ctx,
+		`INSERT INTO discord_guilds (user_id, guild_id, guild_name) VALUES ($1, $2, $3)`,
+		owner, "guild-123", "Owner's Server")
+	require.NoError(t, err)
+
+	t.Run("connected guild is owned", func(t *testing.T) {
+		owns, err := repo.UserOwnsGuild(ctx, owner, "guild-123")
+		require.NoError(t, err)
+		assert.True(t, owns)
+	})
+
+	t.Run("another user's guild is not owned", func(t *testing.T) {
+		owns, err := repo.UserOwnsGuild(ctx, stranger, "guild-123")
+		require.NoError(t, err)
+		assert.False(t, owns,
+			"a guild connected by someone else must never authorize this user")
+	})
+
+	t.Run("unconnected guild is not owned", func(t *testing.T) {
+		owns, err := repo.UserOwnsGuild(ctx, owner, "guild-999")
+		require.NoError(t, err)
+		assert.False(t, owns)
+	})
+
+	t.Run("empty guild id is not owned", func(t *testing.T) {
+		owns, err := repo.UserOwnsGuild(ctx, owner, "")
+		require.NoError(t, err)
+		assert.False(t, owns,
+			"an empty guild id must not match — the client returns a sentinel error instead")
+	})
+}


### PR DESCRIPTION
## The hole

Adding a Discord chat source performed **no guild validation whatsoever**. `HandleAddSource` validated `shared_overlay` against `share_requests`, then fell straight through to `Create` + `setDiscordChannelRegistry` for `discord`.

Every Discord capability is exercised by the **shared bot**, so Discord authorizes the bot rather than the requesting user and refuses nothing. Any user in the `moderation` cohort could attach an arbitrary channel id to their own overlay and then:

- **read** that guild's chat — the `discord:channels:{id}` registry routes it to their overlay;
- **moderate** its members — `IsModeratableSource` only checks the row exists on the overlay, and `dispatch/discord.go` discards the actor id, so delete/timeout/ban all run as the bot, bounded only by its permissions there;
- **relay into it** — discord-listener provisions a webhook for `relay_channel_id`.

Channel ids are trivially copyable by anyone in a mutual guild (Developer Mode → Copy ID). This needed no special access and no moderators.

## The fix

Bind each channel to its guild the only way that cannot be spoofed: **ask Discord**. A new read-only client resolves channel → guild via `GET /channels/{id}`, and that guild must have a `discord_guilds` row for the overlay owner (migration 035, written by the bot-invite callback — which Discord only offers to members holding Manage Server).

A `guild_id` supplied in config is **never** the binding; a value that contradicts Discord's answer is refused rather than stored, so a source cannot be mislabelled in the UI.

Every channel the request puts to work is checked, not just `channel_id`: `inbound_channel_id` is the registry key (read capability) and `relay_channel_id` is an outbound webhook target (write capability).

**Fails closed throughout** — an unconfigured guard, a Discord API error and a database error all refuse, because "cannot verify" must never read as "allowed".

## Two adjacent holes, same class, same handler

- `HandleUpdateSourceConfig` ran `UpdateConfig` keyed on `source_id` alone, so owning *any* overlay let a caller patch a source on **someone else's**. Now requires the source to belong to the overlay in the path, and applies the guard to relay/inbound targets introduced by PATCH. Only channels named in the request are validated, so a primary channel deleted on Discord's side cannot strand the owner (they can still turn a relay off).
- `HandleAddSourceAuto` (internal, for the OAuth callback) accepted `platform=discord`. A row alone makes a channel moderatable; it now refuses `discord` outright, which has no legitimate caller there.

## Blast radius, measured before choosing to hard-fail

Production: **12 Discord sources, all 12 carrying `guild_id`, 0 without a matching `discord_guilds` row for the owner.** Nothing to grandfather.

## Deploy ordering

⚠️ **caesar-deployment#44 must deploy first** — it adds `DISCORD_BOT_TOKEN` to overlay-manager. Without it the guard fails closed and Discord source add/patch returns 503. Other platforms are unaffected either way.

## Tests

An end-to-end test is not possible: the positive path needs a real Discord guild, a real bot membership and a live API. Coverage is:

- the decision logic against a faked resolver (unowned guild, unconfigured guard, resolver error, DB error, unknown channel, guild mismatch, inbound target, relay target, non-Discord unaffected, auto-endpoint refusal, PATCH scoping) — `sources_discord_test.go`
- the client's HTTP contract via `httptest` (bot auth header, 404/403/DM/500 mapping) — `clients/discord_test.go`
- the ownership query against a real Postgres, including "another user's guild does not authorize you" — `repository/discord_guild_repo_test.go`

Context: **ADR-0048**, which needs this guard before delegated moderators can extend the Discord write path to non-owners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLgC8YAUZgQuXKtJPC4AHd