### PR TITLE
feat(auth): delegated-moderator consent as its own OAuth flow

### DIFF
--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -560,16 +560,22 @@ func main() {
 		publicAPI.GET("/auth/twitch/add-source/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		// Opt-in moderation re-consent (ADR-0017); auth-service applies its own JWT middleware.
 		publicAPI.GET("/auth/twitch/moderation/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
+		// Delegated-moderator consent (ADR-0048); auth-service applies its own JWT middleware.
+		publicAPI.GET("/auth/twitch/mod-consent", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/youtube/login", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/youtube/callback", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/youtube/add-source/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		// Opt-in moderation re-consent (ADR-0017); auth-service applies its own JWT middleware.
 		publicAPI.GET("/auth/youtube/moderation/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
+		// Delegated-moderator consent (ADR-0048); auth-service applies its own JWT middleware.
+		publicAPI.GET("/auth/youtube/mod-consent", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/kick/login", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/kick/callback", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/kick/add-source/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		// Opt-in moderation re-consent (ADR-0017); auth-service applies its own JWT middleware.
 		publicAPI.GET("/auth/kick/moderation/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
+		// Delegated-moderator consent (ADR-0048); auth-service applies its own JWT middleware.
+		publicAPI.GET("/auth/kick/mod-consent", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/tiktok/login", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/tiktok/callback", proxyHandler.ForwardRequest)
 		publicAPI.GET("/auth/tiktok/add-source/:overlay_id", localmiddleware.CookieToBearer(), proxyHandler.ForwardRequest)

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -399,6 +399,15 @@ func main() {
 		protected.GET("/kick/moderation/:overlay_id", platformAuthHandlerV2.HandleEnableModeration(oauth.PlatformKick))
 		protected.GET("/youtube/moderation/:overlay_id", platformAuthHandlerV2.HandleEnableModeration(oauth.PlatformYouTube))
 
+		// Delegated-moderator consent (ADR-0048): a MODERATOR granting All-Chat their own
+		// moderation scopes. Distinct from the routes above in three ways — no overlay id (the
+		// platform scopes are role-based, so one consent serves every streamer who delegated
+		// that platform), no base login scopes, and the credential lands in
+		// mod_oauth_credentials rather than touching their login grant.
+		protected.GET("/twitch/mod-consent", platformAuthHandlerV2.HandleModConsent(oauth.PlatformTwitch))
+		protected.GET("/kick/mod-consent", platformAuthHandlerV2.HandleModConsent(oauth.PlatformKick))
+		protected.GET("/youtube/mod-consent", platformAuthHandlerV2.HandleModConsent(oauth.PlatformYouTube))
+
 		// Discord guild management routes (require JWT)
 		if discordHandler != nil {
 			protected.GET("/discord/connect", discordHandler.HandleConnect)

--- a/services/auth-service/handlers/mod_consent.go
+++ b/services/auth-service/handlers/mod_consent.go
@@ -1,0 +1,251 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+// Delegated-moderator consent (ADR-0048).
+//
+// A moderator grants All-Chat their OWN moderation scopes so they can act on channels they
+// moderate. Three properties make this a separate flow rather than a variant of the streamer's
+// opt-in re-consent (ADR-0017):
+//
+//   - It must not reach addSourceToOverlay. The streamer's moderation re-consent is an
+//     add-source state, and the shared callback calls addSourceToOverlay for every add-source
+//     state; overlay-manager 404s that for a non-owner, so a moderator's consent would persist
+//     their credential and THEN redirect to an error.
+//   - It must not request the base login scopes. GetAuthURLWithScopes prepends them
+//     unconditionally, which would ask a volunteer for channel-point, subscription and bits read
+//     on their own channel — an ADR-0012 regression, and it reads badly on the consent screen.
+//   - It must not touch their login credential or its granted_scopes. The credential goes to
+//     mod_oauth_credentials, keyed on the moderator, which also keeps the scope-downgrade guard
+//     entirely out of the picture.
+//
+// Consent is deferred to first use and is NOT bound to an overlay: Twitch's and Kick's
+// moderation scopes are role-based rather than channel-scoped, so one consent per platform
+// serves every streamer who delegated that platform.
+
+// HandleModConsent starts a delegated moderator's own consent flow for one platform.
+//
+// The moderator must already be signed in — this grants a capability to an existing account and
+// must never create one.
+func (h *PlatformAuthHandlerV2) HandleModConsent(platform oauth.Platform) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		provider, exists := h.providers[platform]
+		if !exists {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Platform %s not supported", platform)})
+			return
+		}
+
+		userID, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized - please log in first"})
+			return
+		}
+		userIDStr, ok := userID.(string)
+		if !ok || userIDStr == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user context"})
+			return
+		}
+
+		// Minimised to exactly the actions delegated to them. Note what is deliberately NOT
+		// folded in, unlike the streamer flow: no chat-send scope (moderators get no send in
+		// v1, and it is a distinct higher-trust capability), and no union with their existing
+		// grant — the credential lands in its own table, so there is nothing to preserve and
+		// no downgrade guard to satisfy.
+		actions := splitActions(c.Query("actions"))
+		twitchProvider, isTwitch := provider.(*oauth.TwitchOAuth)
+		if !isTwitch {
+			// Each platform leg is independently gated (ADR-0048). Kick needs a PKCE variant
+			// of the minimal-scope builder; YouTube additionally needs the moderator's own
+			// channel id resolved before a credential can be attributed.
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": fmt.Sprintf("delegated moderation for %s is not available yet", platform),
+			})
+			return
+		}
+
+		// Only the four moderation actions are delegatable. The shared mapper also accepts
+		// "engagement", which maps to channel:read:polls / channel:read:predictions — scopes on
+		// the requester's OWN channel, for a capability moderators do not get at all (polls and
+		// predictions stay owner-only). Passing the raw query through would let a crafted URL
+		// widen a volunteer's consent screen to scopes delegation never uses.
+		delegatable := filterDelegatableActions(actions)
+		if len(delegatable) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "no valid moderation actions; expected ?actions=delete,timeout,ban,unban",
+			})
+			return
+		}
+
+		modScopes := oauth.ModerationScopesForActions(delegatable)
+		if len(modScopes) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "no valid moderation actions; expected ?actions=delete,timeout,ban,unban",
+			})
+			return
+		}
+
+		csrfToken, err := generateRandomString(32)
+		if err != nil {
+			h.logger.Error("Failed to generate CSRF token", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			return
+		}
+
+		oauthState := oauth.NewModConsentState(csrfToken, userIDStr)
+		if err := oauthState.Validate(); err != nil {
+			h.logger.Error("Invalid mod-consent OAuth state", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			return
+		}
+		stateStr, err := oauthState.Encode()
+		if err != nil {
+			h.logger.Error("Failed to encode mod-consent state", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			return
+		}
+
+		authURL := twitchProvider.GetModConsentAuthURL(stateStr, modScopes)
+		if authURL == "" {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to build consent URL"})
+			return
+		}
+
+		stateKey := fmt.Sprintf("oauth_state:%s:%s", platform, csrfToken)
+		if err := h.redis.Set(c.Request.Context(), stateKey, stateStr, 30*time.Minute).Err(); err != nil {
+			h.logger.Error("Failed to store mod-consent state", zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			return
+		}
+
+		h.logger.Info("Generated delegated-moderator consent URL",
+			zap.String("platform", string(platform)),
+			zap.String("user_id", userIDStr),
+			zap.Strings("mod_scopes", modScopes),
+		)
+		c.JSON(http.StatusOK, gin.H{"auth_url": authURL})
+	}
+}
+
+// completeModConsent finishes a delegated moderator's consent: it stores their credential and
+// returns them to the moderation area. It creates no account, links no platform, and adds no
+// overlay source.
+//
+// It is called from the shared OAuth callback BEFORE any of the login / account-link /
+// add-source machinery, and the caller returns immediately afterwards.
+func (h *PlatformAuthHandlerV2) completeModConsent(
+	c *gin.Context,
+	platform oauth.Platform,
+	state *oauth.OAuthState,
+	platformUser oauth.PlatformUserInfo,
+	token *oauth2.Token,
+) {
+	// Belt and braces: Validate() already requires this, but the credential is keyed on the
+	// moderator and an empty user id must never reach the store.
+	if state.UserID == "" {
+		h.logger.Error("mod-consent callback without a user id", zap.String("platform", string(platform)))
+		h.redirectModConsent(c, platform, state.CSRFToken, "", "invalid_state")
+		return
+	}
+
+	granted := oauth.ExtractGrantedScopes(token)
+	if err := h.userRepo.StoreModCredential(
+		c.Request.Context(),
+		state.UserID,
+		string(platform),
+		platformUser.GetID(),
+		platformUser.GetUsername(),
+		token,
+		granted,
+	); err != nil {
+		h.logger.Error("Failed to store delegated-moderator credential",
+			zap.String("platform", string(platform)),
+			zap.String("user_id", state.UserID),
+			zap.Error(err))
+		h.redirectModConsent(c, platform, state.CSRFToken, "", "credential_store_failed")
+		return
+	}
+
+	h.logger.Info("Stored delegated-moderator credential",
+		zap.String("platform", string(platform)),
+		zap.String("user_id", state.UserID),
+		zap.String("platform_user_id", platformUser.GetID()),
+		zap.Strings("granted_scopes", granted))
+
+	h.redirectModConsent(c, platform, state.CSRFToken, string(platform), "")
+}
+
+// redirectModConsent returns the moderator to the moderation area.
+//
+// A plain redirect is correct here, unlike the add-source path's auth-code round trip: the
+// moderator was already signed in when they started, and this flow deliberately does not
+// re-issue a session — it grants a capability to an existing account rather than establishing
+// one.
+func (h *PlatformAuthHandlerV2) redirectModConsent(c *gin.Context, platform oauth.Platform, csrfToken, connected, errCode string) {
+	target := fmt.Sprintf("%s/moderate", h.frontendURL)
+	switch {
+	case errCode != "":
+		target = fmt.Sprintf("%s?error=%s&platform=%s", target, errCode, platform)
+	case connected != "":
+		target = fmt.Sprintf("%s?connected=%s", target, connected)
+	}
+	h.redirectWithTombstone(c, platform, csrfToken, target)
+}
+
+// delegatableActions are the only actions a streamer can delegate, and therefore the only ones a
+// moderator's consent may request scopes for. Anything else — notably "engagement", which the
+// shared scope mapper accepts — is dropped rather than silently widening the consent screen.
+var delegatableActions = map[string]bool{
+	"delete":  true,
+	"timeout": true,
+	"ban":     true,
+	"unban":   true,
+}
+
+// filterDelegatableActions keeps only the delegatable actions, preserving order and dropping
+// duplicates so the resulting consent screen is stable across repeat requests.
+func filterDelegatableActions(actions []string) []string {
+	seen := make(map[string]bool, len(actions))
+	out := make([]string, 0, len(actions))
+	for _, a := range actions {
+		if delegatableActions[a] && !seen[a] {
+			seen[a] = true
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// ModCredentialStore is the subset of the user repository the mod-consent flow needs. Declared
+// for the handler tests, which must be able to assert that a mod-consent callback stores a
+// credential and creates no overlay source.
+type ModCredentialStore interface {
+	StoreModCredential(ctx context.Context, userID, platform, platformUserID, platformLogin string,
+		token *oauth2.Token, grantedScopes []string) error
+	DeleteModCredential(ctx context.Context, userID, platform string) error
+}

--- a/services/auth-service/handlers/mod_consent_test.go
+++ b/services/auth-service/handlers/mod_consent_test.go
@@ -1,0 +1,184 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// modConsentTestHandler builds the minimum PlatformAuthHandlerV2 the start endpoint needs: real
+// OAuth providers (they only build URLs) and a real-enough Redis for the state stash.
+func modConsentTestHandler(t *testing.T) *PlatformAuthHandlerV2 {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	return &PlatformAuthHandlerV2{
+		providers: map[oauth.Platform]oauth.OAuthProvider{
+			oauth.PlatformTwitch: oauth.NewTwitchOAuth("client-id", "client-secret", "https://allch.at/cb"),
+			oauth.PlatformKick:   oauth.NewKickOAuth("kick-id", "kick-secret", "https://allch.at/cb"),
+		},
+		redis:       redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		logger:      zap.NewNop(),
+		frontendURL: "https://allch.at",
+	}
+}
+
+func startModConsent(t *testing.T, h *PlatformAuthHandlerV2, platform oauth.Platform, userID, actions string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/:platform/mod-consent", func(c *gin.Context) {
+		if userID != "" {
+			c.Set("user_id", userID)
+		}
+		h.HandleModConsent(platform)(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/"+string(platform)+"/mod-consent?actions="+actions, nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func authURLFrom(t *testing.T, w *httptest.ResponseRecorder) *url.URL {
+	t.Helper()
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotEmpty(t, body["auth_url"], "response carried no auth_url: %s", w.Body.String())
+	parsed, err := url.Parse(body["auth_url"])
+	require.NoError(t, err)
+	return parsed
+}
+
+// The consent screen must carry exactly the scopes for the delegated actions — no base login
+// scopes, and no chat-send scope. Moderators get no send capability in v1, and the streamer flow
+// deliberately folds send in, so this is the one place that difference is observable.
+func TestHandleModConsent_RequestsOnlyTheDelegatedModerationScopes(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformTwitch, "mod-user-1", "delete")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	scopes := strings.Fields(authURLFrom(t, w).Query().Get("scope"))
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, scopes)
+	assert.NotContains(t, scopes, oauth.TwitchSendScope,
+		"a moderator must not be granted chat-send in v1")
+	assert.NotContains(t, scopes, "channel:read:subscriptions",
+		"the streamer login scopes must not appear on a volunteer's consent screen")
+}
+
+func TestHandleModConsent_ScopesFollowTheRequestedActions(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformTwitch, "mod-user-1", "timeout,ban")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	scopes := strings.Fields(authURLFrom(t, w).Query().Get("scope"))
+	assert.Contains(t, scopes, "moderator:manage:banned_users")
+	assert.NotContains(t, scopes, "moderator:manage:chat_messages",
+		"delete was not requested, so its scope must not be asked for")
+}
+
+// The state must be a mod-consent state, not an add-source one — that is what keeps the callback
+// away from addSourceToOverlay, which 404s for a non-owner.
+func TestHandleModConsent_StashesAModConsentState(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformTwitch, "mod-user-1", "delete")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	state, err := oauth.DecodeOAuthState(authURLFrom(t, w).Query().Get("state"))
+	require.NoError(t, err)
+
+	assert.True(t, state.IsModConsent())
+	assert.False(t, state.IsAddSource(),
+		"an add-source state would route the callback into addSourceToOverlay")
+	assert.Equal(t, "mod-user-1", state.UserID)
+	assert.Empty(t, state.OverlayID,
+		"consent is per platform and account-wide, so it must not be bound to an overlay")
+}
+
+// This grants a capability to an existing account and must never create one.
+func TestHandleModConsent_RequiresAuthentication(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformTwitch, "", "delete")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// "engagement" is accepted by the shared scope mapper (it maps to channel:read:polls /
+// channel:read:predictions) but is NOT delegatable — polls and predictions stay owner-only. A
+// crafted URL must not be able to widen a volunteer's consent screen to scopes on their own
+// channel that delegation never uses.
+func TestHandleModConsent_RejectsNoValidActions(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	for _, actions := range []string{"", "nonsense", "engagement"} {
+		t.Run("actions="+actions, func(t *testing.T) {
+			w := startModConsent(t, h, oauth.PlatformTwitch, "mod-user-1", actions)
+			assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		})
+	}
+}
+
+// A mix of delegatable and non-delegatable actions keeps only the former, rather than refusing
+// outright or letting the extra scopes through.
+func TestHandleModConsent_DropsNonDelegatableActionsFromAMix(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformTwitch, "mod-user-1", "delete,engagement")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	scopes := strings.Fields(authURLFrom(t, w).Query().Get("scope"))
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, scopes)
+	for _, engagement := range []string{"channel:read:polls", "channel:read:predictions"} {
+		assert.NotContains(t, scopes, engagement,
+			"engagement scopes are not delegatable and must never reach a moderator's consent screen")
+	}
+}
+
+// Each platform leg is independently gated. A platform whose leg has not landed must say so
+// rather than issue a consent screen that cannot be completed.
+func TestHandleModConsent_UnlandedPlatformIsRefused(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformKick, "mod-user-1", "ban")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "not available yet")
+}
+
+func TestHandleModConsent_UnknownPlatformIsRefused(t *testing.T) {
+	h := modConsentTestHandler(t)
+
+	w := startModConsent(t, h, oauth.PlatformYouTube, "mod-user-1", "ban")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/services/auth-service/handlers/platform_auth_v2.go
+++ b/services/auth-service/handlers/platform_auth_v2.go
@@ -752,6 +752,19 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 			}
 		}
 
