### PR TITLE
feat(moderation): delegated-moderator grant lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Platform Listeners (Twitch IRC, YouTube API, Kick Pusher, TikTok WS, Discord Bot
 | `overlay-manager` | Overlay CRUD, source configuration, settings |
 | `source-manager` | Leader election, active source tracking, demand coordination |
 | `share-service` | Shareable overlay link generation; admin premium/beta-tester/ambassador role grants + feature gates; public ambassador showcase (ADR-0041) |
-| `moderation-service` | Cross-platform chat moderation write-path: delete / timeout / ban (ADR-0017) |
+| `moderation-service` | Cross-platform chat moderation write-path: delete / timeout / ban (ADR-0017); delegated-moderator grants (ADR-0048) |
 | `payment-service` | Patreon premium entitlements: grants `users.is_premium` (streamer, ADR-0018) and `viewers.is_premium` (viewer split, ADR-0019) from subscriptions |
 | `token-refresh-service` | OAuth token refresh on schedule |
 | `engagement-service` | Polls, predictions, and a per-overlay viewer points economy (#523) |

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -737,6 +737,20 @@ func main() {
 		// keeps reporting an ended/crashed stream as live.
 		protectedAPI.POST("/moderation/overlays/:id/youtube/rediscover", proxyHandler.ForwardRequest)
 
+		// Delegated moderators (ADR-0048) — grant lifecycle. Owner-only; moderation-service
+		// resolves the caller's role itself and answers a non-owner exactly as it answers an
+		// unknown overlay.
+		protectedAPI.GET("/moderation/overlays/:id/moderators", proxyHandler.ForwardRequest)
+		protectedAPI.POST("/moderation/overlays/:id/moderators", proxyHandler.ForwardRequest)
+		protectedAPI.PATCH("/moderation/overlays/:id/moderators/:grant_id", proxyHandler.ForwardRequest)
+		protectedAPI.DELETE("/moderation/overlays/:id/moderators/:grant_id", proxyHandler.ForwardRequest)
+		protectedAPI.DELETE("/moderation/overlays/:id/moderators", proxyHandler.ForwardRequest)
+		// Invite redemption is authorized by the SECRET, which travels in the request body — never
+		// in the path, where it would be captured by every access log along the way. The caller
+		// still needs a signed-in All-Chat account for the grant to bind to.
+		protectedAPI.POST("/moderation/invites/preview", proxyHandler.ForwardRequest)
+		protectedAPI.POST("/moderation/invites/accept", proxyHandler.ForwardRequest)
+
 		// Ambassador self-service (ADR-0041) — a streamer reads/sets their own
 		// homepage-showcase opt-in. -> share-service (enforces the ambassador role).
 		protectedAPI.GET("/ambassadors/me/showcase", proxyHandler.ForwardRequest)

--- a/services/auth-service/handlers/data_export.go
+++ b/services/auth-service/handlers/data_export.go
@@ -30,36 +30,56 @@ import (
 // It returns all personal data we store for the requesting user in a
 // machine-readable JSON format.
 type DataExportResponse struct {
-	ExportedAt string                   `json:"exported_at"`
-	User       DataExportUser           `json:"user"`
-	Overlays   []DataExportOverlay      `json:"overlays"`
-	Viewers    []DataExportViewer       `json:"viewers,omitempty"`
-	Guilds     []DataExportGuild        `json:"guilds,omitempty"`
-	Messages   []DataExportMessage      `json:"messages,omitempty"`
+	ExportedAt string              `json:"exported_at"`
+	User       DataExportUser      `json:"user"`
+	Overlays   []DataExportOverlay `json:"overlays"`
+	Viewers    []DataExportViewer  `json:"viewers,omitempty"`
+	Guilds     []DataExportGuild   `json:"guilds,omitempty"`
+	Messages   []DataExportMessage `json:"messages,omitempty"`
+	// Delegations covers both directions of a moderation grant (ADR-0048): people this user
+	// delegated moderation to, and overlays delegated to this user. Both are personal data about
+	// the exporting user, and neither is derivable from the sections above.
+	Delegations []DataExportDelegation `json:"moderation_delegations,omitempty"`
+}
+
+// DataExportDelegation is one delegated-moderation grant, from whichever side the exporting user
+// sits on.
+type DataExportDelegation struct {
+	// Direction is "granted" when the user delegated moderation on their own overlay, and
+	// "received" when someone delegated it to them.
+	Direction   string     `json:"direction"`
+	OverlayID   string     `json:"overlay_id"`
+	OverlayName string     `json:"overlay_name"`
+	Status      string     `json:"status"`
+	Actions     []string   `json:"actions"`
+	Counterpart string     `json:"counterpart,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	AcceptedAt  *time.Time `json:"accepted_at,omitempty"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
 }
 
 // DataExportUser contains the user profile (tokens excluded).
 type DataExportUser struct {
-	ID              string     `json:"id"`
-	Username        string     `json:"username"`
-	DisplayName     string     `json:"display_name"`
-	ProfileImageURL string     `json:"profile_image_url"`
-	AuthProvider    string     `json:"auth_provider"`
-	TwitchID        *string    `json:"twitch_id,omitempty"`
-	GoogleID        *string    `json:"google_id,omitempty"`
-	KickID          *string    `json:"kick_id,omitempty"`
-	IsPremium       bool       `json:"is_premium"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID              string    `json:"id"`
+	Username        string    `json:"username"`
+	DisplayName     string    `json:"display_name"`
+	ProfileImageURL string    `json:"profile_image_url"`
+	AuthProvider    string    `json:"auth_provider"`
+	TwitchID        *string   `json:"twitch_id,omitempty"`
+	GoogleID        *string   `json:"google_id,omitempty"`
+	KickID          *string   `json:"kick_id,omitempty"`
+	IsPremium       bool      `json:"is_premium"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // DataExportOverlay is a single overlay with its sources.
 type DataExportOverlay struct {
-	ID        string               `json:"id"`
-	Name      string               `json:"name"`
-	IsActive  bool                 `json:"is_active"`
-	CreatedAt time.Time            `json:"created_at"`
-	Sources   []DataExportSource   `json:"sources"`
+	ID        string             `json:"id"`
+	Name      string             `json:"name"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt time.Time          `json:"created_at"`
+	Sources   []DataExportSource `json:"sources"`
 }
 
 // DataExportSource is a connected chat source.
@@ -72,10 +92,10 @@ type DataExportSource struct {
 
 // DataExportViewer is a viewer session (tokens excluded).
 type DataExportViewer struct {
-	Platform      string    `json:"platform"`
-	Username      string    `json:"username"`
-	DisplayName   string    `json:"display_name"`
-	CreatedAt     time.Time `json:"created_at"`
+	Platform    string    `json:"platform"`
+	Username    string    `json:"username"`
+	DisplayName string    `json:"display_name"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // DataExportGuild is a connected Discord server.
@@ -136,6 +156,7 @@ func (h *AuthHandler) HandleDataExport(c *gin.Context) {
 	export.Viewers = fetchViewerSessions(ctx, db, uid, h.logger)
 	export.Guilds = fetchGuilds(ctx, db, uid, h.logger)
 	export.Messages = fetchMessages(ctx, db, uid, h.logger)
+	export.Delegations = fetchDelegations(ctx, db, uid, h.logger)
 
 	c.Header("Content-Disposition", "attachment; filename=allchat-data-export.json")
 	c.JSON(http.StatusOK, export)
@@ -224,6 +245,54 @@ func fetchGuilds(ctx context.Context, db *pgxpool.Pool, userID string, log *zap.
 			continue
 		}
 		out = append(out, g)
+	}
+	return out
+}
+
+// fetchDelegations returns every delegated-moderation grant the user is a party to, in both
+// directions (ADR-0048).
+//
+// Revoked grants are included deliberately: they are retained as history, so a portability export
+// that omitted them would misreport what All-Chat still holds. Erasure needs no counterpart here —
+// overlay_moderators cascades from both overlays and users, so deleting the account removes every
+// row where this user is the moderator, and every row on their own overlays.
+func fetchDelegations(ctx context.Context, db *pgxpool.Pool, userID string, log *zap.Logger) []DataExportDelegation {
+	rows, err := db.Query(ctx, `
+		SELECT 'granted', m.overlay_id::text, o.name, m.status, m.actions,
+		       -- The name captured at accept time, else whoever the account says it is now, else
+		       -- the label the streamer typed on an invite nobody has redeemed.
+		       COALESCE(NULLIF(m.moderator_display_name, ''), NULLIF(mod_user.display_name, ''),
+		                m.invitee_label, ''),
+		       m.created_at, m.accepted_at, m.revoked_at
+		FROM overlay_moderators m
+		JOIN overlays o ON o.id = m.overlay_id
+		LEFT JOIN users mod_user ON mod_user.id = m.moderator_user_id
+		WHERE o.user_id = $1
+		UNION ALL
+		SELECT 'received', m.overlay_id::text, o.name, m.status, m.actions,
+		       COALESCE(owner.display_name, ''),
+		       m.created_at, m.accepted_at, m.revoked_at
+		FROM overlay_moderators m
+		JOIN overlays o ON o.id = m.overlay_id
+		JOIN users owner ON owner.id = o.user_id
+		WHERE m.moderator_user_id = $1
+		ORDER BY 7`, userID)
+	if err != nil {
+		// The table may not exist yet on a deployment that has not run migration 080. A partial
+		// export is better than none.
+		log.Warn("Data export: failed to fetch moderation delegations", zap.Error(err))
+		return nil
+	}
+	defer rows.Close()
+
+	var out []DataExportDelegation
+	for rows.Next() {
+		var d DataExportDelegation
+		if err := rows.Scan(&d.Direction, &d.OverlayID, &d.OverlayName, &d.Status, &d.Actions,
+			&d.Counterpart, &d.CreatedAt, &d.AcceptedAt, &d.RevokedAt); err != nil {
+			continue
+		}
+		out = append(out, d)
 	}
 	return out
 }

--- a/services/auth-service/handlers/data_export_delegations_test.go
+++ b/services/auth-service/handlers/data_export_delegations_test.go
@@ -1,0 +1,236 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.uber.org/zap"
+)
+
+// A delegated-moderation grant is personal data about both parties (ADR-0048), and it is not
+// derivable from any other section of the export: the streamer's overlays list says nothing about
+// who may moderate them, and a moderator's own overlays say nothing about channels delegated to
+// them. So both directions have to appear.
+func TestFetchDelegations_ReportsBothDirections(t *testing.T) {
+	pool, cleanup := setupDelegationExportDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		streamer = "11111111-1111-1111-1111-111111111111"
+		mod      = "22222222-2222-2222-2222-222222222222"
+		other    = "33333333-3333-3333-3333-333333333333"
+		mine     = "aaaaaaaa-1111-1111-1111-111111111111"
+		theirs   = "aaaaaaaa-2222-2222-2222-222222222222"
+	)
+	_, err := pool.Exec(ctx, `
+		INSERT INTO users (id, display_name) VALUES
+			($1, 'The Streamer'), ($2, 'Sarah'), ($3, 'Another Streamer')`, streamer, mod, other)
+	if err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'My Overlay'), ($3, $4, 'Their Overlay')`,
+		mine, streamer, theirs, other); err != nil {
+		t.Fatalf("seed overlays: %v", err)
+	}
+	// The streamer delegated to Sarah on their own overlay, and Another Streamer delegated to the
+	// streamer on theirs.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO overlay_moderators
+			(overlay_id, moderator_user_id, granted_by, status, actions, accepted_at, created_at)
+		VALUES
+			($1, $2, $3, 'active', '{delete,timeout}', NOW(), NOW() - INTERVAL '2 days'),
+			($4, $3, $5, 'active', '{delete}', NOW(), NOW() - INTERVAL '1 day')`,
+		mine, mod, streamer, theirs, other); err != nil {
+		t.Fatalf("seed grants: %v", err)
+	}
+
+	got := fetchDelegations(ctx, pool, streamer, zap.NewNop())
+	if len(got) != 2 {
+		t.Fatalf("expected both directions, got %d: %+v", len(got), got)
+	}
+
+	byDirection := map[string]DataExportDelegation{}
+	for _, d := range got {
+		byDirection[d.Direction] = d
+	}
+	granted, ok := byDirection["granted"]
+	if !ok {
+		t.Fatal("the moderators a streamer delegated to must appear in their export")
+	}
+	if granted.OverlayName != "My Overlay" || granted.Counterpart != "Sarah" {
+		t.Errorf("granted grant misreported: %+v", granted)
+	}
+	if len(granted.Actions) != 2 {
+		t.Errorf("the delegated actions are part of the record: %+v", granted.Actions)
+	}
+
+	received, ok := byDirection["received"]
+	if !ok {
+		t.Fatal("overlays delegated TO the user must appear too — nothing else in the export shows them")
+	}
+	if received.OverlayName != "Their Overlay" || received.Counterpart != "Another Streamer" {
+		t.Errorf("received grant misreported: %+v", received)
+	}
+
+	// A revoked grant is retained as history, so an export that hid it would misreport what
+	// All-Chat still holds about the person.
+	t.Run("revoked grants are still reported", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `
+			UPDATE overlay_moderators SET status = 'revoked', revoked_at = NOW()
+			WHERE overlay_id = $1`, mine); err != nil {
+			t.Fatalf("revoke: %v", err)
+		}
+		got := fetchDelegations(ctx, pool, streamer, zap.NewNop())
+		if len(got) != 2 {
+			t.Fatalf("expected 2 grants after revocation, got %d", len(got))
+		}
+		for _, d := range got {
+			if d.Direction == "granted" && d.RevokedAt == nil {
+				t.Error("a revoked grant must carry its revocation date")
+			}
+		}
+	})
+
+	t.Run("a user with no delegations gets no section", func(t *testing.T) {
+		if got := fetchDelegations(ctx, pool, mod, zap.NewNop()); len(got) != 1 {
+			t.Fatalf("Sarah has exactly one received grant, got %d", len(got))
+		}
+		lonely := "44444444-4444-4444-4444-444444444444"
+		if _, err := pool.Exec(ctx, `INSERT INTO users (id, display_name) VALUES ($1, 'Nobody')`, lonely); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		if got := fetchDelegations(ctx, pool, lonely, zap.NewNop()); len(got) != 0 {
+			t.Fatalf("expected no delegations, got %+v", got)
+		}
+	})
+}
+
+// Erasure needs no delegation-specific code: overlay_moderators cascades from BOTH overlays and
+// users, so deleting the account takes every row on either side with it. If that ever stops being
+// true, a deleted volunteer would keep a live grant on someone's channel.
+func TestDeletingAnAccountCascadesItsDelegations(t *testing.T) {
+	pool, cleanup := setupDelegationExportDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		streamer = "11111111-1111-1111-1111-111111111111"
+		mod      = "22222222-2222-2222-2222-222222222222"
+		overlay  = "aaaaaaaa-1111-1111-1111-111111111111"
+	)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (id, display_name) VALUES ($1, 'Streamer'), ($2, 'Sarah')`, streamer, mod); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'My Overlay')`, overlay, streamer); err != nil {
+		t.Fatalf("seed overlay: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO overlay_moderators (overlay_id, moderator_user_id, granted_by, status)
+		VALUES ($1, $2, $3, 'active')`, overlay, mod, streamer); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, mod); err != nil {
+		t.Fatalf("delete moderator: %v", err)
+	}
+	var remaining int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM overlay_moderators`).Scan(&remaining); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if remaining != 0 {
+		t.Errorf("deleting the moderator's account must remove their grant, %d left", remaining)
+	}
+}
+
+// setupDelegationExportDB starts a throwaway Postgres carrying the columns the delegation export
+// reads, with migration 080's cascade behaviour intact.
+func setupDelegationExportDB(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:16-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "testuser",
+			"POSTGRES_PASSWORD": "testpass",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req, Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "5432")
+	if err != nil {
+		t.Fatalf("container port: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, "postgres://testuser:testpass@"+host+":"+port.Port()+"/testdb?sslmode=disable")
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE users (
+			id UUID PRIMARY KEY,
+			display_name VARCHAR(100) NOT NULL DEFAULT ''
+		);
+		CREATE TABLE overlays (
+			id UUID PRIMARY KEY,
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			name VARCHAR(100) NOT NULL DEFAULT ''
+		);
+		CREATE TABLE overlay_moderators (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			overlay_id UUID NOT NULL REFERENCES overlays(id) ON DELETE CASCADE,
+			moderator_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+			granted_by UUID NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'pending',
+			actions TEXT[] NOT NULL DEFAULT '{delete,timeout}',
+			invitee_label VARCHAR(120),
+			moderator_display_name VARCHAR(120),
+			created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			accepted_at TIMESTAMP,
+			revoked_at TIMESTAMP
+		);`); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+
+	return pool, func() {
+		pool.Close()
+		_ = container.Terminate(ctx)
+	}
+}

--- a/services/moderation-service/README.md
+++ b/services/moderation-service/README.md
@@ -25,6 +25,50 @@ All require a user JWT (forwarded by the gateway; re-validated here). Mounted un
 Send a unique `Idempotency-Key` header on each POST (double-click/retry dedup). Per-user rate limiting
 applies (`MODERATION_RATE_PER_MIN`, default 30/min).
 
+### Delegation grant lifecycle (ADR-0048)
+
+Owner-only. A delegated moderator gets the same 403 a stranger does — managing who may moderate is an
+ownership power, not a moderation power.
+
+| Method | Path | Body |
+|---|---|---|
+| `GET`    | `/overlays/:id/moderators` | — → `{ moderators: [{id, status, display_name?, invitee_label?, actions[], platforms: [{platform, enabled, verification}], invite_expires_at?, …}], cap, used }` |
+| `POST`   | `/overlays/:id/moderators` | `{ actions?, platforms?, invitee_label?, expected_platform?, expected_platform_user_id? }` → **201** `{ grant_id, invite_token, expires_at, … }` |
+| `PATCH`  | `/overlays/:id/moderators/:grant_id` | `{ actions?, platforms? }` — `platforms` is a `{platform: bool}` map; only the platforms it names change |
+| `DELETE` | `/overlays/:id/moderators/:grant_id` | — revoke one |
+| `DELETE` | `/overlays/:id/moderators` | — the kill switch: revoke every grant on the overlay, unredeemed invites included |
+
+`invite_token` is a 256-bit secret returned **exactly once**; only its SHA-256 is stored, so a lost
+invite is re-minted rather than re-displayed. It expires after 7 days, is single-use, and dies the
+moment the grant is revoked.
+
+Absent `actions` grants the safe default (`delete`, `timeout`); an explicitly empty list is a 400 rather
+than being widened. Absent `platforms` enables nothing — absence *is* disablement, which is what keeps
+Discord (the one platform with no external authority behind it) off until the streamer opts in.
+`expected_platform` pre-binds an invite to one account and is accepted for Twitch only, because that is
+the only platform where acceptance can actually verify the redeeming account; storing an unverifiable
+binding would look like a constraint while protecting nobody.
+
+The 10-moderator cap is enforced at invite time (409 `moderator_cap_reached`), never retroactively, so
+lowering it can't cut off a working mod team mid-stream. Admins bypass it. The count is taken under a row
+lock on the overlay, so two tabs cannot both see nine and both insert.
+
+Redemption is keyed on the secret, not on any role:
+
+| Method | Path | Body |
+|---|---|---|
+| `POST` | `/invites/preview` | `{ token }` → `{ overlay_name, owner_display_name, actions[], platforms[], expires_at, expected_account? }` |
+| `POST` | `/invites/accept`  | `{ token }` → `{ grant_id, overlay_id, overlay_name, … }` |
+
+The secret travels in the **body**, never in a path — a URL would put a live moderation credential into
+every access log, proxy log and `Referer` header along the way. `preview` deliberately omits
+`overlay_id`: an overlay UUID already grants chat *read* to whoever holds it, so it is disclosed on
+acceptance rather than to everyone who merely opens the link. Accepting grants nothing by itself; each
+platform's consent is deferred to the first time the moderator actually uses it.
+
+Only invite **creation** is gated. Listing, narrowing and revoking always work, including after the
+feature is rolled back — otherwise a streamer could be left holding moderators they cannot remove.
+
 ## Authorization (owner or delegated moderator — ADR-0017, amended by ADR-0048)
 
 1. `ResolveOverlayAccess` resolves, in one round trip, the caller's role (`owner` / `moderator` /
@@ -83,6 +127,11 @@ moderation permissions reports no actions and the dashboard shows the re-invite 
 
 ## Rollout (feature gate, ADR-0008)
 
+Delegation has its **own** gate key, `delegated_moderation` (seeded `is_premium=TRUE`, migration 080), so
+it can be rolled back without disabling owner moderation. It requires both keys: closing `moderation`
+necessarily closes delegation, since there would be nothing left to delegate. Both are evaluated against
+the **overlay owner**.
+
 The write path is gated on the `moderation` feature gate, seeded `is_premium=TRUE` (migration 061) so
 it ships to a premium cohort first. The `delete/timeout/ban/unban` routes enforce it inside
 `authorize()`, keyed on the **overlay owner** (ADR-0048 — `RequirePremium` middleware keys on the
@@ -126,15 +175,16 @@ no redeploy. Locally, non-premium users can either set `users.is_premium=true` o
 
 ```
 cmd/main.go        # wiring: db, redis, JWT keychain, cipher, per-platform token sources, dispatch router, rate-limit, routes
-handler/           # HTTP handlers + idempotency middleware (owner-only authz, dispatch, capabilities); scope-check router
+handler/           # HTTP handlers + idempotency middleware (role authz, dispatch, capabilities); grant lifecycle; scope-check router
 clients/           # per-platform moderation API clients (twitch, kick, discord, youtube + liveChat resolver; httptest-mocked)
+invites/           # invite secrets: crypto/rand mint + SHA-256 digest (the plaintext is never stored)
 tokens/            # broadcaster-token resolve/refresh (ADR-0016 selection) + granted-scope checkers (twitch, kick, youtube)
 dispatch/          # per-platform routers + orchestration: multi.go routes by platform; scope pre-check, refresh, 401-retry, 403->re-consent
 quota/             # YouTube ban quota reservation over the shared SQL functions (ADR-0006)
 publisher/         # reflect-back: RawChatMessage{message_deletion} -> chat:raw (carries target_uuid)
-repository/        # owner/source authorization queries (mirrors api-gateway/subscription)
+repository/        # role/source authorization queries + delegation grant lifecycle (migration 080)
 audit/             # moderation_actions audit log (migration 060)
-models/            # request DTOs + capability model + platform support matrix + per-platform scope mapping
+models/            # request DTOs + capability model + platform support matrix + per-platform scope mapping + grant DTOs
 ```
 
 ## Configuration

--- a/services/moderation-service/cmd/main.go
+++ b/services/moderation-service/cmd/main.go
@@ -199,14 +199,20 @@ func main() {
 	var dispatcher handler.Dispatcher = dispatch.NewMulti(dispatchers)
 	var scopeChecker handler.ScopeChecker = handler.MultiScopeChecker(scopeCheckers)
 
+	gate := moderationGate{gates: gateCache, repo: repo}
+
 	modHandler := handler.New(repo, deletionPublisher, auditStore, scopeChecker, dispatcher, log)
 	// Surface the cohort decision on the capabilities endpoint so the dashboard hides
 	// controls for users outside the rollout (the action routes are gated separately).
-	modHandler.SetFeatureGate(moderationGate{gates: gateCache, repo: repo})
+	modHandler.SetFeatureGate(gate)
 	// Wire the chat-send capability checker so capabilities report can_send per source.
 	modHandler.SetSendChecker(handler.MultiSendChecker(sendCheckers))
 	// Wire the YouTube stream re-discovery publisher (owner-triggered recovery from /view).
 	modHandler.SetRediscoverPublisher(publisher.NewRediscoverPublisher(redisClient, log))
+
+	// Delegated-moderator grant lifecycle (ADR-0048): invite, accept, revoke.
+	grantHandler := handler.NewGrantHandler(repo, repo, log)
+	grantHandler.SetFeatureGate(gate)
 
 	if cfg.GinMode == "release" {
 		gin.SetMode(gin.ReleaseMode)
@@ -270,6 +276,23 @@ func main() {
 		actions.POST("/overlays/:id/unban", modHandler.HandleUnban)
 	}
 
+	// Delegation grant lifecycle (ADR-0048). Owner-only, enforced in the handler against the same
+	// role resolution the action path uses, so an unknown overlay and an unauthorized one are
+	// indistinguishable here too. Only invite creation is gated: listing, narrowing and revoking a
+	// grant must keep working after a rollback, or a streamer could be left with moderators they
+	// cannot remove.
+	api.GET("/overlays/:id/moderators", grantHandler.HandleListModerators)
+	api.POST("/overlays/:id/moderators", grantHandler.HandleCreateInvite)
+	api.PATCH("/overlays/:id/moderators/:grant_id", grantHandler.HandleUpdateGrant)
+	api.DELETE("/overlays/:id/moderators/:grant_id", grantHandler.HandleRevokeGrant)
+	api.DELETE("/overlays/:id/moderators", grantHandler.HandleRevokeAll)
+
+	// Invite redemption is keyed on the SECRET, not on any role: the holder has no relationship to
+	// the overlay yet. The secret travels in the request body rather than the path so it never
+	// lands in an access log, a proxy log or a Referer header.
+	api.POST("/invites/preview", grantHandler.HandlePreviewInvite)
+	api.POST("/invites/accept", grantHandler.HandleAcceptInvite)
+
 	srv := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      router,
@@ -310,6 +333,21 @@ type moderationGate struct {
 
 func (g moderationGate) ModerationEnabled(ctx context.Context, userID string) (bool, error) {
 	if !g.gates.IsPremium(featuregates.GateModeration) {
+		return true, nil
+	}
+	return g.repo.IsUserPremium(ctx, userID)
+}
+
+// DelegationEnabled gates handing the write-path to someone else (ADR-0048). Delegation requires
+// the base moderation gate AND its own key, so `delegated_moderation` can be closed to roll
+// delegation back without taking owner moderation away — and closing `moderation` necessarily
+// closes delegation too, since there is nothing left to delegate.
+func (g moderationGate) DelegationEnabled(ctx context.Context, userID string) (bool, error) {
+	enabled, err := g.ModerationEnabled(ctx, userID)
+	if err != nil || !enabled {
+		return false, err
+	}
+	if !g.gates.IsPremium(featuregates.GateDelegatedModeration) {
 		return true, nil
 	}
 	return g.repo.IsUserPremium(ctx, userID)

--- a/services/moderation-service/handler/grants.go
+++ b/services/moderation-service/handler/grants.go
@@ -1,0 +1,621 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/invites"
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/zap"
+)
+
+// GrantStore is the grant-lifecycle surface of the repository (ADR-0048). Declared here per the
+// codebase's interface-for-DI convention so the handlers are unit-testable with fakes.
+type GrantStore interface {
+	CreateInvite(ctx context.Context, p repository.InviteParams) (repository.Grant, error)
+	ListGrants(ctx context.Context, overlayID string) ([]repository.Grant, error)
+	UpdateGrant(ctx context.Context, overlayID, grantID string, actions []string, legs map[string]bool) (repository.Grant, error)
+	RevokeGrant(ctx context.Context, overlayID, grantID, revokedBy string) (bool, error)
+	RevokeAllGrants(ctx context.Context, overlayID, revokedBy string) (int, error)
+	PreviewInvite(ctx context.Context, tokenHash []byte) (repository.InviteDetails, error)
+	AcceptInvite(ctx context.Context, tokenHash []byte, userID string) (repository.InviteDetails, error)
+}
+
+// AccessResolver answers who the caller is on an overlay. The grant endpoints need only the role,
+// but they resolve it exactly the way the action path does, so "the overlay does not exist" and
+// "you have no role" stay indistinguishable everywhere.
+type AccessResolver interface {
+	ResolveOverlayAccess(ctx context.Context, overlayID, callerID string) (repository.OverlayAccess, error)
+}
+
+// grantEvents counts lifecycle transitions, which is what a streamer's support ticket ("someone
+// removed my mods") and a security review both need. The grant rows carry the durable trail;
+// this makes the rate visible.
+var grantEvents = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "allchat_moderation_grant_events_total",
+	Help: "Delegated-moderation grant lifecycle events.",
+}, []string{"event"})
+
+// Machine-readable codes for the delegation endpoints. The frontend keys its copy on these rather
+// than on message text.
+const (
+	codeCapReached        = "moderator_cap_reached"
+	codeGrantNotFound     = "grant_not_found"
+	codeInviteNotFound    = "invite_not_found"
+	codeInviteExpired     = "invite_expired"
+	codeAlreadyModerator  = "already_moderator"
+	codeOwnerCannotAccept = "owner_cannot_accept"
+	codeInviteBound       = "invite_bound_to_other_account"
+	codeUnavailable       = "delegation_unavailable"
+	codeInvalidRequest    = "invalid_request"
+)
+
+// GrantHandler serves the delegated-moderator grant lifecycle: invite, accept, revoke.
+//
+// Every owner-side route is owner-only. Managing who may moderate is an ownership power, not a
+// moderation power: a delegated moderator who could invite others, widen their own grant or revoke
+// a colleague would have escalated past what the streamer handed them.
+type GrantHandler struct {
+	access AccessResolver
+	grants GrantStore
+	gate   FeatureGate
+	logger *zap.Logger
+}
+
+// NewGrantHandler creates the grant-lifecycle handler. The gate defaults to OpenGate (always
+// enabled) for local/dry-run deployments; production overrides it with SetFeatureGate.
+func NewGrantHandler(access AccessResolver, grants GrantStore, logger *zap.Logger) *GrantHandler {
+	return &GrantHandler{access: access, grants: grants, gate: OpenGate{}, logger: logger}
+}
+
+// SetFeatureGate overrides the feature gate (ADR-0008). Call once at startup before serving.
+func (h *GrantHandler) SetFeatureGate(g FeatureGate) { h.gate = g }
+
+// HandleListModerators reports the overlay's delegation roster.
+//
+// Never gated. A streamer must always be able to see — and therefore remove — whoever can moderate
+// for them, including after a rollback of the delegation feature.
+func (h *GrantHandler) HandleListModerators(c *gin.Context) {
+	overlayID, _, ok := h.requireOwner(c)
+	if !ok {
+		return
+	}
+
+	grants, err := h.grants.ListGrants(c.Request.Context(), overlayID)
+	if err != nil {
+		h.internalError(c, "list grants failed", err)
+		return
+	}
+
+	list := models.ModeratorList{
+		Moderators: make([]models.ModeratorGrant, 0, len(grants)),
+		Cap:        models.ModeratorsPerOverlayCap,
+		Used:       len(grants),
+	}
+	for _, g := range grants {
+		list.Moderators = append(list.Moderators, toModeratorGrant(g))
+	}
+	c.JSON(http.StatusOK, list)
+}
+
+// HandleCreateInvite mints a single-use invite.
+//
+// The secret is returned in this response and never again: it is stored only as a digest, so there
+// is no "show it again" — a lost invite is re-minted, which is the correct trade for a token that
+// can hand someone the moderation write-path on a live channel.
+func (h *GrantHandler) HandleCreateInvite(c *gin.Context) {
+	overlayID, access, ok := h.requireOwner(c)
+	if !ok {
+		return
+	}
+
+	var req models.CreateInviteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.badRequest(c, err.Error())
+		return
+	}
+
+	actions, err := models.NormalizeDelegatedActions(req.Actions)
+	if err != nil {
+		h.badRequest(c, err.Error())
+		return
+	}
+	platforms, err := models.NormalizeDelegatedPlatforms(req.Platforms)
+	if err != nil {
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error(), "code": codeInvalidRequest})
+		return
+	}
+	if err := validatePreBinding(req.ExpectedPlatform, req.ExpectedPlatformUserID); err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, errBindingUnsupported) {
+			status = http.StatusUnprocessableEntity
+		}
+		c.JSON(status, gin.H{"error": err.Error(), "code": codeInvalidRequest})
+		return
+	}
+
+	// Entitlement keys on the overlay owner, who is also the caller here — but the copy stays
+	// owner-facing, because only the streamer can act on it.
+	enabled, err := h.gate.DelegationEnabled(c.Request.Context(), access.OwnerUserID)
+	if err != nil {
+		h.internalError(c, "delegation gate check failed", err)
+		return
+	}
+	if !enabled {
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":       "delegating moderation requires All-Chat premium",
+			"code":        codeUnavailable,
+			"upgrade_url": "/upgrade",
+		})
+		return
+	}
+
+	secret, err := invites.NewSecret()
+	if err != nil {
+		h.internalError(c, "mint invite secret failed", err)
+		return
+	}
+	expiresAt := time.Now().Add(invites.TTL)
+
+	grant, err := h.grants.CreateInvite(c.Request.Context(), repository.InviteParams{
+		OverlayID:              overlayID,
+		GrantedBy:              c.GetString("user_id"),
+		Actions:                actions,
+		Platforms:              platforms,
+		InviteeLabel:           models.TrimInviteeLabel(req.InviteeLabel),
+		ExpectedPlatform:       req.ExpectedPlatform,
+		ExpectedPlatformUserID: req.ExpectedPlatformUserID,
+		TokenHash:              invites.Hash(secret),
+		ExpiresAt:              expiresAt,
+		// An admin raising the cap for a large channel is the documented escape hatch.
+		BypassCap: isAdmin(c),
+	})
+	switch {
+	case errors.Is(err, repository.ErrModeratorCapReached):
+		grantEvents.WithLabelValues("cap_reached").Inc()
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "this overlay already has the maximum number of moderators",
+			"code":  codeCapReached,
+			"cap":   models.ModeratorsPerOverlayCap,
+		})
+		return
+	case errors.Is(err, repository.ErrOverlayNotFound):
+		// Racing a deletion between the access check and the insert.
+		h.denyNoRole(c, overlayID, "unknown_overlay")
+		return
+	case err != nil:
+		h.internalError(c, "create invite failed", err)
+		return
+	}
+
+	grantEvents.WithLabelValues("invited").Inc()
+	h.logger.Info("delegated-moderation invite created",
+		zap.String("overlay_id", overlayID),
+		zap.String("grant_id", grant.ID),
+		zap.String("granted_by", c.GetString("user_id")),
+		zap.Strings("actions", actions),
+		zap.Strings("platforms", platforms))
+
+	c.JSON(http.StatusCreated, models.InviteCreated{
+		GrantID:      grant.ID,
+		InviteToken:  secret,
+		ExpiresAt:    expiresAt,
+		Actions:      actions,
+		Platforms:    platforms,
+		InviteeLabel: grant.InviteeLabel,
+	})
+}
+
+// HandleUpdateGrant narrows or widens a live grant: which actions it carries, and which platform
+// legs are enabled.
+//
+// Not gated. Narrowing a grant is a de-escalation, and a closed gate must never stand between a
+// streamer and taking a permission away.
+func (h *GrantHandler) HandleUpdateGrant(c *gin.Context) {
+	overlayID, _, ok := h.requireOwner(c)
+	if !ok {
+		return
+	}
+
+	var req models.UpdateGrantRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.badRequest(c, err.Error())
+		return
+	}
+
+	var actions []string
+	if req.Actions != nil {
+		normalized, err := models.NormalizeDelegatedActions(req.Actions)
+		if err != nil {
+			h.badRequest(c, err.Error())
+			return
+		}
+		actions = normalized
+	}
+	for platform := range req.Platforms {
+		if _, err := models.NormalizeDelegatedPlatforms([]string{platform}); err != nil {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error(), "code": codeInvalidRequest})
+			return
+		}
+	}
+
+	grantID := c.Param("grant_id")
+	updated, err := h.grants.UpdateGrant(c.Request.Context(), overlayID, grantID, actions, req.Platforms)
+	switch {
+	case errors.Is(err, repository.ErrGrantNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "no such moderator on this overlay", "code": codeGrantNotFound})
+		return
+	case err != nil:
+		h.internalError(c, "update grant failed", err)
+		return
+	}
+
+	grantEvents.WithLabelValues("updated").Inc()
+	h.logger.Info("delegated-moderation grant updated",
+		zap.String("overlay_id", overlayID),
+		zap.String("grant_id", grantID),
+		zap.Strings("actions", updated.Actions))
+
+	c.JSON(http.StatusOK, toModeratorGrant(updated))
+}
+
+// HandleRevokeGrant removes one delegation. Revocation takes effect on the very next request: the
+// action path reads the grant live and never caches it.
+//
+// Never gated — see HandleListModerators.
+func (h *GrantHandler) HandleRevokeGrant(c *gin.Context) {
+	overlayID, _, ok := h.requireOwner(c)
+	if !ok {
+		return
+	}
+
+	grantID := c.Param("grant_id")
+	revoked, err := h.grants.RevokeGrant(c.Request.Context(), overlayID, grantID, c.GetString("user_id"))
+	if err != nil {
+		h.internalError(c, "revoke grant failed", err)
+		return
+	}
+	if !revoked {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no such moderator on this overlay", "code": codeGrantNotFound})
+		return
+	}
+
+	grantEvents.WithLabelValues("revoked").Inc()
+	h.logger.Info("delegated-moderation grant revoked",
+		zap.String("overlay_id", overlayID),
+		zap.String("grant_id", grantID),
+		zap.String("revoked_by", c.GetString("user_id")))
+
+	c.JSON(http.StatusOK, gin.H{"revoked": true})
+}
+
+// HandleRevokeAll is the kill switch: every delegation on the overlay goes at once, unredeemed
+// invites included.
+//
+// Never gated, and deliberately blunt — the streamer reaching for this is not in a mood to
+// deselect ten checkboxes.
+func (h *GrantHandler) HandleRevokeAll(c *gin.Context) {
+	overlayID, _, ok := h.requireOwner(c)
+	if !ok {
+		return
+	}
+
+	count, err := h.grants.RevokeAllGrants(c.Request.Context(), overlayID, c.GetString("user_id"))
+	if err != nil {
+		h.internalError(c, "revoke all grants failed", err)
+		return
+	}
+
+	grantEvents.WithLabelValues("revoked_all").Add(float64(count))
+	h.logger.Warn("delegated moderation revoked for a whole overlay",
+		zap.String("overlay_id", overlayID),
+		zap.String("revoked_by", c.GetString("user_id")),
+		zap.Int("revoked", count))
+
+	c.JSON(http.StatusOK, gin.H{"revoked": count})
+}
+
+// HandlePreviewInvite shows what an invite is for, without redeeming it: which overlay, whose, and
+// what the moderator would be agreeing to do.
+//
+// Authentication is still required (the route sits behind the service's JWT middleware) but no
+// role is: the invite secret is the authority, and the holder has no relationship to the overlay
+// yet by definition.
+func (h *GrantHandler) HandlePreviewInvite(c *gin.Context) {
+	hash, ok := h.inviteHash(c)
+	if !ok {
+		return
+	}
+
+	details, err := h.grants.PreviewInvite(c.Request.Context(), hash)
+	if !h.writeInviteError(c, err) {
+		return
+	}
+
+	c.JSON(http.StatusOK, models.InvitePreview{
+		OverlayName:      details.OverlayName,
+		OwnerDisplayName: details.OwnerDisplayName,
+		Actions:          details.Actions,
+		Platforms:        toLegs(details.Platforms),
+		ExpiresAt:        derefTime(details.InviteExpiresAt),
+		InviteeLabel:     details.InviteeLabel,
+		ExpectedPlatform: details.ExpectedPlatform,
+		ExpectedAccount:  expectedAccount(details.Grant),
+	})
+}
+
+// HandleAcceptInvite redeems an invite for the signed-in account.
+//
+// Acceptance is the record that this person agreed to act on someone else's behalf, and it is what
+// binds a pre-bound invite to the right account. It grants nothing by itself: consent for each
+// platform is deferred to the first time the moderator actually uses it.
+func (h *GrantHandler) HandleAcceptInvite(c *gin.Context) {
+	callerID := c.GetString("user_id")
+	if callerID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing user context"})
+		return
+	}
+	hash, ok := h.inviteHash(c)
+	if !ok {
+		return
+	}
+
+	details, err := h.grants.AcceptInvite(c.Request.Context(), hash, callerID)
+	// Handled here rather than in writeInviteError because only acceptance can produce it, and the
+	// response needs the expectation the repository returned alongside the error: naming the
+	// account the invite is for turns a dead end into "sign in as that account".
+	if errors.Is(err, repository.ErrInviteBoundToOtherAccount) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":             "this invite was created for a different account",
+			"code":              codeInviteBound,
+			"expected_account":  details.InviteeLabel,
+			"expected_platform": details.ExpectedPlatform,
+		})
+		return
+	}
+	if !h.writeInviteError(c, err) {
+		return
+	}
+
+	grantEvents.WithLabelValues("accepted").Inc()
+	h.logger.Info("delegated-moderation invite accepted",
+		zap.String("overlay_id", details.OverlayID),
+		zap.String("grant_id", details.ID),
+		zap.String("moderator_user_id", callerID))
+
+	c.JSON(http.StatusOK, models.InviteAccepted{
+		GrantID:          details.ID,
+		OverlayID:        details.OverlayID,
+		OverlayName:      details.OverlayName,
+		OwnerDisplayName: details.OwnerDisplayName,
+		Actions:          details.Actions,
+		Platforms:        toLegs(details.Platforms),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Shared plumbing
+// ---------------------------------------------------------------------------
+
+// requireOwner resolves the caller's role and admits only the overlay owner.
+//
+// Every refusal — no role, a delegated moderator reaching for an owner power, or an overlay that
+// does not exist — produces the identical 403 body, so these endpoints cannot be used to discover
+// which overlay ids are real.
+func (h *GrantHandler) requireOwner(c *gin.Context) (string, repository.OverlayAccess, bool) {
+	overlayID := c.Param("id")
+	callerID := c.GetString("user_id")
+	if callerID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing user context"})
+		return "", repository.OverlayAccess{}, false
+	}
+
+	access, err := h.access.ResolveOverlayAccess(c.Request.Context(), overlayID, callerID)
+	switch {
+	case errors.Is(err, repository.ErrOverlayNotFound):
+		h.denyNoRole(c, overlayID, "unknown_overlay")
+		return "", repository.OverlayAccess{}, false
+	case err != nil:
+		h.internalError(c, "overlay access resolution failed", err)
+		return "", repository.OverlayAccess{}, false
+	}
+	if !access.IsOwner() {
+		reason := "not_owner"
+		if access.Role == repository.RoleModerator {
+			// Worth its own label: a moderator reaching for an owner power is a different signal
+			// from a stranger probing ids.
+			reason = "moderator_attempted_owner_action"
+		}
+		h.denyNoRole(c, overlayID, reason)
+		return "", repository.OverlayAccess{}, false
+	}
+	return overlayID, access, true
+}
+
+// inviteHash reads and hashes the submitted secret. The plaintext never leaves this function, and
+// is never logged.
+func (h *GrantHandler) inviteHash(c *gin.Context) ([]byte, bool) {
+	var req models.InviteTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		h.badRequest(c, "an invite token is required")
+		return nil, false
+	}
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		h.badRequest(c, "an invite token is required")
+		return nil, false
+	}
+	return invites.Hash(token), true
+}
+
+// writeInviteError maps the invite sentinels onto responses and reports whether the caller may
+// proceed.
+//
+// "Unknown", "already redeemed" and "revoked" collapse into one 404: all three are equally dead
+// and the difference tells the holder nothing they can act on. Expiry is distinct because whoever
+// holds the secret already knows the invite was real, and "expired, ask again" beats "not found".
+func (h *GrantHandler) writeInviteError(c *gin.Context, err error) bool {
+	switch {
+	case err == nil:
+		return true
+	case errors.Is(err, repository.ErrInviteNotFound):
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "this invite is no longer valid", "code": codeInviteNotFound})
+	case errors.Is(err, repository.ErrInviteExpired):
+		c.JSON(http.StatusGone, gin.H{
+			"error": "this invite has expired — ask the streamer for a new one", "code": codeInviteExpired})
+	case errors.Is(err, repository.ErrAlreadyModerator):
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "you already moderate this overlay", "code": codeAlreadyModerator})
+	case errors.Is(err, repository.ErrOwnerCannotAccept):
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "this is your own overlay — you already have full moderation access",
+			"code":  codeOwnerCannotAccept})
+	default:
+		h.internalError(c, "invite operation failed", err)
+	}
+	return false
+}
+
+// denyNoRole refuses a caller who is not the overlay owner, indistinguishably from a caller
+// naming an overlay that does not exist. The real reason goes to the metric and the log, which the
+// caller cannot see.
+func (h *GrantHandler) denyNoRole(c *gin.Context, overlayID, reason string) {
+	unauthorizedDenials.WithLabelValues(reason).Inc()
+	h.logger.Warn("delegation management request from a caller who does not own the overlay",
+		zap.String("user_id", c.GetString("user_id")),
+		zap.String("overlay_id", overlayID),
+		zap.String("reason", reason))
+	c.JSON(http.StatusForbidden, gin.H{"error": notAuthorizedMsg})
+}
+
+func (h *GrantHandler) badRequest(c *gin.Context, msg string) {
+	c.JSON(http.StatusBadRequest, gin.H{"error": msg, "code": codeInvalidRequest})
+}
+
+func (h *GrantHandler) internalError(c *gin.Context, msg string, err error) {
+	h.logger.Error(msg, zap.Error(err))
+	c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+}
+
+// errBindingUnsupported marks a pre-binding to a platform whose identity acceptance cannot verify.
+// It is the one pre-binding failure that is a semantic refusal (422) rather than a malformed
+// request (400).
+var errBindingUnsupported = errors.New("an invite can only be pre-bound to a Twitch account")
+
+// maxPlatformUserIDLen mirrors overlay_moderators.expected_platform_user_id.
+const maxPlatformUserIDLen = 100
+
+// validatePreBinding admits a pre-binding only where acceptance can actually verify it.
+func validatePreBinding(platform, platformUserID string) error {
+	if platform == "" && platformUserID == "" {
+		return nil
+	}
+	if platform == "" || platformUserID == "" {
+		return errors.New("expected_platform and expected_platform_user_id must be given together")
+	}
+	// The message names no platform on purpose: it would be echoing unvalidated input back to the
+	// caller, and the only platform that works is documented.
+	if !models.PreBindablePlatform(platform) {
+		return errBindingUnsupported
+	}
+	// The column is VARCHAR(100). Bounding it here turns an over-long value into a 400 instead of
+	// letting Postgres raise 22001 and surface as a 500.
+	if len(platformUserID) > maxPlatformUserIDLen {
+		return errors.New("expected_platform_user_id is too long")
+	}
+	return nil
+}
+
+// isAdmin reports whether the caller holds the admin role, as set by the shared JWT middleware.
+func isAdmin(c *gin.Context) bool {
+	roles, ok := c.Get("roles")
+	if !ok {
+		return false
+	}
+	list, ok := roles.([]string)
+	if !ok {
+		return false
+	}
+	for _, role := range list {
+		if role == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
+func toLegs(in []repository.GrantLeg) []models.GrantPlatformLeg {
+	out := make([]models.GrantPlatformLeg, 0, len(in))
+	for _, leg := range in {
+		out = append(out, models.GrantPlatformLeg{
+			Platform:     leg.Platform,
+			Enabled:      leg.Enabled,
+			Verification: leg.Verification,
+			VerifiedAt:   leg.VerifiedAt,
+		})
+	}
+	return out
+}
+
+func toModeratorGrant(g repository.Grant) models.ModeratorGrant {
+	return models.ModeratorGrant{
+		ID:               g.ID,
+		Status:           g.Status,
+		ModeratorUserID:  g.ModeratorUserID,
+		DisplayName:      g.ModeratorDisplayName,
+		InviteeLabel:     g.InviteeLabel,
+		Actions:          g.Actions,
+		Platforms:        toLegs(g.Platforms),
+		ExpectedPlatform: g.ExpectedPlatform,
+		ExpectedAccount:  expectedAccount(g),
+		CreatedAt:        g.CreatedAt,
+		AcceptedAt:       g.AcceptedAt,
+		InviteExpiresAt:  g.InviteExpiresAt,
+		SuspendedAt:      g.SuspendedAt,
+		LastActionAt:     g.LastActionAt,
+	}
+}
+
+// expectedAccount names the account a pre-bound invite is for.
+//
+// There is no column holding the login: the streamer picks a moderator from a platform list, so
+// the label they were shown IS the account name, while expected_platform_user_id holds the id we
+// actually compare. Without a binding the label is a free-text note and means nothing about which
+// account may redeem, so it is not reported as an expectation.
+func expectedAccount(g repository.Grant) string {
+	if g.ExpectedPlatform == "" {
+		return ""
+	}
+	return g.InviteeLabel
+}
+
+func derefTime(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}

--- a/services/moderation-service/handler/grants_test.go
+++ b/services/moderation-service/handler/grants_test.go
@@ -1,0 +1,761 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/invites"
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// strangerUserID holds no role on the overlay at all.
+const strangerUserID = "44444444-4444-4444-8444-444444444444"
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+type fakeGrantStore struct {
+	created     []repository.InviteParams
+	createErr   error
+	grants      []repository.Grant
+	listErr     error
+	updated     repository.Grant
+	updateErr   error
+	updateCalls []struct {
+		OverlayID, GrantID string
+		Actions            []string
+		Legs               map[string]bool
+	}
+	revokedOK   bool
+	revokeErr   error
+	revokedIDs  []string
+	revokedAll  int
+	revokeAllOK []string
+	preview     repository.InviteDetails
+	previewErr  error
+	accepted    repository.InviteDetails
+	acceptErr   error
+	acceptedFor []string
+	seenHashes  [][]byte
+}
+
+func (f *fakeGrantStore) CreateInvite(_ context.Context, p repository.InviteParams) (repository.Grant, error) {
+	f.created = append(f.created, p)
+	if f.createErr != nil {
+		return repository.Grant{}, f.createErr
+	}
+	return repository.Grant{
+		ID: "grant-new", OverlayID: p.OverlayID, Status: models.GrantStatusPending,
+		Actions: p.Actions, InviteeLabel: p.InviteeLabel, ExpectedPlatform: p.ExpectedPlatform,
+		InviteExpiresAt: &p.ExpiresAt,
+	}, nil
+}
+
+func (f *fakeGrantStore) ListGrants(context.Context, string) ([]repository.Grant, error) {
+	return f.grants, f.listErr
+}
+
+func (f *fakeGrantStore) UpdateGrant(_ context.Context, overlayID, grantID string, actions []string, legs map[string]bool) (repository.Grant, error) {
+	f.updateCalls = append(f.updateCalls, struct {
+		OverlayID, GrantID string
+		Actions            []string
+		Legs               map[string]bool
+	}{overlayID, grantID, actions, legs})
+	return f.updated, f.updateErr
+}
+
+func (f *fakeGrantStore) RevokeGrant(_ context.Context, _, grantID, _ string) (bool, error) {
+	f.revokedIDs = append(f.revokedIDs, grantID)
+	return f.revokedOK, f.revokeErr
+}
+
+func (f *fakeGrantStore) RevokeAllGrants(_ context.Context, overlayID, _ string) (int, error) {
+	f.revokeAllOK = append(f.revokeAllOK, overlayID)
+	return f.revokedAll, f.revokeErr
+}
+
+func (f *fakeGrantStore) PreviewInvite(_ context.Context, hash []byte) (repository.InviteDetails, error) {
+	f.seenHashes = append(f.seenHashes, hash)
+	return f.preview, f.previewErr
+}
+
+func (f *fakeGrantStore) AcceptInvite(_ context.Context, hash []byte, userID string) (repository.InviteDetails, error) {
+	f.seenHashes = append(f.seenHashes, hash)
+	f.acceptedFor = append(f.acceptedFor, userID)
+	if f.acceptErr != nil {
+		return f.accepted, f.acceptErr
+	}
+	return f.accepted, nil
+}
+
+// delegationGateFor reports delegation enabled only for the listed user ids, so a test can prove
+// the gate is asked about the overlay OWNER.
+type delegationGateFor map[string]bool
+
+func (g delegationGateFor) ModerationEnabled(_ context.Context, userID string) (bool, error) {
+	return g[userID], nil
+}
+
+func (g delegationGateFor) DelegationEnabled(_ context.Context, userID string) (bool, error) {
+	return g[userID], nil
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+func grantHandler(t *testing.T, role string, store *fakeGrantStore, gate FeatureGate) *GrantHandler {
+	t.Helper()
+	access := &repository.OverlayAccess{OwnerUserID: ownerID, OwnerIsPremium: true, Role: role}
+	auth := &fakeAuthorizer{access: access}
+	h := NewGrantHandler(auth, store, zap.NewNop())
+	if gate != nil {
+		h.SetFeatureGate(gate)
+	}
+	return h
+}
+
+func grantRouter(h *GrantHandler, userID string, roles ...string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if userID != "" {
+			c.Set("user_id", userID)
+		}
+		if len(roles) > 0 {
+			c.Set("roles", roles)
+		}
+		c.Next()
+	})
+	api := r.Group("/api/v1/moderation")
+	api.GET("/overlays/:id/moderators", h.HandleListModerators)
+	api.POST("/overlays/:id/moderators", h.HandleCreateInvite)
+	api.PATCH("/overlays/:id/moderators/:grant_id", h.HandleUpdateGrant)
+	api.DELETE("/overlays/:id/moderators/:grant_id", h.HandleRevokeGrant)
+	api.DELETE("/overlays/:id/moderators", h.HandleRevokeAll)
+	api.POST("/invites/preview", h.HandlePreviewInvite)
+	api.POST("/invites/accept", h.HandleAcceptInvite)
+	return r
+}
+
+func modsPath() string  { return "/api/v1/moderation/overlays/" + overlayID + "/moderators" }
+func grantPath() string { return modsPath() + "/bbbbbbbb-2222-2222-2222-222222222222" }
+
+func decode(t *testing.T, resp *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	return body
+}
+
+// ---------------------------------------------------------------------------
+// Owner-only authorization
+// ---------------------------------------------------------------------------
+
+// Managing the mod team is an ownership power, not a moderation power. A delegated moderator must
+// not be able to invite more moderators, widen their own grant, or revoke a colleague — and the
+// refusal must look exactly like a stranger's, so the endpoints never confirm an overlay exists.
+func TestGrantEndpoints_AreOwnerOnlyAndIndistinguishable(t *testing.T) {
+	body := `{"actions":["delete"]}`
+	requests := []struct {
+		name, method, path, body string
+	}{
+		{"list", http.MethodGet, modsPath(), ""},
+		{"invite", http.MethodPost, modsPath(), body},
+		{"update", http.MethodPatch, grantPath(), body},
+		{"revoke", http.MethodDelete, grantPath(), ""},
+		{"revoke all", http.MethodDelete, modsPath(), ""},
+	}
+
+	for _, req := range requests {
+		t.Run(req.name, func(t *testing.T) {
+			store := &fakeGrantStore{}
+			asModerator := do(grantRouter(grantHandler(t, repository.RoleModerator, store, nil), modUserID),
+				req.method, req.path, req.body)
+			asStranger := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), strangerUserID),
+				req.method, req.path, req.body)
+
+			unknown := &fakeAuthorizer{accessErr: repository.ErrOverlayNotFound}
+			hUnknown := NewGrantHandler(unknown, store, zap.NewNop())
+			onUnknown := do(grantRouter(hUnknown, ownerID), req.method, req.path, req.body)
+
+			assert.Equal(t, http.StatusForbidden, asModerator.Code,
+				"a delegated moderator must not manage the mod team")
+			assert.Equal(t, http.StatusForbidden, asStranger.Code)
+			assert.Equal(t, http.StatusForbidden, onUnknown.Code)
+			assert.JSONEq(t, asStranger.Body.String(), onUnknown.Body.String(),
+				"a nonexistent overlay must be indistinguishable from one the caller cannot touch")
+			assert.JSONEq(t, asStranger.Body.String(), asModerator.Body.String())
+
+			assert.Empty(t, store.created, "a refused request must not reach the database")
+			assert.Empty(t, store.updateCalls)
+			assert.Empty(t, store.revokedIDs)
+			assert.Empty(t, store.revokeAllOK)
+		})
+	}
+}
+
+func TestGrantEndpoints_RequireAuthentication(t *testing.T) {
+	store := &fakeGrantStore{}
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ""), http.MethodGet, modsPath(), "")
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Invite creation
+// ---------------------------------------------------------------------------
+
+func TestCreateInvite_ReturnsTheSecretExactlyOnce(t *testing.T) {
+	store := &fakeGrantStore{}
+	h := grantHandler(t, repository.RoleOwner, store, nil)
+
+	resp := do(grantRouter(h, ownerID), http.MethodPost, modsPath(),
+		`{"actions":["delete","ban"],"platforms":["twitch"],"invitee_label":"Sarah"}`)
+	require.Equal(t, http.StatusCreated, resp.Code, resp.Body.String())
+
+	body := decode(t, resp)
+	secret, ok := body["invite_token"].(string)
+	require.True(t, ok, "the streamer must receive the secret to pass on")
+	assert.NotEmpty(t, secret)
+	assert.NotEmpty(t, body["expires_at"])
+
+	require.Len(t, store.created, 1)
+	created := store.created[0]
+	assert.Equal(t, overlayID, created.OverlayID)
+	assert.Equal(t, ownerID, created.GrantedBy)
+	assert.Equal(t, []string{"delete", "ban"}, created.Actions)
+	assert.Equal(t, []string{"twitch"}, created.Platforms)
+	assert.Equal(t, "Sarah", created.InviteeLabel)
+
+	// Only the digest is handed to storage — the plaintext stops at the HTTP response.
+	assert.Equal(t, invites.Hash(secret), created.TokenHash)
+	assert.NotContains(t, string(created.TokenHash), secret)
+
+	assert.WithinDuration(t, time.Now().Add(invites.TTL), created.ExpiresAt, time.Minute)
+
+	t.Run("the roster never replays a secret", func(t *testing.T) {
+		store.grants = []repository.Grant{{ID: "grant-new", Status: models.GrantStatusPending}}
+		list := do(grantRouter(h, ownerID), http.MethodGet, modsPath(), "")
+		require.Equal(t, http.StatusOK, list.Code)
+		assert.NotContains(t, list.Body.String(), secret,
+			"a lost invite is re-minted, never re-displayed")
+		assert.NotContains(t, list.Body.String(), "invite_token")
+	})
+}
+
+func TestCreateInvite_ActionDefaultsAndValidation(t *testing.T) {
+	t.Run("an absent action list grants the safe default pair", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(), `{}`)
+		require.Equal(t, http.StatusCreated, resp.Code)
+		assert.Equal(t, []string{"delete", "timeout"}, store.created[0].Actions)
+	})
+
+	t.Run("an explicitly empty list is a bad request, never widened", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(), `{"actions":[]}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.created)
+	})
+
+	// "engagement" is accepted by ModerationScopesForActions downstream, where it maps to
+	// channel-point and prediction read scopes. A grant must never be able to carry it.
+	t.Run("a non-moderation action is refused", func(t *testing.T) {
+		for _, action := range []string{"engagement", "send", "rediscover"} {
+			store := &fakeGrantStore{}
+			resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+				http.MethodPost, modsPath(), `{"actions":["`+action+`"]}`)
+			assert.Equal(t, http.StatusBadRequest, resp.Code, "action %q must not be delegatable", action)
+			assert.Empty(t, store.created)
+		}
+	})
+
+	t.Run("a platform with no moderation API is refused rather than stored dead", func(t *testing.T) {
+		for _, platform := range []string{"tiktok", "shared_overlay", "myspace"} {
+			store := &fakeGrantStore{}
+			resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+				http.MethodPost, modsPath(), `{"platforms":["`+platform+`"]}`)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, "platform %q", platform)
+			assert.Empty(t, store.created)
+		}
+	})
+
+	t.Run("no platform enabled is allowed and delegates nothing", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(), `{}`)
+		require.Equal(t, http.StatusCreated, resp.Code)
+		assert.Empty(t, store.created[0].Platforms, "absence is disablement; Discord stays off")
+	})
+}
+
+// A binding we cannot verify at accept time would be a constraint that silently does nothing, so
+// the API refuses to store one instead of pretending it protects anybody.
+func TestCreateInvite_PreBindingOnlyWherePlatformIdentityIsProvable(t *testing.T) {
+	t.Run("twitch is accepted", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(),
+			`{"expected_platform":"twitch","expected_platform_user_id":"77777"}`)
+		require.Equal(t, http.StatusCreated, resp.Code)
+		assert.Equal(t, "twitch", store.created[0].ExpectedPlatform)
+		assert.Equal(t, "77777", store.created[0].ExpectedPlatformUserID)
+	})
+
+	t.Run("other platforms are refused", func(t *testing.T) {
+		for _, platform := range []string{"kick", "youtube", "discord"} {
+			store := &fakeGrantStore{}
+			resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+				http.MethodPost, modsPath(),
+				`{"expected_platform":"`+platform+`","expected_platform_user_id":"1"}`)
+			assert.Equal(t, http.StatusUnprocessableEntity, resp.Code, "platform %q", platform)
+			assert.Empty(t, store.created)
+		}
+	})
+
+	t.Run("a platform without an id is refused", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(), `{"expected_platform":"twitch"}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.created)
+	})
+
+	// The column is VARCHAR(100); without a bound, Postgres raises 22001 and the client gets a 500
+	// for what is plainly a bad request.
+	t.Run("an over-long platform id is a bad request, not a 500", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPost, modsPath(),
+			`{"expected_platform":"twitch","expected_platform_user_id":"`+strings.Repeat("9", 101)+`"}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.created)
+	})
+}
+
+// The label is stored in a VARCHAR(120), and a streamer pasting something long must not produce an
+// error — the label is decoration, so it is trimmed.
+func TestCreateInvite_AnOverLongLabelIsTrimmedNotRejected(t *testing.T) {
+	store := &fakeGrantStore{}
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+		http.MethodPost, modsPath(), `{"invitee_label":"`+strings.Repeat("a", 500)+`"}`)
+
+	require.Equal(t, http.StatusCreated, resp.Code)
+	require.Len(t, store.created, 1)
+	assert.LessOrEqual(t, len(store.created[0].InviteeLabel), 120)
+}
+
+func TestCreateInvite_CapIsRefusedWithAnExplanation(t *testing.T) {
+	store := &fakeGrantStore{createErr: repository.ErrModeratorCapReached}
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+		http.MethodPost, modsPath(), `{}`)
+
+	assert.Equal(t, http.StatusConflict, resp.Code)
+	body := decode(t, resp)
+	assert.Equal(t, "moderator_cap_reached", body["code"])
+	assert.EqualValues(t, models.ModeratorsPerOverlayCap, body["cap"],
+		"the UI must be able to say what the limit is")
+}
+
+// An admin raising the cap for a big channel is the documented escape hatch.
+func TestCreateInvite_AdminBypassesTheCap(t *testing.T) {
+	store := &fakeGrantStore{}
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID, "admin"),
+		http.MethodPost, modsPath(), `{}`)
+
+	require.Equal(t, http.StatusCreated, resp.Code)
+	require.Len(t, store.created, 1)
+	assert.True(t, store.created[0].BypassCap)
+
+	t.Run("an ordinary owner does not", func(t *testing.T) {
+		plain := &fakeGrantStore{}
+		do(grantRouter(grantHandler(t, repository.RoleOwner, plain, nil), ownerID),
+			http.MethodPost, modsPath(), `{}`)
+		require.Len(t, plain.created, 1)
+		assert.False(t, plain.created[0].BypassCap)
+	})
+}
+
+// The gate keys on the OWNER, and here the owner IS the caller — but the copy still has to be
+// owner-facing, because only the streamer can act on it.
+func TestCreateInvite_GateClosedIsRefusedWithOwnerFacingCopy(t *testing.T) {
+	store := &fakeGrantStore{}
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, delegationGateFor{}), ownerID),
+		http.MethodPost, modsPath(), `{}`)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	body := decode(t, resp)
+	assert.Equal(t, "delegation_unavailable", body["code"])
+	assert.Contains(t, body["error"], "premium")
+	assert.Empty(t, store.created)
+}
+
+// Rolling delegation back must never trap a streamer with moderators they cannot remove.
+func TestRevocation_IsNeverGated(t *testing.T) {
+	t.Run("revoke one", func(t *testing.T) {
+		store := &fakeGrantStore{revokedOK: true}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, delegationGateFor{}), ownerID),
+			http.MethodDelete, grantPath(), "")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Len(t, store.revokedIDs, 1)
+	})
+
+	t.Run("revoke all", func(t *testing.T) {
+		store := &fakeGrantStore{revokedAll: 3}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, delegationGateFor{}), ownerID),
+			http.MethodDelete, modsPath(), "")
+		require.Equal(t, http.StatusOK, resp.Code)
+		assert.EqualValues(t, 3, decode(t, resp)["revoked"])
+	})
+
+	t.Run("and neither is listing", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, delegationGateFor{}), ownerID),
+			http.MethodGet, modsPath(), "")
+		assert.Equal(t, http.StatusOK, resp.Code,
+			"a streamer must always be able to see who can moderate for them")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+// ---------------------------------------------------------------------------
+
+func TestListModerators_ReportsRosterWithCapUsage(t *testing.T) {
+	accepted := time.Now().Add(-time.Hour)
+	store := &fakeGrantStore{grants: []repository.Grant{
+		{ID: "g1", Status: models.GrantStatusActive, ModeratorUserID: modUserID,
+			ModeratorDisplayName: "Sarah", Actions: []string{"delete", "timeout"},
+			AcceptedAt: &accepted,
+			Platforms: []repository.GrantLeg{
+				{Platform: "twitch", Enabled: true, Verification: "verified"},
+				{Platform: "discord", Enabled: false, Verification: "unverified"},
+			}},
+		{ID: "g2", Status: models.GrantStatusPending, InviteeLabel: "Bob", Actions: []string{"delete"}},
+	}}
+
+	resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+		http.MethodGet, modsPath(), "")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var list models.ModeratorList
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &list))
+	require.Len(t, list.Moderators, 2)
+	assert.Equal(t, models.ModeratorsPerOverlayCap, list.Cap)
+	assert.Equal(t, 2, list.Used, "pending invites occupy a seat, so the count must include them")
+
+	assert.Equal(t, "Sarah", list.Moderators[0].DisplayName)
+	require.Len(t, list.Moderators[0].Platforms, 2)
+	assert.True(t, list.Moderators[0].Platforms[0].Enabled)
+	assert.Equal(t, "verified", list.Moderators[0].Platforms[0].Verification)
+	assert.Equal(t, "Bob", list.Moderators[1].InviteeLabel)
+	assert.Empty(t, list.Moderators[1].DisplayName)
+
+	t.Run("an empty roster serializes as a list, not null", func(t *testing.T) {
+		empty := &fakeGrantStore{grants: []repository.Grant{}}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, empty, nil), ownerID),
+			http.MethodGet, modsPath(), "")
+		assert.Contains(t, resp.Body.String(), `"moderators":[]`)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+func TestUpdateGrant(t *testing.T) {
+	t.Run("actions and legs are passed through", func(t *testing.T) {
+		store := &fakeGrantStore{updated: repository.Grant{ID: "g1", Status: models.GrantStatusActive,
+			Actions: []string{"delete"}}}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"actions":["delete"],"platforms":{"twitch":true,"discord":false}}`)
+
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		require.Len(t, store.updateCalls, 1)
+		call := store.updateCalls[0]
+		assert.Equal(t, overlayID, call.OverlayID, "the overlay must scope the write, not just the check")
+		assert.Equal(t, []string{"delete"}, call.Actions)
+		assert.Equal(t, map[string]bool{"twitch": true, "discord": false}, call.Legs)
+	})
+
+	t.Run("an absent field leaves that dimension alone", func(t *testing.T) {
+		store := &fakeGrantStore{updated: repository.Grant{ID: "g1", Status: models.GrantStatusActive}}
+		do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"platforms":{"twitch":true}}`)
+		require.Len(t, store.updateCalls, 1)
+		assert.Nil(t, store.updateCalls[0].Actions, "nil means untouched, not cleared")
+	})
+
+	t.Run("an explicitly empty action list is refused", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"actions":[]}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.updateCalls)
+	})
+
+	t.Run("a non-delegatable action is refused", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"actions":["engagement"]}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.updateCalls)
+	})
+
+	t.Run("a leg for an unmoderatable platform is refused", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"platforms":{"tiktok":true}}`)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		assert.Empty(t, store.updateCalls)
+	})
+
+	t.Run("an unknown grant", func(t *testing.T) {
+		store := &fakeGrantStore{updateErr: repository.ErrGrantNotFound}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodPatch, grantPath(), `{"actions":["delete"]}`)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, "grant_not_found", decode(t, resp)["code"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Revoke
+// ---------------------------------------------------------------------------
+
+func TestRevokeGrant(t *testing.T) {
+	t.Run("a live grant", func(t *testing.T) {
+		store := &fakeGrantStore{revokedOK: true}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodDelete, grantPath(), "")
+		require.Equal(t, http.StatusOK, resp.Code)
+		assert.Equal(t, true, decode(t, resp)["revoked"])
+	})
+
+	t.Run("nothing to revoke", func(t *testing.T) {
+		store := &fakeGrantStore{revokedOK: false}
+		resp := do(grantRouter(grantHandler(t, repository.RoleOwner, store, nil), ownerID),
+			http.MethodDelete, grantPath(), "")
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, "grant_not_found", decode(t, resp)["code"])
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+func TestPreviewInvite(t *testing.T) {
+	expires := time.Now().Add(invites.TTL)
+	details := repository.InviteDetails{
+		Grant: repository.Grant{
+			ID: "g1", OverlayID: overlayID, Status: models.GrantStatusPending,
+			Actions: []string{"delete", "timeout"}, InviteeLabel: "@sarah",
+			InviteExpiresAt: &expires,
+			Platforms:       []repository.GrantLeg{{Platform: "twitch", Enabled: true, Verification: "unverified"}},
+		},
+		OverlayName:      "Main Overlay",
+		OwnerDisplayName: "The Streamer",
+	}
+
+	t.Run("says who is asking and for what, without needing an account of any kind", func(t *testing.T) {
+		store := &fakeGrantStore{preview: details}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/preview", `{"token":"a-secret"}`)
+
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		body := decode(t, resp)
+		assert.Equal(t, "Main Overlay", body["overlay_name"])
+		assert.Equal(t, "The Streamer", body["owner_display_name"])
+		assert.Equal(t, []any{"delete", "timeout"}, body["actions"])
+
+		// An overlay UUID already grants chat READ to anyone holding it, so it is disclosed on
+		// acceptance rather than to everyone who merely opens the link.
+		assert.NotContains(t, resp.Body.String(), overlayID)
+		assert.NotContains(t, body, "overlay_id")
+
+		require.Len(t, store.seenHashes, 1)
+		assert.Equal(t, invites.Hash("a-secret"), store.seenHashes[0])
+	})
+
+	t.Run("a pasted secret is trimmed before hashing", func(t *testing.T) {
+		store := &fakeGrantStore{preview: details}
+		do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/preview", `{"token":"  a-secret\n"}`)
+		require.Len(t, store.seenHashes, 1)
+		assert.Equal(t, invites.Hash("a-secret"), store.seenHashes[0],
+			"a copy-paste newline must not read as a different secret")
+	})
+
+	t.Run("an unknown secret", func(t *testing.T) {
+		store := &fakeGrantStore{previewErr: repository.ErrInviteNotFound}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/preview", `{"token":"x"}`)
+		assert.Equal(t, http.StatusNotFound, resp.Code)
+		assert.Equal(t, "invite_not_found", decode(t, resp)["code"])
+	})
+
+	t.Run("an expired secret says so, because the holder already knows it was real", func(t *testing.T) {
+		store := &fakeGrantStore{previewErr: repository.ErrInviteExpired}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/preview", `{"token":"x"}`)
+		assert.Equal(t, http.StatusGone, resp.Code)
+		assert.Equal(t, "invite_expired", decode(t, resp)["code"])
+	})
+
+	t.Run("a missing token is a bad request", func(t *testing.T) {
+		store := &fakeGrantStore{}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/preview", `{}`)
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Empty(t, store.seenHashes)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Accept
+// ---------------------------------------------------------------------------
+
+func TestAcceptInvite(t *testing.T) {
+	accepted := repository.InviteDetails{
+		Grant: repository.Grant{
+			ID: "g1", OverlayID: overlayID, Status: models.GrantStatusActive,
+			ModeratorUserID: modUserID, Actions: []string{"delete", "timeout"},
+			Platforms: []repository.GrantLeg{{Platform: "twitch", Enabled: true, Verification: "unverified"}},
+		},
+		OverlayName:      "Main Overlay",
+		OwnerDisplayName: "The Streamer",
+	}
+
+	t.Run("binds to the signed-in account and hands over the overlay", func(t *testing.T) {
+		store := &fakeGrantStore{accepted: accepted}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/accept", `{"token":"a-secret"}`)
+
+		require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+		body := decode(t, resp)
+		assert.Equal(t, overlayID, body["overlay_id"], "acceptance is where the overlay is disclosed")
+		assert.Equal(t, "Main Overlay", body["overlay_name"])
+		assert.Equal(t, []any{"delete", "timeout"}, body["actions"])
+		assert.Equal(t, []string{modUserID}, store.acceptedFor)
+	})
+
+	t.Run("an anonymous caller cannot accept", func(t *testing.T) {
+		store := &fakeGrantStore{accepted: accepted}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), ""),
+			http.MethodPost, "/api/v1/moderation/invites/accept", `{"token":"a-secret"}`)
+		assert.Equal(t, http.StatusUnauthorized, resp.Code)
+		assert.Empty(t, store.acceptedFor)
+	})
+
+	refusals := []struct {
+		name string
+		err  error
+		code int
+		want string
+	}{
+		{"unknown", repository.ErrInviteNotFound, http.StatusNotFound, "invite_not_found"},
+		{"expired", repository.ErrInviteExpired, http.StatusGone, "invite_expired"},
+		{"already a moderator", repository.ErrAlreadyModerator, http.StatusConflict, "already_moderator"},
+		{"the owner themselves", repository.ErrOwnerCannotAccept, http.StatusConflict, "owner_cannot_accept"},
+	}
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeGrantStore{acceptErr: tc.err}
+			resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+				http.MethodPost, "/api/v1/moderation/invites/accept", `{"token":"x"}`)
+			assert.Equal(t, tc.code, resp.Code)
+			assert.Equal(t, tc.want, decode(t, resp)["code"])
+		})
+	}
+
+	// The whole point of pre-binding: tell Bob the invite is Sarah's instead of silently making
+	// him a moderator or failing with something unhelpful.
+	t.Run("the wrong account is told whose invite it is", func(t *testing.T) {
+		store := &fakeGrantStore{
+			acceptErr: repository.ErrInviteBoundToOtherAccount,
+			accepted: repository.InviteDetails{Grant: repository.Grant{
+				InviteeLabel: "@sarah", ExpectedPlatform: "twitch",
+			}},
+		}
+		resp := do(grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID),
+			http.MethodPost, "/api/v1/moderation/invites/accept", `{"token":"x"}`)
+
+		assert.Equal(t, http.StatusConflict, resp.Code)
+		body := decode(t, resp)
+		assert.Equal(t, "invite_bound_to_other_account", body["code"])
+		assert.Equal(t, "@sarah", body["expected_account"])
+		assert.Equal(t, "twitch", body["expected_platform"])
+	})
+}
+
+// The secret is a bearer credential for a moderation grant, so it must not be reachable through a
+// URL, where it would land in access logs, proxy logs and Referer headers.
+func TestInviteEndpoints_TakeTheSecretInABodyNotAPath(t *testing.T) {
+	store := &fakeGrantStore{preview: repository.InviteDetails{}}
+	router := grantRouter(grantHandler(t, repository.RoleNone, store, nil), modUserID)
+
+	for _, path := range []string{
+		"/api/v1/moderation/invites/preview/a-secret",
+		"/api/v1/moderation/invites/a-secret",
+		"/api/v1/moderation/invites/accept/a-secret",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusNotFound, resp.Code, "no route may carry a secret in its path: %s", path)
+	}
+	assert.Empty(t, store.seenHashes)
+}
+
+func TestGrantHandler_StoreFailuresAreInternalErrors(t *testing.T) {
+	boom := errors.New("database on fire")
+	cases := []struct {
+		name, method, path, body string
+		store                    *fakeGrantStore
+	}{
+		{"list", http.MethodGet, modsPath(), "", &fakeGrantStore{listErr: boom}},
+		{"invite", http.MethodPost, modsPath(), `{}`, &fakeGrantStore{createErr: boom}},
+		{"update", http.MethodPatch, grantPath(), `{"actions":["delete"]}`, &fakeGrantStore{updateErr: boom}},
+		{"revoke", http.MethodDelete, grantPath(), "", &fakeGrantStore{revokeErr: boom}},
+		{"revoke all", http.MethodDelete, modsPath(), "", &fakeGrantStore{revokeErr: boom}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := do(grantRouter(grantHandler(t, repository.RoleOwner, tc.store, nil), ownerID),
+				tc.method, tc.path, tc.body)
+			assert.Equal(t, http.StatusInternalServerError, resp.Code)
+			assert.NotContains(t, resp.Body.String(), "on fire", "internals must not leak to the client")
+		})
+	}
+}

--- a/services/moderation-service/handler/moderation.go
+++ b/services/moderation-service/handler/moderation.go
@@ -51,6 +51,9 @@ type Authorizer interface {
 	ResolveOverlayAccess(ctx context.Context, overlayID, callerID string) (repository.OverlayAccess, error)
 	IsModeratableSource(ctx context.Context, overlayID, platform, channelID string) (bool, error)
 	ListModeratableSources(ctx context.Context, overlayID string) ([]repository.Source, error)
+	// TouchGrantActivity records that a delegated grant was just used, which is what the
+	// dormancy rule reads. A no-op for owner actions, which carry no grant.
+	TouchGrantActivity(ctx context.Context, grantID string) error
 }
 
 // DeletionEmitter publishes the reflect-back deletion event onto chat:raw.
@@ -98,12 +101,15 @@ func (DryRunDispatcher) Dispatch(context.Context, string, models.Action, models.
 	return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 }
 
-// FeatureGate reports whether the moderation feature is enabled for a user under
-// the ADR-0008 cohort rollout. The capabilities endpoint surfaces this so the
-// dashboard hides controls for users outside the cohort; the action endpoints are
-// independently gated in cmd/main.go (defense in depth).
+// FeatureGate reports whether a moderation capability is enabled for a user under the ADR-0008
+// cohort rollout. Both questions are asked about the OVERLAY OWNER, never the caller: a delegated
+// moderator moderates on a premium streamer's overlay for free (ADR-0048).
 type FeatureGate interface {
+	// ModerationEnabled gates the moderation write-path itself.
 	ModerationEnabled(ctx context.Context, userID string) (bool, error)
+	// DelegationEnabled gates handing that write-path to someone else. A separate key so
+	// delegation can be rolled back without disabling owner moderation.
+	DelegationEnabled(ctx context.Context, userID string) (bool, error)
 }
 
 // OpenGate enables moderation for everyone. It is the default when no feature-gate
@@ -114,12 +120,15 @@ type OpenGate struct{}
 // ModerationEnabled always reports enabled.
 func (OpenGate) ModerationEnabled(context.Context, string) (bool, error) { return true, nil }
 
+// DelegationEnabled always reports enabled.
+func (OpenGate) DelegationEnabled(context.Context, string) (bool, error) { return true, nil }
+
 // Handler serves the moderation endpoints.
 type Handler struct {
-	repo     Authorizer
-	pub      DeletionEmitter
-	audit    Recorder
-	scopes   ScopeChecker
+	repo       Authorizer
+	pub        DeletionEmitter
+	audit      Recorder
+	scopes     ScopeChecker
 	send       SendChecker
 	dispatch   Dispatcher
 	gate       FeatureGate
@@ -479,7 +488,24 @@ func (h *Handler) execute(c *gin.Context, cl caller, action models.Action, dreq 
 		e.Outcome = audit.OutcomeSuccess
 	}
 	h.record(ctx, e)
+	h.touchGrant(ctx, cl)
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "dry_run": dryRun})
+}
+
+// touchGrant stamps a delegated grant's last successful action.
+//
+// This is what the 90-day dormancy suspension reads, so it is written from the very first delegated
+// action: a dormancy job introduced later must not find a working mod team looking idle since the
+// day their grant was created. Owners have no grant to stamp. A failure is logged, never surfaced —
+// the moderation action already succeeded and the stamp is bookkeeping.
+func (h *Handler) touchGrant(ctx context.Context, cl caller) {
+	if cl.access.GrantID == "" {
+		return
+	}
+	if err := h.repo.TouchGrantActivity(ctx, cl.access.GrantID); err != nil {
+		h.logger.Warn("failed to stamp grant activity",
+			zap.String("grant_id", cl.access.GrantID), zap.Error(err))
+	}
 }
 
 // denyUnauthorized refuses a caller who holds no role on the overlay.

--- a/services/moderation-service/handler/moderation_delegation_test.go
+++ b/services/moderation-service/handler/moderation_delegation_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -36,6 +37,10 @@ const modUserID = "33333333-3333-4333-8333-333333333333"
 type gateFor map[string]bool
 
 func (g gateFor) ModerationEnabled(_ context.Context, userID string) (bool, error) {
+	return g[userID], nil
+}
+
+func (g gateFor) DelegationEnabled(_ context.Context, userID string) (bool, error) {
 	return g[userID], nil
 }
 
@@ -77,6 +82,55 @@ func TestDelete_DelegatedModeratorIsAuthorized(t *testing.T) {
 	require.Len(t, rec.entries, 1)
 	assert.Equal(t, modUserID, rec.entries[0].ActorUserID,
 		"the audit row records the human who pressed the button")
+}
+
+// last_action_at is what the 90-day dormancy rule reads. Stamping it from the first delegated
+// action onwards is what stops a dormancy job introduced later from reading a working mod team as
+// idle since the day their grants were created.
+func TestDelete_DelegatedActionStampsGrantActivity(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access: &repository.OverlayAccess{
+			OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleModerator,
+			GrantID: "grant-1", Actions: []string{"delete"},
+		},
+		isSource: map[string]bool{"twitch|somestreamer": true},
+	}
+	h := New(auth, &fakeEmitter{}, &fakeRecorder{}, NoScopeChecker{}, DryRunDispatcher{}, zap.NewNop())
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, []string{"grant-1"}, auth.touchedGrants)
+}
+
+// An owner acts by ownership, not by a grant, so there is nothing to stamp — and no dormancy
+// clock that could ever suspend them.
+func TestDelete_OwnerActionStampsNothing(t *testing.T) {
+	auth := &fakeAuthorizer{owns: true, isSource: map[string]bool{"twitch|somestreamer": true}}
+	h := New(auth, &fakeEmitter{}, &fakeRecorder{}, NoScopeChecker{}, DryRunDispatcher{}, zap.NewNop())
+
+	resp := do(newTestRouter(h, ownerID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Empty(t, auth.touchedGrants)
+}
+
+// A failed stamp is bookkeeping, not the action: the moderation already happened on the platform,
+// so the request must still succeed.
+func TestDelete_AStampFailureDoesNotFailTheAction(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access: &repository.OverlayAccess{
+			OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleModerator,
+			GrantID: "grant-1", Actions: []string{"delete"},
+		},
+		isSource: map[string]bool{"twitch|somestreamer": true},
+		touchErr: errors.New("database unavailable"),
+	}
+	h := New(auth, &fakeEmitter{}, &fakeRecorder{}, NoScopeChecker{}, DryRunDispatcher{}, zap.NewNop())
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
 }
 
 // The action set on the grant is enforced server-side, not merely hidden in the UI.

--- a/services/moderation-service/handler/moderation_test.go
+++ b/services/moderation-service/handler/moderation_test.go
@@ -50,6 +50,10 @@ type fakeAuthorizer struct {
 	// pre-delegation tests keep expressing intent as "the caller owns the overlay".
 	access    *repository.OverlayAccess
 	accessErr error
+	// touchedGrants records the grants whose activity stamp was refreshed, which is what the
+	// dormancy rule later reads.
+	touchedGrants []string
+	touchErr      error
 }
 
 func (f *fakeAuthorizer) VerifyOverlayOwnership(context.Context, string, string) (bool, error) {
@@ -84,6 +88,10 @@ func (f *fakeAuthorizer) IsModeratableSource(_ context.Context, _, platform, cha
 func (f *fakeAuthorizer) ListModeratableSources(context.Context, string) ([]repository.Source, error) {
 	return f.sources, nil
 }
+func (f *fakeAuthorizer) TouchGrantActivity(_ context.Context, grantID string) error {
+	f.touchedGrants = append(f.touchedGrants, grantID)
+	return f.touchErr
+}
 
 type fakeEmitter struct{ published []*mpmodels.RawChatMessage }
 
@@ -112,6 +120,10 @@ type fakeGate struct {
 }
 
 func (f fakeGate) ModerationEnabled(context.Context, string) (bool, error) {
+	return f.enabled, f.err
+}
+
+func (f fakeGate) DelegationEnabled(context.Context, string) (bool, error) {
 	return f.enabled, f.err
 }
 

--- a/services/moderation-service/invites/token.go
+++ b/services/moderation-service/invites/token.go
@@ -1,0 +1,67 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package invites mints and hashes the single-use secrets that redeem a delegated-moderation
+// grant (ADR-0048).
+//
+// The secret is a bearer credential for a moderation grant, so it is treated like one: it is
+// generated from crypto/rand, shown to the streamer exactly once, and persisted only as a
+// SHA-256 digest. Nothing in All-Chat can re-display or re-derive it — losing it means minting a
+// new invite, which is the correct trade for a token that can hand someone the moderation
+// write-path on a live channel.
+//
+// A plain digest (no salt, no KDF) is deliberate and sufficient here: the input is 256 bits of
+// uniform randomness, so there is no dictionary to attack and nothing for a work factor to slow
+// down. The digest exists to keep a database read from yielding usable tokens, and to give the
+// lookup an exact-match key.
+package invites
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+const (
+	// TTL is how long a fresh invite stays redeemable. Long enough to survive "I'll set this up
+	// after stream", short enough that a forgotten invite in a Discord DM stops being a key to
+	// the channel.
+	TTL = 7 * 24 * time.Hour
+
+	// secretBytes is the entropy behind an invite. 256 bits makes guessing irrelevant next to
+	// every other way an invite can leak.
+	secretBytes = 32
+)
+
+// NewSecret returns a fresh invite secret, base64url-encoded without padding so it can be pasted
+// into a URL, a chat message, or a form field without escaping.
+func NewSecret() (string, error) {
+	buf := make([]byte, secretBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate invite secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// Hash returns the SHA-256 digest of secret — the only form ever written to the database, and the
+// lookup key for redeeming it. It hashes the exact string given: callers trim user input first,
+// so that a stray newline from a copy-paste is not silently accepted as a different secret.
+func Hash(secret string) []byte {
+	sum := sha256.Sum256([]byte(secret))
+	return sum[:]
+}

--- a/services/moderation-service/invites/token_test.go
+++ b/services/moderation-service/invites/token_test.go
@@ -1,0 +1,75 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package invites
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSecret_IsURLSafeAndHighEntropy(t *testing.T) {
+	secret, err := NewSecret()
+	require.NoError(t, err)
+
+	raw, err := base64.RawURLEncoding.DecodeString(secret)
+	require.NoError(t, err, "the secret must survive a round trip through a URL fragment")
+	assert.Len(t, raw, 32, "256 bits: the secret is the only thing standing between a stranger and a grant")
+	assert.NotContains(t, secret, "=", "padding would be mangled by careless copy-paste")
+	assert.False(t, strings.ContainsAny(secret, "+/"), "the secret must be URL- and path-safe")
+}
+
+func TestNewSecret_NeverRepeats(t *testing.T) {
+	seen := make(map[string]struct{}, 256)
+	for i := 0; i < 256; i++ {
+		secret, err := NewSecret()
+		require.NoError(t, err)
+		_, dup := seen[secret]
+		require.False(t, dup, "a repeated secret would hand one invite to two people")
+		seen[secret] = struct{}{}
+	}
+}
+
+func TestHash_IsStableAndOneWay(t *testing.T) {
+	secret, err := NewSecret()
+	require.NoError(t, err)
+
+	first := Hash(secret)
+	assert.Len(t, first, 32, "SHA-256 digest")
+	assert.Equal(t, first, Hash(secret), "the same secret must always hash to the same lookup key")
+	assert.NotContains(t, string(first), secret, "the digest must not embed the secret")
+
+	other, err := NewSecret()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, Hash(other))
+}
+
+// The digest is what a compromised database row exposes, so it must not be reversible to a
+// usable token: only an exact-match lookup key.
+func TestHash_DiffersForNearlyIdenticalSecrets(t *testing.T) {
+	assert.NotEqual(t, Hash("abc"), Hash("abd"))
+	assert.NotEqual(t, Hash("abc"), Hash("abc "), "hashing is over the exact string; callers trim first")
+}
+
+func TestTTL_IsSevenDays(t *testing.T) {
+	assert.Equal(t, 7*24*time.Hour, TTL,
+		"an invite that outlives the conversation that created it is an unattended key to a channel")
+}

--- a/services/moderation-service/models/grant.go
+++ b/services/moderation-service/models/grant.go
@@ -1,0 +1,275 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Lifecycle states of a delegation grant (ADR-0048). Only `active` authorizes anything;
+// ResolveOverlayAccess ignores every other state.
+const (
+	// GrantStatusPending: an invite exists but nobody has redeemed it, so it is bound to no
+	// account yet.
+	GrantStatusPending = "pending"
+	// GrantStatusActive: redeemed and live.
+	GrantStatusActive = "active"
+	// GrantStatusSuspended: dormancy-suspended after 90 idle days. Only the OWNER reactivates —
+	// if re-consenting lifted it, the suspension would be a speed bump rather than a control.
+	GrantStatusSuspended = "suspended"
+	// GrantStatusRevoked: terminal. The row is kept for history.
+	GrantStatusRevoked = "revoked"
+)
+
+// ModeratorsPerOverlayCap bounds how many live grants an overlay may carry.
+//
+// Enforced at invite time only (the 11th invite is refused with 409), never retroactively: a
+// smaller cap must not silently cut a working mod team off mid-stream. Admins bypass it.
+const ModeratorsPerOverlayCap = 10
+
+// ErrNoActions reports an explicitly empty action list. Distinct from an absent list, which means
+// "use the default" — collapsing the two would grant actions the caller never asked for.
+var ErrNoActions = errors.New("a grant must delegate at least one action")
+
+// DefaultDelegatedActions is what an invite grants when the streamer does not choose: the pair a
+// volunteer moderator needs day to day. Ban and unban stay opt-in.
+var DefaultDelegatedActions = []string{string(ActionDelete), string(ActionTimeout)}
+
+// delegatableActions is the closed allowlist of verbs a grant may carry, in canonical order.
+//
+// This is the ONLY admission point for a grant's actions, and it is load-bearing beyond tidiness:
+// ModerationScopesForActions downstream also accepts "engagement", which maps to
+// channel:read:polls / channel:read:predictions. An unfiltered string reaching it would widen a
+// moderator's consent screen to scopes on their own channel that have nothing to do with
+// moderation (an ADR-0012 regression). Chat send is absent by decision — it is a distinct,
+// higher-trust capability and stays owner-only in v1.
+var delegatableActions = []string{
+	string(ActionDelete), string(ActionTimeout), string(ActionBan), string(ActionUnban),
+}
+
+// IsDelegatableAction reports whether action may be carried by a delegation grant.
+func IsDelegatableAction(action string) bool {
+	for _, a := range delegatableActions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeDelegatedActions validates a requested action set and returns it deduplicated in
+// canonical order, so the stored array, the API response and the UI never disagree about order.
+//
+// A nil list yields DefaultDelegatedActions; an empty-but-present list is ErrNoActions.
+func NormalizeDelegatedActions(requested []string) ([]string, error) {
+	if requested == nil {
+		return append([]string(nil), DefaultDelegatedActions...), nil
+	}
+	if len(requested) == 0 {
+		return nil, ErrNoActions
+	}
+
+	wanted := make(map[string]bool, len(requested))
+	for _, action := range requested {
+		if !IsDelegatableAction(action) {
+			return nil, fmt.Errorf("%q is not a delegatable moderation action", action)
+		}
+		wanted[action] = true
+	}
+
+	out := make([]string, 0, len(wanted))
+	for _, a := range delegatableActions {
+		if wanted[a] {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+// NormalizeDelegatedPlatforms validates the per-platform legs to enable and returns them
+// deduplicated in the order given.
+//
+// A nil or empty list is legitimate and means "no platform enabled yet": absence is disablement
+// (migration 080), so a grant delegates nothing until the streamer opts a platform in. That is
+// what keeps Discord — the one platform with no external authority behind it — off by default.
+func NormalizeDelegatedPlatforms(requested []string) ([]string, error) {
+	out := make([]string, 0, len(requested))
+	seen := make(map[string]bool, len(requested))
+	for _, platform := range requested {
+		// PlatformSupported already excludes TikTok (no moderation API at all) and
+		// shared_overlay (someone else's channel), which is exactly the exclusion a grant needs.
+		if !PlatformSupported(platform) {
+			return nil, fmt.Errorf("%q cannot be moderated, so it cannot be delegated", platform)
+		}
+		if seen[platform] {
+			continue
+		}
+		seen[platform] = true
+		out = append(out, platform)
+	}
+	return out, nil
+}
+
+// PreBindablePlatform reports whether an invite may be pre-bound to an account on this platform.
+//
+// Pre-binding is only honest where acceptance can actually resolve the redeeming user's id on that
+// platform and compare it. Twitch is the only one today — it is where the "pick from your
+// moderators" flow reads its ids from, and an All-Chat account carries a verified Twitch id. For
+// the others we would be storing a constraint that silently does nothing, so the API refuses it
+// rather than pretending.
+func PreBindablePlatform(platform string) bool { return platform == "twitch" }
+
+// maxInviteeLabelLen mirrors overlay_moderators.invitee_label. Trimmed rather than rejected: the
+// label is display-only and a truncated name beats a failed invite.
+const maxInviteeLabelLen = 120
+
+// TrimInviteeLabel normalizes the streamer-supplied display label for an invitee.
+func TrimInviteeLabel(label string) string {
+	label = strings.TrimSpace(label)
+	if len(label) > maxInviteeLabelLen {
+		label = strings.ToValidUTF8(label[:maxInviteeLabelLen], "")
+	}
+	return label
+}
+
+// ---------------------------------------------------------------------------
+// Owner-facing request/response DTOs.
+// ---------------------------------------------------------------------------
+
+// CreateInviteRequest mints an invite for one moderator.
+type CreateInviteRequest struct {
+	// Actions to delegate. Absent = DefaultDelegatedActions; [] = 400.
+	Actions []string `json:"actions"`
+	// Platforms whose legs start enabled. Absent = none, and the grant delegates nothing until
+	// the streamer enables one.
+	Platforms []string `json:"platforms"`
+	// InviteeLabel is display-only ("Sarah, my Twitch mod"), so the list is readable before
+	// anyone accepts.
+	InviteeLabel string `json:"invitee_label"`
+	// ExpectedPlatform / ExpectedPlatformUserID optionally bind the invite to one platform
+	// account, so redeeming it from the wrong account fails with an explanation instead of
+	// silently granting the wrong person.
+	ExpectedPlatform       string `json:"expected_platform"`
+	ExpectedPlatformUserID string `json:"expected_platform_user_id"`
+}
+
+// InviteCreated is the response to a fresh invite. InviteToken appears here and nowhere else,
+// ever again.
+type InviteCreated struct {
+	GrantID string `json:"grant_id"`
+	// InviteToken is the single-use secret. It is not stored in retrievable form, so a streamer
+	// who loses it mints a new invite; there is no "show again".
+	InviteToken  string    `json:"invite_token"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	Actions      []string  `json:"actions"`
+	Platforms    []string  `json:"platforms"`
+	InviteeLabel string    `json:"invitee_label,omitempty"`
+}
+
+// GrantPlatformLeg is one platform's enablement on a grant, plus its last known readiness.
+type GrantPlatformLeg struct {
+	Platform string `json:"platform"`
+	Enabled  bool   `json:"enabled"`
+	// Verification is TELEMETRY for the owner's panel — the platform's answer at action time is
+	// the authority. It is never consulted when authorizing, so a transient 403 cannot lock out
+	// a legitimate moderator.
+	Verification string     `json:"verification"`
+	VerifiedAt   *time.Time `json:"verified_at,omitempty"`
+}
+
+// ModeratorGrant is one delegation as the overlay owner sees it.
+type ModeratorGrant struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	// ModeratorUserID is empty while the invite is unredeemed.
+	ModeratorUserID string `json:"moderator_user_id,omitempty"`
+	// DisplayName is captured at accept time so the list still names the person after their
+	// account is gone.
+	DisplayName  string             `json:"display_name,omitempty"`
+	InviteeLabel string             `json:"invitee_label,omitempty"`
+	Actions      []string           `json:"actions"`
+	Platforms    []GrantPlatformLeg `json:"platforms"`
+	// ExpectedPlatform / ExpectedAccount echo a pre-binding so the panel can show who the
+	// outstanding invite is for.
+	ExpectedPlatform string     `json:"expected_platform,omitempty"`
+	ExpectedAccount  string     `json:"expected_account,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	AcceptedAt       *time.Time `json:"accepted_at,omitempty"`
+	// InviteExpiresAt is set only while the invite is outstanding.
+	InviteExpiresAt *time.Time `json:"invite_expires_at,omitempty"`
+	SuspendedAt     *time.Time `json:"suspended_at,omitempty"`
+	LastActionAt    *time.Time `json:"last_action_at,omitempty"`
+}
+
+// ModeratorList is the owner's Moderators panel payload. Cap and Used are reported so the UI can
+// explain a refused invite before the streamer hits it.
+type ModeratorList struct {
+	Moderators []ModeratorGrant `json:"moderators"`
+	Cap        int              `json:"cap"`
+	Used       int              `json:"used"`
+}
+
+// UpdateGrantRequest changes what an existing grant may do. Both fields are optional; an absent
+// field leaves that dimension untouched.
+type UpdateGrantRequest struct {
+	Actions []string `json:"actions"`
+	// Platforms maps a platform to its enablement. Only the listed platforms change, so the UI
+	// can send one toggle without restating the rest.
+	Platforms map[string]bool `json:"platforms"`
+}
+
+// ---------------------------------------------------------------------------
+// Moderator-facing DTOs.
+// ---------------------------------------------------------------------------
+
+// InviteTokenRequest carries an invite secret. It is a POST body rather than a path parameter on
+// purpose: a secret in a URL ends up in access logs, proxy logs and Referer headers.
+type InviteTokenRequest struct {
+	Token string `json:"token" binding:"required"`
+}
+
+// InvitePreview is what an invite holder is shown before they accept: who is asking, for which
+// overlay, and what they are agreeing to do.
+//
+// The overlay id is deliberately absent. An overlay UUID already grants chat READ to anyone
+// holding it, so it is disclosed at acceptance rather than to everyone who merely opens the link.
+type InvitePreview struct {
+	OverlayName      string             `json:"overlay_name"`
+	OwnerDisplayName string             `json:"owner_display_name"`
+	Actions          []string           `json:"actions"`
+	Platforms        []GrantPlatformLeg `json:"platforms"`
+	ExpiresAt        time.Time          `json:"expires_at"`
+	InviteeLabel     string             `json:"invitee_label,omitempty"`
+	// ExpectedPlatform / ExpectedAccount are set when the invite is pre-bound, so the page can
+	// say "this invite is for @sarah" before the redeem attempt fails.
+	ExpectedPlatform string `json:"expected_platform,omitempty"`
+	ExpectedAccount  string `json:"expected_account,omitempty"`
+}
+
+// InviteAccepted confirms a redeemed invite and hands over the overlay the moderator may now act
+// on.
+type InviteAccepted struct {
+	GrantID          string             `json:"grant_id"`
+	OverlayID        string             `json:"overlay_id"`
+	OverlayName      string             `json:"overlay_name"`
+	OwnerDisplayName string             `json:"owner_display_name"`
+	Actions          []string           `json:"actions"`
+	Platforms        []GrantPlatformLeg `json:"platforms"`
+}

--- a/services/moderation-service/models/grant_test.go
+++ b/services/moderation-service/models/grant_test.go
@@ -1,0 +1,114 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The delegatable set is a closed allowlist, and this is the only place a grant's actions are
+// admitted. ModerationScopesForActions downstream also accepts "engagement" (mapping to
+// channel:read:polls / channel:read:predictions), so anything that reaches it unfiltered is a
+// scope-widening hole. Normalising here is what keeps that from being reachable via a grant.
+func TestNormalizeDelegatedActions_RejectsAnythingOutsideTheFourVerbs(t *testing.T) {
+	for _, bad := range []string{"engagement", "send", "rediscover", "DELETE", "", "delete "} {
+		t.Run(bad, func(t *testing.T) {
+			_, err := NormalizeDelegatedActions([]string{bad})
+			assert.Error(t, err, "%q must not be storable as a delegated action", bad)
+		})
+	}
+}
+
+func TestNormalizeDelegatedActions_AcceptsTheFourVerbs(t *testing.T) {
+	got, err := NormalizeDelegatedActions([]string{"delete", "timeout", "ban", "unban"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"delete", "timeout", "ban", "unban"}, got)
+}
+
+func TestNormalizeDelegatedActions_DedupesAndOrdersCanonically(t *testing.T) {
+	got, err := NormalizeDelegatedActions([]string{"ban", "delete", "ban", "timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"delete", "timeout", "ban"}, got,
+		"canonical order keeps the stored array, the API response and the UI in agreement")
+}
+
+func TestNormalizeDelegatedActions_EmptyMeansTheDefaultPair(t *testing.T) {
+	got, err := NormalizeDelegatedActions(nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"delete", "timeout"}, got,
+		"the safe default is the pair a volunteer needs day to day; ban/unban stay opt-in")
+	assert.Equal(t, DefaultDelegatedActions, got)
+}
+
+// An absent list means "use the default"; an explicitly empty one means "grant nothing", and
+// those must not collapse into each other. Defaulting an explicit [] would hand out delete and
+// timeout to a caller who asked for neither.
+func TestNormalizeDelegatedActions_ExplicitlyEmptyIsNotTheDefault(t *testing.T) {
+	_, err := NormalizeDelegatedActions([]string{})
+	assert.ErrorIs(t, err, ErrNoActions,
+		"an explicitly empty list must be an error, never silently widened to the default")
+}
+
+func TestNormalizeDelegatedPlatforms(t *testing.T) {
+	t.Run("the four moderation platforms are delegatable", func(t *testing.T) {
+		got, err := NormalizeDelegatedPlatforms([]string{"twitch", "kick", "youtube", "discord"})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"twitch", "kick", "youtube", "discord"}, got)
+	})
+
+	t.Run("tiktok has no moderation API, so a leg for it is refused rather than dead", func(t *testing.T) {
+		_, err := NormalizeDelegatedPlatforms([]string{"tiktok"})
+		assert.Error(t, err)
+	})
+
+	// A shared_overlay source displays another streamer's chat. Owner-only authorization made it
+	// unreachable by construction; a delegated grant must not be the thing that reopens it.
+	t.Run("shared_overlay can never be delegated", func(t *testing.T) {
+		_, err := NormalizeDelegatedPlatforms([]string{"shared_overlay"})
+		assert.Error(t, err)
+	})
+
+	t.Run("nothing enabled is the fail-closed default", func(t *testing.T) {
+		got, err := NormalizeDelegatedPlatforms(nil)
+		require.NoError(t, err)
+		assert.Empty(t, got, "a platform is never implicitly delegated — Discord least of all")
+	})
+
+	t.Run("duplicates collapse", func(t *testing.T) {
+		got, err := NormalizeDelegatedPlatforms([]string{"twitch", "twitch"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"twitch"}, got)
+	})
+}
+
+// Pre-binding an invite to a platform account is only honest where we can actually resolve the
+// accepting user's id on that platform. Twitch is the only one today (the mod picker reads Helix);
+// accepting a binding we cannot check would mean storing a constraint that silently does nothing.
+func TestPreBindablePlatform(t *testing.T) {
+	assert.True(t, PreBindablePlatform("twitch"))
+	for _, p := range []string{"kick", "youtube", "discord", "tiktok", "", "shared_overlay"} {
+		assert.False(t, PreBindablePlatform(p), "%q must not be accepted as a pre-binding", p)
+	}
+}
+
+func TestModeratorsPerOverlayCap(t *testing.T) {
+	assert.Equal(t, 10, ModeratorsPerOverlayCap,
+		"the cap is enforced at invite time only, so changing it can never cut off a working mod team")
+}

--- a/services/moderation-service/models/moderation.go
+++ b/services/moderation-service/models/moderation.go
@@ -345,10 +345,10 @@ type UnbanRequest struct {
 
 // SourceCapability describes whether one overlay source can be moderated and how.
 type SourceCapability struct {
-	Platform    string   `json:"platform"`
-	ChannelID   string   `json:"channel_id"`
-	ChannelName string   `json:"channel_name"`
-	Moderatable bool     `json:"moderatable"`
+	Platform    string `json:"platform"`
+	ChannelID   string `json:"channel_id"`
+	ChannelName string `json:"channel_name"`
+	Moderatable bool   `json:"moderatable"`
 	// CanSend reports whether the owner can send chat to this source from the monitor
 	// view (the chat-send scope is granted). Independent of Moderatable/Actions.
 	CanSend bool     `json:"can_send"`

--- a/services/moderation-service/repository/access_test.go
+++ b/services/moderation-service/repository/access_test.go
@@ -30,24 +30,6 @@ import (
 // what role the caller holds — because the premium gate must key on the owner while the
 // authorization keys on the caller.
 
-// addGrantSchema extends the test schema with the delegation tables (migration 080). Kept here
-// rather than in setupTestRepo so the existing ownership tests stay unaffected.
-func addGrantSchema(t *testing.T, r *Repository) {
-	t.Helper()
-	_, err := r.db.Exec(context.Background(), `
-		CREATE TABLE IF NOT EXISTS overlay_moderators (
-			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-			overlay_id UUID NOT NULL,
-			moderator_user_id UUID,
-			granted_by UUID NOT NULL,
-			status VARCHAR(16) NOT NULL DEFAULT 'pending',
-			actions TEXT[] NOT NULL DEFAULT '{delete,timeout}',
-			revoked_at TIMESTAMP,
-			last_action_at TIMESTAMP
-		)`)
-	require.NoError(t, err)
-}
-
 func grant(t *testing.T, r *Repository, modID, status string, actions []string, revoked bool) {
 	t.Helper()
 	revokedAt := "NULL"
@@ -64,7 +46,6 @@ func grant(t *testing.T, r *Repository, modID, status string, actions []string, 
 func TestResolveOverlayAccess(t *testing.T) {
 	repo, cleanup := setupTestRepo(t)
 	defer cleanup()
-	addGrantSchema(t, repo)
 	ctx := context.Background()
 
 	modID := uuid.New().String()
@@ -110,7 +91,6 @@ func TestResolveOverlayAccess(t *testing.T) {
 func TestResolveOverlayAccess_GrantLifecycle(t *testing.T) {
 	repo, cleanup := setupTestRepo(t)
 	defer cleanup()
-	addGrantSchema(t, repo)
 	ctx := context.Background()
 
 	cases := []struct {
@@ -146,7 +126,6 @@ func TestResolveOverlayAccess_GrantLifecycle(t *testing.T) {
 func TestResolveOverlayAccess_UnknownOverlayIsIndistinguishable(t *testing.T) {
 	repo, cleanup := setupTestRepo(t)
 	defer cleanup()
-	addGrantSchema(t, repo)
 	ctx := context.Background()
 
 	t.Run("nonexistent overlay", func(t *testing.T) {

--- a/services/moderation-service/repository/grants.go
+++ b/services/moderation-service/repository/grants.go
@@ -1,0 +1,600 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Grant-lifecycle failures a handler must distinguish. Everything else is an internal error.
+var (
+	// ErrModeratorCapReached: the overlay already carries ModeratorsPerOverlayCap live grants.
+	// Refused at invite time only; existing grants are never affected by the cap changing.
+	ErrModeratorCapReached = errors.New("moderator cap reached for this overlay")
+	// ErrGrantNotFound: no live grant with that id on THIS overlay.
+	ErrGrantNotFound = errors.New("grant not found")
+	// ErrInviteNotFound: the secret matches no outstanding invite. Covers unknown, already
+	// redeemed and revoked alike — all three are equally dead, and the holder learns nothing
+	// useful from the difference.
+	ErrInviteNotFound = errors.New("invite not found")
+	// ErrInviteExpired: the invite existed but its 7 days elapsed. Reported distinctly because
+	// whoever holds the secret already knows the invite was real, and "expired, ask again" is a
+	// far better answer than "not found".
+	ErrInviteExpired = errors.New("invite expired")
+	// ErrAlreadyModerator: this account already holds a live grant on the overlay.
+	ErrAlreadyModerator = errors.New("already a moderator on this overlay")
+	// ErrOwnerCannotAccept: the overlay owner tried to redeem their own invite. Their access
+	// comes from ownership; a self-grant would only add a confusing second row.
+	ErrOwnerCannotAccept = errors.New("the overlay owner cannot accept a delegation")
+	// ErrInviteBoundToOtherAccount: the invite names a specific platform account and the
+	// redeeming user is not it. The returned InviteDetails carry the expectation so the response
+	// can say who the invite is for.
+	ErrInviteBoundToOtherAccount = errors.New("invite is bound to another account")
+)
+
+// GrantLeg is one platform's enablement on a grant.
+type GrantLeg struct {
+	Platform string
+	Enabled  bool
+	// Verification is the last known platform moderator status. TELEMETRY ONLY: never read when
+	// authorizing (migration 080's column comment says the same), because caching a denial would
+	// make All-Chat the stale authority the design exists to avoid.
+	Verification string
+	VerifiedAt   *time.Time
+}
+
+// Grant is one delegation row. It deliberately carries no invite digest: nothing outside this
+// file needs it, so nothing outside this file can leak it.
+type Grant struct {
+	ID              string
+	OverlayID       string
+	ModeratorUserID string // empty while the invite is unredeemed
+	Status          string
+	Actions         []string
+	InviteeLabel    string
+	// ModeratorDisplayName is captured at accept time so an action stays attributable after the
+	// moderator's account is deleted.
+	ModeratorDisplayName   string
+	ExpectedPlatform       string
+	ExpectedPlatformUserID string
+	CreatedAt              time.Time
+	AcceptedAt             *time.Time
+	InviteExpiresAt        *time.Time
+	SuspendedAt            *time.Time
+	LastActionAt           *time.Time
+	Platforms              []GrantLeg
+}
+
+// InviteDetails is a grant plus the context an invite holder needs before agreeing to moderate:
+// which overlay, and whose.
+type InviteDetails struct {
+	Grant
+	OverlayName      string
+	OwnerDisplayName string
+}
+
+// InviteParams is everything CreateInvite needs. TokenHash is a digest — the plaintext secret
+// never reaches the repository.
+type InviteParams struct {
+	OverlayID              string
+	GrantedBy              string
+	Actions                []string
+	Platforms              []string
+	InviteeLabel           string
+	ExpectedPlatform       string
+	ExpectedPlatformUserID string
+	TokenHash              []byte
+	ExpiresAt              time.Time
+	// BypassCap skips the per-overlay moderator cap. Admin-only.
+	BypassCap bool
+}
+
+// CreateInvite mints a pending grant for an unknown recipient.
+//
+// The whole thing runs in one transaction that first takes a row lock on the overlay, so the cap
+// is a real limit rather than a race: two tabs or a double-click cannot both observe nine grants
+// and both insert. The lock also proves the overlay exists before anything else happens.
+func (r *Repository) CreateInvite(ctx context.Context, p InviteParams) (Grant, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Grant{}, fmt.Errorf("begin invite tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var lockedOverlay string
+	err = tx.QueryRow(ctx, `SELECT id::text FROM overlays WHERE id = $1 FOR UPDATE`, p.OverlayID).Scan(&lockedOverlay)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Grant{}, ErrOverlayNotFound
+	}
+	if err != nil {
+		return Grant{}, fmt.Errorf("lock overlay for invite: %w", err)
+	}
+
+	if !p.BypassCap {
+		var live int
+		if err := tx.QueryRow(ctx, `
+			SELECT COUNT(*) FROM overlay_moderators
+			WHERE overlay_id = $1 AND revoked_at IS NULL AND status <> 'revoked'`,
+			p.OverlayID).Scan(&live); err != nil {
+			return Grant{}, fmt.Errorf("count live grants: %w", err)
+		}
+		if live >= models.ModeratorsPerOverlayCap {
+			return Grant{}, ErrModeratorCapReached
+		}
+	}
+
+	var grant Grant
+	err = tx.QueryRow(ctx, `
+		INSERT INTO overlay_moderators
+			(overlay_id, granted_by, status, actions, invite_token_hash, invite_expires_at,
+			 invitee_label, expected_platform, expected_platform_user_id)
+		VALUES ($1, $2, 'pending', $3, $4, $5, NULLIF($6, ''), NULLIF($7, ''), NULLIF($8, ''))
+		RETURNING id::text, created_at`,
+		p.OverlayID, p.GrantedBy, p.Actions, p.TokenHash, p.ExpiresAt.UTC(),
+		p.InviteeLabel, p.ExpectedPlatform, p.ExpectedPlatformUserID,
+	).Scan(&grant.ID, &grant.CreatedAt)
+	if err != nil {
+		return Grant{}, fmt.Errorf("insert invite: %w", err)
+	}
+
+	for _, platform := range p.Platforms {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO overlay_moderator_platforms (grant_id, platform, enabled)
+			VALUES ($1, $2, TRUE)
+			ON CONFLICT (grant_id, platform) DO UPDATE SET enabled = TRUE`,
+			grant.ID, platform); err != nil {
+			return Grant{}, fmt.Errorf("enable platform leg %q: %w", platform, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Grant{}, fmt.Errorf("commit invite: %w", err)
+	}
+
+	grant.OverlayID = p.OverlayID
+	grant.Status = models.GrantStatusPending
+	grant.Actions = p.Actions
+	grant.InviteeLabel = p.InviteeLabel
+	grant.ExpectedPlatform = p.ExpectedPlatform
+	grant.ExpectedPlatformUserID = p.ExpectedPlatformUserID
+	expires := p.ExpiresAt
+	grant.InviteExpiresAt = &expires
+	for _, platform := range p.Platforms {
+		grant.Platforms = append(grant.Platforms, GrantLeg{
+			Platform: platform, Enabled: true, Verification: "unverified",
+		})
+	}
+	return grant, nil
+}
+
+// grantColumns is the projection shared by every grant read. invite_token_hash is absent on
+// purpose: a digest that never leaves this file cannot be logged or serialized by accident.
+const grantColumns = `
+	m.id::text,
+	m.overlay_id::text,
+	COALESCE(m.moderator_user_id::text, ''),
+	m.status,
+	m.actions,
+	COALESCE(m.invitee_label, ''),
+	COALESCE(m.moderator_display_name, ''),
+	COALESCE(m.expected_platform, ''),
+	COALESCE(m.expected_platform_user_id, ''),
+	m.created_at,
+	m.accepted_at,
+	m.invite_expires_at,
+	m.suspended_at,
+	m.last_action_at`
+
+func scanGrant(row pgx.Row) (Grant, error) {
+	var g Grant
+	err := row.Scan(
+		&g.ID, &g.OverlayID, &g.ModeratorUserID, &g.Status, &g.Actions,
+		&g.InviteeLabel, &g.ModeratorDisplayName, &g.ExpectedPlatform, &g.ExpectedPlatformUserID,
+		&g.CreatedAt, &g.AcceptedAt, &g.InviteExpiresAt, &g.SuspendedAt, &g.LastActionAt,
+	)
+	return g, err
+}
+
+// ListGrants returns the overlay's live delegations — pending invites included, revoked rows
+// excluded. Revoked rows stay in the table as history; they are not roster.
+func (r *Repository) ListGrants(ctx context.Context, overlayID string) ([]Grant, error) {
+	if _, err := uuid.Parse(overlayID); err != nil {
+		return nil, ErrOverlayNotFound
+	}
+
+	rows, err := r.db.Query(ctx, `
+		SELECT`+grantColumns+`
+		FROM overlay_moderators m
+		WHERE m.overlay_id = $1 AND m.revoked_at IS NULL AND m.status <> 'revoked'
+		ORDER BY m.created_at`, overlayID)
+	if err != nil {
+		return nil, fmt.Errorf("list grants: %w", err)
+	}
+	defer rows.Close()
+
+	grants := make([]Grant, 0)
+	index := map[string]int{}
+	for rows.Next() {
+		g, err := scanGrant(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan grant: %w", err)
+		}
+		index[g.ID] = len(grants)
+		grants = append(grants, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grants: %w", err)
+	}
+	if len(grants) == 0 {
+		return grants, nil
+	}
+
+	legRows, err := r.db.Query(ctx, `
+		SELECT p.grant_id::text, p.platform, p.enabled, p.verification, p.verified_at
+		FROM overlay_moderator_platforms p
+		JOIN overlay_moderators m ON m.id = p.grant_id
+		WHERE m.overlay_id = $1 AND m.revoked_at IS NULL AND m.status <> 'revoked'
+		ORDER BY p.platform`, overlayID)
+	if err != nil {
+		return nil, fmt.Errorf("list grant platforms: %w", err)
+	}
+	defer legRows.Close()
+
+	for legRows.Next() {
+		var grantID string
+		var leg GrantLeg
+		if err := legRows.Scan(&grantID, &leg.Platform, &leg.Enabled, &leg.Verification, &leg.VerifiedAt); err != nil {
+			return nil, fmt.Errorf("scan grant platform: %w", err)
+		}
+		if i, ok := index[grantID]; ok {
+			grants[i].Platforms = append(grants[i].Platforms, leg)
+		}
+	}
+	if err := legRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate grant platforms: %w", err)
+	}
+	return grants, nil
+}
+
+// legsFor loads one grant's platform legs.
+func (r *Repository) legsFor(ctx context.Context, q pgx.Tx, grantID string) ([]GrantLeg, error) {
+	rows, err := q.Query(ctx, `
+		SELECT platform, enabled, verification, verified_at
+		FROM overlay_moderator_platforms
+		WHERE grant_id = $1
+		ORDER BY platform`, grantID)
+	if err != nil {
+		return nil, fmt.Errorf("load grant platforms: %w", err)
+	}
+	defer rows.Close()
+
+	var legs []GrantLeg
+	for rows.Next() {
+		var leg GrantLeg
+		if err := rows.Scan(&leg.Platform, &leg.Enabled, &leg.Verification, &leg.VerifiedAt); err != nil {
+			return nil, fmt.Errorf("scan grant platform: %w", err)
+		}
+		legs = append(legs, leg)
+	}
+	return legs, rows.Err()
+}
+
+// UpdateGrant narrows or widens a live grant. actions == nil leaves the action set alone; legs ==
+// nil leaves platform enablement alone, and a partial map changes only the platforms it names, so
+// one toggle in the UI does not have to restate the rest.
+//
+// The overlay id scopes the write as well as the authorization: a grant id belonging to another
+// overlay must be invisible here, or an owner could edit somebody else's team by guessing an id.
+func (r *Repository) UpdateGrant(ctx context.Context, overlayID, grantID string, actions []string, legs map[string]bool) (Grant, error) {
+	if _, err := uuid.Parse(grantID); err != nil {
+		return Grant{}, ErrGrantNotFound
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Grant{}, fmt.Errorf("begin grant update: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var live string
+	err = tx.QueryRow(ctx, `
+		SELECT id::text FROM overlay_moderators
+		WHERE id = $1 AND overlay_id = $2 AND revoked_at IS NULL AND status <> 'revoked'
+		FOR UPDATE`, grantID, overlayID).Scan(&live)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Grant{}, ErrGrantNotFound
+	}
+	if err != nil {
+		return Grant{}, fmt.Errorf("lock grant: %w", err)
+	}
+
+	if actions != nil {
+		if _, err := tx.Exec(ctx,
+			`UPDATE overlay_moderators SET actions = $2 WHERE id = $1`, grantID, actions); err != nil {
+			return Grant{}, fmt.Errorf("update grant actions: %w", err)
+		}
+	}
+	for platform, enabled := range legs {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO overlay_moderator_platforms (grant_id, platform, enabled)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (grant_id, platform) DO UPDATE SET enabled = EXCLUDED.enabled`,
+			grantID, platform, enabled); err != nil {
+			return Grant{}, fmt.Errorf("set platform leg %q: %w", platform, err)
+		}
+	}
+
+	updated, err := scanGrant(tx.QueryRow(ctx,
+		`SELECT`+grantColumns+` FROM overlay_moderators m WHERE m.id = $1`, grantID))
+	if err != nil {
+		return Grant{}, fmt.Errorf("reload grant: %w", err)
+	}
+	updated.Platforms, err = r.legsFor(ctx, tx, grantID)
+	if err != nil {
+		return Grant{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Grant{}, fmt.Errorf("commit grant update: %w", err)
+	}
+	return updated, nil
+}
+
+// revokeSQL is shared by single and bulk revocation.
+//
+// Clearing invite_token_hash is the load-bearing part: a revoked invite whose secret is still in
+// someone's inbox must be dead, not merely marked. Nulling the digest also frees the partial
+// unique index for a future invite.
+const revokeSQL = `
+	UPDATE overlay_moderators
+	SET status = 'revoked', revoked_at = NOW(), revoked_by = $1,
+	    invite_token_hash = NULL, invite_expires_at = NULL
+	WHERE overlay_id = $2 AND revoked_at IS NULL AND status <> 'revoked'`
+
+// RevokeGrant revokes one grant. It reports false when there was nothing live to revoke — an
+// unknown id, another overlay's grant, or a second click — which is not an error.
+func (r *Repository) RevokeGrant(ctx context.Context, overlayID, grantID, revokedBy string) (bool, error) {
+	if _, err := uuid.Parse(grantID); err != nil {
+		return false, nil
+	}
+	tag, err := r.db.Exec(ctx, revokeSQL+` AND id = $3`, revokedBy, overlayID, grantID)
+	if err != nil {
+		return false, fmt.Errorf("revoke grant: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// RevokeAllGrants is the kill switch: every live delegation on the overlay goes, unredeemed
+// invites included. Returns how many were revoked.
+func (r *Repository) RevokeAllGrants(ctx context.Context, overlayID, revokedBy string) (int, error) {
+	if _, err := uuid.Parse(overlayID); err != nil {
+		return 0, ErrOverlayNotFound
+	}
+	tag, err := r.db.Exec(ctx, revokeSQL, revokedBy, overlayID)
+	if err != nil {
+		return 0, fmt.Errorf("revoke all grants: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// inviteLookupSQL finds an outstanding invite by digest, together with the overlay and owner an
+// invite holder is entitled to see before agreeing to anything.
+const inviteLookupSQL = `
+	SELECT` + grantColumns + `,
+	       o.name, u.display_name, o.user_id::text
+	FROM overlay_moderators m
+	JOIN overlays o ON o.id = m.overlay_id
+	JOIN users u ON u.id = o.user_id
+	WHERE m.invite_token_hash = $1 AND m.revoked_at IS NULL AND m.status = 'pending'`
+
+// scanInvite reads inviteLookupSQL's projection.
+func scanInvite(row pgx.Row) (InviteDetails, string, error) {
+	var d InviteDetails
+	var ownerUserID string
+	err := row.Scan(
+		&d.ID, &d.OverlayID, &d.ModeratorUserID, &d.Status, &d.Actions,
+		&d.InviteeLabel, &d.ModeratorDisplayName, &d.ExpectedPlatform, &d.ExpectedPlatformUserID,
+		&d.CreatedAt, &d.AcceptedAt, &d.InviteExpiresAt, &d.SuspendedAt, &d.LastActionAt,
+		&d.OverlayName, &d.OwnerDisplayName, &ownerUserID,
+	)
+	return d, ownerUserID, err
+}
+
+// expired reports whether an invite's window has closed. A NULL expiry is treated as expired
+// rather than eternal: an invite with no deadline is a permanent unattended key.
+//
+// invite_expires_at is a naive TIMESTAMP, which pgx reads back as UTC. That is only comparable to
+// a real instant because CreateInvite writes the deadline in UTC — writing a local wall clock
+// would come back offset by the writer's zone, and an already-expired invite would read as valid.
+func expired(d InviteDetails) bool {
+	return d.InviteExpiresAt == nil || d.InviteExpiresAt.Before(time.Now().UTC())
+}
+
+// PreviewInvite reads an outstanding invite without redeeming it, so the invitee can see who is
+// asking and what for. It performs no writes at all.
+func (r *Repository) PreviewInvite(ctx context.Context, tokenHash []byte) (InviteDetails, error) {
+	details, _, err := scanInvite(r.db.QueryRow(ctx, inviteLookupSQL, tokenHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return InviteDetails{}, ErrInviteNotFound
+	}
+	if err != nil {
+		return InviteDetails{}, fmt.Errorf("preview invite: %w", err)
+	}
+	if expired(details) {
+		return InviteDetails{}, ErrInviteExpired
+	}
+
+	legs, err := r.db.Query(ctx, `
+		SELECT platform, enabled, verification, verified_at
+		FROM overlay_moderator_platforms WHERE grant_id = $1 ORDER BY platform`, details.ID)
+	if err != nil {
+		return InviteDetails{}, fmt.Errorf("preview invite platforms: %w", err)
+	}
+	defer legs.Close()
+	for legs.Next() {
+		var leg GrantLeg
+		if err := legs.Scan(&leg.Platform, &leg.Enabled, &leg.Verification, &leg.VerifiedAt); err != nil {
+			return InviteDetails{}, fmt.Errorf("scan invite platform: %w", err)
+		}
+		details.Platforms = append(details.Platforms, leg)
+	}
+	if err := legs.Err(); err != nil {
+		return InviteDetails{}, fmt.Errorf("iterate invite platforms: %w", err)
+	}
+	return details, nil
+}
+
+// AcceptInvite redeems an invite for userID: it binds the grant to that account, activates it, and
+// burns the secret.
+//
+// Burning means nulling the digest, so the row can never be redeemed again and a database leak
+// yields no usable invite. The moderator's display name is read from their own user row rather
+// than taken from a claim, so the owner's roster shows what All-Chat actually knows about them.
+func (r *Repository) AcceptInvite(ctx context.Context, tokenHash []byte, userID string) (InviteDetails, error) {
+	if _, err := uuid.Parse(userID); err != nil {
+		return InviteDetails{}, ErrInviteNotFound
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return InviteDetails{}, fmt.Errorf("begin accept tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	details, ownerUserID, err := scanInvite(tx.QueryRow(ctx, inviteLookupSQL+` FOR UPDATE OF m`, tokenHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return InviteDetails{}, ErrInviteNotFound
+	}
+	if err != nil {
+		return InviteDetails{}, fmt.Errorf("load invite: %w", err)
+	}
+	if expired(details) {
+		return InviteDetails{}, ErrInviteExpired
+	}
+	if ownerUserID == userID {
+		return InviteDetails{}, ErrOwnerCannotAccept
+	}
+
+	// A pre-bound invite names one platform account. Fail closed: if we cannot prove the
+	// redeeming user is that account, the invite is not theirs — the details go back with the
+	// error so the response can say which account it expects.
+	if details.ExpectedPlatform != "" {
+		matches, err := identityMatches(ctx, tx, userID, details.ExpectedPlatform, details.ExpectedPlatformUserID)
+		if err != nil {
+			return InviteDetails{}, err
+		}
+		if !matches {
+			return details, ErrInviteBoundToOtherAccount
+		}
+	}
+
+	var alreadyModerates bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM overlay_moderators
+			WHERE overlay_id = $1 AND moderator_user_id = $2 AND revoked_at IS NULL
+		)`, details.OverlayID, userID).Scan(&alreadyModerates); err != nil {
+		return InviteDetails{}, fmt.Errorf("check existing grant: %w", err)
+	}
+	if alreadyModerates {
+		return InviteDetails{}, ErrAlreadyModerator
+	}
+
+	err = tx.QueryRow(ctx, `
+		UPDATE overlay_moderators m
+		SET moderator_user_id = u.id,
+		    moderator_display_name = LEFT(u.display_name, 120),
+		    status = 'active',
+		    accepted_at = NOW(),
+		    invite_token_hash = NULL,
+		    invite_expires_at = NULL
+		FROM users u
+		WHERE m.id = $1 AND u.id = $2
+		RETURNING m.moderator_user_id::text, m.moderator_display_name, m.accepted_at`,
+		details.ID, userID,
+	).Scan(&details.ModeratorUserID, &details.ModeratorDisplayName, &details.AcceptedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The join found no user row, so the account vanished between authentication and here.
+		return InviteDetails{}, ErrInviteNotFound
+	}
+	// The partial unique index is the last line of defence against two concurrent accepts.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return InviteDetails{}, ErrAlreadyModerator
+	}
+	if err != nil {
+		return InviteDetails{}, fmt.Errorf("accept invite: %w", err)
+	}
+
+	details.Status = models.GrantStatusActive
+	details.InviteExpiresAt = nil
+	details.Platforms, err = r.legsFor(ctx, tx, details.ID)
+	if err != nil {
+		return InviteDetails{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return InviteDetails{}, fmt.Errorf("commit accept: %w", err)
+	}
+	return details, nil
+}
+
+// identityMatches reports whether userID demonstrably owns platformUserID on platform.
+//
+// Only Twitch is answerable today (models.PreBindablePlatform gates what may be stored), and it is
+// answered from three places, any of which is proof: the account's own Twitch identity, a linked
+// Twitch credential (ADR-0016), or a moderator credential from an earlier consent. Anything else
+// is a no, never an error — an unverifiable binding must not become an accidental allow.
+func identityMatches(ctx context.Context, tx pgx.Tx, userID, platform, platformUserID string) (bool, error) {
+	if platform != "twitch" || platformUserID == "" {
+		return false, nil
+	}
+	const query = `
+		SELECT EXISTS(SELECT 1 FROM users WHERE id = $1 AND twitch_id = $2)
+		    OR EXISTS(SELECT 1 FROM twitch_oauth_tokens WHERE user_id = $1 AND twitch_user_id = $2)
+		    OR EXISTS(SELECT 1 FROM mod_oauth_credentials
+		              WHERE user_id = $1 AND platform = 'twitch' AND platform_user_id = $2)`
+	var matches bool
+	if err := tx.QueryRow(ctx, query, userID, platformUserID).Scan(&matches); err != nil {
+		return false, fmt.Errorf("verify invite binding: %w", err)
+	}
+	return matches, nil
+}
+
+// TouchGrantActivity stamps a grant's last successful action.
+//
+// This drives the 90-day dormancy suspension, and it is written from the first delegated action
+// onwards so a later dormancy job cannot mistake a working mod team for an idle one. An empty
+// grant id (an owner acting on their own overlay) is a no-op, not a failure.
+func (r *Repository) TouchGrantActivity(ctx context.Context, grantID string) error {
+	if _, err := uuid.Parse(grantID); err != nil {
+		return nil
+	}
+	if _, err := r.db.Exec(ctx,
+		`UPDATE overlay_moderators SET last_action_at = NOW() WHERE id = $1`, grantID); err != nil {
+		return fmt.Errorf("touch grant activity: %w", err)
+	}
+	return nil
+}

--- a/services/moderation-service/repository/grants_test.go
+++ b/services/moderation-service/repository/grants_test.go
@@ -1,0 +1,629 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/invites"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newModerator inserts a user who can redeem an invite, and returns their id.
+func newModerator(t *testing.T, r *Repository, displayName string) string {
+	t.Helper()
+	id := uuid.New().String()
+	_, err := r.db.Exec(context.Background(),
+		`INSERT INTO users (id, is_premium, display_name) VALUES ($1, false, $2)`, id, displayName)
+	require.NoError(t, err)
+	return id
+}
+
+// inviteFor mints a secret and stores its hash, returning the secret the way a streamer would
+// receive it — the repository never sees the plaintext.
+func inviteFor(t *testing.T, r *Repository, p InviteParams) (Grant, string) {
+	t.Helper()
+	secret, err := invites.NewSecret()
+	require.NoError(t, err)
+	if p.OverlayID == "" {
+		p.OverlayID = overlayID
+	}
+	if p.GrantedBy == "" {
+		p.GrantedBy = ownerID
+	}
+	if p.Actions == nil {
+		p.Actions = []string{"delete", "timeout"}
+	}
+	p.TokenHash = invites.Hash(secret)
+	if p.ExpiresAt.IsZero() {
+		p.ExpiresAt = time.Now().Add(invites.TTL)
+	}
+	grant, err := r.CreateInvite(context.Background(), p)
+	require.NoError(t, err)
+	return grant, secret
+}
+
+func TestCreateInvite_StoresAPendingGrantWithNoAccountBound(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	grant, secret := inviteFor(t, repo, InviteParams{
+		Actions:      []string{"delete", "timeout", "ban"},
+		Platforms:    []string{"twitch"},
+		InviteeLabel: "Sarah",
+	})
+
+	assert.NotEmpty(t, grant.ID)
+	assert.Equal(t, "pending", grant.Status)
+	assert.Empty(t, grant.ModeratorUserID, "an invite is bound to nobody until it is redeemed")
+	assert.Equal(t, []string{"delete", "timeout", "ban"}, grant.Actions)
+	assert.Equal(t, "Sarah", grant.InviteeLabel)
+	require.NotNil(t, grant.InviteExpiresAt)
+
+	// The enabled leg is stored; every other platform stays absent, which is disablement.
+	require.Len(t, grant.Platforms, 1)
+	assert.Equal(t, "twitch", grant.Platforms[0].Platform)
+	assert.True(t, grant.Platforms[0].Enabled)
+	assert.Equal(t, "unverified", grant.Platforms[0].Verification)
+
+	// Only the digest is persisted; the plaintext secret exists nowhere in the database.
+	var stored []byte
+	require.NoError(t, repo.db.QueryRow(ctx,
+		`SELECT invite_token_hash FROM overlay_moderators WHERE id = $1`, grant.ID).Scan(&stored))
+	assert.Equal(t, invites.Hash(secret), stored)
+	assert.NotContains(t, string(stored), secret)
+}
+
+// A pending invite still occupies a seat: otherwise minting invites would be an unbounded way
+// around the cap.
+func TestCreateInvite_CapCountsPendingInvitesAndIsRefusedOnTheEleventh(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		inviteFor(t, repo, InviteParams{})
+	}
+
+	secret, err := invites.NewSecret()
+	require.NoError(t, err)
+	_, err = repo.CreateInvite(ctx, InviteParams{
+		OverlayID: overlayID, GrantedBy: ownerID, Actions: []string{"delete"},
+		TokenHash: invites.Hash(secret), ExpiresAt: time.Now().Add(invites.TTL),
+	})
+	assert.ErrorIs(t, err, ErrModeratorCapReached)
+
+	t.Run("an admin override still gets through", func(t *testing.T) {
+		override, err := invites.NewSecret()
+		require.NoError(t, err)
+		grant, err := repo.CreateInvite(ctx, InviteParams{
+			OverlayID: overlayID, GrantedBy: ownerID, Actions: []string{"delete"},
+			TokenHash: invites.Hash(override), ExpiresAt: time.Now().Add(invites.TTL),
+			BypassCap: true,
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, grant.ID)
+	})
+}
+
+func TestCreateInvite_RevokedGrantsFreeTheirSeat(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	var first Grant
+	for i := 0; i < 10; i++ {
+		g, _ := inviteFor(t, repo, InviteParams{})
+		if i == 0 {
+			first = g
+		}
+	}
+	revoked, err := repo.RevokeGrant(ctx, overlayID, first.ID, ownerID)
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	_, err = repo.CreateInvite(ctx, InviteParams{
+		OverlayID: overlayID, GrantedBy: ownerID, Actions: []string{"delete"},
+		TokenHash: invites.Hash("free-seat"), ExpiresAt: time.Now().Add(invites.TTL),
+	})
+	assert.NoError(t, err, "revoking a moderator must make room for another")
+}
+
+// The cap is only a control if it holds when the streamer double-clicks, or two browser tabs race.
+// Counting without serialising on the overlay would let both transactions see nine and insert.
+func TestCreateInvite_CapHoldsUnderConcurrentInvites(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const attempts = 20
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		succeeded int
+		capErrors int
+	)
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			secret, err := invites.NewSecret()
+			if err != nil {
+				return
+			}
+			_, err = repo.CreateInvite(ctx, InviteParams{
+				OverlayID: overlayID, GrantedBy: ownerID, Actions: []string{"delete"},
+				TokenHash: invites.Hash(secret), ExpiresAt: time.Now().Add(invites.TTL),
+			})
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				succeeded++
+			case err == ErrModeratorCapReached:
+				capErrors++
+			default:
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 10, succeeded, "exactly the cap may be created, however many callers race")
+	assert.Equal(t, attempts-10, capErrors)
+
+	var live int
+	require.NoError(t, repo.db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM overlay_moderators WHERE overlay_id = $1 AND revoked_at IS NULL`,
+		overlayID).Scan(&live))
+	assert.Equal(t, 10, live)
+}
+
+func TestAcceptInvite_BindsTheGrantAndBurnsTheSecret(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	grant, secret := inviteFor(t, repo, InviteParams{Platforms: []string{"twitch", "kick"}})
+	modID := newModerator(t, repo, "Sarah Example")
+
+	accepted, err := repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+	require.NoError(t, err)
+	assert.Equal(t, grant.ID, accepted.ID)
+	assert.Equal(t, "active", accepted.Status)
+	assert.Equal(t, modID, accepted.ModeratorUserID)
+	assert.Equal(t, "Sarah Example", accepted.ModeratorDisplayName,
+		"the name is captured now so the owner's log can still name them after the account is gone")
+	assert.Equal(t, "My Overlay", accepted.OverlayName)
+	assert.Equal(t, "The Streamer", accepted.OwnerDisplayName)
+	assert.Len(t, accepted.Platforms, 2)
+	require.NotNil(t, accepted.AcceptedAt)
+
+	t.Run("the same secret cannot be redeemed twice", func(t *testing.T) {
+		other := newModerator(t, repo, "Someone Else")
+		_, err := repo.AcceptInvite(ctx, invites.Hash(secret), other)
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+	})
+
+	t.Run("the hash is cleared, so a database leak yields no live invite", func(t *testing.T) {
+		var hash []byte
+		require.NoError(t, repo.db.QueryRow(ctx,
+			`SELECT invite_token_hash FROM overlay_moderators WHERE id = $1`, grant.ID).Scan(&hash))
+		assert.Nil(t, hash)
+	})
+}
+
+func TestAcceptInvite_Refusals(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("an unknown secret", func(t *testing.T) {
+		_, err := repo.AcceptInvite(ctx, invites.Hash("never-issued"), newModerator(t, repo, "X"))
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+	})
+
+	t.Run("an expired invite reports expiry, which the holder of the secret may know", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, InviteParams{ExpiresAt: time.Now().Add(-time.Minute)})
+		_, err := repo.AcceptInvite(ctx, invites.Hash(secret), newModerator(t, repo, "Late"))
+		assert.ErrorIs(t, err, ErrInviteExpired)
+	})
+
+	t.Run("the overlay owner cannot delegate to themselves", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, InviteParams{})
+		_, err := repo.AcceptInvite(ctx, invites.Hash(secret), ownerID)
+		assert.ErrorIs(t, err, ErrOwnerCannotAccept)
+	})
+
+	t.Run("someone who already moderates this overlay", func(t *testing.T) {
+		_, first := inviteFor(t, repo, InviteParams{})
+		modID := newModerator(t, repo, "Twice")
+		_, err := repo.AcceptInvite(ctx, invites.Hash(first), modID)
+		require.NoError(t, err)
+
+		_, second := inviteFor(t, repo, InviteParams{})
+		_, err = repo.AcceptInvite(ctx, invites.Hash(second), modID)
+		assert.ErrorIs(t, err, ErrAlreadyModerator)
+	})
+
+	// A revoked invite must be dead even though the secret is still in someone's inbox.
+	t.Run("a revoked invite", func(t *testing.T) {
+		grant, secret := inviteFor(t, repo, InviteParams{})
+		_, err := repo.RevokeGrant(ctx, overlayID, grant.ID, ownerID)
+		require.NoError(t, err)
+		_, err = repo.AcceptInvite(ctx, invites.Hash(secret), newModerator(t, repo, "Too late"))
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+	})
+}
+
+// A pre-bound invite is a promise that only one account can redeem it. If acceptance ignored the
+// binding, the "pick from your Twitch moderators" flow would hand the channel to whoever opened
+// the link first.
+func TestAcceptInvite_PreBinding(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	bound := InviteParams{ExpectedPlatform: "twitch", ExpectedPlatformUserID: "77777", InviteeLabel: "@sarah"}
+
+	t.Run("the account named in the invite is accepted via their All-Chat identity", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, bound)
+		modID := newModerator(t, repo, "Sarah")
+		_, err := repo.db.Exec(ctx, `UPDATE users SET twitch_id = '77777' WHERE id = $1`, modID)
+		require.NoError(t, err)
+
+		accepted, err := repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+		require.NoError(t, err)
+		assert.Equal(t, "active", accepted.Status)
+	})
+
+	t.Run("a linked Twitch credential also proves the identity", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, bound)
+		modID := newModerator(t, repo, "Sarah linked")
+		_, err := repo.db.Exec(ctx,
+			`INSERT INTO twitch_oauth_tokens (user_id, twitch_user_id, twitch_login) VALUES ($1, '77777', 'sarah')`,
+			modID)
+		require.NoError(t, err)
+
+		_, err = repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("a moderator credential from an earlier consent also proves it", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, bound)
+		modID := newModerator(t, repo, "Sarah consented")
+		_, err := repo.db.Exec(ctx,
+			`INSERT INTO mod_oauth_credentials (user_id, platform, platform_user_id, access_token)
+			 VALUES ($1, 'twitch', '77777', 'enc')`, modID)
+		require.NoError(t, err)
+
+		_, err = repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("the wrong account is refused, and told who the invite is for", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, bound)
+		bob := newModerator(t, repo, "Bob")
+		_, err := repo.db.Exec(ctx, `UPDATE users SET twitch_id = '12345' WHERE id = $1`, bob)
+		require.NoError(t, err)
+
+		details, err := repo.AcceptInvite(ctx, invites.Hash(secret), bob)
+		assert.ErrorIs(t, err, ErrInviteBoundToOtherAccount)
+		assert.Equal(t, "@sarah", details.InviteeLabel,
+			"the refusal must carry enough to say which account the invite expects")
+		assert.Equal(t, "twitch", details.ExpectedPlatform)
+	})
+
+	// Fail closed: an account with no Twitch identity at all cannot satisfy a Twitch binding.
+	t.Run("an account with no identity on that platform is refused", func(t *testing.T) {
+		_, secret := inviteFor(t, repo, bound)
+		_, err := repo.AcceptInvite(ctx, invites.Hash(secret), newModerator(t, repo, "No twitch"))
+		assert.ErrorIs(t, err, ErrInviteBoundToOtherAccount)
+	})
+}
+
+func TestListGrants(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	pending, _ := inviteFor(t, repo, InviteParams{InviteeLabel: "Outstanding"})
+	activeGrant, secret := inviteFor(t, repo, InviteParams{Platforms: []string{"twitch"}})
+	modID := newModerator(t, repo, "Active Mod")
+	_, err := repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+	require.NoError(t, err)
+	gone, _ := inviteFor(t, repo, InviteParams{})
+	_, err = repo.RevokeGrant(ctx, overlayID, gone.ID, ownerID)
+	require.NoError(t, err)
+
+	grants, err := repo.ListGrants(ctx, overlayID)
+	require.NoError(t, err)
+
+	byID := map[string]Grant{}
+	for _, g := range grants {
+		byID[g.ID] = g
+	}
+	assert.Len(t, grants, 2, "revoked grants are history, not roster")
+	assert.NotContains(t, byID, gone.ID)
+
+	assert.Equal(t, "pending", byID[pending.ID].Status)
+	assert.Equal(t, "Outstanding", byID[pending.ID].InviteeLabel)
+	require.NotNil(t, byID[pending.ID].InviteExpiresAt, "an outstanding invite still has a deadline")
+
+	live := byID[activeGrant.ID]
+	assert.Equal(t, "active", live.Status)
+	assert.Equal(t, "Active Mod", live.ModeratorDisplayName)
+	assert.Equal(t, modID, live.ModeratorUserID)
+	require.Len(t, live.Platforms, 1)
+	assert.Equal(t, "twitch", live.Platforms[0].Platform)
+
+	t.Run("another overlay's grants are not listed", func(t *testing.T) {
+		otherOverlay := uuid.New().String()
+		_, err := repo.db.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'Other')`,
+			otherOverlay, ownerID)
+		require.NoError(t, err)
+		inviteFor(t, repo, InviteParams{OverlayID: otherOverlay})
+
+		grants, err := repo.ListGrants(ctx, overlayID)
+		require.NoError(t, err)
+		assert.Len(t, grants, 2)
+	})
+}
+
+func TestUpdateGrant(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	grant, _ := inviteFor(t, repo, InviteParams{Actions: []string{"delete"}, Platforms: []string{"twitch"}})
+
+	t.Run("actions are replaced, not merged", func(t *testing.T) {
+		updated, err := repo.UpdateGrant(ctx, overlayID, grant.ID, []string{"timeout"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timeout"}, updated.Actions,
+			"narrowing a grant must actually remove what was taken away")
+	})
+
+	t.Run("a leg can be enabled and disabled", func(t *testing.T) {
+		updated, err := repo.UpdateGrant(ctx, overlayID, grant.ID, nil, map[string]bool{"kick": true})
+		require.NoError(t, err)
+		legs := legsByPlatform(updated)
+		assert.True(t, legs["kick"].Enabled)
+		assert.True(t, legs["twitch"].Enabled, "an unmentioned platform is left alone")
+
+		updated, err = repo.UpdateGrant(ctx, overlayID, grant.ID, nil, map[string]bool{"twitch": false})
+		require.NoError(t, err)
+		legs = legsByPlatform(updated)
+		assert.False(t, legs["twitch"].Enabled)
+		assert.True(t, legs["kick"].Enabled)
+	})
+
+	t.Run("nil arguments leave the grant untouched", func(t *testing.T) {
+		before, err := repo.UpdateGrant(ctx, overlayID, grant.ID, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"timeout"}, before.Actions)
+	})
+
+	// The overlay id in the path is part of the authorization decision, so it must also scope the
+	// write: otherwise an owner could edit a grant on somebody else's overlay by guessing its id.
+	t.Run("a grant on another overlay is invisible", func(t *testing.T) {
+		otherOverlay := uuid.New().String()
+		_, err := repo.db.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'Other')`,
+			otherOverlay, ownerID)
+		require.NoError(t, err)
+		foreign, _ := inviteFor(t, repo, InviteParams{OverlayID: otherOverlay})
+
+		_, err = repo.UpdateGrant(ctx, overlayID, foreign.ID, []string{"ban"}, nil)
+		assert.ErrorIs(t, err, ErrGrantNotFound)
+	})
+
+	t.Run("an unknown or malformed grant id", func(t *testing.T) {
+		_, err := repo.UpdateGrant(ctx, overlayID, uuid.New().String(), []string{"ban"}, nil)
+		assert.ErrorIs(t, err, ErrGrantNotFound)
+		_, err = repo.UpdateGrant(ctx, overlayID, "not-a-uuid", []string{"ban"}, nil)
+		assert.ErrorIs(t, err, ErrGrantNotFound, "a bad id must not surface as a 500")
+	})
+
+	t.Run("a revoked grant cannot be edited back to life", func(t *testing.T) {
+		revoked, _ := inviteFor(t, repo, InviteParams{})
+		_, err := repo.RevokeGrant(ctx, overlayID, revoked.ID, ownerID)
+		require.NoError(t, err)
+		_, err = repo.UpdateGrant(ctx, overlayID, revoked.ID, []string{"ban"}, nil)
+		assert.ErrorIs(t, err, ErrGrantNotFound)
+	})
+}
+
+func TestRevokeGrant(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	grant, secret := inviteFor(t, repo, InviteParams{})
+
+	revoked, err := repo.RevokeGrant(ctx, overlayID, grant.ID, adminActor)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+
+	var status string
+	var revokedBy *string
+	var hash []byte
+	require.NoError(t, repo.db.QueryRow(ctx,
+		`SELECT status, revoked_by::text, invite_token_hash FROM overlay_moderators WHERE id = $1`,
+		grant.ID).Scan(&status, &revokedBy, &hash))
+	assert.Equal(t, "revoked", status)
+	require.NotNil(t, revokedBy)
+	assert.Equal(t, adminActor, *revokedBy, "who revoked is part of the trail")
+	assert.Nil(t, hash, "revoking an outstanding invite must kill the secret already sent out")
+
+	_, err = repo.AcceptInvite(ctx, invites.Hash(secret), newModerator(t, repo, "Denied"))
+	assert.ErrorIs(t, err, ErrInviteNotFound)
+
+	t.Run("revoking twice is not an error but changes nothing", func(t *testing.T) {
+		again, err := repo.RevokeGrant(ctx, overlayID, grant.ID, ownerID)
+		require.NoError(t, err)
+		assert.False(t, again)
+	})
+
+	t.Run("a grant on another overlay is untouched", func(t *testing.T) {
+		otherOverlay := uuid.New().String()
+		_, err := repo.db.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'Other')`,
+			otherOverlay, ownerID)
+		require.NoError(t, err)
+		foreign, _ := inviteFor(t, repo, InviteParams{OverlayID: otherOverlay})
+
+		ok, err := repo.RevokeGrant(ctx, overlayID, foreign.ID, ownerID)
+		require.NoError(t, err)
+		assert.False(t, ok)
+
+		var stillLive string
+		require.NoError(t, repo.db.QueryRow(ctx,
+			`SELECT status FROM overlay_moderators WHERE id = $1`, foreign.ID).Scan(&stillLive))
+		assert.Equal(t, "pending", stillLive)
+	})
+
+	t.Run("a malformed grant id is a miss, not a database error", func(t *testing.T) {
+		ok, err := repo.RevokeGrant(ctx, overlayID, "not-a-uuid", ownerID)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
+// The kill switch: one call, everyone off, including invites nobody has redeemed yet.
+func TestRevokeAllGrants(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, outstanding := inviteFor(t, repo, InviteParams{})
+	_, toAccept := inviteFor(t, repo, InviteParams{})
+	modID := newModerator(t, repo, "Working Mod")
+	_, err := repo.AcceptInvite(ctx, invites.Hash(toAccept), modID)
+	require.NoError(t, err)
+
+	otherOverlay := uuid.New().String()
+	_, err = repo.db.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'Other')`,
+		otherOverlay, ownerID)
+	require.NoError(t, err)
+	untouched, _ := inviteFor(t, repo, InviteParams{OverlayID: otherOverlay})
+
+	count, err := repo.RevokeAllGrants(ctx, overlayID, ownerID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	grants, err := repo.ListGrants(ctx, overlayID)
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+
+	_, err = repo.AcceptInvite(ctx, invites.Hash(outstanding), newModerator(t, repo, "Nope"))
+	assert.ErrorIs(t, err, ErrInviteNotFound, "the kill switch must also kill unredeemed invites")
+
+	access, err := repo.ResolveOverlayAccess(ctx, overlayID, modID)
+	require.NoError(t, err)
+	assert.Equal(t, RoleNone, access.Role, "revocation takes effect on the very next request")
+
+	var foreignStatus string
+	require.NoError(t, repo.db.QueryRow(ctx,
+		`SELECT status FROM overlay_moderators WHERE id = $1`, untouched.ID).Scan(&foreignStatus))
+	assert.Equal(t, "pending", foreignStatus, "another overlay's team must survive")
+
+	t.Run("a second sweep reports nothing left", func(t *testing.T) {
+		count, err := repo.RevokeAllGrants(ctx, overlayID, ownerID)
+		require.NoError(t, err)
+		assert.Zero(t, count)
+	})
+}
+
+func TestPreviewInvite(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, secret := inviteFor(t, repo, InviteParams{
+		Actions:      []string{"delete", "ban"},
+		Platforms:    []string{"twitch"},
+		InviteeLabel: "@sarah",
+	})
+
+	preview, err := repo.PreviewInvite(ctx, invites.Hash(secret))
+	require.NoError(t, err)
+	assert.Equal(t, "My Overlay", preview.OverlayName)
+	assert.Equal(t, "The Streamer", preview.OwnerDisplayName,
+		"an invite must say who is asking before anyone agrees to work for them")
+	assert.Equal(t, []string{"delete", "ban"}, preview.Actions)
+	require.Len(t, preview.Platforms, 1)
+	assert.Equal(t, "@sarah", preview.InviteeLabel)
+
+	t.Run("previewing does not redeem", func(t *testing.T) {
+		_, err := repo.PreviewInvite(ctx, invites.Hash(secret))
+		assert.NoError(t, err)
+		modID := newModerator(t, repo, "Sarah")
+		_, err = repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+		assert.NoError(t, err)
+	})
+
+	t.Run("an unknown secret", func(t *testing.T) {
+		_, err := repo.PreviewInvite(ctx, invites.Hash("nope"))
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+	})
+
+	t.Run("an expired invite", func(t *testing.T) {
+		_, expired := inviteFor(t, repo, InviteParams{ExpiresAt: time.Now().Add(-time.Hour)})
+		_, err := repo.PreviewInvite(ctx, invites.Hash(expired))
+		assert.ErrorIs(t, err, ErrInviteExpired)
+	})
+}
+
+// last_action_at drives the 90-day dormancy suspension. Stamping it from the first delegated
+// action onwards is what keeps a later dormancy job from reading a working mod team as idle.
+func TestTouchGrantActivity(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	grant, secret := inviteFor(t, repo, InviteParams{})
+	modID := newModerator(t, repo, "Busy")
+	_, err := repo.AcceptInvite(ctx, invites.Hash(secret), modID)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.TouchGrantActivity(ctx, grant.ID))
+
+	var lastAction *time.Time
+	require.NoError(t, repo.db.QueryRow(ctx,
+		`SELECT last_action_at FROM overlay_moderators WHERE id = $1`, grant.ID).Scan(&lastAction))
+	require.NotNil(t, lastAction)
+	assert.WithinDuration(t, time.Now(), *lastAction, time.Minute)
+
+	t.Run("an unknown or malformed grant id is not an error", func(t *testing.T) {
+		assert.NoError(t, repo.TouchGrantActivity(ctx, uuid.New().String()))
+		assert.NoError(t, repo.TouchGrantActivity(ctx, ""),
+			"an owner action carries no grant id and must not log a spurious failure")
+	})
+}
+
+func legsByPlatform(g Grant) map[string]GrantLeg {
+	out := make(map[string]GrantLeg, len(g.Platforms))
+	for _, leg := range g.Platforms {
+		out[leg.Platform] = leg
+	}
+	return out
+}

--- a/services/moderation-service/repository/repository_test.go
+++ b/services/moderation-service/repository/repository_test.go
@@ -32,6 +32,9 @@ const (
 	ownerID    = "11111111-1111-1111-1111-111111111111"
 	strangerID = "22222222-2222-2222-2222-222222222222"
 	overlayID  = "aaaaaaaa-1111-1111-1111-111111111111"
+	// adminActor stands in for an admin acting on the grant lifecycle; revoked_by carries no
+	// foreign key precisely so the trail survives the actor's account.
+	adminActor = "99999999-9999-9999-9999-999999999999"
 )
 
 func TestVerifyOverlayOwnership(t *testing.T) {
@@ -134,14 +137,22 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 	pool, err := pgxpool.New(ctx, "postgres://testuser:testpass@"+host+":"+port.Port()+"/testdb?sslmode=disable")
 	require.NoError(t, err)
 
+	// Mirrors the production schema for the columns these queries touch, including the
+	// delegation tables from migration 080 — the partial unique indexes there are part of the
+	// behaviour under test (one live grant per moderator, one live invite per digest).
 	const schema = `
 		CREATE TABLE users (
 			id UUID PRIMARY KEY,
-			is_premium BOOLEAN NOT NULL DEFAULT false
+			is_premium BOOLEAN NOT NULL DEFAULT false,
+			display_name VARCHAR(100) NOT NULL DEFAULT '',
+			twitch_id VARCHAR(50),
+			kick_id VARCHAR(255),
+			google_id VARCHAR(50)
 		);
 		CREATE TABLE overlays (
 			id UUID PRIMARY KEY,
 			user_id UUID NOT NULL,
+			name VARCHAR(100) NOT NULL DEFAULT '',
 			is_active BOOLEAN NOT NULL DEFAULT true
 		);
 		CREATE TABLE overlay_chat_sources (
@@ -151,14 +162,66 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 			channel_id VARCHAR(100) NOT NULL,
 			channel_name VARCHAR(100) NOT NULL,
 			is_active BOOLEAN NOT NULL DEFAULT true
+		);
+		CREATE TABLE twitch_oauth_tokens (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			twitch_user_id VARCHAR(50) NOT NULL,
+			twitch_login VARCHAR(100) NOT NULL
+		);
+		CREATE TABLE mod_oauth_credentials (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			platform VARCHAR(20) NOT NULL,
+			platform_user_id VARCHAR(100) NOT NULL,
+			access_token TEXT NOT NULL,
+			UNIQUE (user_id, platform)
+		);
+		CREATE TABLE overlay_moderators (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			overlay_id UUID NOT NULL REFERENCES overlays(id) ON DELETE CASCADE,
+			moderator_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+			granted_by UUID NOT NULL,
+			status VARCHAR(16) NOT NULL DEFAULT 'pending'
+				CHECK (status IN ('pending', 'active', 'suspended', 'revoked')),
+			actions TEXT[] NOT NULL DEFAULT '{delete,timeout}',
+			invite_token_hash BYTEA,
+			invite_expires_at TIMESTAMP,
+			invitee_label VARCHAR(120),
+			expected_platform VARCHAR(20),
+			expected_platform_user_id VARCHAR(100),
+			moderator_display_name VARCHAR(120),
+			created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+			accepted_at TIMESTAMP,
+			revoked_at TIMESTAMP,
+			revoked_by UUID,
+			suspended_at TIMESTAMP,
+			last_action_at TIMESTAMP
+		);
+		CREATE UNIQUE INDEX uq_overlay_moderators_live
+			ON overlay_moderators (overlay_id, moderator_user_id)
+			WHERE moderator_user_id IS NOT NULL AND revoked_at IS NULL;
+		CREATE UNIQUE INDEX uq_overlay_moderators_invite
+			ON overlay_moderators (invite_token_hash)
+			WHERE invite_token_hash IS NOT NULL;
+		CREATE TABLE overlay_moderator_platforms (
+			grant_id UUID NOT NULL REFERENCES overlay_moderators(id) ON DELETE CASCADE,
+			platform VARCHAR(20) NOT NULL,
+			enabled BOOLEAN NOT NULL DEFAULT FALSE,
+			verification VARCHAR(24) NOT NULL DEFAULT 'unverified',
+			verified_at TIMESTAMP,
+			last_denied_at TIMESTAMP,
+			PRIMARY KEY (grant_id, platform)
 		);`
 	_, err = pool.Exec(ctx, schema)
 	require.NoError(t, err)
 
 	// owner is premium (in the rollout cohort); stranger is a non-premium user.
-	_, err = pool.Exec(ctx, `INSERT INTO users (id, is_premium) VALUES ($1, true), ($2, false)`, ownerID, strangerID)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO users (id, is_premium, display_name) VALUES ($1, true, 'The Streamer'), ($2, false, 'A Stranger')`,
+		ownerID, strangerID)
 	require.NoError(t, err)
-	_, err = pool.Exec(ctx, `INSERT INTO overlays (id, user_id) VALUES ($1, $2)`, overlayID, ownerID)
+	_, err = pool.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'My Overlay')`, overlayID, ownerID)
 	require.NoError(t, err)
 	_, err = pool.Exec(ctx, `
 		INSERT INTO overlay_chat_sources (overlay_id, platform, channel_id, channel_name) VALUES

