### PR TITLE
feat(moderation): owner-side Moderators panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ A Twitch-dashboard-inspired monitor with a **resizable live Chat panel + Activit
 
 You can also open it from your overlay's settings page (or its preview page) via the **Monitor View** button.
 
+**Your moderators can use it too.** Under **Moderators** in the overlay editor you can invite the
+people who already moderate for you (Premium). They act with **their own** platform accounts, so
+Twitch, YouTube and Kick re-check their moderator role on every action and it lands in your native
+mod log under their name — and they never need a plan of their own.
+
 ### 3. Customize the look
 
 All-Chat ships with **16 ready-made themes** you can paste into your OBS Browser Source custom CSS:
@@ -259,6 +264,7 @@ Architecture decisions are documented as ADRs in [`docs/adr/`](./docs/adr/README
 - **ADR-0015**: Dynamic EventSub chat-ownership claim — IRC is the always-on fallback; EventSub owns a channel only while it is actively delivering chat (no silent loss across the partition)
 - **ADR-0026**: Two-phase deprecation of the Twitch IRC listener — `warn` nudges connected sources to re-add their Twitch source (in-overlay notice), `enforce` stops joining channels
 - **ADR-0046**: Twitch chat notices via `channel.chat.notification` — watch streaks and announcements carry the chatter's own message on no other subscription, so they were silently dropped; notices are routed by type, skipping the five a dedicated subscription already delivers
+- **ADR-0048**: Delegated overlay moderators — a moderator acts with their OWN platform credential (never the streamer's, no fallback), so the platform re-checks their role per call; Discord is the exception (the shared bot always acts, so All-Chat verifies guild permissions live) and premium is keyed on the overlay owner
 - **ADR-0027**: Time-limited admin premium grants — an optional expiry on the admin override (streamer + viewer) that reverts on its own; recompute ignores an expired override, and a single-replica payment-service sweep clears lapsed grants
 
 ### Documentation

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -110,7 +110,12 @@ import { EditorNav } from '@/components/editor/EditorNav'
 import { EditorSectionHeader } from '@/components/editor/EditorSectionHeader'
 import { SettingsSearch } from '@/components/editor/SettingsSearch'
 import { AdvancedDisclosure } from '@/components/editor/AdvancedDisclosure'
-import { EDITOR_SECTIONS, type EditorSectionId } from '@/components/editor/sectionRegistry'
+import { ModeratorsPanel } from '@/components/editor/ModeratorsPanel'
+import {
+  EDITOR_SECTIONS,
+  type EditorSectionId,
+  type SpotlightSection,
+} from '@/components/editor/sectionRegistry'
 import dynamic from 'next/dynamic'
 
 // Dynamically import Monaco Editor to avoid SSR issues
@@ -163,10 +168,13 @@ const ENTRY_ANIMATION_OPTIONS: ReadonlyArray<{ value: MessageAnimation | ''; lab
 // Maps onboarding spotlight targets to left-nav sections (ADR-0042). The
 // guide's 'appearance' target predates the flat nav; Typography is the first
 // Appearance-group section, so the "customize" step lands there.
-const SPOTLIGHT_SECTION: Record<'sources' | 'theme' | 'appearance', EditorSectionId> = {
+// Which nav section a spotlight target opens. Keyed on SpotlightSection so adding a
+// "Show me" target is a compile error until it is mapped, rather than a silent no-op.
+const SPOTLIGHT_SECTION: Record<SpotlightSection, EditorSectionId> = {
   sources: 'sources',
   theme: 'theme',
   appearance: 'typography',
+  moderators: 'moderators',
 }
 
 // ---- Types -----------------------------------------------------------------
@@ -1288,7 +1296,9 @@ function AddSourceForm({
         <button
           onClick={() => setTiktokDialogOpen(true)}
           className="flex items-center gap-2.5 rounded-lg px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-bg focus-visible:outline-none"
-          style={{ backgroundColor: '#010101', '--tw-ring-color': '#69C9D0' } as React.CSSProperties}
+          style={
+            { backgroundColor: '#010101', '--tw-ring-color': '#69C9D0' } as React.CSSProperties
+          }
         >
           <svg className="h-4 w-4 shrink-0" viewBox="0 0 24 24" aria-hidden="true">
             <path
@@ -1615,9 +1625,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
   const obsCopiedStep = useOnboardingStore((s) => s.sessionSteps.obsCopied)
   // Explicit spotlight from a checklist "Show me" click; while unset the
   // active step's own section is spotlighted.
-  const [spotlightOverride, setSpotlightOverride] = useState<
-    'sources' | 'theme' | 'appearance' | null
-  >(null)
+  const [spotlightOverride, setSpotlightOverride] = useState<SpotlightSection | null>(null)
 
   // --- Settings navigation (ADR-0042): left nav, one section at a time ---
   const [activeSection, setActiveSection] = useState<EditorSectionId>(() => {
@@ -1721,7 +1729,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
         obsCopied: obsCopiedStep,
       }).find((s) => s.active)?.id
     : undefined
-  const spotlight: 'sources' | 'theme' | 'appearance' | null = !onboardingActive
+  const spotlight: SpotlightSection | null = !onboardingActive
     ? null
     : (spotlightOverride ??
       (onboardingActiveStep === 'connect_source'
@@ -1781,7 +1789,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
     return () => cancelAnimationFrame(frame)
   }, [pendingAnchor, activeSection])
 
-  function handleSpotlightSection(section: 'sources' | 'theme' | 'appearance') {
+  function handleSpotlightSection(section: SpotlightSection) {
     setSpotlightOverride(section)
     // Let the section render land before scrolling the panel into view.
     requestAnimationFrame(() => {
@@ -2267,7 +2275,10 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           // Reconstruct the full editable CSS from the stored delta/fork (ADR-0043):
           // 'linked' → the bundled theme (preloaded, not a blank box), 'diff' → the
           // theme merged with the user's saved changes, 'fork' → the saved copy as-is.
-          const { editor: editorCss, mode: cssMode } = await reconstructEditorCss(themeCss, savedCss)
+          const { editor: editorCss, mode: cssMode } = await reconstructEditorCss(
+            themeCss,
+            savedCss
+          )
           setCustomCss(editorCss)
           setCustomCssMode(cssMode)
 
@@ -3613,6 +3624,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                   {/* Engagement — polls, predictions & viewer points (issue #523) */}
                   {activeSection === 'engagement' && <EngagementPanel overlayId={id} />}
 
+                  {activeSection === 'moderators' && <ModeratorsPanel overlayId={id} />}
+
                   {activeSection === 'custom-css' && (
                     <div className="space-y-3">
                       <div className="flex flex-wrap items-center gap-2">
@@ -3677,7 +3690,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                         const errors = cssIssues.filter((i) => i.severity === 'error')
                         const warnings = cssIssues.filter((i) => i.severity === 'warning')
                         if (errors.length === 0 && warnings.length === 0) {
-                          return <p className="text-xs text-green-400">✓ No CSS problems detected.</p>
+                          return (
+                            <p className="text-xs text-green-400">✓ No CSS problems detected.</p>
+                          )
                         }
                         const parts: string[] = []
                         if (errors.length > 0)
@@ -3688,7 +3703,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                           <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-2">
                             <p className="text-xs font-medium text-amber-300">
                               {parts.join(' · ')} — invalid rules are ignored by the browser, so fix
-                              these for your styles to take effect. Incomplete rules aren’t previewed.
+                              these for your styles to take effect. Incomplete rules aren’t
+                              previewed.
                             </p>
                             <ul className="mt-1 space-y-0.5">
                               {[...errors, ...warnings].slice(0, 5).map((issue, idx) => (

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Check, MessagesSquare, Radio, ShieldCheck, Sparkles, Volume2 } from 'lucide-react'
+import { Check, MessagesSquare, Radio, ShieldCheck, Sparkles, Users, Volume2 } from 'lucide-react'
 import Link from 'next/link'
 import { AppNav } from '@/components/AppNav'
 import { Card } from '@/components/ui/card'
@@ -45,6 +45,12 @@ const features: PremiumFeature[] = [
     title: 'Moderate from your overlay',
     description:
       'Moderate straight from the monitor view — no second dashboard. Delete, timeout, ban and unban on Twitch and Discord; timeout, ban and unban on Kick; ban on YouTube. (TikTok has no moderation API.)',
+  },
+  {
+    icon: Users,
+    title: 'Let your moderators help',
+    description:
+      'Hand the monitor view to the moderators you already trust. They act with their own platform accounts, so Twitch, YouTube and Kick check their moderator role on every action — and they never need a plan of their own.',
   },
   {
     icon: Volume2,

--- a/frontend/src/components/editor/ModeratorsPanel.tsx
+++ b/frontend/src/components/editor/ModeratorsPanel.tsx
@@ -1,0 +1,640 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client'
+
+/**
+ * Owner-side Moderators panel (ADR-0048): invite, narrow and revoke the people who
+ * may moderate this overlay's chat.
+ *
+ * Three behaviours here are load-bearing rather than cosmetic:
+ *
+ * 1. An invite secret is shown EXACTLY once. Only its SHA-256 is stored, so there is
+ *    no endpoint that could show it again — the recovery is a new invite, and the copy
+ *    has to say so rather than implying a second chance.
+ * 2. The moderator cap is enforced locally from `used`/`cap`, so the streamer never
+ *    meets a 409 the UI could have prevented.
+ * 3. `verification` is telemetry, never authorization. A single transient platform 403
+ *    can set `not_a_moderator`, so it renders as "worth checking", never as a denial —
+ *    the platform's answer at action time is the only authority.
+ *
+ * Revocation is deliberately never gated: the server keeps it working after a rollback
+ * of the delegation feature, so this panel must not re-introduce the trap of a streamer
+ * holding moderators they cannot remove.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+
+import { AlertDialog } from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Dialog } from '@/components/ui/dialog'
+import { Switch } from '@/components/ui/switch'
+import { boundInviteAccount, delegationErrorCode, moderationApi } from '@/lib/api/moderation'
+import {
+  DELEGATABLE_ACTIONS,
+  DELEGATABLE_PLATFORMS,
+  type DelegatablePlatform,
+  type GrantVerification,
+  type InviteCreated,
+  type ModerationAction,
+  type ModeratorGrant,
+  type ModeratorList,
+} from '@/lib/types/moderation'
+import { cn } from '@/lib/utils'
+
+const PLATFORM_LABELS: Record<DelegatablePlatform, string> = {
+  twitch: 'Twitch',
+  youtube: 'YouTube',
+  kick: 'Kick',
+  discord: 'Discord',
+}
+
+const ACTION_LABELS: Record<ModerationAction, string> = {
+  delete: 'Delete messages',
+  timeout: 'Timeout',
+  ban: 'Ban',
+  unban: 'Unban',
+}
+
+/**
+ * Advisory readiness copy for a leg. Every string is phrased as something to check or
+ * do, never as a verdict about the person: this value is the last platform answer we
+ * happened to observe, not a decision.
+ */
+function readinessNote(platform: DelegatablePlatform, v: GrantVerification): string | null {
+  const name = PLATFORM_LABELS[platform]
+  switch (v) {
+    case 'not_a_moderator':
+      return `Not a moderator on ${name} yet — add them in ${name}'s own tools.`
+    case 'needs_consent':
+      return `Waiting for them to connect their ${name} account.`
+    case 'needs_discord_link':
+      return 'Waiting for them to link Discord.'
+    case 'unavailable':
+      return `Could not check ${name} just now.`
+    case 'verified':
+    case 'unverified':
+      return null
+  }
+}
+
+/** Human label for a grant's lifecycle state. */
+function statusLabel(grant: ModeratorGrant): string {
+  switch (grant.status) {
+    case 'pending':
+      return 'Invite pending'
+    case 'suspended':
+      return 'Paused after 90 days idle'
+    case 'revoked':
+      return 'Removed'
+    case 'active':
+      return 'Active'
+  }
+}
+
+/** Who a row is about: the accepted account, else whatever the streamer typed. */
+function grantName(grant: ModeratorGrant): string {
+  return grant.display_name || grant.invitee_label || 'Unnamed invite'
+}
+
+export function ModeratorsPanel({ overlayId }: { overlayId: string }) {
+  const [list, setList] = useState<ModeratorList | null>(null)
+  const [loadFailed, setLoadFailed] = useState(false)
+  const [inviteOpen, setInviteOpen] = useState(false)
+  const [revoking, setRevoking] = useState<ModeratorGrant | null>(null)
+  const [revokeAllOpen, setRevokeAllOpen] = useState(false)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [rowError, setRowError] = useState<string | null>(null)
+
+  // A failure here includes the code-less owner-only 403, which is identical for an
+  // unauthorized caller and for an overlay that does not exist — so it tells us nothing
+  // we may report about the caller, and renders as a plain retry.
+  const fetchRoster = useCallback(() => moderationApi.listModerators(overlayId), [overlayId])
+
+  // The initial load sets state from the promise callback rather than the effect body:
+  // a synchronous setState in an effect cascades renders. `cancelled` keeps a slow
+  // response from landing after unmount, or from overwriting a newer overlay's roster.
+  useEffect(() => {
+    let cancelled = false
+    fetchRoster()
+      .then((next) => {
+        if (cancelled) return
+        setList(next)
+        setLoadFailed(false)
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [fetchRoster])
+
+  /** Imperative refresh after a mutation or a retry click (an event, not an effect). */
+  const reload = useCallback(async () => {
+    try {
+      setList(await fetchRoster())
+      setLoadFailed(false)
+    } catch {
+      setLoadFailed(true)
+    }
+  }, [fetchRoster])
+
+  const handleToggleLeg = async (
+    grant: ModeratorGrant,
+    platform: DelegatablePlatform,
+    enabled: boolean
+  ) => {
+    setRowError(null)
+    try {
+      // A partial map: only the platform that moved is sent, so the rest keep whatever
+      // the streamer set before.
+      await moderationApi.updateGrant(overlayId, grant.id, { platforms: { [platform]: enabled } })
+      await reload()
+    } catch {
+      setRowError(`Could not change ${PLATFORM_LABELS[platform]} for ${grantName(grant)}.`)
+    }
+  }
+
+  const handleToggleAction = async (grant: ModeratorGrant, action: ModerationAction) => {
+    const next = grant.actions.includes(action)
+      ? grant.actions.filter((a) => a !== action)
+      : [...grant.actions, action]
+    // An empty action set is a 400 server-side and a nonsense grant besides, so removing
+    // the last one is not offered as an edit — remove the moderator instead.
+    if (next.length === 0) {
+      setRowError(`${grantName(grant)} needs at least one action. Remove them instead.`)
+      return
+    }
+    setRowError(null)
+    try {
+      await moderationApi.updateGrant(overlayId, grant.id, {
+        actions: DELEGATABLE_ACTIONS.filter((a) => next.includes(a)),
+      })
+      await reload()
+    } catch {
+      setRowError(`Could not update ${grantName(grant)}.`)
+    }
+  }
+
+  const handleRevoke = async () => {
+    if (!revoking) return
+    const name = grantName(revoking)
+    setRevoking(null)
+    try {
+      await moderationApi.revokeGrant(overlayId, revoking.id)
+      setNotice(`Removed ${name}.`)
+      await reload()
+    } catch {
+      setRowError(`Could not remove ${name}.`)
+    }
+  }
+
+  const handleRevokeAll = async () => {
+    setRevokeAllOpen(false)
+    try {
+      const { revoked } = await moderationApi.revokeAllModerators(overlayId)
+      setNotice(`Removed ${revoked} ${revoked === 1 ? 'moderator' : 'moderators'}.`)
+      await reload()
+    } catch {
+      setRowError('Could not remove everyone. Try again.')
+    }
+  }
+
+  if (loadFailed) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-text-sub">Could not load this overlay&apos;s moderators.</p>
+        <Button variant="outline" size="sm" onClick={() => void reload()}>
+          Try again
+        </Button>
+      </div>
+    )
+  }
+
+  if (list === null) {
+    return <p className="text-sm text-text-dim">Loading moderators…</p>
+  }
+
+  const atCap = list.used >= list.cap
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-text-sub">
+        Moderators act with <strong>their own</strong> platform accounts, so Twitch, YouTube and
+        Kick check their moderator role on every action. Removing someone here takes effect
+        immediately.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button size="sm" disabled={atCap} onClick={() => setInviteOpen(true)}>
+          Invite a moderator
+        </Button>
+        <span className="text-xs text-text-dim">
+          {list.used} of {list.cap} used
+        </span>
+        {list.moderators.length > 0 && (
+          <Button
+            variant="destructive"
+            size="sm"
+            className="ml-auto"
+            onClick={() => setRevokeAllOpen(true)}
+          >
+            Remove all
+          </Button>
+        )}
+      </div>
+
+      {atCap && (
+        <p className="text-xs text-text-dim">
+          This overlay is at its limit of {list.cap} moderators. Remove someone to invite another.
+        </p>
+      )}
+
+      {notice !== null && (
+        <p role="status" className="text-xs text-text-sub">
+          {notice}
+        </p>
+      )}
+      {rowError !== null && (
+        <p role="alert" className="text-destructive text-xs">
+          {rowError}
+        </p>
+      )}
+
+      {list.moderators.length === 0 ? (
+        <p className="text-sm text-text-dim">
+          No one moderates this overlay yet. Invite someone and they will be able to delete messages
+          and time viewers out from the monitor view, using their own platform accounts.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {list.moderators.map((grant) => (
+            <ModeratorRow
+              key={grant.id}
+              grant={grant}
+              onToggleLeg={(platform, enabled) => void handleToggleLeg(grant, platform, enabled)}
+              onToggleAction={(action) => void handleToggleAction(grant, action)}
+              onRemove={() => setRevoking(grant)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <InviteDialog
+        overlayId={overlayId}
+        open={inviteOpen}
+        onOpenChange={(open) => {
+          setInviteOpen(open)
+          if (!open) void reload()
+        }}
+      />
+
+      <AlertDialog.Root
+        open={revoking !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevoking(null)
+        }}
+      >
+        <AlertDialog.Content size="sm">
+          <AlertDialog.Title className="text-sm font-medium">
+            Remove {revoking === null ? '' : grantName(revoking)}?
+          </AlertDialog.Title>
+          <AlertDialog.Description className="text-xs">
+            They lose access to this overlay&apos;s moderation on their next action. Their past
+            actions stay in the log.
+          </AlertDialog.Description>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialog.Close
+              render={
+                <Button variant="outline" size="sm">
+                  Cancel
+                </Button>
+              }
+            />
+            <Button variant="destructive" size="sm" onClick={() => void handleRevoke()}>
+              Remove
+            </Button>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+
+      <AlertDialog.Root open={revokeAllOpen} onOpenChange={setRevokeAllOpen}>
+        <AlertDialog.Content size="sm">
+          <AlertDialog.Title className="text-sm font-medium">
+            Remove every moderator?
+          </AlertDialog.Title>
+          <AlertDialog.Description className="text-xs">
+            This removes everyone on this overlay, including invites nobody has accepted yet. You
+            can invite people again afterwards.
+          </AlertDialog.Description>
+          <div className="mt-4 flex justify-end gap-2">
+            <AlertDialog.Close
+              render={
+                <Button variant="outline" size="sm">
+                  Cancel
+                </Button>
+              }
+            />
+            <Button variant="destructive" size="sm" onClick={() => void handleRevokeAll()}>
+              Remove everyone
+            </Button>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Root>
+    </div>
+  )
+}
+
+interface ModeratorRowProps {
+  grant: ModeratorGrant
+  onToggleLeg: (platform: DelegatablePlatform, enabled: boolean) => void
+  onToggleAction: (action: ModerationAction) => void
+  onRemove: () => void
+}
+
+function ModeratorRow({ grant, onToggleLeg, onToggleAction, onRemove }: ModeratorRowProps) {
+  const name = grantName(grant)
+  const legs = new Map(grant.platforms.map((leg) => [leg.platform, leg]))
+
+  return (
+    <li className="rounded-lg border border-border bg-surface p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-text">{name}</p>
+          <p className="text-xs text-text-dim">
+            {statusLabel(grant)}
+            {grant.status === 'pending' && grant.expected_account !== undefined && (
+              <> · for {grant.expected_account}</>
+            )}
+          </p>
+        </div>
+        <Button variant="destructive" size="sm" aria-label={`Remove ${name}`} onClick={onRemove}>
+          Remove
+        </Button>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {DELEGATABLE_ACTIONS.map((action) => {
+          const on = grant.actions.includes(action)
+          return (
+            <button
+              key={action}
+              type="button"
+              aria-pressed={on}
+              onClick={() => onToggleAction(action)}
+              className={cn(
+                'rounded-md border px-2 py-0.5 text-xs transition-colors focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none',
+                on
+                  ? 'border-twitch/40 bg-twitch/10 text-text'
+                  : 'bg-surface-alt border-border text-text-dim'
+              )}
+            >
+              {ACTION_LABELS[action]}
+            </button>
+          )
+        })}
+      </div>
+
+      <ul className="mt-3 space-y-1.5">
+        {DELEGATABLE_PLATFORMS.map((platform) => {
+          const leg = legs.get(platform)
+          const enabled = leg?.enabled ?? false
+          const note = leg === undefined ? null : readinessNote(platform, leg.verification)
+          return (
+            <li key={platform} className="flex items-start gap-2">
+              <Switch.Root
+                checked={enabled}
+                aria-label={`${PLATFORM_LABELS[platform]} moderation for ${name}`}
+                onCheckedChange={(next: boolean) => onToggleLeg(platform, next)}
+              >
+                <Switch.Thumb />
+              </Switch.Root>
+              <div className="min-w-0">
+                <span className="text-xs text-text-sub">{PLATFORM_LABELS[platform]}</span>
+                {enabled && note !== null && <p className="text-xs text-text-dim">{note}</p>}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </li>
+  )
+}
+
+interface InviteDialogProps {
+  overlayId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function InviteDialog({ overlayId, open, onOpenChange }: InviteDialogProps) {
+  const [actions, setActions] = useState<ModerationAction[]>(['delete', 'timeout'])
+  const [platforms, setPlatforms] = useState<DelegatablePlatform[]>([])
+  const [label, setLabel] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [created, setCreated] = useState<InviteCreated | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [gateBlocked, setGateBlocked] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const reset = () => {
+    setActions(['delete', 'timeout'])
+    setPlatforms([])
+    setLabel('')
+    setCreated(null)
+    setError(null)
+    setGateBlocked(false)
+    setCopied(false)
+  }
+
+  const handleCreate = async () => {
+    // Unreachable via the UI (the button is disabled), but an explicitly empty action
+    // list is a 400 server-side, so never let one leave here.
+    if (actions.length === 0) return
+    setCreating(true)
+    setError(null)
+    setGateBlocked(false)
+    try {
+      setCreated(
+        await moderationApi.createInvite(overlayId, {
+          actions: DELEGATABLE_ACTIONS.filter((a) => actions.includes(a)),
+          platforms: DELEGATABLE_PLATFORMS.filter((p) => platforms.includes(p)),
+          invitee_label: label.trim(),
+        })
+      )
+    } catch (err) {
+      const code = delegationErrorCode(err)
+      if (code === 'delegation_unavailable') {
+        // Sticky and inline, not a toast: this is something the streamer has to act on.
+        setGateBlocked(true)
+      } else if (code === 'moderator_cap_reached') {
+        setError('This overlay already has the maximum number of moderators.')
+      } else {
+        const bound = boundInviteAccount(err)
+        setError(
+          bound === null
+            ? 'Could not create the invite. Try again.'
+            : `That invite belongs to ${bound.account}.`
+        )
+      }
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (created === null) return
+    try {
+      await navigator.clipboard.writeText(created.invite_token)
+      setCopied(true)
+    } catch {
+      setError('Could not copy. Select the code and copy it manually.')
+    }
+  }
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(next: boolean) => {
+        if (!next) reset()
+        onOpenChange(next)
+      }}
+    >
+      <Dialog.Content size="sm">
+        <Dialog.Title className="text-sm font-medium">Invite a moderator</Dialog.Title>
+
+        {created !== null ? (
+          <div className="space-y-3">
+            <Dialog.Description className="text-xs">
+              Send this code to the person you want to moderate. It works once, expires in 7 days,
+              and <strong>won&apos;t be shown again</strong> — if it gets lost, create a new invite.
+            </Dialog.Description>
+            <code className="bg-surface-alt block overflow-x-auto rounded-lg border border-border p-2 text-xs break-all text-text">
+              {created.invite_token}
+            </code>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" size="sm" onClick={() => void handleCopy()}>
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+              <Button size="sm" onClick={() => onOpenChange(false)}>
+                Done
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <Dialog.Description className="text-xs">
+              They accept with their own All-Chat account, then connect each platform the first time
+              they moderate on it.
+            </Dialog.Description>
+
+            <label className="block space-y-1">
+              <span className="text-xs text-text-sub">Who is this for? (optional)</span>
+              <input
+                type="text"
+                value={label}
+                maxLength={120}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Sarah, my Twitch mod"
+                className="w-full rounded-lg border border-border bg-surface px-2 py-1 text-sm text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+              />
+            </label>
+
+            <fieldset className="space-y-1.5">
+              <legend className="text-xs text-text-sub">What may they do?</legend>
+              {DELEGATABLE_ACTIONS.map((action) => (
+                <label key={action} className="flex items-center gap-2 text-xs text-text">
+                  <input
+                    type="checkbox"
+                    checked={actions.includes(action)}
+                    onChange={(e) =>
+                      setActions((prev) =>
+                        e.target.checked ? [...prev, action] : prev.filter((a) => a !== action)
+                      )
+                    }
+                    className="accent-twitch"
+                  />
+                  {ACTION_LABELS[action]}
+                </label>
+              ))}
+            </fieldset>
+
+            <fieldset className="space-y-1.5">
+              <legend className="text-xs text-text-sub">
+                On which platforms? Off means they cannot act there.
+              </legend>
+              {DELEGATABLE_PLATFORMS.map((platform) => (
+                <label key={platform} className="flex items-center gap-2 text-xs text-text">
+                  <input
+                    type="checkbox"
+                    checked={platforms.includes(platform)}
+                    onChange={(e) =>
+                      setPlatforms((prev) =>
+                        e.target.checked ? [...prev, platform] : prev.filter((p) => p !== platform)
+                      )
+                    }
+                    className="accent-twitch"
+                  />
+                  {PLATFORM_LABELS[platform]}
+                </label>
+              ))}
+            </fieldset>
+
+            {gateBlocked && (
+              <div className="bg-surface-alt space-y-1 rounded-lg border border-border p-2">
+                <p className="text-xs text-text-sub">
+                  Delegating moderation is part of All-Chat premium. Your moderators never pay —
+                  only your own plan matters.
+                </p>
+                <a
+                  href="/upgrade"
+                  className="text-xs text-twitch underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+                >
+                  Upgrade to invite moderators
+                </a>
+              </div>
+            )}
+            {error !== null && (
+              <p role="alert" className="text-destructive text-xs">
+                {error}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <Dialog.Close
+                render={
+                  <Button variant="outline" size="sm">
+                    Cancel
+                  </Button>
+                }
+              />
+              <Button
+                size="sm"
+                disabled={actions.length === 0 || creating}
+                onClick={() => void handleCreate()}
+              >
+                {creating ? 'Creating…' : 'Create invite'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/frontend/src/components/editor/__tests__/ModeratorsPanel.test.tsx
+++ b/frontend/src/components/editor/__tests__/ModeratorsPanel.test.tsx
@@ -1,0 +1,421 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ModeratorsPanel } from '@/components/editor/ModeratorsPanel'
+import { ApiError } from '@/lib/api/client'
+import type { ModeratorGrant, ModeratorList } from '@/lib/types/moderation'
+
+// Base UI's dialog measures the viewport and traps focus; jsdom lacks matchMedia.
+if (typeof window.matchMedia !== 'function') {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList
+}
+
+// vi.hoisted, because vi.mock's factory is lifted above the imports and would
+// otherwise reference these before initialization.
+const api = vi.hoisted(() => ({
+  listModerators: vi.fn(),
+  createInvite: vi.fn(),
+  updateGrant: vi.fn(),
+  revokeGrant: vi.fn(),
+  revokeAllModerators: vi.fn(),
+}))
+
+vi.mock('@/lib/api/moderation', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/moderation')>('@/lib/api/moderation')
+  return { ...actual, moderationApi: api }
+})
+
+const OVERLAY = 'aaaaaaaa-1111-1111-1111-111111111111'
+
+function grant(over: Partial<ModeratorGrant> = {}): ModeratorGrant {
+  return {
+    id: 'grant-1',
+    status: 'active',
+    moderator_user_id: 'user-2',
+    display_name: 'Sarah',
+    actions: ['delete', 'timeout'],
+    platforms: [{ platform: 'twitch', enabled: true, verification: 'verified' }],
+    created_at: '2026-08-01T10:00:00Z',
+    accepted_at: '2026-08-01T11:00:00Z',
+    ...over,
+  }
+}
+
+function roster(over: Partial<ModeratorList> = {}): ModeratorList {
+  return { moderators: [grant()], cap: 10, used: 1, ...over }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.listModerators.mockResolvedValue(roster())
+  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+})
+
+afterEach(() => cleanup())
+
+async function renderPanel() {
+  const view = render(<ModeratorsPanel overlayId={OVERLAY} />)
+  await waitFor(() => expect(api.listModerators).toHaveBeenCalledWith(OVERLAY))
+  return view
+}
+
+describe('ModeratorsPanel roster', () => {
+  it('names each moderator and distinguishes granted actions from withheld ones', async () => {
+    // Every action renders as a chip so the streamer can grant it in one click; what the
+    // grant actually carries has to be visible in the pressed state, not just the label.
+    await renderPanel()
+    expect(await screen.findByText('Sarah')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete messages/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByRole('button', { name: /^timeout$/i })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByRole('button', { name: /^ban$/i })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: /^unban$/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  it('grants a withheld action in one click, sending the full new set', async () => {
+    api.updateGrant.mockResolvedValue(grant({ actions: ['delete', 'timeout', 'ban'] }))
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /^ban$/i }))
+
+    await waitFor(() =>
+      expect(api.updateGrant).toHaveBeenCalledWith(OVERLAY, 'grant-1', {
+        actions: ['delete', 'timeout', 'ban'],
+      })
+    )
+  })
+
+  // Removing the last action would be a 400 and a grant that can do nothing; the right
+  // answer is to remove the person.
+  it('refuses to empty a grant action set, pointing at removal instead', async () => {
+    api.listModerators.mockResolvedValue(roster({ moderators: [grant({ actions: ['delete'] })] }))
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /delete messages/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/at least one action/i)
+    expect(api.updateGrant).not.toHaveBeenCalled()
+  })
+
+  it('labels an unredeemed invite by what the streamer typed, not as a moderator', async () => {
+    api.listModerators.mockResolvedValue(
+      roster({
+        moderators: [
+          grant({
+            id: 'g2',
+            status: 'pending',
+            display_name: undefined,
+            moderator_user_id: undefined,
+            invitee_label: 'Bob from Discord',
+            invite_expires_at: '2026-08-14T10:00:00Z',
+          }),
+        ],
+      })
+    )
+    await renderPanel()
+    expect(await screen.findByText('Bob from Discord')).toBeInTheDocument()
+    expect(screen.getByText(/invite pending/i)).toBeInTheDocument()
+  })
+
+  it('explains itself when nobody is delegated yet', async () => {
+    api.listModerators.mockResolvedValue(roster({ moderators: [], used: 0 }))
+    await renderPanel()
+    expect(await screen.findByText(/no one moderates this overlay yet/i)).toBeInTheDocument()
+  })
+
+  it('surfaces a load failure with a way to retry instead of an empty panel', async () => {
+    api.listModerators.mockRejectedValueOnce(new Error('network'))
+    render(<ModeratorsPanel overlayId={OVERLAY} />)
+
+    const retry = await screen.findByRole('button', { name: /try again/i })
+    api.listModerators.mockResolvedValue(roster())
+    fireEvent.click(retry)
+    expect(await screen.findByText('Sarah')).toBeInTheDocument()
+  })
+})
+
+describe('ModeratorsPanel cap', () => {
+  // The backend refuses the 11th invite with 409. Explaining a failure the UI could
+  // have prevented is worse than not offering the button.
+  it('refuses to offer an invite at the cap, and says why', async () => {
+    api.listModerators.mockResolvedValue(
+      roster({ moderators: Array.from({ length: 10 }, (_, i) => grant({ id: `g${i}` })), used: 10 })
+    )
+    await renderPanel()
+
+    const invite = await screen.findByRole('button', { name: /invite a moderator/i })
+    expect(invite).toBeDisabled()
+    expect(screen.getByText(/10 of 10/i)).toBeInTheDocument()
+  })
+
+  it('offers the invite below the cap', async () => {
+    await renderPanel()
+    expect(await screen.findByRole('button', { name: /invite a moderator/i })).toBeEnabled()
+  })
+})
+
+describe('ModeratorsPanel invite', () => {
+  async function openInvite() {
+    await renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: /invite a moderator/i }))
+    return screen.findByRole('button', { name: /create invite/i })
+  }
+
+  it('sends exactly the actions and platforms the streamer picked', async () => {
+    api.createInvite.mockResolvedValue({
+      grant_id: 'g9',
+      invite_token: 'SEEKRIT-TOKEN-VALUE',
+      expires_at: '2026-08-14T10:00:00Z',
+      actions: ['delete'],
+      platforms: ['twitch'],
+    })
+    const create = await openInvite()
+
+    // Defaults are delete+timeout; drop timeout and add the twitch leg.
+    fireEvent.click(screen.getByRole('checkbox', { name: /timeout/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /twitch/i }))
+    fireEvent.click(create)
+
+    await waitFor(() => expect(api.createInvite).toHaveBeenCalled())
+    expect(api.createInvite).toHaveBeenCalledWith(OVERLAY, {
+      actions: ['delete'],
+      platforms: ['twitch'],
+      invitee_label: '',
+    })
+  })
+
+  // `actions: []` is a 400 server-side, deliberately, so it must be unreachable here.
+  it('never submits an empty action set', async () => {
+    const create = await openInvite()
+    fireEvent.click(screen.getByRole('checkbox', { name: /delete/i }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /timeout/i }))
+
+    expect(create).toBeDisabled()
+    fireEvent.click(create)
+    expect(api.createInvite).not.toHaveBeenCalled()
+  })
+
+  it('shows the secret once, says it cannot be shown again, and copies it', async () => {
+    api.createInvite.mockResolvedValue({
+      grant_id: 'g9',
+      invite_token: 'SEEKRIT-TOKEN-VALUE',
+      expires_at: '2026-08-14T10:00:00Z',
+      actions: ['delete', 'timeout'],
+      platforms: [],
+    })
+    const create = await openInvite()
+    fireEvent.click(create)
+
+    expect(await screen.findByText('SEEKRIT-TOKEN-VALUE')).toBeInTheDocument()
+    // The digest is all that is stored, so the copy must not promise a second chance.
+    expect(screen.getByText(/won't be shown again/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('SEEKRIT-TOKEN-VALUE')
+    )
+  })
+
+  it('drops the secret from the DOM once the reveal is dismissed', async () => {
+    api.createInvite.mockResolvedValue({
+      grant_id: 'g9',
+      invite_token: 'SEEKRIT-TOKEN-VALUE',
+      expires_at: '2026-08-14T10:00:00Z',
+      actions: ['delete'],
+      platforms: [],
+    })
+    const create = await openInvite()
+    fireEvent.click(create)
+    await screen.findByText('SEEKRIT-TOKEN-VALUE')
+
+    fireEvent.click(screen.getByRole('button', { name: /done/i }))
+    await waitFor(() => expect(screen.queryByText('SEEKRIT-TOKEN-VALUE')).not.toBeInTheDocument())
+  })
+
+  // A moderator must never be shown an upgrade prompt, but the OWNER here is the caller,
+  // and a vanishing toast is the wrong home for "your plan does not include this".
+  it('renders the gate refusal inline with an upgrade link, not as a toast', async () => {
+    api.createInvite.mockRejectedValue(
+      new ApiError(403, 'delegating moderation requires All-Chat premium', {
+        error: 'delegating moderation requires All-Chat premium',
+        code: 'delegation_unavailable',
+        upgrade_url: '/upgrade',
+      })
+    )
+    const create = await openInvite()
+    fireEvent.click(create)
+
+    expect(await screen.findByRole('link', { name: /upgrade/i })).toHaveAttribute(
+      'href',
+      '/upgrade'
+    )
+  })
+
+  it('reports a cap refusal from the server if it slips past the local check', async () => {
+    api.createInvite.mockRejectedValue(
+      new ApiError(409, 'this overlay already has the maximum number of moderators', {
+        error: 'this overlay already has the maximum number of moderators',
+        code: 'moderator_cap_reached',
+        cap: 10,
+      })
+    )
+    const create = await openInvite()
+    fireEvent.click(create)
+    expect(await screen.findByText(/maximum number of moderators/i)).toBeInTheDocument()
+  })
+})
+
+describe('ModeratorsPanel grant edits', () => {
+  it('sends only the platform that moved, as a partial map', async () => {
+    api.updateGrant.mockResolvedValue(
+      grant({ platforms: [{ platform: 'kick', enabled: true, verification: 'unverified' }] })
+    )
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('switch', { name: /kick/i }))
+
+    await waitFor(() => expect(api.updateGrant).toHaveBeenCalled())
+    expect(api.updateGrant).toHaveBeenCalledWith(OVERLAY, 'grant-1', {
+      platforms: { kick: true },
+    })
+  })
+
+  it('turning a platform off disables that leg rather than dropping the grant', async () => {
+    api.updateGrant.mockResolvedValue(
+      grant({ platforms: [{ platform: 'twitch', enabled: false, verification: 'verified' }] })
+    )
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('switch', { name: /twitch/i }))
+    await waitFor(() =>
+      expect(api.updateGrant).toHaveBeenCalledWith(OVERLAY, 'grant-1', {
+        platforms: { twitch: false },
+      })
+    )
+    expect(api.revokeGrant).not.toHaveBeenCalled()
+  })
+
+  // verification is telemetry: a single transient 403 can set not_a_moderator, so it
+  // must read as something to check, never as "this person is blocked".
+  it('renders a not_a_moderator leg as advisory readiness, not a denial', async () => {
+    api.listModerators.mockResolvedValue(
+      roster({
+        moderators: [
+          grant({
+            platforms: [{ platform: 'twitch', enabled: true, verification: 'not_a_moderator' }],
+          }),
+        ],
+      })
+    )
+    await renderPanel()
+
+    const note = await screen.findByText(/not a moderator on twitch yet/i)
+    expect(note).toBeInTheDocument()
+    expect(screen.queryByText(/blocked|denied|cannot moderate/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('ModeratorsPanel revocation', () => {
+  it('confirms before revoking, then drops the row', async () => {
+    api.revokeGrant.mockResolvedValue({ revoked: true })
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove sarah/i }))
+    expect(api.revokeGrant).not.toHaveBeenCalled()
+
+    api.listModerators.mockResolvedValue(roster({ moderators: [], used: 0 }))
+    fireEvent.click(await screen.findByRole('button', { name: /^remove$/i }))
+
+    await waitFor(() => expect(api.revokeGrant).toHaveBeenCalledWith(OVERLAY, 'grant-1'))
+    await waitFor(() => expect(screen.queryByText('Sarah')).not.toBeInTheDocument())
+  })
+
+  it('confirms the kill switch and reports how many it removed', async () => {
+    api.listModerators.mockResolvedValue(
+      roster({ moderators: [grant(), grant({ id: 'g2', display_name: 'Bob' })], used: 2 })
+    )
+    api.revokeAllModerators.mockResolvedValue({ revoked: 2 })
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /remove all/i }))
+    expect(api.revokeAllModerators).not.toHaveBeenCalled()
+
+    api.listModerators.mockResolvedValue(roster({ moderators: [], used: 0 }))
+    fireEvent.click(await screen.findByRole('button', { name: /remove everyone/i }))
+
+    await waitFor(() => expect(api.revokeAllModerators).toHaveBeenCalledWith(OVERLAY))
+    expect(await screen.findByText(/removed 2 moderators/i)).toBeInTheDocument()
+  })
+
+  // Revocation is never gated server-side, precisely so a rollback cannot trap a streamer
+  // with moderators they cannot remove. The UI must not re-introduce that trap.
+  it('keeps revocation available after the gate refuses an invite', async () => {
+    api.createInvite.mockRejectedValue(
+      new ApiError(403, 'delegating moderation requires All-Chat premium', {
+        error: 'delegating moderation requires All-Chat premium',
+        code: 'delegation_unavailable',
+      })
+    )
+    await renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /invite a moderator/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create invite/i }))
+    await screen.findByRole('link', { name: /upgrade/i })
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(await screen.findByRole('button', { name: /remove sarah/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /remove all/i })).toBeEnabled()
+  })
+})
+
+describe('ModeratorsPanel authorization', () => {
+  // An unknown overlay, an unauthorized caller and a delegated moderator all get the same
+  // code-less 403. Reading a role out of that would be a security-relevant mistake.
+  it('does not present a code-less 403 as anything about the caller', async () => {
+    api.listModerators.mockRejectedValue(
+      new ApiError(403, 'not authorized for this overlay', {
+        error: 'not authorized for this overlay',
+      })
+    )
+    render(<ModeratorsPanel overlayId={OVERLAY} />)
+
+    expect(await screen.findByRole('button', { name: /try again/i })).toBeInTheDocument()
+    expect(screen.queryByText(/you are a moderator/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /upgrade/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/editor/sectionRegistry.ts
+++ b/frontend/src/components/editor/sectionRegistry.ts
@@ -35,6 +35,7 @@ export type EditorGroupId = 'setup' | 'appearance' | 'behavior' | 'advanced'
 export type EditorSectionId =
   | 'theme'
   | 'sources'
+  | 'moderators'
   | 'testing'
   | 'typography'
   | 'colors'
@@ -50,6 +51,15 @@ export type EditorSectionId =
   | 'engagement'
   | 'custom-css'
   | 'danger-zone'
+
+/**
+ * Sections the onboarding guide can steer the nav to from a "Show me" click.
+ *
+ * A deliberate subset of EditorSectionId — only sections the checklist actually
+ * points at — but declared once here so the editor page, its spotlight state and
+ * OnboardingChecklist cannot drift apart.
+ */
+export type SpotlightSection = 'sources' | 'theme' | 'appearance' | 'moderators'
 
 export interface EditorGroup {
   id: EditorGroupId
@@ -112,6 +122,23 @@ export const EDITOR_SECTIONS: EditorSection[] = [
       { label: 'Shared overlays', keywords: 'share partner collab accepted' },
       { label: 'Discord relay', keywords: 'relay channel server' },
       { label: 'YouTube stream selection', keywords: 'stream select strategy multiple' },
+    ],
+  },
+  {
+    id: 'moderators',
+    group: 'setup',
+    title: 'Moderators',
+    description: 'People who may moderate this overlay’s chat with their own accounts.',
+    keywords: 'mod mods moderator delegate invite permission team revoke trust helper',
+    entries: [
+      {
+        label: 'Invite a moderator',
+        keywords: 'add mod invite link code delegate trust helper volunteer',
+      },
+      { label: 'Which actions they may use', keywords: 'delete timeout ban unban permission' },
+      { label: 'Which platforms they may act on', keywords: 'twitch youtube kick discord leg' },
+      { label: 'Remove a moderator', keywords: 'revoke remove kick out delete access' },
+      { label: 'Remove all moderators', keywords: 'revoke all kill switch panic emergency' },
     ],
   },
   {
@@ -379,9 +406,7 @@ export const EDITOR_SECTIONS: EditorSection[] = [
     title: 'Custom CSS',
     description: 'Full control over overlay styling. Applied on top of all settings above.',
     keywords: 'expert code stylesheet',
-    entries: [
-      { label: 'Custom CSS', keywords: 'css style stylesheet monaco editor code expert' },
-    ],
+    entries: [{ label: 'Custom CSS', keywords: 'css style stylesheet monaco editor code expert' }],
   },
   {
     id: 'danger-zone',

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -46,6 +46,7 @@ import {
 import { trackEvent } from '@/lib/analytics'
 import { DISCORD_INVITE_URL, PATREON_JOIN_URL } from '@/lib/constants'
 import { cn } from '@/lib/utils'
+import type { SpotlightSection } from '@/components/editor/sectionRegistry'
 
 const STEP_LABELS: Record<OnboardingStepId, string> = {
   create_overlay: 'Create your overlay',
@@ -75,7 +76,7 @@ export interface OnboardingChecklistProps {
   /** Editor only: currently applied theme id (null = none yet). */
   themeId?: string | null
   /** Editor only: scroll to + force open an editor section. */
-  onSpotlightSection?: (section: 'sources' | 'theme' | 'appearance') => void
+  onSpotlightSection?: (section: SpotlightSection) => void
   /** Dashboard only: overlays count from the overlay store. */
   overlayCount?: number
 }
@@ -319,6 +320,46 @@ export function OnboardingChecklist({
                     Delete, timeout, ban and unban from the Monitor View button at the top of the
                     editor. Full controls on Twitch and Discord; Kick has no single-message delete;
                     YouTube is ban-only. (Premium)
+                  </p>
+                </li>
+                <li>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-text">Let your mods help</span>
+                    {surface === 'editor' && onSpotlightSection ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => {
+                          trackEvent('cta_click', {
+                            cta: 'moderators',
+                            location: 'onboarding-extras',
+                          })
+                          onSpotlightSection('moderators')
+                        }}
+                      >
+                        Show me
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!activeOverlayId}
+                        onClick={() => {
+                          trackEvent('cta_click', {
+                            cta: 'moderators',
+                            location: 'onboarding-extras',
+                          })
+                          if (activeOverlayId) router.push(`/overlays/${activeOverlayId}`)
+                        }}
+                      >
+                        Show me
+                      </Button>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-sub">
+                    Hand the Monitor View to your existing moderators under Moderators. They act
+                    with their own platform accounts, and they never need Premium themselves.
+                    (Premium)
                   </p>
                 </li>
                 <li>

--- a/frontend/src/lib/api/__tests__/moderation.test.ts
+++ b/frontend/src/lib/api/__tests__/moderation.test.ts
@@ -19,7 +19,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { ApiError } from '@/lib/api/client'
-import { isModerationReauthError } from '@/lib/api/moderation'
+import {
+  boundInviteAccount,
+  delegationErrorCode,
+  isModerationReauthError,
+} from '@/lib/api/moderation'
 
 describe('isModerationReauthError', () => {
   it('is true when the moderation endpoint asks for re-consent', () => {
@@ -54,5 +58,56 @@ describe('isModerationReauthError', () => {
     expect(isModerationReauthError(new TypeError('Failed to fetch'))).toBe(false)
     expect(isModerationReauthError(undefined)).toBe(false)
     expect(isModerationReauthError(null)).toBe(false)
+  })
+})
+
+describe('delegationErrorCode', () => {
+  it('reads the machine-readable code off the error body', () => {
+    // The UI must switch on `code`, never on the prose in `error` — the copy is
+    // free to change and is localized per role.
+    const err = new ApiError(409, 'this overlay already has the maximum number of moderators', {
+      error: 'this overlay already has the maximum number of moderators',
+      code: 'moderator_cap_reached',
+      cap: 10,
+    })
+    expect(delegationErrorCode(err)).toBe('moderator_cap_reached')
+  })
+
+  it('is undefined when there is no code (so callers fall back to generic copy)', () => {
+    expect(
+      delegationErrorCode(new ApiError(500, 'internal error', { error: 'internal error' }))
+    ).toBeUndefined()
+    expect(delegationErrorCode(new TypeError('Failed to fetch'))).toBeUndefined()
+    expect(delegationErrorCode(null)).toBeUndefined()
+  })
+
+  // An unknown overlay, an unauthorized one, and a delegated moderator reaching for an
+  // owner power all return the SAME 403 with no code. The UI must not infer a role from it.
+  it('is undefined for the deliberately indistinguishable owner-only 403', () => {
+    const err = new ApiError(403, 'not authorized for this overlay', {
+      error: 'not authorized for this overlay',
+    })
+    expect(delegationErrorCode(err)).toBeUndefined()
+  })
+})
+
+describe('boundInviteAccount', () => {
+  it('names the account a pre-bound invite belongs to', () => {
+    // Turning a dead end into an instruction: "this is @sarah's invite, sign in as her".
+    const err = new ApiError(409, 'this invite was created for a different account', {
+      error: 'this invite was created for a different account',
+      code: 'invite_bound_to_other_account',
+      expected_account: '@sarah',
+      expected_platform: 'twitch',
+    })
+    expect(boundInviteAccount(err)).toEqual({ account: '@sarah', platform: 'twitch' })
+  })
+
+  it('is null for any other failure', () => {
+    const err = new ApiError(409, 'you already moderate this overlay', {
+      error: 'you already moderate this overlay',
+      code: 'already_moderator',
+    })
+    expect(boundInviteAccount(err)).toBeNull()
   })
 })

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -117,10 +117,14 @@ class ApiClient {
       // it must NOT trigger the generic refresh→retry path.
       let errorValue: string | undefined
       try {
-        const errorData = await response.clone().json().catch(() => ({} as Record<string, unknown>))
-        errorValue = typeof (errorData as Record<string, unknown>).error === 'string'
-          ? (errorData as Record<string, unknown>).error as string
-          : undefined
+        const errorData = await response
+          .clone()
+          .json()
+          .catch(() => ({}) as Record<string, unknown>)
+        errorValue =
+          typeof (errorData as Record<string, unknown>).error === 'string'
+            ? ((errorData as Record<string, unknown>).error as string)
+            : undefined
       } catch {
         errorValue = undefined
       }
@@ -154,13 +158,17 @@ class ApiClient {
         if (typeof window !== 'undefined' && !endpoint.startsWith('/api/v1/auth/me')) {
           window.location.href = '/'
         }
-        throw new ApiError(401, errorValue || 'Unauthorized', { error: errorValue || 'Unauthorized' })
+        throw new ApiError(401, errorValue || 'Unauthorized', {
+          error: errorValue || 'Unauthorized',
+        })
       }
       // reauth_required: fall through to the generic error path (no refresh, no redirect)
     }
 
     if (!response.ok) {
-      const errorData: Record<string, unknown> = await response.json().catch(() => ({ error: 'Unknown error' }))
+      const errorData: Record<string, unknown> = await response
+        .json()
+        .catch(() => ({ error: 'Unknown error' }))
       const errorValue = typeof errorData.error === 'string' ? errorData.error : undefined
       throw new ApiError(response.status, errorValue || response.statusText, errorData)
     }
@@ -224,6 +232,18 @@ class ApiClient {
 
   async delete(endpoint: string): Promise<void> {
     await this.fetch(endpoint, { method: 'DELETE' })
+  }
+
+  /**
+   * DELETE whose response body matters (e.g. "how many were revoked").
+   *
+   * A sibling of `delete` rather than a change to it: every existing caller
+   * legitimately ignores the body, and widening `delete`'s return type would
+   * invite callers to await a body that most endpoints do not send.
+   */
+  async deleteJson<T>(endpoint: string): Promise<T> {
+    const response = await this.fetch(endpoint, { method: 'DELETE' })
+    return response.json()
   }
 }
 

--- a/frontend/src/lib/api/moderation.ts
+++ b/frontend/src/lib/api/moderation.ts
@@ -26,7 +26,18 @@
  */
 
 import { ApiError, apiClient } from './client'
-import type { ModerationAction, ModerationCapabilities, ModerationPlatform } from '@/lib/types/moderation'
+import type {
+  CreateInviteRequest,
+  DelegatablePlatform,
+  DelegationErrorCode,
+  InviteCreated,
+  ModerationAction,
+  ModerationCapabilities,
+  ModerationPlatform,
+  ModeratorGrant,
+  ModeratorList,
+  UpdateGrantRequest,
+} from '@/lib/types/moderation'
 import type { ViewItem } from '@/lib/utils/overlayViewModel'
 
 /**
@@ -141,6 +152,34 @@ export function buildUnbanRequest(item: ViewItem): UnbanUserRequest {
   }
 }
 
+/**
+ * The machine-readable `code` on a delegation error body (ADR-0048), or undefined.
+ *
+ * Always branch on this rather than on the human-readable `error` string: the copy
+ * differs by role and is free to change. Undefined covers both a non-delegation
+ * failure and the deliberately code-less owner-only 403, which is identical for an
+ * unauthorized caller, a delegated moderator, and an overlay that does not exist —
+ * so it must never be read as evidence of a role.
+ */
+export function delegationErrorCode(err: unknown): DelegationErrorCode | undefined {
+  if (!(err instanceof ApiError)) return undefined
+  const code = err.data?.code
+  return typeof code === 'string' ? (code as DelegationErrorCode) : undefined
+}
+
+/**
+ * The account a pre-bound invite belongs to, when acceptance was refused because the
+ * signed-in user is someone else. Turns a dead end into an instruction.
+ */
+export function boundInviteAccount(err: unknown): { account: string; platform: string } | null {
+  if (delegationErrorCode(err) !== 'invite_bound_to_other_account') return null
+  const data = (err as ApiError).data
+  return {
+    account: typeof data?.expected_account === 'string' ? data.expected_account : '',
+    platform: typeof data?.expected_platform === 'string' ? data.expected_platform : '',
+  }
+}
+
 /** Response of the moderation re-consent endpoint. */
 interface ConsentUrlResponse {
   auth_url: string
@@ -234,6 +273,60 @@ export const moderationApi = {
       `/api/v1/moderation/overlays/${overlayId}/youtube/rediscover`,
       {},
       idempotencyHeader()
+    )
+  },
+
+  // --- Delegated moderators (ADR-0048) ------------------------------------
+  // Owner-only. Every one of these answers a non-owner with the same 403 body an
+  // unknown overlay gets, so a failure here says nothing about who the caller is.
+
+  /** The overlay's delegation roster, plus `used`/`cap` for the invite button. */
+  listModerators(overlayId: string): Promise<ModeratorList> {
+    return apiClient.get<ModeratorList>(`/api/v1/moderation/overlays/${overlayId}/moderators`)
+  },
+
+  /**
+   * Mint an invite. The returned `invite_token` is the ONLY time the secret exists
+   * outside the streamer's clipboard — only its digest is stored, so there is no
+   * endpoint that can show it again.
+   */
+  createInvite(overlayId: string, body: CreateInviteRequest): Promise<InviteCreated> {
+    return apiClient.post<InviteCreated>(
+      `/api/v1/moderation/overlays/${overlayId}/moderators`,
+      body,
+      idempotencyHeader()
+    )
+  },
+
+  /**
+   * Narrow or widen a grant. Omit a field to leave that dimension alone; `platforms`
+   * is a partial map, so one toggle sends one key.
+   */
+  updateGrant(
+    overlayId: string,
+    grantId: string,
+    body: UpdateGrantRequest
+  ): Promise<ModeratorGrant> {
+    return apiClient.patch<ModeratorGrant>(
+      `/api/v1/moderation/overlays/${overlayId}/moderators/${grantId}`,
+      body
+    )
+  },
+
+  /** Revoke one grant. Takes effect on the moderator's very next request. */
+  revokeGrant(overlayId: string, grantId: string): Promise<{ revoked: boolean }> {
+    return apiClient.deleteJson<{ revoked: boolean }>(
+      `/api/v1/moderation/overlays/${overlayId}/moderators/${grantId}`
+    )
+  },
+
+  /**
+   * The kill switch: revoke every grant on the overlay, unredeemed invites included.
+   * Deliberately still available when the delegation gate is closed.
+   */
+  revokeAllModerators(overlayId: string): Promise<{ revoked: number }> {
+    return apiClient.deleteJson<{ revoked: number }>(
+      `/api/v1/moderation/overlays/${overlayId}/moderators`
     )
   },
 }

--- a/frontend/src/lib/types/moderation.ts
+++ b/frontend/src/lib/types/moderation.ts
@@ -79,3 +79,143 @@ export const TIMEOUT_PRESETS: ReadonlyArray<{ label: string; seconds: number }> 
   { label: '10m', seconds: 600 },
   { label: '1h', seconds: 3600 },
 ]
+
+// ---------------------------------------------------------------------------
+// Delegated moderators (ADR-0048)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle state of a delegation grant. `revoked` never reaches the client —
+ * the roster endpoint excludes it — but it is in the union because the backend
+ * column allows it and a future activity view will show it.
+ */
+export type GrantStatus = 'pending' | 'active' | 'suspended' | 'revoked'
+
+/**
+ * Last known platform moderator status for one leg of a grant.
+ *
+ * TELEMETRY ONLY. The platform's own answer at action time is the authority, so
+ * this must be rendered as advisory readiness and never as an authorization
+ * verdict: a single transient 403 can set `not_a_moderator`, and treating that
+ * as a denial would lock out a legitimate moderator.
+ */
+export type GrantVerification =
+  | 'unverified'
+  | 'verified'
+  | 'not_a_moderator'
+  | 'needs_consent'
+  | 'needs_discord_link'
+  | 'unavailable'
+
+/** Platforms a grant can delegate. TikTok has no moderation API, so it is absent. */
+export type DelegatablePlatform = 'twitch' | 'youtube' | 'kick' | 'discord'
+
+/** One platform's enablement on a grant. An absent leg means disabled. */
+export interface GrantPlatformLeg {
+  platform: DelegatablePlatform
+  enabled: boolean
+  verification: GrantVerification
+  verified_at?: string
+}
+
+/** One delegation grant as the overlay owner sees it. */
+export interface ModeratorGrant {
+  id: string
+  status: GrantStatus
+  /** Absent while the invite is unredeemed. */
+  moderator_user_id?: string
+  /** Captured at accept time, so it survives the moderator deleting their account. */
+  display_name?: string
+  /** What the streamer typed when creating the invite. Display only. */
+  invitee_label?: string
+  actions: ModerationAction[]
+  platforms: GrantPlatformLeg[]
+  /** Set when the invite is pre-bound to one platform account. */
+  expected_platform?: DelegatablePlatform
+  expected_account?: string
+  created_at: string
+  accepted_at?: string
+  /** Present only while an invite is still outstanding. */
+  invite_expires_at?: string
+  suspended_at?: string
+  last_action_at?: string
+}
+
+/**
+ * The owner's Moderators roster. `used`/`cap` let the UI refuse an over-cap
+ * invite before the request, rather than explaining a 409 afterwards.
+ */
+export interface ModeratorList {
+  moderators: ModeratorGrant[]
+  cap: number
+  used: number
+}
+
+/** Body for creating an invite. Omit a field to leave it at its default. */
+export interface CreateInviteRequest {
+  /**
+   * Absent means the backend default (`delete` + `timeout`). An explicitly empty
+   * array is a 400 rather than being widened, so never send `[]` to mean
+   * "unchanged" — omit the key.
+   */
+  actions?: ModerationAction[]
+  /** Absent enables nothing: absence IS disablement, so the grant does nothing yet. */
+  platforms?: DelegatablePlatform[]
+  invitee_label?: string
+  /** Twitch only — the one platform where acceptance can verify the account. */
+  expected_platform?: 'twitch'
+  expected_platform_user_id?: string
+}
+
+/**
+ * A freshly minted invite. `invite_token` is returned exactly once and stored
+ * only as a SHA-256 digest, so it can never be re-displayed: a lost invite is
+ * re-minted, not recovered.
+ */
+export interface InviteCreated {
+  grant_id: string
+  invite_token: string
+  expires_at: string
+  actions: ModerationAction[]
+  platforms: DelegatablePlatform[]
+  invitee_label?: string
+}
+
+/** Body for narrowing or widening an existing grant. */
+export interface UpdateGrantRequest {
+  /** Omit to leave the action set untouched. */
+  actions?: ModerationAction[]
+  /** Partial map: only the platforms named here change. */
+  platforms?: Partial<Record<DelegatablePlatform, boolean>>
+}
+
+/**
+ * Machine-readable `code` on every delegation error body. Switch on these
+ * rather than parsing the human-readable `error` string.
+ */
+export type DelegationErrorCode =
+  | 'moderator_cap_reached'
+  | 'delegation_unavailable'
+  | 'grant_not_found'
+  | 'invalid_request'
+  | 'invite_not_found'
+  | 'invite_expired'
+  | 'already_moderator'
+  | 'owner_cannot_accept'
+  | 'invite_bound_to_other_account'
+
+/** Platforms a grant leg may cover, in display order. */
+export const DELEGATABLE_PLATFORMS: ReadonlyArray<DelegatablePlatform> = [
+  'twitch',
+  'youtube',
+  'kick',
+  'discord',
+]
+
+/** Every action a grant may delegate, in the backend's canonical order. */
+export const DELEGATABLE_ACTIONS: ReadonlyArray<ModerationAction> = [
+  'delete',
+  'timeout',
+  'ban',
+  'unban',
+]

--- a/frontend/tests/e2e/overlay-moderators.spec.ts
+++ b/frontend/tests/e2e/overlay-moderators.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * End-to-end cover for the owner-side Moderators panel (ADR-0048), driving the real
+ * editor page through the real left nav with the moderation API stubbed at the network
+ * boundary — so this exercises routing, the registry entry and the panel together,
+ * which the component tests cannot.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OVERLAY = {
+  id: 'aaaaaaaa-1111-1111-1111-111111111111',
+  name: 'Main Overlay',
+  is_active: true,
+}
+
+const USER = {
+  id: 'user-1',
+  username: 'tester',
+  display_name: 'Tester',
+  auth_provider: 'twitch',
+  onboarding_completed_at: '2026-01-01T00:00:00Z',
+}
+
+const GRANT = {
+  id: 'grant-1',
+  status: 'active',
+  moderator_user_id: 'user-2',
+  display_name: 'Sarah',
+  actions: ['delete', 'timeout'],
+  platforms: [{ platform: 'twitch', enabled: true, verification: 'verified' }],
+  created_at: '2026-08-01T10:00:00Z',
+  accepted_at: '2026-08-01T11:00:00Z',
+}
+
+const INVITE_SECRET = 'e2e-invite-secret-value'
+
+function json(body: unknown, status = 200) {
+  return { status, contentType: 'application/json', body: JSON.stringify(body) }
+}
+
+const MODERATORS_URL = `**/api/v1/moderation/overlays/${OVERLAY.id}/moderators`
+
+test.describe('overlay editor — Moderators panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    // Catch-all first — Playwright matches routes last-registered-first.
+    await page.route('**/api/v1/**', (route) => route.fulfill(json({}, 404)))
+    await page.route('**/api/v1/auth/me', (route) => route.fulfill(json(USER)))
+    await page.route(`**/api/v1/overlays/${OVERLAY.id}`, (route) => route.fulfill(json(OVERLAY)))
+    await page.route(`**/api/v1/overlays/${OVERLAY.id}/sources`, (route) => route.fulfill(json([])))
+    await page.route(`**/api/v1/overlays/${OVERLAY.id}/config`, (route) => route.fulfill(json({})))
+  })
+
+  async function openModerators(page: import('@playwright/test').Page) {
+    await page.goto(`/overlays/${OVERLAY.id}`)
+    await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
+    await page
+      .getByRole('navigation', { name: 'Overlay settings' })
+      .getByRole('button', { name: 'Moderators' })
+      .click()
+    await expect(page.getByRole('heading', { name: 'Moderators' })).toBeVisible()
+  }
+
+  test('is reachable from the settings nav and lists the current moderators', async ({ page }) => {
+    await page.route(MODERATORS_URL, (route) =>
+      route.fulfill(json({ moderators: [GRANT], cap: 10, used: 1 }))
+    )
+    await openModerators(page)
+
+    await expect(page.getByText('Sarah')).toBeVisible()
+    await expect(page.getByText('1 of 10 used')).toBeVisible()
+  })
+
+  test('is findable through settings search, which is what the nav is for', async ({ page }) => {
+    await page.route(MODERATORS_URL, (route) =>
+      route.fulfill(json({ moderators: [], cap: 10, used: 0 }))
+    )
+    await page.goto(`/overlays/${OVERLAY.id}`)
+    await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
+
+    const search = page.getByRole('combobox', { name: 'Search settings' })
+    await search.fill('mod')
+    const listbox = page.getByRole('listbox', { name: 'Matching settings' })
+    await expect(listbox).toBeVisible()
+    await listbox
+      .getByRole('option', { name: /Invite a moderator/ })
+      .first()
+      .click()
+
+    await expect(page.getByRole('heading', { name: 'Moderators' })).toBeVisible()
+  })
+
+  test('creates an invite, reveals the secret once, and does not replay it', async ({ page }) => {
+    let created = false
+    await page.route(MODERATORS_URL, (route) => {
+      if (route.request().method() === 'POST') {
+        created = true
+        return route.fulfill(
+          json({
+            grant_id: 'grant-9',
+            invite_token: INVITE_SECRET,
+            expires_at: '2026-08-14T10:00:00Z',
+            actions: ['delete', 'timeout'],
+            platforms: ['twitch'],
+          })
+        )
+      }
+      // After creation the roster carries a pending invite — but never the secret.
+      return route.fulfill(
+        json(
+          created
+            ? {
+                moderators: [
+                  {
+                    ...GRANT,
+                    id: 'grant-9',
+                    status: 'pending',
+                    display_name: undefined,
+                    moderator_user_id: undefined,
+                    invitee_label: 'Sarah',
+                    invite_expires_at: '2026-08-14T10:00:00Z',
+                  },
+                ],
+                cap: 10,
+                used: 1,
+              }
+            : { moderators: [], cap: 10, used: 0 }
+        )
+      )
+    })
+    await openModerators(page)
+
+    await page.getByRole('button', { name: 'Invite a moderator' }).click()
+    await page.getByLabel(/who is this for/i).fill('Sarah')
+    await page.getByRole('checkbox', { name: 'Twitch' }).check()
+    await page.getByRole('button', { name: 'Create invite' }).click()
+
+    // Shown once, with copy that does not promise a second chance.
+    await expect(page.getByText(INVITE_SECRET)).toBeVisible()
+    await expect(page.getByText(/won't be shown again/i)).toBeVisible()
+
+    await page.getByRole('button', { name: 'Done' }).click()
+    await expect(page.getByText(INVITE_SECRET)).toHaveCount(0)
+    await expect(page.getByText('Invite pending')).toBeVisible()
+    // The roster is the only source now, and it has no way to expose the secret.
+    await expect(page.locator('body')).not.toContainText(INVITE_SECRET)
+  })
+
+  test('will not offer an invite once the overlay is at its cap', async ({ page }) => {
+    await page.route(MODERATORS_URL, (route) =>
+      route.fulfill(
+        json({
+          moderators: Array.from({ length: 10 }, (_, i) => ({ ...GRANT, id: `g${i}` })),
+          cap: 10,
+          used: 10,
+        })
+      )
+    )
+    await openModerators(page)
+
+    await expect(page.getByRole('button', { name: 'Invite a moderator' })).toBeDisabled()
+    await expect(page.getByText(/at its limit of 10 moderators/i)).toBeVisible()
+  })
+
+  test('removes a moderator only after confirmation', async ({ page }) => {
+    let deleteCalls = 0
+    await page.route(`${MODERATORS_URL}/grant-1`, (route) => {
+      deleteCalls += 1
+      return route.fulfill(json({ revoked: true }))
+    })
+    await page.route(MODERATORS_URL, (route) =>
+      route.fulfill(
+        json(
+          deleteCalls > 0
+            ? { moderators: [], cap: 10, used: 0 }
+            : { moderators: [GRANT], cap: 10, used: 1 }
+        )
+      )
+    )
+    await openModerators(page)
+
+    // The row's own control, not the text: the confirm dialog's title also names Sarah.
+    const removeSarah = page.getByRole('button', { name: 'Remove Sarah' })
+    await removeSarah.click()
+    await expect(page.getByRole('alertdialog')).toBeVisible()
+
+    // Backing out must leave the grant alone — no request, still on the roster.
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(removeSarah).toBeVisible()
+    expect(deleteCalls).toBe(0)
+
+    await removeSarah.click()
+    await page.getByRole('button', { name: 'Remove', exact: true }).click()
+    await expect(page.getByText(/no one moderates this overlay yet/i)).toBeVisible()
+    expect(deleteCalls).toBe(1)
+  })
+
+  // The gate refusal has to be actionable and stay put, not vanish as a toast.
+  test('shows an inline upgrade path when the premium gate refuses the invite', async ({
+    page,
+  }) => {
+    await page.route(MODERATORS_URL, (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill(
+          json(
+            {
+              error: 'delegating moderation requires All-Chat premium',
+              code: 'delegation_unavailable',
+              upgrade_url: '/upgrade',
+            },
+            403
+          )
+        )
+      }
+      return route.fulfill(json({ moderators: [GRANT], cap: 10, used: 1 }))
+    })
+    await openModerators(page)
+
+    await page.getByRole('button', { name: 'Invite a moderator' }).click()
+    await page.getByRole('button', { name: 'Create invite' }).click()
+
+    const upgrade = page.getByRole('link', { name: /upgrade to invite moderators/i })
+    await expect(upgrade).toBeVisible()
+    await expect(upgrade).toHaveAttribute('href', '/upgrade')
+
+    // Revocation is never gated server-side; the UI must not gate it either.
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByRole('button', { name: 'Remove Sarah' })).toBeEnabled()
+    await expect(page.getByRole('button', { name: 'Remove all' })).toBeEnabled()
+  })
+})


### PR DESCRIPTION
Makes the ADR-0048 delegation API (merged yesterday, #658) reachable. A streamer can now invite the people who already moderate for them, narrow what each one may do, and remove them again — from a **Moderators** section in the overlay editor's left nav (ADR-0042), not a page nobody links to.

This is the slice that turns Phase 1 from inert infrastructure into a feature.

## The three behaviours worth reviewing

These are the traps the API's design implies, not styling choices:

- **The invite secret is shown exactly once.** Only its SHA-256 is stored, so no endpoint *could* show it again. The reveal says so, and offers "create a new invite" as the recovery rather than implying a second chance. An e2e test asserts the secret is gone from the document once the reveal is dismissed, and that the roster never carries it.
- **The 10-moderator cap is enforced from the roster's own `used`/`cap`.** At the limit the invite button is unavailable with the reason beside it. Explaining a 409 the UI could have prevented is worse than not offering the button.
- **`verification` renders as advisory readiness, never a verdict** — "Not a moderator on Twitch yet — add them in Twitch's own tools." It is telemetry, a single transient platform 403 can set it, and the platform's answer at action time is the only authority. A test asserts none of "blocked / denied / cannot moderate" appears.

## Carried through from the API contract

- An absent `actions` means the backend default; an explicitly empty one is a 400, and is unreachable here — the create button disables, and removing a grant's last action points at removing the person instead of sending `[]`.
- Platform toggles send a partial `{platform: bool}` map, so one switch is one key and the rest keep whatever the streamer set.
- **The gate refusal is inline with an upgrade link, not a toast** — it is something the streamer must act on. Revocation stays enabled behind it, because the server never gates revocation and the UI must not re-introduce the trap of moderators you cannot remove. Tested.
- **A code-less 403 is not read as anything about the caller.** It is identical for an unauthorized caller, a delegated moderator and a nonexistent overlay, so it renders as a plain retry.

## Release checklist (CLAUDE.md)

1. Premium toggle — shipped with the API (`delegated_moderation`, owner-keyed).
2. **Onboarding extras tour** — added here, with the matching `/upgrade` card. The keep-in-sync comments at both sites require it.
3. Patreon post — follows the deploy.

## Cleanups along the way

- The spotlight-target union was duplicated in **four** places (`OnboardingChecklist` prop, the page's state, its `spotlight` const, and `handleSpotlightSection`). Now one exported `SpotlightSection`, and `SPOTLIGHT_SECTION` is keyed on it — so adding a "Show me" target that nobody mapped is a compile error instead of a silent no-op. That error is exactly what caught this section on the first build.
- `apiClient` gains `deleteJson<T>` for DELETEs whose body matters (the revoke-all count). A sibling rather than a change to `delete`, whose existing callers legitimately ignore the body.
- The panel is its own component file rather than 400 more lines in the 3,900-line editor page, which ADR-0042 explicitly wants decomposed.

## Tests

- 21 component tests, 4 new API-layer tests.
- **6 route-mocked Playwright specs** driving the real editor through the real nav — including reaching the panel via settings search, which no component test can cover. CLAUDE.md asks for e2e where possible; the existing `settings-nav.spec.ts` harness stubs the API at the network boundary, so no backend is needed.
- Full frontend unit suite green (84 files, 827 tests). `tsc` clean. ESLint clean on every file I authored, including the ENFORCE-03 design-token rules. A11y gate green: `eslint.a11y.config.mjs` reports 0 errors, the token-contrast lock passes, and the axe page smoke passes.
- Fixed one lint error of my own along the way (`react-hooks/set-state-in-effect`) by moving the initial load into the promise callback — which also fixed a real gap, since my first version had no cancellation and a slow response could land after unmount or clobber a newer overlay's roster.

Note for anyone running the whole Playwright suite locally: `dashboard.spec.ts` has 7 pre-existing failures on clean `main` (verified by stashing), and CI only runs the `a11y` project.