+		// Delegated-moderator consent (ADR-0048) is handled here and returns, BEFORE any of
+		// the login / account-link / add-source machinery below.
+		//
+		// It must not run any of it: the moderator is already signed in (so no account is
+		// created or linked), their login credential and granted_scopes must stay untouched
+		// (so the scope-downgrade guard is never involved), and above all it must not reach
+		// addSourceToOverlay — which the add-source-shaped moderation state does, and which
+		// overlay-manager 404s for a non-owner.
+		if oauthState.IsModConsent() {
+			h.completeModConsent(c, platform, oauthState, platformUser, token)
+			return
+		}
+
 		// Get or create user based on platform and context
 		var user *models.User
 		var jwtToken string

--- a/services/auth-service/oauth/mod_consent_test.go
+++ b/services/auth-service/oauth/mod_consent_test.go
@@ -1,0 +1,132 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Delegated-moderator consent (ADR-0048) is its OWN OAuth action, not a variant of add-source.
+// The existing moderation re-consent flow (NewModerationState) is deliberately an add-source
+// state, and the shared callback calls addSourceToOverlay for every add-source state — which
+// 404s for a non-owner. A moderator going through that path would have their credential
+// persisted and THEN be redirected to an error.
+
+func TestNewModConsentState_IsNotAnAddSourceState(t *testing.T) {
+	s := NewModConsentState("csrf-1", "user-9")
+
+	assert.True(t, s.IsModConsent())
+	assert.False(t, s.IsAddSource(),
+		"a mod-consent state must never satisfy IsAddSource — that is what routes it into addSourceToOverlay")
+	assert.False(t, s.IsLogin())
+	assert.False(t, s.IsModeration(),
+		"the owner's moderation re-consent purpose must not be confused with a moderator's consent")
+	assert.Equal(t, "user-9", s.UserID)
+	assert.Empty(t, s.OverlayID,
+		"mod consent is per platform and account-wide, so it is not bound to an overlay")
+}
+
+func TestModConsentState_Validate(t *testing.T) {
+	t.Run("accepted as a valid action", func(t *testing.T) {
+		require.NoError(t, NewModConsentState("csrf-1", "user-9").Validate())
+	})
+
+	t.Run("requires the moderator's user id", func(t *testing.T) {
+		s := NewModConsentState("csrf-1", "")
+		err := s.Validate()
+		require.Error(t, err, "without a user id there is nobody to attribute the credential to")
+		assert.Contains(t, err.Error(), "user_id")
+	})
+
+	t.Run("still requires a csrf token", func(t *testing.T) {
+		s := NewModConsentState("", "user-9")
+		assert.Error(t, s.Validate())
+	})
+}
+
+func TestModConsentState_RoundTrip(t *testing.T) {
+	encoded, err := NewModConsentState("csrf-1", "user-9").Encode()
+	require.NoError(t, err)
+
+	decoded, err := DecodeOAuthState(encoded)
+	require.NoError(t, err)
+
+	assert.True(t, decoded.IsModConsent())
+	assert.False(t, decoded.IsAddSource())
+	assert.Equal(t, "user-9", decoded.UserID)
+}
+
+// The consent screen a volunteer sees must ask for the moderation scopes and nothing else.
+// GetAuthURLWithScopes unconditionally prepends the base login set (channel:read:redemptions,
+// channel:read:subscriptions, bits:read, moderator:read:followers), which would ask a moderator
+// for channel-point, subscription and bits read on their OWN channel — an ADR-0012 regression.
+func TestTwitchOAuth_GetModConsentAuthURL_OmitsBaseLoginScopes(t *testing.T) {
+	tw := NewTwitchOAuth("client-id", "client-secret", "https://allch.at/callback")
+
+	raw := tw.GetModConsentAuthURL("state-1", []string{"moderator:manage:chat_messages"})
+
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	scopes := strings.Fields(parsed.Query().Get("scope"))
+
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, scopes)
+	for _, base := range []string{"channel:read:redemptions", "channel:read:subscriptions", "bits:read", "moderator:read:followers"} {
+		assert.NotContains(t, scopes, base,
+			"a moderator's consent screen must not request the streamer login scopes")
+	}
+}
+
+// force_verify is required for the same reason the owner flow needs it: without it Twitch may
+// silently reissue a prior, narrower grant, so the moderation scopes would never be requested.
+func TestTwitchOAuth_GetModConsentAuthURL_ForcesVerify(t *testing.T) {
+	tw := NewTwitchOAuth("client-id", "client-secret", "https://allch.at/callback")
+
+	parsed, err := url.Parse(tw.GetModConsentAuthURL("state-1", []string{"moderator:manage:banned_users"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", parsed.Query().Get("force_verify"))
+	assert.Equal(t, "state-1", parsed.Query().Get("state"))
+}
+
+// Deduped and stable, so a repeat consent produces the same screen.
+func TestTwitchOAuth_GetModConsentAuthURL_DedupesScopes(t *testing.T) {
+	tw := NewTwitchOAuth("client-id", "client-secret", "https://allch.at/callback")
+
+	parsed, err := url.Parse(tw.GetModConsentAuthURL("state-1", []string{
+		"moderator:manage:chat_messages",
+		"moderator:manage:banned_users",
+		"moderator:manage:chat_messages",
+	}))
+	require.NoError(t, err)
+
+	scopes := strings.Fields(parsed.Query().Get("scope"))
+	assert.Equal(t, []string{"moderator:manage:chat_messages", "moderator:manage:banned_users"}, scopes)
+}
+
+// An empty scope set would produce a consent screen granting nothing, which then fails at the
+// first moderation call with a confusing "missing scope". Refuse to build it.
+func TestTwitchOAuth_GetModConsentAuthURL_RejectsEmptyScopes(t *testing.T) {
+	tw := NewTwitchOAuth("client-id", "client-secret", "https://allch.at/callback")
+
+	assert.Empty(t, tw.GetModConsentAuthURL("state-1", nil),
+		"no scopes means no meaningful consent to ask for")
+}

--- a/services/auth-service/oauth/state.go
+++ b/services/auth-service/oauth/state.go
@@ -29,6 +29,15 @@ const (
 	ActionLogin OAuthAction = "login"
 	// ActionAddSource is for adding a chat source to an overlay
 	ActionAddSource OAuthAction = "add_source"
+	// ActionModConsent is a delegated moderator granting All-Chat their OWN moderation
+	// scopes (ADR-0048).
+	//
+	// It is deliberately NOT an add-source action. The shared callback calls
+	// addSourceToOverlay for every add-source state, and overlay-manager 404s that for a
+	// non-owner — so a moderator would have their credential persisted and then be
+	// redirected to an error. It also must not touch the moderator's login credential or
+	// granted_scopes: the credential lands in its own table, keyed on the moderator.
+	ActionModConsent OAuthAction = "mod_consent"
 )
 
 // PurposeModeration marks an add-source flow that is really an opt-in moderation
@@ -79,6 +88,25 @@ func (s *OAuthState) IsModeration() bool {
 	return s.Purpose == PurposeModeration
 }
 
+// NewModConsentState creates a state for a delegated moderator granting their own moderation
+// scopes (ADR-0048).
+//
+// No overlay id: because Twitch's and Kick's moderation scopes are role-based rather than
+// channel-scoped, one consent per platform serves every streamer who delegated that platform.
+// Binding it to an overlay would imply a per-streamer consent that the platforms do not model.
+func NewModConsentState(csrfToken, userID string) *OAuthState {
+	return &OAuthState{
+		CSRFToken: csrfToken,
+		UserID:    userID,
+		Action:    ActionModConsent,
+	}
+}
+
+// IsModConsent reports whether this state is a delegated moderator's own consent flow.
+func (s *OAuthState) IsModConsent() bool {
+	return s.Action == ActionModConsent
+}
+
 // Encode serializes the state to JSON string
 func (s *OAuthState) Encode() (string, error) {
 	data, err := json.Marshal(s)
@@ -112,11 +140,16 @@ func (s *OAuthState) Validate() error {
 	if s.CSRFToken == "" {
 		return fmt.Errorf("csrf_token is required")
 	}
-	if s.Action != ActionLogin && s.Action != ActionAddSource {
+	if s.Action != ActionLogin && s.Action != ActionAddSource && s.Action != ActionModConsent {
 		return fmt.Errorf("invalid action: %s", s.Action)
 	}
 	if s.Action == ActionAddSource && s.OverlayID == "" {
 		return fmt.Errorf("overlay_id is required for add_source action")
+	}
+	// A moderator's credential is keyed on them, so without a user id there is nobody to
+	// attribute it to — and the callback must never fall back to creating an account here.
+	if s.Action == ActionModConsent && s.UserID == "" {
+		return fmt.Errorf("user_id is required for mod_consent action")
 	}
 	return nil
 }

--- a/services/auth-service/oauth/twitch.go
+++ b/services/auth-service/oauth/twitch.go
@@ -144,6 +144,37 @@ func (t *TwitchOAuth) GetAuthURLWithScopes(state string, extra []string) string 
 	)
 }
 
+// GetModConsentAuthURL builds the consent URL for a delegated moderator granting their own
+// moderation scopes (ADR-0048).
+//
+// Unlike GetAuthURLWithScopes it does NOT prepend the base login scopes. Those exist for a
+// streamer's own channel (channel points, subscriptions, bits, followers) and asking a
+// volunteer for them — on their own channel, to do unpaid work on someone else's — is an
+// ADR-0012 scope-minimisation regression and reads badly on the consent screen.
+//
+// force_verify is still required: without it Twitch may silently reissue a prior, narrower
+// grant, so the moderation scopes would never actually be requested.
+//
+// Returns "" when no scopes are requested: a consent screen granting nothing would only fail
+// later, at the first moderation call, as a confusing missing-scope error.
+func (t *TwitchOAuth) GetModConsentAuthURL(state string, scopes []string) string {
+	seen := make(map[string]bool)
+	minimal := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			minimal = append(minimal, s)
+		}
+	}
+	if len(minimal) == 0 {
+		return ""
+	}
+	return t.config.AuthCodeURL(state,
+		oauth2.SetAuthURLParam("scope", strings.Join(minimal, " ")),
+		oauth2.SetAuthURLParam("force_verify", "true"),
+	)
+}
+
 // ExtractGrantedScopes pulls the granted scope list out of a Twitch token exchange
 // or refresh response. Twitch returns "scope" as a JSON array, which oauth2 surfaces
 // via Extra("scope") as []interface{}. Returns nil when absent. The string case is

--- a/services/auth-service/repository/mod_credential_repository.go
+++ b/services/auth-service/repository/mod_credential_repository.go
@@ -1,0 +1,120 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// StoreModCredential persists a delegated moderator's OWN platform credential (ADR-0048).
+//
+// This is deliberately a separate table from every other credential store, keyed on the
+// moderator rather than on a channel. Two listeners select a channel's credential by channel
+// with NO user scoping — twitch-eventsub-listener by `LOWER(twitch_login) = LOWER(channel_id)`
+// and kick-listener by `kick_oauth_tokens WHERE channel_id = $1` — so a moderator-scoped row in
+// either table could become a candidate INGEST credential and silently break chat on a real
+// channel. Writing here also means a moderator's consent can never touch their own login
+// credential or its granted_scopes, which removes any interaction with the scope-downgrade
+// guard.
+//
+// One row per (moderator, platform), so there is exactly one refresh owner and nothing races
+// token-refresh-service. Re-consenting with a different account on the same platform replaces
+// the row; the capabilities payload echoes which account is acting so it is never a mystery.
+func (r *UserRepository) StoreModCredential(
+	ctx context.Context,
+	userID, platform, platformUserID, platformLogin string,
+	token *oauth2.Token,
+	grantedScopes []string,
+) error {
+	if userID == "" {
+		return fmt.Errorf("user_id is required for storing a moderator credential")
+	}
+	if platform == "" {
+		return fmt.Errorf("platform is required for storing a moderator credential")
+	}
+	// The platform id is what we send as moderator_id and what the platform re-checks the role
+	// against. A credential we cannot attribute to a platform identity is unusable.
+	if platformUserID == "" {
+		return fmt.Errorf("platform_user_id is required for storing a moderator credential")
+	}
+	if token == nil || token.AccessToken == "" {
+		return fmt.Errorf("access token is required for storing a moderator credential")
+	}
+	if !token.Expiry.IsZero() && token.Expiry.Before(time.Now().Add(-5*time.Minute)) {
+		return fmt.Errorf("refusing to store expired %s moderator token (expiry: %s)",
+			platform, token.Expiry.Format(time.RFC3339))
+	}
+
+	accessToken, err := r.encryptToken(token.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt moderator access token: %w", err)
+	}
+	refreshToken, err := r.encryptToken(token.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to encrypt moderator refresh token: %w", err)
+	}
+
+	if grantedScopes == nil {
+		grantedScopes = []string{}
+	}
+
+	var expiry *time.Time
+	if !token.Expiry.IsZero() {
+		expiry = &token.Expiry
+	}
+
+	const query = `
+		INSERT INTO mod_oauth_credentials (
+			user_id, platform, platform_user_id, platform_login,
+			access_token, refresh_token, token_type, token_expires_at,
+			granted_scopes, encryption_version, created_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, $6, COALESCE(NULLIF($7, ''), 'bearer'), $8, $9, 1, NOW(), NOW())
+		ON CONFLICT (user_id, platform)
+		DO UPDATE SET
+			platform_user_id   = EXCLUDED.platform_user_id,
+			platform_login     = EXCLUDED.platform_login,
+			access_token       = EXCLUDED.access_token,
+			refresh_token      = EXCLUDED.refresh_token,
+			token_type         = EXCLUDED.token_type,
+			token_expires_at   = EXCLUDED.token_expires_at,
+			granted_scopes     = EXCLUDED.granted_scopes,
+			encryption_version = EXCLUDED.encryption_version,
+			updated_at         = NOW()`
+
+	if _, err := r.db.Exec(ctx, query,
+		userID, platform, platformUserID, platformLogin,
+		accessToken, refreshToken, token.TokenType, expiry, grantedScopes,
+	); err != nil {
+		return fmt.Errorf("failed to store %s moderator credential: %w", platform, err)
+	}
+
+	return nil
+}
+
+// DeleteModCredential removes a moderator's credential for one platform, so revoking their last
+// grant (or a user disconnecting) does not leave a usable token behind.
+func (r *UserRepository) DeleteModCredential(ctx context.Context, userID, platform string) error {
+	const query = `DELETE FROM mod_oauth_credentials WHERE user_id = $1 AND platform = $2`
+	if _, err := r.db.Exec(ctx, query, userID, platform); err != nil {
+		return fmt.Errorf("failed to delete %s moderator credential: %w", platform, err)
+	}
+	return nil
+}

--- a/services/auth-service/repository/mod_credential_repository_test.go
+++ b/services/auth-service/repository/mod_credential_repository_test.go
@@ -1,0 +1,241 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// reverseCipher is a trivially reversible stand-in for the real encryptor: enough to prove the
+// token is transformed on the way in and recoverable, without pulling key management into the test.
+type reverseCipher struct{}
+
+func (reverseCipher) Encrypt(s string) (string, error) { return reverse(s), nil }
+func (reverseCipher) Decrypt(s string) (string, error) { return reverse(s), nil }
+
+func reverse(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
+// modCredTestRepo builds a repository over a database with the full migration set applied, so
+// mod_oauth_credentials matches migration 080 exactly (constraints included).
+func modCredTestRepo(t *testing.T) (*UserRepository, string, func()) {
+	t.Helper()
+	pool, cleanup := setupMigrationTestDB(t)
+	runMigrations(t, pool, loadUpMigrations(t))
+
+	ctx := context.Background()
+	var modID string
+	err := pool.QueryRow(ctx, `
+		INSERT INTO users (twitch_id, auth_provider, username, display_name,
+		                   access_token, refresh_token, token_expires_at)
+		VALUES ('717171', 'twitch', 'volunteer_mod', 'Volunteer Mod',
+		        'access', 'refresh', NOW() + INTERVAL '4 hours')
+		RETURNING id`).Scan(&modID)
+	if err != nil {
+		t.Fatalf("failed to insert moderator: %v", err)
+	}
+
+	return NewUserRepository(pool, reverseCipher{}), modID, cleanup
+}
+
+func TestStoreModCredential(t *testing.T) {
+	repo, modID, cleanup := modCredTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	token := &oauth2.Token{
+		AccessToken:  "mod-access",
+		RefreshToken: "mod-refresh",
+		TokenType:    "bearer",
+		Expiry:       time.Now().Add(4 * time.Hour),
+	}
+
+	err := repo.StoreModCredential(ctx, modID, "twitch", "717171", "volunteer_mod",
+		token, []string{"moderator:manage:chat_messages"})
+	if err != nil {
+		t.Fatalf("StoreModCredential: %v", err)
+	}
+
+	var stored, platformUserID string
+	var scopes []string
+	var version int
+	err = repo.db.QueryRow(ctx, `
+		SELECT access_token, platform_user_id, granted_scopes, encryption_version
+		FROM mod_oauth_credentials WHERE user_id = $1 AND platform = 'twitch'`, modID).
+		Scan(&stored, &platformUserID, &scopes, &version)
+	if err != nil {
+		t.Fatalf("reading back the credential: %v", err)
+	}
+
+	if stored == "mod-access" {
+		t.Error("the access token was stored in plaintext")
+	}
+	if reverse(stored) != "mod-access" {
+		t.Errorf("stored token does not decrypt to the original: %q", stored)
+	}
+	if platformUserID != "717171" {
+		t.Errorf("platform_user_id = %q, want 717171 (this is what we send as moderator_id)", platformUserID)
+	}
+	if version != 1 {
+		t.Errorf("encryption_version = %d, want 1", version)
+	}
+	if len(scopes) != 1 || scopes[0] != "moderator:manage:chat_messages" {
+		t.Errorf("granted_scopes = %v", scopes)
+	}
+}
+
+// Exactly one row per (moderator, platform): one refresh owner, so nothing races
+// token-refresh-service. Re-consenting replaces rather than accumulating.
+func TestStoreModCredential_ReplacesRatherThanAccumulates(t *testing.T) {
+	repo, modID, cleanup := modCredTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	first := &oauth2.Token{AccessToken: "first", RefreshToken: "r1", Expiry: time.Now().Add(time.Hour)}
+	if err := repo.StoreModCredential(ctx, modID, "twitch", "111", "acct-one", first, []string{"moderator:manage:chat_messages"}); err != nil {
+		t.Fatalf("first store: %v", err)
+	}
+
+	// A different Twitch account for the same All-Chat user.
+	second := &oauth2.Token{AccessToken: "second", RefreshToken: "r2", Expiry: time.Now().Add(time.Hour)}
+	if err := repo.StoreModCredential(ctx, modID, "twitch", "222", "acct-two", second, []string{"moderator:manage:banned_users"}); err != nil {
+		t.Fatalf("second store: %v", err)
+	}
+
+	var count int
+	if err := repo.db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM mod_oauth_credentials WHERE user_id = $1 AND platform = 'twitch'`, modID).
+		Scan(&count); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d credential rows, want exactly 1 — a second row means two refresh owners", count)
+	}
+
+	var platformUserID string
+	var scopes []string
+	if err := repo.db.QueryRow(ctx,
+		`SELECT platform_user_id, granted_scopes FROM mod_oauth_credentials WHERE user_id = $1 AND platform = 'twitch'`, modID).
+		Scan(&platformUserID, &scopes); err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if platformUserID != "222" {
+		t.Errorf("platform_user_id = %q, want the most recent consent (222)", platformUserID)
+	}
+	if len(scopes) != 1 || scopes[0] != "moderator:manage:banned_users" {
+		t.Errorf("granted_scopes = %v, want the newest grant's scopes", scopes)
+	}
+}
+
+// Distinct platforms coexist: a moderator can consent for Twitch and Kick independently.
+func TestStoreModCredential_PerPlatformRows(t *testing.T) {
+	repo, modID, cleanup := modCredTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, platform := range []string{"twitch", "kick"} {
+		token := &oauth2.Token{AccessToken: "a-" + platform, Expiry: time.Now().Add(time.Hour)}
+		if err := repo.StoreModCredential(ctx, modID, platform, "id-"+platform, platform+"-login", token, nil); err != nil {
+			t.Fatalf("store %s: %v", platform, err)
+		}
+	}
+
+	var count int
+	if err := repo.db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM mod_oauth_credentials WHERE user_id = $1`, modID).Scan(&count); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("got %d rows, want one per platform", count)
+	}
+}
+
+func TestStoreModCredential_Rejections(t *testing.T) {
+	repo, modID, cleanup := modCredTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	valid := func() *oauth2.Token {
+		return &oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(time.Hour)}
+	}
+
+	cases := []struct {
+		name       string
+		user       string
+		platform   string
+		platformID string
+		token      *oauth2.Token
+		wantSubstr string
+	}{
+		{"no user id", "", "twitch", "1", valid(), "user_id"},
+		{"no platform", modID, "", "1", valid(), "platform is required"},
+		{"no platform user id", modID, "twitch", "", valid(), "platform_user_id"},
+		{"nil token", modID, "twitch", "1", nil, "access token"},
+		{"empty access token", modID, "twitch", "1", &oauth2.Token{}, "access token"},
+		{
+			"already-expired token", modID, "twitch", "1",
+			&oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(-time.Hour)},
+			"expired",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := repo.StoreModCredential(ctx, tc.user, tc.platform, tc.platformID, "login", tc.token, nil)
+			if err == nil {
+				t.Fatalf("expected a rejection, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("error %q does not mention %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// Revoking a moderator's last grant must be able to leave no usable token behind.
+func TestDeleteModCredential(t *testing.T) {
+	repo, modID, cleanup := modCredTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	token := &oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(time.Hour)}
+	if err := repo.StoreModCredential(ctx, modID, "twitch", "1", "login", token, nil); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := repo.DeleteModCredential(ctx, modID, "twitch"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	var count int
+	if err := repo.db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM mod_oauth_credentials WHERE user_id = $1`, modID).Scan(&count); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("credential survived deletion")
+	}
+}


### PR DESCRIPTION
_Re-raised against `main` after #654 squash-merged: GitHub closed #655 when its base branch was deleted, and the base of a closed PR cannot be changed. Same branch, rebased onto main; `git diff` against the pre-rebase tip shows only the files #652/#653 added, nothing of this slice's own._

Second slice of **ADR-0048**. Stacked on **#654** (base branch is `feat/delegated-moderators-foundation`, so review that first).

A moderator can now grant All-Chat their own Twitch moderation scopes, stored separately from their login credential.

## Why this couldn't reuse the streamer's re-consent path

Three independent reasons, each verified against the code:

- **`NewModerationState` is an add-source state** (its own comment says so), and the shared callback calls `addSourceToOverlay` for *every* add-source state. overlay-manager 404s that for a non-owner — so a moderator's consent would persist their credential and *then* redirect to an error. Hence a third action kind (`ActionModConsent`), a `Validate` arm requiring the moderator's user id, and a callback fork that returns **before** any of the login / account-link / add-source machinery.
- **`GetAuthURLWithScopes` unconditionally prepends the base login scopes** (`channel:read:redemptions`, `channel:read:subscriptions`, `bits:read`, `moderator:read:followers`). Asking a volunteer for channel-point, subscription and bits read on their *own* channel — to do unpaid work on someone else's — is an ADR-0012 regression and reads badly. `GetModConsentAuthURL` requests the action scopes and nothing else, keeping `force_verify` (without it Twitch may silently reissue a prior, narrower grant, so the moderation scopes would never actually be requested).
- **Storing in the moderator's existing rows** would drag in the scope-downgrade guard and `StoreTwitchToken`'s `granted_scopes` replacement. `mod_oauth_credentials` sidesteps both: keyed on the moderator, one row per (moderator, platform) so there is exactly one refresh owner, and **never on a channel** — `twitch-eventsub-listener` and `kick-listener` select credentials by channel with **no user scoping**, so a moderator-scoped row keyed to a channel could become a candidate *ingest* credential and break chat on a real channel.

## Consent is not bound to an overlay

Twitch's and Kick's moderation scopes are **role-based, not channel-scoped**, so one consent per platform serves every streamer who delegated that platform. A mod working for three streamers consents once.

## A test caught a real scope-widening hole

`ModerationScopesForActions` also accepts `"engagement"`, which maps to `channel:read:polls` / `channel:read:predictions` — scopes on the requester's **own** channel, for a capability moderators never get (polls and predictions stay owner-only). A crafted `?actions=engagement` would have widened a volunteer's consent screen to scopes delegation does not use. The endpoint now filters to the four delegatable actions before mapping, with a test for the mixed case.

Also deliberately absent, unlike the streamer flow: **no chat-send scope** (moderators get no send in v1) and **no union** with their existing grant.

## Per-platform gating

Kick and YouTube return an explicit "not available yet" rather than issuing a consent screen that cannot be completed — Kick needs a PKCE variant of the minimal-scope builder, YouTube needs the moderator's own channel id resolved first. Each platform leg is independently gated by design.

## Tests

- `oauth/mod_consent_test.go` — mod-consent is **not** an add-source state (the property that keeps it away from `addSourceToOverlay`), `Validate` requires the user id, round-trip, and the auth URL omits every base login scope while keeping `force_verify`.
- `repository/mod_credential_repository_test.go` — against a real Postgres with the **full migration set** applied: the token is encrypted at rest, `platform_user_id` (what we send as `moderator_id`) survives, re-consent **replaces rather than accumulates** (one refresh owner), platforms coexist, six rejection cases, and delete.
- `handlers/mod_consent_test.go` — scopes match exactly the delegated actions, no send scope, no streamer login scopes, the stashed state is a mod-consent state bound to no overlay, auth required, and the `engagement` filter.

`go build` and `go vet` clean for auth-service and api-gateway. **Note for reviewers:** `TestAuthHandlerLogout` fails locally because it dials a real Redis at `localhost:6379` — pre-existing and unrelated.

## Next

Credential refresh loop for `mod_oauth_credentials` (without it grants die long before the 90-day dormancy rule can fire), then invite/accept/revoke, then the mod-scoped capabilities payload and the `/moderate` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLgC8YAUZgQuXKtJPC4AHd