--- a/shared/featuregates/cache.go
+++ b/shared/featuregates/cache.go
@@ -54,6 +54,13 @@ const (
 	// cohort first; flip to is_premium=false to graduate to all users.
 	GateModeration = "moderation"
 
+	// GateDelegatedModeration is the feature key for handing the moderation write-path to
+	// someone else's account (ADR-0048). Deliberately separate from GateModeration so
+	// delegation can be rolled back without disabling owner moderation, and keyed on the
+	// overlay OWNER: a premium streamer's moderators moderate for free. Seeded premium-only
+	// (migration 080).
+	GateDelegatedModeration = "delegated_moderation"
+
 	// GateEngagement is the feature key for starting All-Chat polls/predictions
 	// (issue #523). Seeded premium-only: opening a round posts the round + participate
 	// link to chat (announce_on_start), which consumes the streamer's send quota — a


### PR DESCRIPTION
Stacked on #656 (`--base` set to its branch, so this PR shows only its own diff). Part of the ADR-0048 delegated-moderator stack: caesar-deployment#44 → #652 → #653 → #654 → #655 → #656 → **this**.

Invite / accept / revoke for delegated overlay moderators. **Nothing user-visible yet** — the API exists but no UI reaches it; the owner-side Moderators panel is the next slice.

## Endpoints

Owner-only, on moderation-service under `/api/v1/moderation`:

| Method | Path |
|---|---|
| `GET` | `/overlays/:id/moderators` |
| `POST` | `/overlays/:id/moderators` → **201** with the invite secret |
| `PATCH` | `/overlays/:id/moderators/:grant_id` |
| `DELETE` | `/overlays/:id/moderators/:grant_id` |
| `DELETE` | `/overlays/:id/moderators` (kill switch) |

Keyed on the secret rather than a role, since the holder has no relationship to the overlay yet:

| Method | Path |
|---|---|
| `POST` | `/invites/preview` |
| `POST` | `/invites/accept` |

The secret travels in the **body**, never a path: a URL would put a live moderation credential into every access log, proxy log and `Referer` header along the way. `preview` omits `overlay_id` — an overlay UUID already grants chat *read* to whoever holds it, so it is disclosed on acceptance rather than to everyone who opens the link.

## The decisions worth reviewing

- **The invite is treated as a bearer credential.** 256 bits from `crypto/rand`, returned once, stored only as SHA-256. The digest is nulled on acceptance *and* on revocation, so a secret still sitting in someone's DMs dies the moment the streamer changes their mind. No "show it again" — a lost invite is re-minted.
- **Owner-only, indistinguishably.** A delegated moderator inviting others or widening their own grant would be escalation. All four refusals (no role, moderator reaching for an owner power, unknown overlay, malformed id) return a byte-identical 403, so these endpoints are not an overlay-existence oracle.
- **Only creation is gated.** Listing, narrowing and revoking work even with `delegated_moderation` closed. Gating them would let a rollback leave a streamer holding moderators they cannot remove.
- **The cap is a real limit.** Pending invites occupy a seat (otherwise minting invites is an unbounded bypass), and the count is taken under a row lock on the overlay, so two tabs cannot both see nine and both insert. There is a 20-goroutine test for exactly that. Admins bypass.
- **Pre-binding is Twitch-only.** It is the only platform where acceptance can resolve the redeeming account and compare it — from any of three proofs: the account's own Twitch identity, a linked credential (ADR-0016), or a moderator credential from an earlier consent. Storing a binding we cannot verify would look like a constraint while protecting nobody, so the API refuses it. Mismatch fails closed and names the expected account.
- **`NormalizeDelegatedActions` is the single admission point** for a grant's actions. Load-bearing: `ModerationScopesForActions` downstream accepts `"engagement"` → `channel:read:polls`/`channel:read:predictions`, so an unfiltered string would widen a volunteer's consent screen on their own channel (ADR-0012 regression). Absent list = the default pair; explicitly empty = 400, never widened.

## Two things that came along

- **`last_action_at` is stamped from the first delegated action.** Without it, the dormancy job in a later slice would read a working mod team as idle since the day their grants were created.
- **DSGVO export covers both directions of a grant.** Neither is derivable from any other section — a streamer's overlay list says nothing about who may moderate it, and a moderator's own overlays say nothing about channels delegated to them. Erasure needs no new code (`overlay_moderators` cascades from both `overlays` and `users`); a test pins that cascade, because if it ever breaks, a deleted volunteer keeps a live grant on someone's channel.

## A real bug this found

The invite deadline was written as a local-time value into a naive `TIMESTAMP`, which pgx reads back as UTC — so an already-expired invite read as two hours in the future and was accepted. Now written in UTC, with the expiry test as the regression.

## Tests

TDD throughout: 630 lines of repository tests against a real Postgres (testcontainers, using migration 080's actual partial unique indexes) and 780 of handler tests. `go test ./...` green in moderation-service, auth-service (except the pre-existing `TestAuthHandlerLogout`, which dials a real Redis), api-gateway and shared. `govulncheck` clean under the CI toolchain for both touched services.

Also: `addGrantSchema` in `access_test.go` is gone — the shared test schema now carries the delegation tables — and the two files in this service that `gofmt` had been flagging are formatted.

## Not in this slice

The owner-side Moderators panel (editor left nav, ADR-0042), mod-scoped capabilities + the `/moderate` list, the per-platform legs, the dormancy job, and the release checklist (`/upgrade` + `OnboardingChecklist` keep-in-sync, Patreon post).