### PR TITLE
feat(token-refresh): refresh delegated-moderator credentials

### DIFF
--- a/services/token-refresh-service/README.md
+++ b/services/token-refresh-service/README.md
@@ -138,6 +138,27 @@ spec:
 
 ## Token Refresh Logic
 
+### Credential sources
+
+Each batch queries every credential source separately and refreshes them in one pass. The
+`token_type` on each row decides which table the refreshed token is written back to — writing one
+source's token through another's updater would target the wrong row, and for the channel-keyed
+tables could make a credential visible to a listener that selects by channel with no user scoping.
+
+| `token_type` | Table | What it is |
+|---|---|---|
+| `user` | `users` | The account's login credential |
+| `viewer` | `viewer_sessions` | Viewer sessions |
+| `youtube_channel` | `youtube_oauth_tokens` | Per-channel YouTube grants, keyed `(user_id, channel_id)` |
+| `twitch_link` | `twitch_oauth_tokens` | Linked Twitch credentials (ADR-0016), keyed `(user_id, twitch_login)` |
+| `mod_credential` | `mod_oauth_credentials` | Delegated-moderator credentials (ADR-0048), keyed `(user_id, platform)` |
+
+`mod_credential` is the only source that **spans platforms**, so its platform is read from the row
+rather than assumed. It is not optional: without it a moderator's credential simply expires, the
+grant keeps looking active in the UI while every action fails, and the 90-day dormancy suspension
+can never fire because the moderator stopped being able to act long before that. A refresh never
+rewrites `granted_scopes` — a periodic job must not be able to narrow what someone consented to.
+
 ### Query Expiring Tokens
 
 ```sql

--- a/services/token-refresh-service/refresher/manager.go
+++ b/services/token-refresh-service/refresher/manager.go
@@ -41,11 +41,15 @@ type TokenRepo interface {
 	GetExpiringViewerTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
 	GetExpiringYouTubeTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
 	GetExpiringTwitchLinkTokens(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
+	// Delegated-moderator credentials (ADR-0048). Without this the credential expires and
+	// every delegated action fails while the grant still looks active.
+	GetExpiringModCredentials(ctx context.Context, expiresWithin time.Duration, limit int) ([]*repository.ExpiringToken, error)
 
 	UpdateUserTokens(ctx context.Context, userID string, token *oauth2Lib.Token) error
 	UpdateViewerTokens(ctx context.Context, sessionID string, token *oauth2Lib.Token) error
 	UpdateYouTubeTokens(ctx context.Context, userID, channelID string, token *oauth2Lib.Token) error
 	UpdateTwitchLinkTokens(ctx context.Context, userID, twitchLogin string, token *oauth2Lib.Token) error
+	UpdateModCredentialTokens(ctx context.Context, userID, platform string, token *oauth2Lib.Token) error
 
 	GetUserOverlays(ctx context.Context, userID string) ([]string, error)
 
@@ -53,6 +57,7 @@ type TokenRepo interface {
 	MarkViewerTokenPermanentlyFailed(ctx context.Context, sessionID string, suppressDuration time.Duration) error
 	MarkYouTubeTokenPermanentlyFailed(ctx context.Context, userID, channelID string, suppressDuration time.Duration) error
 	MarkTwitchLinkTokenPermanentlyFailed(ctx context.Context, userID, twitchLogin string, suppressDuration time.Duration) error
+	MarkModCredentialPermanentlyFailed(ctx context.Context, userID, platform string, suppressDuration time.Duration) error
 }
 
 // permanentFailSuppress is the duration pushed onto token_expires_at after a
@@ -216,16 +221,23 @@ func (m *Manager) ProcessBatch(ctx context.Context) error {
 		return fmt.Errorf("failed to get expiring linked Twitch tokens: %w", err)
 	}
 
+	modCredentials, err := m.repo.GetExpiringModCredentials(ctx, m.expiryBuffer, m.batchSize)
+	if err != nil {
+		return fmt.Errorf("failed to get expiring moderator credentials: %w", err)
+	}
+
 	// Combine all tokens
 	allTokens := append(userTokens, viewerTokens...)
 	allTokens = append(allTokens, youtubeTokens...)
 	allTokens = append(allTokens, twitchLinkTokens...)
+	allTokens = append(allTokens, modCredentials...)
 
 	m.logger.Info("Found expiring tokens",
 		zap.Int("user_tokens", len(userTokens)),
 		zap.Int("viewer_tokens", len(viewerTokens)),
 		zap.Int("youtube_tokens", len(youtubeTokens)),
 		zap.Int("twitch_link_tokens", len(twitchLinkTokens)),
+		zap.Int("mod_credentials", len(modCredentials)),
 		zap.Int("total", len(allTokens)),
 	)
 
@@ -335,6 +347,9 @@ func (m *Manager) refreshPlatform(ctx context.Context, platform oauth.Platform, 
 			updateErr = m.repo.UpdateYouTubeTokens(ctx, token.ID, token.ChannelID, newToken)
 		case "twitch_link":
 			updateErr = m.repo.UpdateTwitchLinkTokens(ctx, token.ID, token.ChannelID, newToken)
+		case "mod_credential":
+			// ChannelID carries the platform here: the row is keyed (user_id, platform).
+			updateErr = m.repo.UpdateModCredentialTokens(ctx, token.ID, token.ChannelID, newToken)
 		default:
 			updateErr = fmt.Errorf("unknown token type: %s", token.TokenType)
 		}
@@ -484,6 +499,8 @@ func (m *Manager) markTokenPermanentlyFailed(ctx context.Context, token *reposit
 		markErr = m.repo.MarkYouTubeTokenPermanentlyFailed(ctx, token.ID, token.ChannelID, permanentFailSuppress)
 	case "twitch_link":
 		markErr = m.repo.MarkTwitchLinkTokenPermanentlyFailed(ctx, token.ID, token.ChannelID, permanentFailSuppress)
+	case "mod_credential":
+		markErr = m.repo.MarkModCredentialPermanentlyFailed(ctx, token.ID, token.ChannelID, permanentFailSuppress)
 	default:
 		m.logger.Warn("Unknown token type for permanent-failure marking",
 			zap.String("token_type", token.TokenType),

--- a/services/token-refresh-service/refresher/manager_test.go
+++ b/services/token-refresh-service/refresher/manager_test.go
@@ -65,6 +65,11 @@ type fakeRepo struct {
 
 	updatedTwitchLinks []updatedTwitchLinkCall
 
+	// Delegated-moderator credentials (ADR-0048).
+	modCredentials     []*repository.ExpiringToken
+	updatedModCreds    []updatedModCredCall
+	markedModCreds     []markedModCredCall
+
 	// If non-nil, UpdateUserTokens / UpdateViewerTokens / UpdateYouTubeTokens return this.
 	updateErr error
 }
@@ -90,6 +95,15 @@ type markedTwitchLinkCall struct {
 type updatedTwitchLinkCall struct {
 	userID      string
 	twitchLogin string
+}
+type updatedModCredCall struct {
+	userID   string
+	platform string
+}
+type markedModCredCall struct {
+	userID           string
+	platform         string
+	suppressDuration time.Duration
 }
 
 func (r *fakeRepo) GetExpiringUserTokens(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
@@ -140,6 +154,23 @@ func (r *fakeRepo) UpdateTwitchLinkTokens(_ context.Context, userID, twitchLogin
 	defer r.mu.Unlock()
 	r.updatedTwitchLinks = append(r.updatedTwitchLinks, updatedTwitchLinkCall{userID: userID, twitchLogin: twitchLogin})
 	return r.updateErr
+}
+func (r *fakeRepo) GetExpiringModCredentials(_ context.Context, _ time.Duration, _ int) ([]*repository.ExpiringToken, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.modCredentials, nil
+}
+func (r *fakeRepo) UpdateModCredentialTokens(_ context.Context, userID, platform string, _ *oauth2.Token) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.updatedModCreds = append(r.updatedModCreds, updatedModCredCall{userID: userID, platform: platform})
+	return r.updateErr
+}
+func (r *fakeRepo) MarkModCredentialPermanentlyFailed(_ context.Context, userID, platform string, d time.Duration) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.markedModCreds = append(r.markedModCreds, markedModCredCall{userID: userID, platform: platform, suppressDuration: d})
+	return nil
 }
 func (r *fakeRepo) MarkTwitchLinkTokenPermanentlyFailed(_ context.Context, userID, twitchLogin string, d time.Duration) error {
 	r.mu.Lock()

--- a/services/token-refresh-service/refresher/mod_credential_test.go
+++ b/services/token-refresh-service/refresher/mod_credential_test.go
@@ -1,0 +1,127 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package refresher_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	authOAuth "github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/caesar/all-chat/services/token-refresh-service/repository"
+	"golang.org/x/oauth2"
+)
+
+// modProviders returns providers that refresh successfully for both delegated platforms.
+func modProviders() map[authOAuth.Platform]authOAuth.OAuthProvider {
+	fresh := &oauth2.Token{AccessToken: "new-access", RefreshToken: "new-refresh", Expiry: time.Now().Add(4 * time.Hour)}
+	return map[authOAuth.Platform]authOAuth.OAuthProvider{
+		authOAuth.PlatformTwitch: &fakeProvider{platform: authOAuth.PlatformTwitch, token: fresh},
+		authOAuth.PlatformKick:   &fakeProvider{platform: authOAuth.PlatformKick, token: fresh},
+	}
+}
+
+// Delegated-moderator credentials (ADR-0048) must be refreshed like every other credential.
+// Without this loop the credential simply expires: the grant keeps looking active in the UI
+// while every action fails, and the 90-day dormancy rule can never fire because the moderator
+// stopped being able to act long before that.
+
+func modCredential(userID, platform string) *repository.ExpiringToken {
+	return &repository.ExpiringToken{
+		ID:           userID,
+		Platform:     platform,
+		ChannelID:    platform, // the row is keyed (user_id, platform)
+		Username:     "volunteer_mod",
+		TokenType:    "mod_credential",
+		AccessToken:  "old-access",
+		RefreshToken: "refresh-me",
+		ExpiresAt:    time.Now().Add(2 * time.Minute),
+	}
+}
+
+func TestProcessBatch_RefreshesModCredentials(t *testing.T) {
+	repo := &fakeRepo{
+		modCredentials: []*repository.ExpiringToken{modCredential("mod-1", "twitch")},
+	}
+	m := newTestManager(repo, modProviders())
+
+	if err := m.ProcessBatch(context.Background()); err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.updatedModCreds) != 1 {
+		t.Fatalf("got %d moderator credential updates, want 1", len(repo.updatedModCreds))
+	}
+	got := repo.updatedModCreds[0]
+	if got.userID != "mod-1" {
+		t.Errorf("userID = %q, want mod-1", got.userID)
+	}
+	if got.platform != "twitch" {
+		t.Errorf("platform = %q, want twitch — the row is keyed (user_id, platform), so a wrong value here silently updates nothing", got.platform)
+	}
+}
+
+// The table spans platforms, unlike every other source in this loop, so each row's platform must
+// come from the row rather than being assumed.
+func TestProcessBatch_ModCredentialsKeepTheirOwnPlatform(t *testing.T) {
+	repo := &fakeRepo{
+		modCredentials: []*repository.ExpiringToken{
+			modCredential("mod-1", "twitch"),
+			modCredential("mod-2", "kick"),
+		},
+	}
+	m := newTestManager(repo, modProviders())
+
+	if err := m.ProcessBatch(context.Background()); err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	seen := map[string]string{}
+	for _, u := range repo.updatedModCreds {
+		seen[u.userID] = u.platform
+	}
+	if seen["mod-1"] != "twitch" {
+		t.Errorf("mod-1 updated with platform %q, want twitch", seen["mod-1"])
+	}
+	if seen["mod-2"] != "kick" {
+		t.Errorf("mod-2 updated with platform %q, want kick", seen["mod-2"])
+	}
+}
+
+// A moderator credential must never be written back through another source's updater — that
+// would target the wrong table and, worse, could write a moderator's token into a row a
+// listener selects from by channel.
+func TestProcessBatch_ModCredentialDoesNotTouchOtherTables(t *testing.T) {
+	repo := &fakeRepo{
+		modCredentials: []*repository.ExpiringToken{modCredential("mod-1", "twitch")},
+	}
+	m := newTestManager(repo, modProviders())
+
+	if err := m.ProcessBatch(context.Background()); err != nil {
+		t.Fatalf("ProcessBatch: %v", err)
+	}
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.updatedTwitchLinks) != 0 {
+		t.Errorf("a moderator credential was written to twitch_oauth_tokens (%d calls) — that table is selected from by channel with no user scoping", len(repo.updatedTwitchLinks))
+	}
+}

--- a/services/token-refresh-service/repository/token_repository.go
+++ b/services/token-refresh-service/repository/token_repository.go
@@ -645,3 +645,145 @@ func (r *TokenRepository) decryptToken(token string) (string, error) {
 	}
 	return r.cipher.DecryptString(token)
 }
+
+// QueryGetExpiringModCredentials selects expiring delegated-moderator credentials
+// (mod_oauth_credentials, ADR-0048). Unlike every other source here this table spans
+// platforms, so the platform is read from the row rather than assumed.
+//
+// Without this loop a moderator's credential simply expires. The grant would still look
+// active in the UI while every action failed, and the 90-day dormancy rule could never
+// fire because the moderator stopped being able to act long before that. Same bounded
+// 48-hour recovery window as the other sources.
+const QueryGetExpiringModCredentials = `
+	SELECT user_id, platform, platform_login, access_token, refresh_token, token_expires_at
+	FROM mod_oauth_credentials
+	WHERE (
+	    (token_expires_at < $1 AND token_expires_at > NOW())
+	    OR (token_expires_at BETWEEN NOW() - INTERVAL '48 hours' AND NOW())
+	  )
+	  AND refresh_token IS NOT NULL
+	  AND refresh_token != ''
+	ORDER BY token_expires_at ASC
+	LIMIT $2
+`
+
+// GetExpiringModCredentials returns delegated-moderator credentials (ADR-0048) expiring
+// within the specified duration.
+func (r *TokenRepository) GetExpiringModCredentials(ctx context.Context, expiresWithin time.Duration, limit int) ([]*ExpiringToken, error) {
+	expiryThreshold := time.Now().Add(expiresWithin)
+	rows, err := r.db.Query(ctx, QueryGetExpiringModCredentials, expiryThreshold, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query expiring moderator credentials: %w", err)
+	}
+	defer rows.Close()
+
+	var tokens []*ExpiringToken
+	for rows.Next() {
+		var token ExpiringToken
+		var encAccessToken, encRefreshToken string
+		var platformLogin *string
+
+		if err := rows.Scan(
+			&token.ID, // user_id (the moderator)
+			&token.Platform,
+			&platformLogin,
+			&encAccessToken,
+			&encRefreshToken,
+			&token.ExpiresAt,
+		); err != nil {
+			r.logger.Warn("Failed to scan moderator credential row", zap.Error(err))
+			continue
+		}
+
+		token.AccessToken, err = r.decryptToken(encAccessToken)
+		if err != nil {
+			r.logger.Warn("Failed to decrypt moderator access token",
+				zap.String("user_id", token.ID),
+				zap.String("platform", token.Platform),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		token.RefreshToken, err = r.decryptToken(encRefreshToken)
+		if err != nil {
+			r.logger.Warn("Failed to decrypt moderator refresh token",
+				zap.String("user_id", token.ID),
+				zap.String("platform", token.Platform),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		if platformLogin != nil {
+			token.Username = *platformLogin
+		}
+		// ChannelID doubles as the second half of this row's key, as it does for the other
+		// composite-key sources — here the platform, since the row is keyed
+		// (user_id, platform).
+		token.ChannelID = token.Platform
+		token.TokenType = "mod_credential"
+		tokens = append(tokens, &token)
+	}
+
+	return tokens, rows.Err()
+}
+
+// UpdateModCredentialTokens writes a refreshed delegated-moderator credential.
+//
+// granted_scopes is deliberately untouched: a refresh does not change what was consented
+// to, and rewriting it here would let a periodic job silently narrow a moderator's grant.
+func (r *TokenRepository) UpdateModCredentialTokens(ctx context.Context, userID, platform string, token *oauth2.Token) error {
+	encAccessToken, err := r.encryptToken(token.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt moderator access token: %w", err)
+	}
+
+	encRefreshToken, err := r.encryptToken(token.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt moderator refresh token: %w", err)
+	}
+
+	query := `
+		UPDATE mod_oauth_credentials
+		SET access_token = $3,
+		    refresh_token = $4,
+		    token_expires_at = $5,
+		    updated_at = NOW()
+		WHERE user_id = $1 AND platform = $2
+	`
+
+	result, err := r.db.Exec(ctx, query, userID, platform, encAccessToken, encRefreshToken, token.Expiry)
+	if err != nil {
+		return fmt.Errorf("failed to update moderator credential: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("moderator credential not found: user_id=%s, platform=%s", userID, platform)
+	}
+
+	return nil
+}
+
+// MarkModCredentialPermanentlyFailed suppresses a credential whose refresh token the
+// platform has permanently rejected, so the loop stops retrying it every cycle.
+//
+// The row is kept rather than deleted: the moderator's grants stay intact and the
+// capabilities payload can tell them to reconnect, which is actionable. Deleting it would
+// present as "you were never connected".
+func (r *TokenRepository) MarkModCredentialPermanentlyFailed(ctx context.Context, userID, platform string, suppressDuration time.Duration) error {
+	query := `
+		UPDATE mod_oauth_credentials
+		SET token_expires_at = NOW() + $3::interval,
+		    updated_at = NOW()
+		WHERE user_id = $1 AND platform = $2
+	`
+	interval := fmt.Sprintf("%d seconds", int(suppressDuration.Seconds()))
+	result, err := r.db.Exec(ctx, query, userID, platform, interval)
+	if err != nil {
+		return fmt.Errorf("failed to mark moderator credential permanently failed: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("moderator credential not found: user_id=%s, platform=%s", userID, platform)
+	}
+	return nil
+}

--- a/services/token-refresh-service/repository/token_repository_test.go
+++ b/services/token-refresh-service/repository/token_repository_test.go
@@ -174,3 +174,41 @@ func TestMarkTwitchLinkTokenPermanentlyFailed_MethodExists(t *testing.T) {
 	}
 	var _ permanentFailMarker = (*repository.TokenRepository)(nil)
 }
+
+// Delegated-moderator credentials (ADR-0048) get the same query-shape guarantees as every other
+// source: a bounded recovery window rather than an unbounded "expired" sweep, and a batch limit
+// that comes from the caller rather than being hardcoded.
+func TestGetExpiringModCredentials_QueryHasBoundedRecoveryWindow(t *testing.T) {
+	q := repository.QueryGetExpiringModCredentials
+	assertNoBoundedExpiredClause(t, "GetExpiringModCredentials", q)
+	assertBoundedRecoveryWindow(t, "GetExpiringModCredentials", q)
+}
+
+// The table is keyed (user_id, platform) and spans platforms, so both must be selected — the
+// platform cannot be assumed the way it can for the single-platform sources.
+func TestGetExpiringModCredentials_SelectsBothKeyColumns(t *testing.T) {
+	q := repository.QueryGetExpiringModCredentials
+	if !contains(q, "user_id") {
+		t.Error("query must select user_id")
+	}
+	if !contains(q, "platform") {
+		t.Error("query must select platform — the row is keyed (user_id, platform) and the table spans platforms")
+	}
+	if !contains(q, "mod_oauth_credentials") {
+		t.Error("query must read mod_oauth_credentials, not another credential table")
+	}
+}
+
+func TestUpdateModCredentialTokens_MethodExists(t *testing.T) {
+	type updater interface {
+		UpdateModCredentialTokens(ctx context.Context, userID, platform string, token *oauth2.Token) error
+	}
+	var _ updater = (*repository.TokenRepository)(nil)
+}
+
+func TestMarkModCredentialPermanentlyFailed_MethodExists(t *testing.T) {
+	type permanentFailMarker interface {
+		MarkModCredentialPermanentlyFailed(ctx context.Context, userID, platform string, suppressDuration time.Duration) error
+	}
+	var _ permanentFailMarker = (*repository.TokenRepository)(nil)
+}


### PR DESCRIPTION
Third slice of **ADR-0048**. Stacked on **#655** (base branch `feat/mod-consent-oauth-flow`).

## Why this is a prerequisite, not an optimisation

Without this loop a moderator's credential simply **expires**. The grant keeps looking active in the UI while every action fails with a confusing missing-scope or 401, and the **90-day dormancy suspension can never fire** — the moderator stopped being able to act long before that. The feature would appear broken for a reason nobody would connect to token expiry.

## What's different about this source

`mod_oauth_credentials` is the only source in the loop that **spans platforms**, so the platform is read from each row rather than assumed. `ChannelID` carries it, matching how the other composite-key sources carry the second half of their key, and the write-back dispatches on `token_type` like everything else.

That dispatch matters: writing one source's token through another's updater would target the wrong row, and for the channel-keyed tables could put a moderator's credential somewhere a listener selects from **by channel with no user scoping** — the exact hazard the separate table exists to avoid. There's a test asserting a moderator credential never reaches `twitch_oauth_tokens`.

## Two deliberate choices

- **`granted_scopes` is never rewritten on refresh.** A refresh does not change what was consented to, and letting a periodic job touch it would allow the loop to silently narrow someone's grant.
- **A permanently rejected refresh token suppresses the row rather than deleting it**, matching the other sources. The moderator's grants stay intact and the capabilities payload can tell them to reconnect, which is actionable; deleting would present as "you were never connected".

Same bounded 48-hour recovery window and caller-supplied batch limit as every other source, with the query-shape tests to match.

## Tests

- `refresher/mod_credential_test.go` — a credential is refreshed and written back with the right `(user_id, platform)` key; rows keep their own platform when Twitch and Kick are mixed in one batch; a moderator credential never reaches another table's updater.
- `repository/token_repository_test.go` — bounded recovery window (no unbounded expired sweep), caller-supplied limit, both key columns selected, correct table, and the update/mark-failed methods exist.

Also documents every credential source and its `token_type` in the service README, which previously described only a generic `oauth_tokens` query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLgC8YAUZgQuXKtJPC4AHd