### PR TITLE
feat(moderation): mod-scoped capabilities and the channels-I-moderate list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ A Twitch-dashboard-inspired monitor with a **resizable live Chat panel + Activit
 You can also open it from your overlay's settings page (or its preview page) via the **Monitor View** button.
 
 **Your moderators can use it too.** Under **Moderators** in the overlay editor you can invite the
-people who already moderate for you (Premium). They act with **their own** platform accounts, so
-Twitch, YouTube and Kick re-check their moderator role on every action and it lands in your native
-mod log under their name — and they never need a plan of their own.
+people who already moderate for you (Premium). You get a private link to send them; they accept it
+with their own All-Chat account, and every channel handed to them shows up under **Channels you
+moderate** (`/moderate`). They act with **their own** platform accounts, so Twitch, YouTube and Kick
+re-check their moderator role on every action and it lands in your native mod log under their name —
+and they never need a plan of their own. Connecting a platform is deferred until the first time they
+moderate on it, and one connection covers every streamer who delegated that platform to them.
 
 ### 3. Customize the look
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -34,6 +34,7 @@ import { PlatformBadge } from '@/components/ui/badge'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { MaintenanceBanner } from '@/components/MaintenanceBanner'
 import { EventSubMigrationBanner } from '@/components/EventSubMigrationBanner'
+import { ModeratingElsewhereCard } from '@/components/ModeratingElsewhereCard'
 import { OnboardingChecklist } from '@/components/onboarding/OnboardingChecklist'
 import { CreateOverlayDialog } from '@/components/onboarding/CreateOverlayDialog'
 import { useOnboardingStore } from '@/lib/stores/onboarding-store'
@@ -252,6 +253,9 @@ function DashboardContent() {
         <div className="mb-4 space-y-4">
           <MaintenanceBanner />
           <EventSubMigrationBanner sourcesByOverlay={sourcesByOverlay} />
+          {/* Channels other streamers delegated to this user. Renders nothing when there
+              are none, so it costs a non-moderator a single request and no pixels. */}
+          <ModeratingElsewhereCard />
         </div>
         <div className="mb-8 flex items-center justify-between">
           <h1 className="text-2xl font-bold text-text">Overlays</h1>

--- a/frontend/src/app/moderate/__tests__/page.test.tsx
+++ b/frontend/src/app/moderate/__tests__/page.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ModeratePage from '@/app/moderate/page'
+import type { Delegation } from '@/lib/types/moderation'
+
+// vi.hoisted, because vi.mock's factory is lifted above the imports and would otherwise
+// reference these before initialization.
+const api = vi.hoisted(() => ({ listDelegations: vi.fn() }))
+const nav = vi.hoisted(() => ({ params: new URLSearchParams() }))
+
+vi.mock('@/lib/api/moderation', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/moderation')>('@/lib/api/moderation')
+  return { ...actual, moderationApi: api }
+})
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => nav.params,
+  usePathname: () => '/moderate',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}))
+
+// The page is behind ProtectedRoute, which pulls in the auth store and its network init.
+// The delegation list is what is under test, so the guard is stubbed to a pass-through.
+vi.mock('@/components/ProtectedRoute', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/components/AppNav', () => ({ AppNav: () => null }))
+
+const OVERLAY = 'aaaaaaaa-1111-1111-1111-111111111111'
+
+function delegation(over: Partial<Delegation> = {}): Delegation {
+  return {
+    grant_id: 'grant-1',
+    overlay_id: OVERLAY,
+    overlay_name: 'Main overlay',
+    owner_display_name: 'SomeStreamer',
+    status: 'active',
+    actions: ['delete', 'timeout'],
+    platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+    available: true,
+    ...over,
+  }
+}
+
+async function renderPage(delegations: Delegation[]) {
+  api.listDelegations.mockResolvedValue({ delegations })
+  render(<ModeratePage />)
+  await waitFor(() => expect(api.listDelegations).toHaveBeenCalled())
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  nav.params = new URLSearchParams()
+})
+afterEach(cleanup)
+
+describe('channels you moderate', () => {
+  // The link to the overlay is the entire reason this page exists: /api/v1/overlays is
+  // owner-filtered, so without it an accepted grant has no route into the overlay.
+  it('links each channel to its monitor', async () => {
+    await renderPage([delegation()])
+
+    const link = await screen.findByRole('link', { name: /open chat monitor/i })
+    expect(link).toHaveAttribute('href', `/overlay/${OVERLAY}/view`)
+  })
+
+  it('names the streamer the channel belongs to', async () => {
+    await renderPage([delegation()])
+
+    expect(await screen.findByText('Main overlay')).toBeInTheDocument()
+    expect(screen.getByText(/for SomeStreamer/)).toBeInTheDocument()
+  })
+
+  it('tells a moderator with no channels how they get one', async () => {
+    await renderPage([])
+
+    expect(await screen.findByText(/no channels yet/i)).toBeInTheDocument()
+  })
+
+  // A failed load must offer a retry rather than looking like "you moderate nothing",
+  // which would send the moderator to ask the streamer about a revocation that never
+  // happened.
+  it('offers a retry instead of an empty state when the load fails', async () => {
+    api.listDelegations.mockRejectedValue(new Error('network'))
+    render(<ModeratePage />)
+
+    expect(await screen.findByRole('button', { name: /try again/i })).toBeInTheDocument()
+    expect(screen.queryByText(/no channels yet/i)).not.toBeInTheDocument()
+  })
+
+  // Entitlement is the STREAMER's. Linking a volunteer to /upgrade would sell them a plan
+  // that would not fix anything even if they bought it.
+  it('blames the streamer plan for an unavailable channel and offers no upgrade link', async () => {
+    await renderPage([delegation({ available: false })])
+
+    expect(
+      await screen.findByText(/SomeStreamer's plan does not include moderation/)
+    ).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /upgrade/i })).not.toBeInTheDocument()
+  })
+
+  // A suspended grant that simply vanished would be indistinguishable from a revocation,
+  // leaving the moderator with nothing to ask about.
+  it('keeps a suspended channel visible and explains it', async () => {
+    await renderPage([delegation({ status: 'suspended' })])
+
+    expect(await screen.findByText(/paused after 90 days/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /open chat monitor/i })).toBeInTheDocument()
+  })
+
+  it('says so when the streamer has enabled no platform yet', async () => {
+    await renderPage([delegation({ platforms: [] })])
+
+    expect(await screen.findByText(/no platforms turned on yet/i)).toBeInTheDocument()
+  })
+
+  // A disabled leg is not a delegated platform, so it must not be advertised as one.
+  it('shows only the platforms whose leg is enabled', async () => {
+    await renderPage([
+      delegation({
+        platforms: [
+          { platform: 'twitch', enabled: true, verification: 'unverified' },
+          { platform: 'kick', enabled: false, verification: 'unverified' },
+        ],
+      }),
+    ])
+
+    expect(await screen.findByText('TWITCH')).toBeInTheDocument()
+    expect(screen.queryByText('KICK')).not.toBeInTheDocument()
+  })
+
+  it('confirms a completed platform connection from the consent redirect', async () => {
+    nav.params = new URLSearchParams('connected=twitch')
+    await renderPage([delegation()])
+
+    expect(await screen.findByText(/Twitch connected/)).toBeInTheDocument()
+  })
+
+  it('explains a failed platform connection from the consent redirect', async () => {
+    nav.params = new URLSearchParams('error=credential_store_failed&platform=twitch')
+    await renderPage([delegation()])
+
+    expect(await screen.findByText(/did not complete/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/moderate/accept/__tests__/page.test.tsx
+++ b/frontend/src/app/moderate/accept/__tests__/page.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AcceptInvitePage from '@/app/moderate/accept/page'
+import { ApiError } from '@/lib/api/client'
+import type { InvitePreview } from '@/lib/types/moderation'
+
+// vi.hoisted, because vi.mock's factory is lifted above the imports and would otherwise
+// reference these before initialization.
+const api = vi.hoisted(() => ({ previewInvite: vi.fn(), acceptInvite: vi.fn() }))
+const nav = vi.hoisted(() => ({ params: new URLSearchParams('token=SEEKRIT'), push: vi.fn() }))
+const auth = vi.hoisted(() => ({
+  state: { user: { id: 'u1' } as { id: string } | null, loading: false, init: vi.fn() },
+}))
+
+vi.mock('@/lib/api/moderation', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/api/moderation')>('@/lib/api/moderation')
+  return { ...actual, moderationApi: api }
+})
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => nav.params,
+  usePathname: () => '/moderate/accept',
+  useRouter: () => ({ push: nav.push, replace: vi.fn() }),
+}))
+
+vi.mock('@/lib/stores/auth-store', () => ({ useAuthStore: () => auth.state }))
+vi.mock('@/hooks/useHydrated', () => ({ useHydrated: () => true }))
+vi.mock('@/components/AppNav', () => ({ AppNav: () => null }))
+
+const OVERLAY = 'aaaaaaaa-1111-1111-1111-111111111111'
+
+function preview(over: Partial<InvitePreview> = {}): InvitePreview {
+  return {
+    overlay_name: 'Main overlay',
+    owner_display_name: 'SomeStreamer',
+    actions: ['delete', 'timeout'],
+    platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+    expires_at: '2026-08-14T10:00:00Z',
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  nav.params = new URLSearchParams('token=SEEKRIT')
+  auth.state = { user: { id: 'u1' }, loading: false, init: vi.fn() }
+})
+afterEach(cleanup)
+
+describe('accepting a moderation invite', () => {
+  it('shows who is asking, for what, and on which platforms', async () => {
+    api.previewInvite.mockResolvedValue(preview())
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText('Main overlay')).toBeInTheDocument()
+    expect(screen.getByText('SomeStreamer')).toBeInTheDocument()
+    expect(screen.getByText('Delete messages')).toBeInTheDocument()
+    expect(screen.getByText('TWITCH')).toBeInTheDocument()
+    // Ban was not delegated, so it must not appear as something they would gain.
+    expect(screen.queryByText('Ban viewers')).not.toBeInTheDocument()
+  })
+
+  // Consent is deferred to first use (ADR-0048), so the page must not imply that
+  // accepting hands anything over yet.
+  it('says accepting asks nothing of them yet', async () => {
+    api.previewInvite.mockResolvedValue(preview())
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/Nothing is asked of you now/i)).toBeInTheDocument()
+  })
+
+  // The overlay id exists only in the accept response — preview withholds it, because an
+  // overlay UUID already grants chat READ to whoever holds it.
+  it('goes to the overlay the accept response discloses', async () => {
+    api.previewInvite.mockResolvedValue(preview())
+    api.acceptInvite.mockResolvedValue({
+      grant_id: 'g1',
+      overlay_id: OVERLAY,
+      overlay_name: 'Main overlay',
+      owner_display_name: 'SomeStreamer',
+      actions: ['delete'],
+      platforms: [],
+    })
+    render(<AcceptInvitePage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept and start moderating/i }))
+
+    await waitFor(() => expect(api.acceptInvite).toHaveBeenCalledWith('SEEKRIT'))
+    expect(nav.push).toHaveBeenCalledWith(`/overlay/${OVERLAY}/view`)
+  })
+
+  // The server keeps unknown, already-redeemed and revoked deliberately
+  // indistinguishable, so the copy must cover all three rather than guessing one.
+  it('explains a dead invite without guessing why', async () => {
+    api.previewInvite.mockRejectedValue(
+      new ApiError(404, 'invite not found', { error: 'invite not found', code: 'invite_not_found' })
+    )
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/already have been used/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /accept/i })).not.toBeInTheDocument()
+  })
+
+  it('tells an expired invite to ask for a new one', async () => {
+    api.previewInvite.mockRejectedValue(
+      new ApiError(410, 'invite expired', { error: 'invite expired', code: 'invite_expired' })
+    )
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/expired\. Ask the streamer for a new one/i)).toBeInTheDocument()
+  })
+
+  // A pre-bound invite refused for the wrong account has to name the account, or the
+  // reader has no way to tell which of their accounts to use.
+  it('names the account a pre-bound invite belongs to', async () => {
+    api.previewInvite.mockResolvedValue(preview())
+    api.acceptInvite.mockRejectedValue(
+      new ApiError(409, 'invite is bound to another account', {
+        error: 'invite is bound to another account',
+        code: 'invite_bound_to_other_account',
+        expected_account: '@sarah',
+        expected_platform: 'twitch',
+      })
+    )
+    render(<AcceptInvitePage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept and start moderating/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('@sarah')
+  })
+
+  it('reports the owner accepting their own invite as the no-op it is', async () => {
+    api.previewInvite.mockRejectedValue(
+      new ApiError(409, 'the overlay owner cannot accept a delegation', {
+        error: 'the overlay owner cannot accept a delegation',
+        code: 'owner_cannot_accept',
+      })
+    )
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/your own overlay/i)).toBeInTheDocument()
+  })
+
+  it('refuses a link with no invite code rather than calling the API', async () => {
+    nav.params = new URLSearchParams()
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/missing its invite code/i)).toBeInTheDocument()
+    expect(api.previewInvite).not.toHaveBeenCalled()
+  })
+
+  // The URL is the only copy of the secret the recipient has. A redirect to the homepage
+  // would take it with them, so the signed-out state stays on this page.
+  it('keeps the invite in place and asks a signed-out visitor to sign in', async () => {
+    auth.state = { user: null, loading: false, init: vi.fn() }
+    render(<AcceptInvitePage />)
+
+    expect(await screen.findByText(/sign in to accept this invite/i)).toBeInTheDocument()
+    expect(api.previewInvite).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/moderate/accept/page.tsx
+++ b/frontend/src/app/moderate/accept/page.tsx
@@ -1,0 +1,344 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Delegation invite acceptance (ADR-0048).
+ *
+ * The invite secret arrives in the URL because that is the only way a streamer can hand
+ * it over, but it never leaves this page in one: both calls put it in a POST body, so it
+ * stays out of access logs, proxy logs and `Referer` headers on every hop after this one.
+ *
+ * Preview deliberately returns no `overlay_id`. An overlay UUID already grants chat READ
+ * to anyone holding it, so it is disclosed on acceptance rather than to everyone who
+ * merely opens the link — which means "accept" is the first moment this page knows where
+ * to send the moderator.
+ *
+ * Accepting costs the moderator nothing: consent for each platform is deferred to the
+ * first time they actually try to moderate on it, so nobody faces a stack of OAuth
+ * screens before they have done anything.
+ */
+
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Info, ShieldCheck } from 'lucide-react'
+
+import { AppNav } from '@/components/AppNav'
+import { useHydrated } from '@/hooks/useHydrated'
+import { useAuthStore } from '@/lib/stores/auth-store'
+import { InfinityLogo } from '@/components/InfinityLogo'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { PlatformBadge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { VisuallyHidden } from '@/components/ui/visually-hidden'
+import { boundInviteAccount, delegationErrorCode, moderationApi } from '@/lib/api/moderation'
+import {
+  DELEGATABLE_ACTIONS,
+  type InvitePreview,
+  type ModerationAction,
+} from '@/lib/types/moderation'
+
+const ACTION_LABELS: Record<ModerationAction, string> = {
+  delete: 'Delete messages',
+  timeout: 'Time viewers out',
+  ban: 'Ban viewers',
+  unban: 'Lift bans and timeouts',
+}
+
+/**
+ * Human copy for a failed preview or accept, keyed on the machine-readable `code` rather
+ * than the message text — the copy differs by role server-side and is free to change.
+ *
+ * Every branch ends somewhere the reader can act. "Not found" covers unknown, already
+ * redeemed and revoked alike, which the server keeps deliberately indistinguishable, so
+ * the copy names all three rather than guessing one.
+ */
+function inviteErrorMessage(err: unknown): string {
+  switch (delegationErrorCode(err)) {
+    case 'invite_not_found':
+      return 'This invite is not valid any more — it may already have been used, or the streamer may have withdrawn it. Ask them for a new one.'
+    case 'invite_expired':
+      return 'This invite has expired. Ask the streamer for a new one.'
+    case 'already_moderator':
+      return 'You already moderate this channel. It is on your channels page.'
+    case 'owner_cannot_accept':
+      return 'This is your own overlay — you already have full moderation on it.'
+    case 'invite_bound_to_other_account': {
+      const bound = boundInviteAccount(err)
+      const account = bound?.account ? ` (${bound.account})` : ''
+      const platform = bound?.platform ? ` ${bound.platform}` : ''
+      return `This invite is for a specific${platform} account${account}. Sign in as that account, or ask the streamer to send a new invite for this one.`
+    }
+    default:
+      return 'Could not open this invite. Check the link and try again.'
+  }
+}
+
+function InvitePreviewSkeleton() {
+  return (
+    <div role="status" className="space-y-4 rounded-xl border border-border bg-surface p-6">
+      <VisuallyHidden>Loading invite</VisuallyHidden>
+      <Skeleton className="h-5 w-2/3" />
+      <Skeleton className="h-3 w-1/2" />
+      <div className="flex gap-1.5">
+        <Skeleton className="h-4 w-16 rounded-full" />
+        <Skeleton className="h-4 w-16 rounded-full" />
+      </div>
+    </div>
+  )
+}
+
+function DeadEnd({ message }: { message: string }) {
+  return (
+    <Card className="p-6">
+      <div className="flex items-start gap-3">
+        <Info className="mt-0.5 size-5 shrink-0 text-text-dim" aria-hidden="true" />
+        <div className="space-y-4">
+          <p className="text-sm text-text">{message}</p>
+          <Link
+            href="/moderate"
+            className="inline-flex w-fit items-center rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-sub transition-colors hover:border-border-md hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          >
+            Go to your channels
+          </Link>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+/**
+ * The signed-out state.
+ *
+ * Deliberately NOT `ProtectedRoute`, which bounces to the homepage with `router.push('/')`
+ * and takes the invite secret with it. The URL is the only copy of that secret the
+ * recipient has, so this branch leaves it exactly where it is and tells them what to do —
+ * the sign-in flow has no return-to for a client-chosen destination, and inventing one by
+ * stashing the secret in browser storage would put a live moderation credential somewhere
+ * it does not need to be.
+ */
+function SignInPrompt() {
+  return (
+    <Card className="p-6">
+      <div className="flex items-start gap-3">
+        <Info className="mt-0.5 size-5 shrink-0 text-text-dim" aria-hidden="true" />
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-text">Sign in to accept this invite</p>
+            <p className="text-sm text-text-sub">
+              Moderating is tied to an All-Chat account, so we need to know which one to hand this
+              to. Sign in, then open the invite link again — it stays valid.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="inline-flex w-fit items-center rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-sub transition-colors hover:border-border-md hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function AcceptContent() {
+  const router = useRouter()
+  const token = useSearchParams().get('token') ?? ''
+  const { user, loading, init } = useAuthStore()
+  const isHydrated = useHydrated()
+
+  const [preview, setPreview] = useState<InvitePreview | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [accepting, setAccepting] = useState(false)
+
+  useEffect(() => {
+    if (isHydrated) init()
+  }, [isHydrated, init])
+
+  const loadPreview = useCallback(() => moderationApi.previewInvite(token), [token])
+
+  // Preview has no side effects, so it is safe to run on load; acceptance is a deliberate
+  // click. Both endpoints require a session, so this waits for one rather than turning a
+  // valid invite into a 401. State is set from the promise callback rather than the effect
+  // body, with a `cancelled` flag so a slow response cannot land after unmount.
+  useEffect(() => {
+    if (!user) return
+    if (!token) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- terminal state for a malformed link, not a fetch result
+      setError('This link is missing its invite code. Ask the streamer to send it again.')
+      return
+    }
+    let cancelled = false
+    loadPreview()
+      .then((p) => {
+        if (!cancelled) setPreview(p)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(inviteErrorMessage(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [user, token, loadPreview])
+
+  const handleAccept = async () => {
+    setAccepting(true)
+    setError(null)
+    try {
+      // The overlay id exists only from here on — the preview withholds it.
+      const accepted = await moderationApi.acceptInvite(token)
+      router.push(`/overlay/${accepted.overlay_id}/view`)
+    } catch (err) {
+      setError(inviteErrorMessage(err))
+      setAccepting(false)
+    }
+  }
+
+  const actions = preview ? DELEGATABLE_ACTIONS.filter((a) => preview.actions.includes(a)) : []
+  const platforms = preview?.platforms.filter((leg) => leg.enabled) ?? []
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <AppNav />
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto max-w-2xl px-4 py-12 sm:px-6 lg:px-8"
+      >
+        <div className="mb-8 flex items-center gap-3">
+          <ShieldCheck className="size-7 text-twitch" strokeWidth={1.5} aria-hidden="true" />
+          <h1 className="text-2xl font-bold text-text">Moderation invite</h1>
+        </div>
+
+        {!isHydrated || loading ? (
+          <div className="flex justify-center py-12">
+            <InfinityLogo size={64} />
+          </div>
+        ) : !user ? (
+          <SignInPrompt />
+        ) : error && !preview ? (
+          <DeadEnd message={error} />
+        ) : preview === null ? (
+          <InvitePreviewSkeleton />
+        ) : (
+          <Card className="p-6">
+            <div className="space-y-6">
+              <div>
+                <p className="text-sm text-text-sub">
+                  <span className="font-semibold text-text">{preview.owner_display_name}</span> is
+                  asking you to help moderate
+                </p>
+                <p className="mt-1 text-lg font-semibold text-text">{preview.overlay_name}</p>
+                {preview.invitee_label && (
+                  <p className="mt-1 text-xs text-text-dim">
+                    They addressed this invite to &ldquo;{preview.invitee_label}&rdquo;.
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <h2 className="text-sm font-semibold text-text">What you would be able to do</h2>
+                <ul className="mt-2 space-y-1">
+                  {actions.map((action) => (
+                    <li key={action} className="text-sm text-text-sub">
+                      {ACTION_LABELS[action]}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div>
+                <h2 className="text-sm font-semibold text-text">On these platforms</h2>
+                {platforms.length > 0 ? (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {platforms.map((leg) => (
+                      <PlatformBadge key={leg.platform} platform={leg.platform} size="sm" />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-2 text-sm text-text-sub">
+                    None yet — {preview.owner_display_name} still has to turn a platform on.
+                  </p>
+                )}
+              </div>
+
+              {/* The one thing a volunteer most needs to know before agreeing: this does
+                  not touch their own channel, and it does not ask for anything yet. */}
+              <p className="flex items-start gap-2 rounded-lg border border-border bg-surface-2 px-4 py-3 text-xs text-text-sub">
+                <Info className="mt-0.5 size-3.5 shrink-0 text-text-dim" aria-hidden="true" />
+                <span>
+                  You will act with your own platform account, so each platform still checks that{' '}
+                  {preview.owner_display_name} made you a moderator there. Nothing is asked of you
+                  now — you connect a platform the first time you moderate on it.
+                </span>
+              </p>
+
+              {preview.expected_account && (
+                <p className="text-xs text-text-dim">
+                  This invite is meant for {preview.expected_platform ?? ''}{' '}
+                  {preview.expected_account}.
+                </p>
+              )}
+
+              {error && (
+                <p role="alert" className="text-destructive text-sm">
+                  {error}
+                </p>
+              )}
+
+              <div className="flex flex-wrap gap-3">
+                <Button variant="gradient" onClick={() => void handleAccept()} disabled={accepting}>
+                  {accepting ? 'Accepting…' : 'Accept and start moderating'}
+                </Button>
+                <Link
+                  href="/dashboard"
+                  className="inline-flex items-center rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-sub transition-colors hover:border-border-md hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+                >
+                  Not now
+                </Link>
+              </div>
+            </div>
+          </Card>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default function AcceptInvitePage() {
+  return (
+    // useSearchParams (the invite secret) opts this subtree out of static rendering, so it
+    // needs its own boundary.
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-bg">
+          <AppNav />
+          <main className="mx-auto max-w-2xl px-4 py-12 sm:px-6 lg:px-8">
+            <InvitePreviewSkeleton />
+          </main>
+        </div>
+      }
+    >
+      <AcceptContent />
+    </Suspense>
+  )
+}

--- a/frontend/src/app/moderate/page.tsx
+++ b/frontend/src/app/moderate/page.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * "Channels you moderate" (ADR-0048).
+ *
+ * This page is not a convenience. `GET /api/v1/overlays` is owner-filtered and there is
+ * no shared-with-me listing, so without it an accepted delegation is unreachable — the
+ * moderator would hold a grant with no way to open the overlay it applies to.
+ *
+ * Two things it deliberately does NOT do:
+ *
+ * - It never links a moderator to `/upgrade`. Entitlement is the STREAMER's (the gate is
+ *   keyed on the overlay owner), so a lapsed plan is reported as the streamer's plan,
+ *   with no call to action a volunteer could act on.
+ * - It does not claim per-platform readiness. Whether the moderator has connected their
+ *   own account for a platform is answered per source by the capabilities endpoint when
+ *   they open the monitor, which is also where the "Connect to moderate" action lives.
+ *   Repeating a guess here would be a second, staler source of truth.
+ */
+
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Info, MonitorPlay, ShieldCheck } from 'lucide-react'
+
+import { AppNav } from '@/components/AppNav'
+import { ProtectedRoute } from '@/components/ProtectedRoute'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { PlatformBadge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { VisuallyHidden } from '@/components/ui/visually-hidden'
+import { moderationApi } from '@/lib/api/moderation'
+import { DELEGATABLE_ACTIONS, type Delegation, type ModerationAction } from '@/lib/types/moderation'
+
+const ACTION_LABELS: Record<ModerationAction, string> = {
+  delete: 'Delete messages',
+  timeout: 'Timeout',
+  ban: 'Ban',
+  unban: 'Unban',
+}
+
+const PLATFORM_LABELS: Record<string, string> = {
+  twitch: 'Twitch',
+  youtube: 'YouTube',
+  kick: 'Kick',
+  discord: 'Discord',
+}
+
+/**
+ * Copy for the mod-consent redirect's query string. The OAuth flow returns here rather
+ * than to the overlay because one consent covers every streamer who delegated that
+ * platform, so there is no single overlay it belongs to.
+ */
+function consentNotice(connected: string | null, error: string | null): string | null {
+  if (error) {
+    return 'That connection did not complete. Open a channel below and try again from there.'
+  }
+  if (connected) {
+    const name = PLATFORM_LABELS[connected] ?? connected
+    return `${name} connected. It now covers every channel that delegated ${name} to you.`
+  }
+  return null
+}
+
+function DelegationSkeleton() {
+  return (
+    <div role="status" className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <VisuallyHidden>Loading channels</VisuallyHidden>
+      {Array.from({ length: 2 }).map((_, i) => (
+        <div key={i} className="space-y-3 rounded-xl border border-border bg-surface p-6">
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-3 w-1/3" />
+          <div className="flex gap-1.5">
+            <Skeleton className="h-4 w-16 rounded-full" />
+            <Skeleton className="h-4 w-16 rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-4 py-24 text-center">
+      <ShieldCheck className="size-16 text-text-dim" strokeWidth={1} aria-hidden="true" />
+      <h2 className="text-xl font-semibold text-text">No channels yet</h2>
+      <p className="max-w-md text-sm text-text-sub">
+        When a streamer invites you to moderate their overlay, they send you a private link. Open it
+        while signed in to this account and their channel appears here.
+      </p>
+    </div>
+  )
+}
+
+function DelegationCard({ delegation }: { delegation: Delegation }) {
+  // Rendered in the backend's canonical order rather than the array's, so two grants with
+  // the same permissions always read identically.
+  const actions = DELEGATABLE_ACTIONS.filter((a) => delegation.actions.includes(a))
+  const platforms = delegation.platforms.filter((leg) => leg.enabled)
+  const suspended = delegation.status === 'suspended'
+
+  return (
+    <Card className="flex flex-col overflow-hidden">
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <div className="min-w-0">
+          <h2 className="truncate font-semibold text-text">{delegation.overlay_name}</h2>
+          <p className="truncate text-sm text-text-sub">for {delegation.owner_display_name}</p>
+        </div>
+
+        {platforms.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {platforms.map((leg) => (
+              <PlatformBadge key={leg.platform} platform={leg.platform} size="sm" />
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-text-dim">
+            No platforms turned on yet — ask {delegation.owner_display_name} to enable one.
+          </p>
+        )}
+
+        <ul className="flex flex-wrap gap-1.5">
+          {actions.map((action) => (
+            <li
+              key={action}
+              className="rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[0.65rem] text-text-sub"
+            >
+              {ACTION_LABELS[action]}
+            </li>
+          ))}
+        </ul>
+
+        {suspended && (
+          <p className="flex items-start gap-2 text-xs text-text-sub">
+            <Info className="mt-0.5 size-3.5 shrink-0 text-text-dim" aria-hidden="true" />
+            <span>
+              Paused after 90 days without any actions. Ask {delegation.owner_display_name} to turn
+              it back on.
+            </span>
+          </p>
+        )}
+
+        {/* The streamer's plan, never the moderator's: there is nothing here a volunteer
+            could buy, so this states the cause and stops. */}
+        {!delegation.available && (
+          <p className="flex items-start gap-2 text-xs text-text-sub">
+            <Info className="mt-0.5 size-3.5 shrink-0 text-text-dim" aria-hidden="true" />
+            <span>
+              {delegation.owner_display_name}&apos;s plan does not include moderation right now, so
+              actions are unavailable until they renew it.
+            </span>
+          </p>
+        )}
+
+        {/* Always reachable, even suspended or unavailable: reading the chat is not the
+            capability in question, and a dead card would leave the moderator nowhere. */}
+        <Link
+          href={`/overlay/${delegation.overlay_id}/view`}
+          className="mt-auto inline-flex w-fit items-center gap-2 rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-sub transition-colors hover:border-border-md hover:text-text focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+        >
+          <MonitorPlay className="size-4" aria-hidden="true" />
+          Open chat monitor
+        </Link>
+      </div>
+    </Card>
+  )
+}
+
+function ModerateContent() {
+  const params = useSearchParams()
+  const notice = consentNotice(params.get('connected'), params.get('error'))
+
+  const [delegations, setDelegations] = useState<Delegation[] | null>(null)
+  const [loadFailed, setLoadFailed] = useState(false)
+
+  const fetchDelegations = useCallback(() => moderationApi.listDelegations(), [])
+
+  // State is set from the promise callback, not the effect body: a synchronous setState
+  // in an effect cascades renders, and `cancelled` keeps a slow response from landing
+  // after unmount.
+  useEffect(() => {
+    let cancelled = false
+    fetchDelegations()
+      .then((list) => {
+        if (cancelled) return
+        setDelegations(list.delegations)
+        setLoadFailed(false)
+      })
+      .catch(() => {
+        if (!cancelled) setLoadFailed(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [fetchDelegations])
+
+  const reload = useCallback(async () => {
+    try {
+      setDelegations((await fetchDelegations()).delegations)
+      setLoadFailed(false)
+    } catch {
+      setLoadFailed(true)
+    }
+  }, [fetchDelegations])
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <AppNav />
+      <main id="main-content" tabIndex={-1} className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold text-text">Channels you moderate</h1>
+          <p className="mt-1 text-sm text-text-sub">
+            Overlays other streamers have handed you. You act with your own platform account, so
+            each platform still checks that you are one of their moderators.
+          </p>
+        </div>
+
+        {notice && (
+          <div className="mb-6 flex items-start gap-2 rounded-lg border border-border bg-surface-2 px-4 py-3 text-sm text-text-sub">
+            <Info className="mt-0.5 size-4 shrink-0 text-text-dim" aria-hidden="true" />
+            <span>{notice}</span>
+          </div>
+        )}
+
+        {loadFailed ? (
+          <div className="space-y-3">
+            <p className="text-sm text-text-sub">Could not load your channels.</p>
+            <Button variant="outline" size="sm" onClick={() => void reload()}>
+              Try again
+            </Button>
+          </div>
+        ) : delegations === null ? (
+          <DelegationSkeleton />
+        ) : delegations.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {delegations.map((d) => (
+              <DelegationCard key={d.grant_id} delegation={d} />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default function ModeratePage() {
+  return (
+    <ProtectedRoute>
+      {/* useSearchParams (the mod-consent redirect's ?connected= / ?error=) opts this
+          subtree out of static rendering, so it needs its own boundary. */}
+      <Suspense
+        fallback={
+          <div className="min-h-screen bg-bg">
+            <AppNav />
+            <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+              <DelegationSkeleton />
+            </main>
+          </div>
+        }
+      >
+        <ModerateContent />
+      </Suspense>
+    </ProtectedRoute>
+  )
+}

--- a/frontend/src/app/overlay/[id]/view/page.tsx
+++ b/frontend/src/app/overlay/[id]/view/page.tsx
@@ -66,7 +66,12 @@ import {
   moderationApi,
 } from '@/lib/api/moderation'
 import type { ChatMessage, DeletionMetadata } from '@/lib/types/message'
-import type { ModerationCapabilities, SourceCapability } from '@/lib/types/moderation'
+import type {
+  DelegatablePlatform,
+  ModerationAction,
+  ModerationCapabilities,
+  SourceCapability,
+} from '@/lib/types/moderation'
 import type { EventSettings } from '@/lib/types/overlay'
 import {
   applyModerationMark,
@@ -200,8 +205,9 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     }
   }, [id])
 
-  // Fetch moderation capabilities once the user is known. A non-owner gets
-  // { is_owner:false, sources:[] }; any failure leaves moderation disabled.
+  // Fetch moderation capabilities once the user is known. A caller with no role gets
+  // { role:'none', sources:[] } — the same body an overlay that does not exist produces,
+  // so it says nothing about the overlay. Any failure leaves moderation disabled.
   useEffect(() => {
     let cancelled = false
     moderationApi
@@ -210,7 +216,14 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         if (!cancelled) setCapabilities(data)
       })
       .catch(() => {
-        if (!cancelled) setCapabilities({ is_owner: false, enabled: false, sources: [] })
+        if (!cancelled)
+          setCapabilities({
+            role: 'none',
+            is_owner: false,
+            enabled: false,
+            can_moderate: false,
+            sources: [],
+          })
       })
     return () => {
       cancelled = true
@@ -302,6 +315,28 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     [id]
   )
 
+  // A delegated moderator connecting their OWN account for a platform (ADR-0048).
+  //
+  // A different flow from enableModeration above, not a variant of it: it carries no
+  // overlay id, because Twitch's and Kick's moderation scopes are role-based rather than
+  // channel-scoped — one consent covers every streamer who delegated that platform. It
+  // also requests only the delegated actions, so a volunteer is never shown a consent
+  // screen asking for channel-point or subscription read on their own channel.
+  const connectAsModerator = useCallback(
+    async (platform: DelegatablePlatform, actions: ModerationAction[]) => {
+      try {
+        const url = await moderationApi.getModConsentUrl(platform, actions)
+        if (url) window.location.href = url
+      } catch {
+        toastManager.add({
+          title: `Connecting ${platform} is not available yet. Ask the streamer to moderate there for now.`,
+          type: 'error',
+        })
+      }
+    },
+    []
+  )
+
   // Re-consent when a send fails with `reauth_required` (the streamer's platform
   // send token expired or was revoked). Chat sending requires the advanced-controls
   // grant — Twitch `user:write:chat`, Kick `chat:write`, YouTube force-ssl — which is
@@ -352,10 +387,16 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
   // --- Moderation capability lookups ---------------------------------------
 
   const isOwner = capabilities?.is_owner === true
-  // The moderation feature gate (ADR-0008): an owner outside the rollout cohort can
-  // view the dashboard but gets no controls (the endpoints would 403 anyway).
-  const moderationEnabled = isOwner && capabilities?.enabled === true
-  const featureGated = isOwner && capabilities?.enabled === false
+  // A delegated moderator (ADR-0048). They get the moderation controls their grant allows
+  // and nothing else: no engagement, no send bar, no stream re-discovery — those are
+  // ownership powers, not moderation powers.
+  const isModerator = capabilities?.role === 'moderator'
+  const hasRole = isOwner || isModerator
+  // The moderation feature gate (ADR-0008), keyed on the OVERLAY OWNER. Someone with a
+  // role but a closed gate can view the monitor but gets no controls (the endpoints would
+  // 403 anyway).
+  const moderationEnabled = capabilities?.can_moderate === true
+  const featureGated = hasRole && capabilities?.can_moderate === false
   const capabilitiesByChannel = useMemo(() => {
     const map = new Map<string, SourceCapability>()
     capabilities?.sources.forEach((s) => map.set(s.channel_id, s))
@@ -365,6 +406,14 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
   // Sources the owner could moderate but hasn't granted the scope for.
   const missingScopeSources = useMemo(
     () => (capabilities?.sources ?? []).filter((s) => s.reason === 'missing_scope'),
+    [capabilities]
+  )
+
+  // Sources a delegated moderator could moderate once they connect their OWN account for
+  // that platform. Consent is deferred to first use, so this is the normal state on a
+  // fresh grant rather than an error.
+  const needsConsentSources = useMemo(
+    () => (capabilities?.sources ?? []).filter((s) => s.reason === 'needs_consent'),
     [capabilities]
   )
 
@@ -643,30 +692,78 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         </div>
       </header>
 
-      {/* Non-owner notice: viewing is allowed, moderation is not. */}
-      {capabilities && !isOwner && (
+      {/* No-role notice: viewing is allowed, moderation is not. Says nothing about the
+          overlay itself — the payload behind it is identical for an overlay that does not
+          exist, so it must not be phrased as a fact about this one. */}
+      {capabilities && !hasRole && (
         <div className="flex items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
           <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
-          You can view this monitor but aren&apos;t its owner — moderation is disabled.
+          You can view this monitor, but you don&apos;t moderate here — moderation is disabled.
         </div>
       )}
 
-      {/* Feature-gated notice: owner is outside the moderation rollout cohort. */}
-      {featureGated && (
-        <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
-          <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
-          <span>Chat moderation is a premium feature.</span>
-          <Link
-            href="/upgrade"
-            className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
-          >
-            Upgrade to moderate from your overlay
-          </Link>
-        </div>
-      )}
+      {/* Feature-gated notice. The gate is keyed on the OWNER, so a moderator is told
+          whose plan it is and given no call to action: /upgrade would sell them a plan
+          that is not theirs to buy. */}
+      {featureGated &&
+        (isOwner ? (
+          <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
+            <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
+            <span>Chat moderation is a premium feature.</span>
+            <Link
+              href="/upgrade"
+              className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+            >
+              Upgrade to moderate from your overlay
+            </Link>
+          </div>
+        ) : (
+          <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
+            <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
+            <span>
+              This streamer&apos;s plan doesn&apos;t include moderation right now, so your actions
+              are unavailable until they renew it.
+            </span>
+          </div>
+        ))}
 
-      {/* Missing-scope notices: owner must grant permissions per platform. */}
+      {/* Connect-to-moderate notices: a delegated moderator acts with their OWN account,
+          and consent is deferred to the first time they need it — so this is the normal
+          state on a fresh grant rather than an error. */}
       {moderationEnabled &&
+        isModerator &&
+        needsConsentSources.map((s) => (
+          <div
+            key={s.channel_id}
+            className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub"
+          >
+            <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
+            <span>
+              Connect your own {s.platform} account to moderate
+              {s.channel_name ? ` ${s.channel_name}` : ''}.
+            </span>
+            {s.platform === 'twitch' || s.platform === 'kick' || s.platform === 'youtube' ? (
+              <button
+                type="button"
+                onClick={() =>
+                  void connectAsModerator(
+                    s.platform as DelegatablePlatform,
+                    capabilities?.delegated_actions ?? []
+                  )
+                }
+                className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+              >
+                Connect {s.platform}
+              </button>
+            ) : null}
+          </div>
+        ))}
+
+      {/* Missing-scope notices: owner must grant permissions per platform. Owner-only —
+          the flow behind it re-consents the STREAMER's broadcaster credential, which is
+          not a moderator's to re-consent. */}
+      {moderationEnabled &&
+        isOwner &&
         missingScopeSources.map((s) => (
           <div
             key={s.channel_id}
@@ -699,26 +796,38 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         ))}
 
       {/* Re-auth prompt: a moderation action failed because the platform token can no
-          longer perform it. The backend asked for re-consent; give the streamer the CTA. */}
+          longer perform it. The backend asked for re-consent; give the actor the CTA —
+          which differs by role. Sending a moderator down the streamer's re-consent path
+          would half-succeed and then error: that flow is an add-source state, and
+          add-source 404s for anyone who does not own the overlay. */}
       {reauthPrompt && (
         <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
           <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
           <span>
             Your {reauthPrompt.platform} moderation permission expired or was never granted —
-            re-authorize to keep moderating from your overlay.
+            re-authorize to keep moderating {isOwner ? 'from your overlay' : 'here'}.
           </span>
           <button
             type="button"
             onClick={() => {
               const platform = reauthPrompt.platform
               setReauthPrompt(null)
+              if (isModerator) {
+                void connectAsModerator(
+                  platform as DelegatablePlatform,
+                  capabilities?.delegated_actions ?? []
+                )
+                return
+              }
               void enableModeration(platform)
             }}
             className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
           >
             {reauthPrompt.platform === 'discord'
               ? 'Re-invite the bot'
-              : 'Re-authorize moderation & chat sending'}
+              : isModerator
+                ? `Reconnect ${reauthPrompt.platform}`
+                : 'Re-authorize moderation & chat sending'}
           </button>
         </div>
       )}

--- a/frontend/src/components/ModeratingElsewhereCard.tsx
+++ b/frontend/src/components/ModeratingElsewhereCard.tsx
@@ -1,0 +1,77 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+'use client'
+
+/**
+ * Dashboard entry point to the channels this user moderates for other people (ADR-0048).
+ *
+ * The dashboard lists overlays a user OWNS, and there is no other listing that could
+ * surface someone else's — so without a pointer here, a volunteer who accepted an invite
+ * last week has no way back to it except the original invite link, which is single-use.
+ *
+ * It renders nothing at all when there is nothing to point at, including on error: a
+ * streamer who moderates for nobody must not grow an empty section, and a failed request
+ * must not turn into a broken one.
+ */
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { ShieldCheck } from 'lucide-react'
+
+import { moderationApi } from '@/lib/api/moderation'
+
+export function ModeratingElsewhereCard() {
+  const [count, setCount] = useState(0)
+
+  // Set from the promise callback, not the effect body: a synchronous setState in an
+  // effect cascades renders. Failures stay silent — this is a shortcut, not a feature.
+  useEffect(() => {
+    let cancelled = false
+    moderationApi
+      .listDelegations()
+      .then((list) => {
+        if (!cancelled) setCount(list.delegations.length)
+      })
+      .catch(() => {
+        /* no shortcut this load; the /moderate page still works if they know it */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (count === 0) return null
+
+  return (
+    <Link
+      href="/moderate"
+      className="flex items-center gap-3 rounded-xl border border-border bg-surface px-4 py-3 text-sm transition-colors hover:border-border-md focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+    >
+      <ShieldCheck className="size-5 shrink-0 text-twitch" aria-hidden="true" />
+      <span className="text-text-sub">
+        You moderate{' '}
+        <span className="font-semibold text-text">
+          {count} {count === 1 ? 'channel' : 'channels'}
+        </span>{' '}
+        for other streamers.
+      </span>
+      <span className="ml-auto font-medium text-twitch">Open</span>
+    </Link>
+  )
+}

--- a/frontend/src/components/editor/ModeratorsPanel.tsx
+++ b/frontend/src/components/editor/ModeratorsPanel.tsx
@@ -112,6 +112,18 @@ function grantName(grant: ModeratorGrant): string {
   return grant.display_name || grant.invitee_label || 'Unnamed invite'
 }
 
+/**
+ * The redemption link for a fresh invite secret.
+ *
+ * Absolute, because the streamer pastes it into a DM on some other service where a
+ * relative path means nothing. Built from the current origin rather than a configured
+ * base URL so a preview deployment hands out links to itself.
+ */
+function inviteURL(token: string): string {
+  const path = `/moderate/accept?token=${encodeURIComponent(token)}`
+  return typeof window === 'undefined' ? path : `${window.location.origin}${path}`
+}
+
 export function ModeratorsPanel({ overlayId }: { overlayId: string }) {
   const [list, setList] = useState<ModeratorList | null>(null)
   const [loadFailed, setLoadFailed] = useState(false)
@@ -498,13 +510,19 @@ function InviteDialog({ overlayId, open, onOpenChange }: InviteDialogProps) {
     }
   }
 
+  // What the streamer actually sends. A bare secret is not actionable — the recipient
+  // would have to be told separately where to paste it — so the invite is handed over as
+  // the link that redeems it. The secret is still the only thing that authorizes, and it
+  // still exists only in this response.
+  const inviteLink = created === null ? '' : inviteURL(created.invite_token)
+
   const handleCopy = async () => {
     if (created === null) return
     try {
-      await navigator.clipboard.writeText(created.invite_token)
+      await navigator.clipboard.writeText(inviteLink)
       setCopied(true)
     } catch {
-      setError('Could not copy. Select the code and copy it manually.')
+      setError('Could not copy. Select the link and copy it manually.')
     }
   }
 
@@ -522,15 +540,15 @@ function InviteDialog({ overlayId, open, onOpenChange }: InviteDialogProps) {
         {created !== null ? (
           <div className="space-y-3">
             <Dialog.Description className="text-xs">
-              Send this code to the person you want to moderate. It works once, expires in 7 days,
+              Send this link to the person you want to moderate. It works once, expires in 7 days,
               and <strong>won&apos;t be shown again</strong> — if it gets lost, create a new invite.
             </Dialog.Description>
             <code className="bg-surface-alt block overflow-x-auto rounded-lg border border-border p-2 text-xs break-all text-text">
-              {created.invite_token}
+              {inviteLink}
             </code>
             <div className="flex justify-end gap-2">
               <Button variant="outline" size="sm" onClick={() => void handleCopy()}>
-                {copied ? 'Copied' : 'Copy'}
+                {copied ? 'Copied' : 'Copy link'}
               </Button>
               <Button size="sm" onClick={() => onOpenChange(false)}>
                 Done

--- a/frontend/src/components/editor/__tests__/ModeratorsPanel.test.tsx
+++ b/frontend/src/components/editor/__tests__/ModeratorsPanel.test.tsx
@@ -230,7 +230,9 @@ describe('ModeratorsPanel invite', () => {
     expect(api.createInvite).not.toHaveBeenCalled()
   })
 
-  it('shows the secret once, says it cannot be shown again, and copies it', async () => {
+  // Handed over as the link that redeems it, not a bare secret: a code the recipient has
+  // to be told where to paste is not something a streamer can just send.
+  it('shows the redemption link once, says it cannot be shown again, and copies it', async () => {
     api.createInvite.mockResolvedValue({
       grant_id: 'g9',
       invite_token: 'SEEKRIT-TOKEN-VALUE',
@@ -241,14 +243,13 @@ describe('ModeratorsPanel invite', () => {
     const create = await openInvite()
     fireEvent.click(create)
 
-    expect(await screen.findByText('SEEKRIT-TOKEN-VALUE')).toBeInTheDocument()
+    const link = `${window.location.origin}/moderate/accept?token=SEEKRIT-TOKEN-VALUE`
+    expect(await screen.findByText(link)).toBeInTheDocument()
     // The digest is all that is stored, so the copy must not promise a second chance.
     expect(screen.getByText(/won't be shown again/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /copy/i }))
-    await waitFor(() =>
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('SEEKRIT-TOKEN-VALUE')
-    )
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledWith(link))
   })
 
   it('drops the secret from the DOM once the reveal is dismissed', async () => {
@@ -261,10 +262,10 @@ describe('ModeratorsPanel invite', () => {
     })
     const create = await openInvite()
     fireEvent.click(create)
-    await screen.findByText('SEEKRIT-TOKEN-VALUE')
+    await screen.findByText(/SEEKRIT-TOKEN-VALUE/)
 
     fireEvent.click(screen.getByRole('button', { name: /done/i }))
-    await waitFor(() => expect(screen.queryByText('SEEKRIT-TOKEN-VALUE')).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.queryByText(/SEEKRIT-TOKEN-VALUE/)).not.toBeInTheDocument())
   })
 
   // A moderator must never be shown an upgrade prompt, but the OWNER here is the caller,

--- a/frontend/src/lib/api/__tests__/moderation.test.ts
+++ b/frontend/src/lib/api/__tests__/moderation.test.ts
@@ -16,13 +16,22 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// vi.mock's factory is hoisted above every import, so anything it closes over must be
+// created with vi.hoisted() or the suite fails to collect.
+const client = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('@/lib/api/client', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/client')>('@/lib/api/client')
+  return { ...actual, apiClient: client }
+})
 
 import { ApiError } from '@/lib/api/client'
 import {
   boundInviteAccount,
   delegationErrorCode,
   isModerationReauthError,
+  moderationApi,
 } from '@/lib/api/moderation'
 
 describe('isModerationReauthError', () => {
@@ -109,5 +118,50 @@ describe('boundInviteAccount', () => {
       code: 'already_moderator',
     })
     expect(boundInviteAccount(err)).toBeNull()
+  })
+})
+
+describe('moderator-side endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reads the delegation list from the moderator-scoped route', async () => {
+    client.get.mockResolvedValue({ delegations: [] })
+    await moderationApi.listDelegations()
+    expect(client.get).toHaveBeenCalledWith('/api/v1/moderation/delegations')
+  })
+
+  // The secret must never reach a URL: a path parameter would be captured by every
+  // access log, proxy log and Referer header between here and the service.
+  it('sends the invite secret in the body, never the path', async () => {
+    client.post.mockResolvedValue({})
+    await moderationApi.previewInvite('SEEKRIT')
+    const [path, body] = client.post.mock.calls[0]
+    expect(path).toBe('/api/v1/moderation/invites/preview')
+    expect(path).not.toContain('SEEKRIT')
+    expect(body).toEqual({ token: 'SEEKRIT' })
+  })
+
+  it('accepts an invite with the secret in the body and an idempotency key', async () => {
+    client.post.mockResolvedValue({})
+    await moderationApi.acceptInvite('SEEKRIT')
+    const [path, body, headers] = client.post.mock.calls[0]
+    expect(path).toBe('/api/v1/moderation/invites/accept')
+    expect(path).not.toContain('SEEKRIT')
+    expect(body).toEqual({ token: 'SEEKRIT' })
+    expect(headers).toHaveProperty('Idempotency-Key')
+  })
+
+  // A moderator's consent carries no overlay id — Twitch/Kick moderation scopes are
+  // role-based, so one consent serves every streamer who delegated that platform — and
+  // requests only the delegated actions, so a volunteer is never shown a wider screen.
+  it('requests mod consent without an overlay and with only the delegated actions', async () => {
+    client.get.mockResolvedValue({ auth_url: 'https://id.twitch.tv/authorize?x' })
+    const url = await moderationApi.getModConsentUrl('twitch', ['delete', 'timeout'])
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/auth/twitch/mod-consent?actions=delete,timeout'
+    )
+    expect(url).toBe('https://id.twitch.tv/authorize?x')
   })
 })

--- a/frontend/src/lib/api/moderation.ts
+++ b/frontend/src/lib/api/moderation.ts
@@ -30,7 +30,10 @@ import type {
   CreateInviteRequest,
   DelegatablePlatform,
   DelegationErrorCode,
+  DelegationList,
+  InviteAccepted,
   InviteCreated,
+  InvitePreview,
   ModerationAction,
   ModerationCapabilities,
   ModerationPlatform,
@@ -328,5 +331,54 @@ export const moderationApi = {
     return apiClient.deleteJson<{ revoked: number }>(
       `/api/v1/moderation/overlays/${overlayId}/moderators`
     )
+  },
+
+  // --- Moderator side (ADR-0048) -------------------------------------------
+
+  /**
+   * The channels this user moderates for other people.
+   *
+   * `GET /api/v1/overlays` is owner-filtered and there is no shared-with-me listing,
+   * so this is the ONLY route a delegated moderator has into an overlay they do not
+   * own. Never feature-gated: a moderator must be able to see a delegation even when
+   * the streamer's plan has lapsed, which shows up as `available: false` per row.
+   */
+  listDelegations(): Promise<DelegationList> {
+    return apiClient.get<DelegationList>('/api/v1/moderation/delegations')
+  },
+
+  /**
+   * Read an invite without redeeming it. The secret travels in the BODY, never the
+   * path — a moderation credential in a URL lands in access logs, proxy logs and
+   * `Referer` headers on the way. The response carries no `overlay_id`; that is
+   * disclosed on acceptance.
+   */
+  previewInvite(token: string): Promise<InvitePreview> {
+    return apiClient.post<InvitePreview>('/api/v1/moderation/invites/preview', { token })
+  },
+
+  /** Redeem an invite, binding the grant to the signed-in account. */
+  acceptInvite(token: string): Promise<InviteAccepted> {
+    return apiClient.post<InviteAccepted>(
+      '/api/v1/moderation/invites/accept',
+      { token },
+      idempotencyHeader()
+    )
+  },
+
+  /**
+   * Fetch the OAuth URL for a delegated moderator's OWN consent (ADR-0048).
+   *
+   * Distinct from `get*ConsentUrl` above in three ways that matter: no overlay id
+   * (Twitch/Kick moderation scopes are role-based, so one consent serves every
+   * streamer who delegated that platform), no base login scopes on the screen, and
+   * the credential lands in the moderator's own store rather than touching their
+   * login grant. Twitch is the only platform wired today; the others answer 400.
+   */
+  async getModConsentUrl(platform: DelegatablePlatform, actions: ModerationAction[]) {
+    const res = await apiClient.get<ConsentUrlResponse>(
+      `/api/v1/auth/${platform}/mod-consent?actions=${actions.join(',')}`
+    )
+    return res.auth_url
   },
 }

--- a/frontend/src/lib/types/moderation.ts
+++ b/frontend/src/lib/types/moderation.ts
@@ -32,8 +32,23 @@ export type ModerationPlatform = 'twitch' | 'youtube' | 'kick' | 'tiktok' | 'dis
 /** A single moderation action the backend can perform on a source. */
 export type ModerationAction = 'delete' | 'timeout' | 'ban' | 'unban'
 
-/** Why a source cannot be moderated, when `moderatable` is false. */
-export type ModerationUnavailableReason = 'unsupported_platform' | 'missing_scope'
+/**
+ * Why a source cannot be moderated, when `moderatable` is false.
+ *
+ * The first two can describe either role. The last three only ever describe a
+ * delegated moderator's source (ADR-0048), and they differ in who can clear
+ * them: `not_delegated` needs the streamer, `needs_consent` needs the
+ * moderator, and `needs_discord_link` needs neither — nothing can clear it yet.
+ */
+export type ModerationUnavailableReason =
+  | 'unsupported_platform'
+  | 'missing_scope'
+  | 'not_delegated'
+  | 'needs_consent'
+  | 'needs_discord_link'
+
+/** The caller's role on an overlay's moderation write-path. */
+export type ModerationRole = 'owner' | 'moderator' | 'none'
 
 /** Per-source moderation capability, as returned by the capabilities endpoint. */
 export interface SourceCapability {
@@ -52,13 +67,34 @@ export interface SourceCapability {
 
 /** Overlay-wide moderation capabilities for the logged-in viewer. */
 export interface ModerationCapabilities {
+  /**
+   * The caller's role. A caller with no role and an overlay that does not exist
+   * produce the identical payload, so `none` must never be read as proof that
+   * the overlay is real.
+   */
+  role: ModerationRole
   is_owner: boolean
   /**
-   * Whether the moderation feature gate (ADR-0008) is open for this viewer. When
-   * false, the owner is outside the rollout cohort: controls are hidden and the
-   * action endpoints would 403. Always false for non-owners.
+   * Whether the moderation feature gate (ADR-0008) is open. Keyed on the overlay
+   * OWNER, never the caller: a premium streamer's moderators moderate for free,
+   * so a moderator seeing `false` here must be shown the streamer's plan as the
+   * cause, never an upgrade prompt.
    */
   enabled: boolean
+  /**
+   * The single flag the controls switch on: the caller holds a role AND the
+   * owner's plan has moderation open. Which actions are actually available is
+   * still decided source by source.
+   */
+  can_moderate: boolean
+  /**
+   * The grant's action set, present for a moderator only.
+   *
+   * What a `needs_consent` source's "Connect to moderate" requests scopes for: such a
+   * source reports no usable actions yet, and guessing high would ask a volunteer for
+   * ban scope the streamer never delegated.
+   */
+  delegated_actions?: ModerationAction[]
   sources: SourceCapability[]
 }
 
@@ -181,6 +217,35 @@ export interface InviteCreated {
   invitee_label?: string
 }
 
+/**
+ * What an invite holder is shown before agreeing to moderate.
+ *
+ * Deliberately carries NO `overlay_id`: an overlay UUID already grants chat read
+ * to anyone holding it, so it is disclosed on acceptance rather than to everyone
+ * who merely opens the link.
+ */
+export interface InvitePreview {
+  overlay_name: string
+  owner_display_name: string
+  actions: ModerationAction[]
+  platforms: GrantPlatformLeg[]
+  expires_at: string
+  invitee_label?: string
+  /** Set when the invite is pre-bound to one platform account. */
+  expected_platform?: DelegatablePlatform
+  expected_account?: string
+}
+
+/** A redeemed invite, with the overlay the moderator may now act on. */
+export interface InviteAccepted {
+  grant_id: string
+  overlay_id: string
+  overlay_name: string
+  owner_display_name: string
+  actions: ModerationAction[]
+  platforms: GrantPlatformLeg[]
+}
+
 /** Body for narrowing or widening an existing grant. */
 export interface UpdateGrantRequest {
   /** Omit to leave the action set untouched. */
@@ -203,6 +268,38 @@ export type DelegationErrorCode =
   | 'already_moderator'
   | 'owner_cannot_accept'
   | 'invite_bound_to_other_account'
+
+/**
+ * One channel a moderator has been handed, as the MODERATOR sees it.
+ *
+ * The mirror image of `ModeratorGrant`: the owner's view names the moderator,
+ * this one names the streamer. It carries no user ids — a volunteer learns who
+ * delegated to them, not who else moderates there.
+ */
+export interface Delegation {
+  grant_id: string
+  /** The only way to reach the overlay: `GET /api/v1/overlays` is owner-filtered. */
+  overlay_id: string
+  overlay_name: string
+  owner_display_name: string
+  /** `active` or `suspended`. A suspended grant is listed, not hidden. */
+  status: GrantStatus
+  actions: ModerationAction[]
+  platforms: GrantPlatformLeg[]
+  /**
+   * Whether the streamer's plan currently has delegated moderation open. False
+   * means the streamer's plan lapsed — say so, and never link a volunteer to
+   * `/upgrade` for a plan that is not theirs to buy.
+   */
+  available: boolean
+  accepted_at?: string
+  last_action_at?: string
+}
+
+/** The "channels I moderate" payload. */
+export interface DelegationList {
+  delegations: Delegation[]
+}
 
 /** Platforms a grant leg may cover, in display order. */
 export const DELEGATABLE_PLATFORMS: ReadonlyArray<DelegatablePlatform> = [

--- a/frontend/tests/e2e/a11y.spec.ts
+++ b/frontend/tests/e2e/a11y.spec.ts
@@ -183,4 +183,48 @@ test.describe('a11y smoke (axe, WCAG 2.2 AA)', () => {
     await expect(page.getByText(OVERLAY.name)).toBeVisible({ timeout: 20_000 })
     await expectNoNewA11yViolations(page, 'overlay-editor', testInfo)
   })
+
+  // The moderator's side of delegation (ADR-0048). Worth its own scan rather than
+  // trusting the owner pages: it is the only surface a volunteer ever sees, and they
+  // reach it from a link rather than by exploring the app.
+  test('channels you moderate', async ({ page }, testInfo) => {
+    await mockAuthedApi(page, {
+      '**/api/v1/moderation/delegations': {
+        delegations: [
+          {
+            grant_id: 'grant-1',
+            overlay_id: OVERLAY.id,
+            overlay_name: OVERLAY.name,
+            owner_display_name: 'Some Streamer',
+            status: 'active',
+            actions: ['delete', 'timeout'],
+            platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+            available: true,
+          },
+        ],
+      },
+    })
+    await page.goto('/moderate')
+    await expect(page.getByRole('heading', { name: 'Channels you moderate' })).toBeVisible({
+      timeout: 20_000,
+    })
+    await expectNoNewA11yViolations(page, 'moderate-delegations', testInfo)
+  })
+
+  test('moderation invite acceptance', async ({ page }, testInfo) => {
+    await mockAuthedApi(page, {
+      '**/api/v1/moderation/invites/preview': {
+        overlay_name: OVERLAY.name,
+        owner_display_name: 'Some Streamer',
+        actions: ['delete', 'timeout'],
+        platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+        expires_at: '2026-08-14T10:00:00Z',
+      },
+    })
+    await page.goto('/moderate/accept?token=a11y-smoke-token')
+    await expect(page.getByRole('heading', { name: 'Moderation invite' })).toBeVisible({
+      timeout: 20_000,
+    })
+    await expectNoNewA11yViolations(page, 'moderate-accept', testInfo)
+  })
 })

--- a/frontend/tests/e2e/moderate-delegations.spec.ts
+++ b/frontend/tests/e2e/moderate-delegations.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * End-to-end cover for the moderator's side of delegation (ADR-0048): finding a channel
+ * someone handed you, and redeeming the invite that handed it over.
+ *
+ * The moderation API is stubbed at the network boundary, so this exercises routing, the
+ * auth guard and the real pages together — which the component tests cannot. The path
+ * under test is the one with no alternative: `GET /api/v1/overlays` is owner-filtered, so
+ * if this list breaks, an accepted grant becomes unreachable.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const OVERLAY_ID = 'aaaaaaaa-1111-1111-1111-111111111111'
+
+const USER = {
+  id: 'user-2',
+  username: 'sarah',
+  display_name: 'Sarah',
+  auth_provider: 'twitch',
+  onboarding_completed_at: '2026-01-01T00:00:00Z',
+}
+
+const DELEGATION = {
+  grant_id: 'grant-1',
+  overlay_id: OVERLAY_ID,
+  overlay_name: 'Main Overlay',
+  owner_display_name: 'SomeStreamer',
+  status: 'active',
+  actions: ['delete', 'timeout'],
+  platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+  available: true,
+  accepted_at: '2026-08-01T11:00:00Z',
+}
+
+const INVITE_SECRET = 'e2e-invite-secret-value'
+
+function json(body: unknown, status = 200) {
+  return { status, contentType: 'application/json', body: JSON.stringify(body) }
+}
+
+test.describe('moderator — channels you moderate', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    // Catch-all first — Playwright matches routes last-registered-first.
+    await page.route('**/api/v1/**', (route) => route.fulfill(json({}, 404)))
+    await page.route('**/api/v1/auth/me', (route) => route.fulfill(json(USER)))
+  })
+
+  test('lists a delegated channel and links to its monitor', async ({ page }) => {
+    await page.route('**/api/v1/moderation/delegations', (route) =>
+      route.fulfill(json({ delegations: [DELEGATION] }))
+    )
+
+    await page.goto('/moderate')
+
+    await expect(page.getByRole('heading', { name: 'Channels you moderate' })).toBeVisible({
+      timeout: 20_000,
+    })
+    await expect(page.getByText('Main Overlay')).toBeVisible()
+    await expect(page.getByText('for SomeStreamer')).toBeVisible()
+    await expect(page.getByRole('link', { name: /open chat monitor/i })).toHaveAttribute(
+      'href',
+      `/overlay/${OVERLAY_ID}/view`
+    )
+  })
+
+  test('explains how to get a channel when there are none', async ({ page }) => {
+    await page.route('**/api/v1/moderation/delegations', (route) =>
+      route.fulfill(json({ delegations: [] }))
+    )
+
+    await page.goto('/moderate')
+
+    await expect(page.getByRole('heading', { name: 'No channels yet' })).toBeVisible({
+      timeout: 20_000,
+    })
+  })
+
+  // Entitlement is keyed on the overlay OWNER, so a lapsed plan is the streamer's. A
+  // volunteer must never be pointed at an upgrade page for a plan that is not theirs.
+  test('names the streamer plan for an unavailable channel, with no upgrade link', async ({
+    page,
+  }) => {
+    await page.route('**/api/v1/moderation/delegations', (route) =>
+      route.fulfill(json({ delegations: [{ ...DELEGATION, available: false }] }))
+    )
+
+    await page.goto('/moderate')
+
+    await expect(page.getByText(/SomeStreamer's plan does not include moderation/)).toBeVisible({
+      timeout: 20_000,
+    })
+    await expect(page.getByRole('link', { name: /upgrade/i })).toHaveCount(0)
+  })
+})
+
+test.describe('moderator — invite acceptance', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.route('**/api/v1/**', (route) => route.fulfill(json({}, 404)))
+    await page.route('**/api/v1/auth/me', (route) => route.fulfill(json(USER)))
+  })
+
+  test('previews an invite and redeems it into the overlay it discloses', async ({ page }) => {
+    const seenPaths: string[] = []
+    await page.route('**/api/v1/moderation/invites/preview', (route) => {
+      seenPaths.push(route.request().url())
+      return route.fulfill(
+        json({
+          overlay_name: 'Main Overlay',
+          owner_display_name: 'SomeStreamer',
+          actions: ['delete', 'timeout'],
+          platforms: [{ platform: 'twitch', enabled: true, verification: 'unverified' }],
+          expires_at: '2026-08-14T10:00:00Z',
+        })
+      )
+    })
+    await page.route('**/api/v1/moderation/invites/accept', (route) => {
+      seenPaths.push(route.request().url())
+      return route.fulfill(
+        json({
+          grant_id: 'grant-1',
+          overlay_id: OVERLAY_ID,
+          overlay_name: 'Main Overlay',
+          owner_display_name: 'SomeStreamer',
+          actions: ['delete', 'timeout'],
+          platforms: [],
+        })
+      )
+    })
+
+    await page.goto(`/moderate/accept?token=${INVITE_SECRET}`)
+
+    await expect(page.getByText('Main Overlay')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('Delete messages')).toBeVisible()
+
+    await page.getByRole('button', { name: /accept and start moderating/i }).click()
+    await expect(page).toHaveURL(new RegExp(`/overlay/${OVERLAY_ID}/view`))
+
+    // The secret travels in the body on every call: a path parameter would be captured by
+    // every access log and Referer header between the browser and the service.
+    expect(seenPaths.length).toBeGreaterThan(0)
+    for (const url of seenPaths) {
+      expect(url).not.toContain(INVITE_SECRET)
+    }
+  })
+
+  test('sends a dead invite somewhere it can act instead of a raw error', async ({ page }) => {
+    await page.route('**/api/v1/moderation/invites/preview', (route) =>
+      route.fulfill(json({ error: 'invite not found', code: 'invite_not_found' }, 404))
+    )
+
+    await page.goto(`/moderate/accept?token=${INVITE_SECRET}`)
+
+    await expect(page.getByText(/already have been used/i)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('link', { name: /go to your channels/i })).toBeVisible()
+  })
+})

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -750,6 +750,9 @@ func main() {
 		// still needs a signed-in All-Chat account for the grant to bind to.
 		protectedAPI.POST("/moderation/invites/preview", proxyHandler.ForwardRequest)
 		protectedAPI.POST("/moderation/invites/accept", proxyHandler.ForwardRequest)
+		// "Channels I moderate". /overlays is owner-filtered, so this is the only listing that
+		// can surface an overlay someone else owns to a delegated moderator.
+		protectedAPI.GET("/moderation/delegations", proxyHandler.ForwardRequest)
 
 		// Ambassador self-service (ADR-0041) — a streamer reads/sets their own
 		// homepage-showcase opt-in. -> share-service (enforces the ambassador role).

--- a/services/moderation-service/README.md
+++ b/services/moderation-service/README.md
@@ -16,7 +16,7 @@ All require a user JWT (forwarded by the gateway; re-validated here). Mounted un
 
 | Method | Path | Body |
 |---|---|---|
-| `GET`  | `/overlays/:id/capabilities` | — → `{ is_owner, enabled, sources: [{platform, channel_id, channel_name, moderatable, reason?, actions[]}] }` |
+| `GET`  | `/overlays/:id/capabilities` | — → `{ role, is_owner, enabled, can_moderate, delegated_actions?, sources: [{platform, channel_id, channel_name, moderatable, reason?, actions[]}] }` |
 | `POST` | `/overlays/:id/delete`  | `{ platform, channel_id, native_message_id, target_uuid }` |
 | `POST` | `/overlays/:id/timeout` | `{ platform, channel_id, target_user_id, target_username, duration_seconds, reason? }` |
 | `POST` | `/overlays/:id/ban`     | `{ platform, channel_id, target_user_id, target_username, reason? }` |
@@ -24,6 +24,20 @@ All require a user JWT (forwarded by the gateway; re-validated here). Mounted un
 
 Send a unique `Idempotency-Key` header on each POST (double-click/retry dedup). Per-user rate limiting
 applies (`MODERATION_RATE_PER_MIN`, default 30/min).
+
+`capabilities` is role-aware (ADR-0048): `role` is `owner` / `moderator` / `none`, and `can_moderate` is
+the single flag the UI switches controls on. An owner's per-source answer comes from the scopes on their
+broadcaster credential; a **moderator's** comes from what the streamer delegated intersected with the
+scopes on the moderator's *own* credential, so `reason` gains three moderator-only values that differ in
+who can clear them: `not_delegated` (only the streamer can), `needs_consent` (only the moderator can —
+this is the "Connect to moderate" state) and `needs_discord_link` (nobody yet; Discord has no per-user
+moderation API and All-Chat holds no Discord identity for a user). `can_send` is never true for a
+moderator: chat send is a distinct, higher-trust capability and stays owner-only in v1.
+`delegated_actions` echoes the grant's action set so a `needs_consent` source can request scopes for
+exactly what was delegated rather than guessing high.
+
+A caller with **no role** and an overlay that **does not exist** produce a byte-identical body, so this
+endpoint is not an overlay-existence oracle either.
 
 ### Delegation grant lifecycle (ADR-0048)
 
@@ -60,6 +74,19 @@ Redemption is keyed on the secret, not on any role:
 | `POST` | `/invites/preview` | `{ token }` → `{ overlay_name, owner_display_name, actions[], platforms[], expires_at, expected_account? }` |
 | `POST` | `/invites/accept`  | `{ token }` → `{ grant_id, overlay_id, overlay_name, … }` |
 
+Once accepted, the moderator finds the channel through their own listing:
+
+| Method | Path | Body |
+|---|---|---|
+| `GET` | `/delegations` | — → `{ delegations: [{grant_id, overlay_id, overlay_name, owner_display_name, status, actions[], platforms[], available, accepted_at?, last_action_at?}] }` |
+
+This is **not** a convenience: `GET /api/v1/overlays` is owner-filtered and there is no shared-with-me
+listing, so without it an accepted grant is unreachable. It is keyed on the caller alone, carries no user
+ids (the moderator learns who delegated to them, not who else moderates there), and is never gated — a
+moderator must be able to see a delegation even when the streamer's plan has lapsed, which surfaces as
+`available: false` with the streamer's plan named as the cause. `suspended` grants are listed rather than
+hidden: a channel that silently vanished would be indistinguishable from a revocation.
+
 The secret travels in the **body**, never in a path — a URL would put a live moderation credential into
 every access log, proxy log and `Referer` header along the way. `preview` deliberately omits
 `overlay_id`: an overlay UUID already grants chat *read* to whoever holds it, so it is disclosed on
@@ -80,8 +107,11 @@ feature is rolled back — otherwise a streamer could be left holding moderators
    moderate for free, and a moderator never sees an upgrade prompt for a plan that is not theirs to
    buy. Enforced inside `authorize()` rather than in `RequirePremium` middleware, which keys on the
    caller — so the denial is audited like every other denial and the copy can differ by role.
-3. A delegated moderator may only perform the actions the grant lists; an owner may perform anything
-   the platform supports.
+3. A delegated moderator may only perform the actions the grant lists, **and** only on the platforms
+   whose leg the grant enables. Two separate grants of authority: the action names are shared across
+   platforms, so an action-only check would let a Twitch-only moderator act on every source the overlay
+   carries. An absent leg row is a disabled leg, so this fails closed. An owner may perform anything the
+   platform supports and is narrowed by neither.
 4. The `(platform, channel_id)` must be a real source on that overlay and **not** `shared_overlay`.
    Under owner-only authorization that exclusion was true by construction; under role-based
    authorization this predicate carries it alone, so it has its own regression test.
@@ -170,6 +200,13 @@ no redeploy. Locally, non-premium users can either set `users.is_premium=true` o
   resolves the guild from the channel and performs member ops; `handler.DiscordScopeChecker` reports the
   actions the bot's guild permissions allow; the auth-service `GetModerationAuthURL` (elevated invite) +
   `HandleConnect?moderation=true` give an opt-in re-invite that upgrades existing bots in place.
+- **Phase 6 (in progress): delegated moderators** (ADR-0048). Landed so far: role resolution and
+  owner-keyed entitlement; the grant lifecycle; the owner's Moderators panel; the moderator's
+  `/delegations` listing and role-aware `capabilities`; per-platform leg enforcement on the action path.
+  **Not yet landed:** the per-platform legs themselves — the dispatcher still resolves a credential by
+  `(caller, channel)`, so a delegated action currently fails **closed** with `422 no credential` rather
+  than falling back to the owner's token. Twitch is next (`moderator_id`/`broadcaster_id` split + the
+  owner-reach anchor), then Kick, Discord and YouTube, each independently gated.
 
 ## Layout
 

--- a/services/moderation-service/cmd/main.go
+++ b/services/moderation-service/cmd/main.go
@@ -293,6 +293,11 @@ func main() {
 	api.POST("/invites/preview", grantHandler.HandlePreviewInvite)
 	api.POST("/invites/accept", grantHandler.HandleAcceptInvite)
 
+	// "Channels I moderate" — the moderator's own delegations. Ungated and keyed on nothing but
+	// the caller's own id: /api/v1/overlays is owner-filtered, so this is the only route an
+	// accepted moderator has into an overlay they do not own (ADR-0048).
+	api.GET("/delegations", grantHandler.HandleListDelegations)
+
 	srv := &http.Server{
 		Addr:         ":" + cfg.Port,
 		Handler:      router,

--- a/services/moderation-service/handler/capabilities_delegation_test.go
+++ b/services/moderation-service/handler/capabilities_delegation_test.go
@@ -1,0 +1,288 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Capabilities for a DELEGATED MODERATOR (ADR-0048).
+//
+// The moderator's answer is computed from a different authority than the owner's: what the
+// streamer delegated, intersected with the scopes on the moderator's OWN credential. These tests
+// pin that the two never get crossed — a moderator must never inherit the streamer's scopes, and
+// the streamer's grant must never be widened by the moderator's consent.
+
+const capsPath = "/api/v1/moderation/overlays/" + overlayID + "/capabilities"
+
+// twitchModScopes is a moderator credential granting the full Twitch moderation set.
+var twitchModScopes = []string{
+	models.ScopeTwitchManageMessages, models.ScopeTwitchManageBannedUsers,
+}
+
+func modCapsHandler(t *testing.T, auth *fakeAuthorizer) *Handler {
+	t.Helper()
+	// fakeScopes stands in for the OWNER's broadcaster scopes and deliberately reports the full
+	// set: any of it leaking into a moderator's answer is the bug these tests exist to catch.
+	owner := fakeScopes{actions: []models.Action{
+		models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban,
+	}}
+	return New(auth, &fakeEmitter{}, &fakeRecorder{}, owner, DryRunDispatcher{}, zap.NewNop())
+}
+
+func modCaps(t *testing.T, auth *fakeAuthorizer) models.Capabilities {
+	t.Helper()
+	resp := do(newTestRouter(modCapsHandler(t, auth), modUserID, ""), http.MethodGet, capsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &caps))
+	return caps
+}
+
+func moderatorAccess(actions, platforms []string) *repository.OverlayAccess {
+	return &repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleModerator,
+		GrantID:        "grant-1",
+		Actions:        actions,
+		Platforms:      platforms,
+	}
+}
+
+func twitchSource() []repository.Source {
+	return []repository.Source{{Platform: "twitch", ChannelID: "somestreamer", ChannelName: "SomeStreamer"}}
+}
+
+// A moderator who has consented sees exactly the intersection of their own scopes and the
+// streamer's grant — never more.
+func TestCapabilities_ModeratorSeesDelegatedIntersection(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete", "timeout"}, []string{"twitch"}),
+		sources:   twitchSource(),
+		modScopes: map[string][]string{"twitch": twitchModScopes},
+	}
+
+	caps := modCaps(t, auth)
+
+	assert.Equal(t, repository.RoleModerator, caps.Role)
+	assert.False(t, caps.IsOwner, "a moderator is not an owner and the UI branches on this")
+	assert.True(t, caps.CanModerate)
+	require.Len(t, caps.Sources, 1)
+	assert.True(t, caps.Sources[0].Moderatable)
+	assert.ElementsMatch(t,
+		[]models.Action{models.ActionDelete, models.ActionTimeout}, caps.Sources[0].Actions,
+		"the moderator's own scopes allow ban/unban too, but the streamer did not delegate them")
+}
+
+// The owner's broadcaster scopes must never reach a moderator's answer. If they did, a moderator
+// would be shown controls backed by the streamer's credential — the exact fallback ADR-0048 exists
+// to forbid.
+func TestCapabilities_ModeratorDoesNotInheritOwnerScopes(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:  moderatorAccess([]string{"delete", "timeout", "ban", "unban"}, []string{"twitch"}),
+		sources: twitchSource(),
+		// No moderator credential at all, while the owner (fakeScopes) holds everything.
+		modScopes: map[string][]string{},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].Moderatable)
+	assert.Equal(t, models.ReasonNeedsConsent, caps.Sources[0].Reason)
+	assert.Empty(t, caps.Sources[0].Actions)
+}
+
+// A platform the streamer did not enable reads as "ask the streamer", not "connect your account":
+// only the streamer can clear it, so pointing the moderator at a consent screen would be a dead
+// end.
+func TestCapabilities_PlatformNotDelegatedReadsAsNotDelegated(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete"}, []string{"kick"}),
+		sources:   twitchSource(),
+		modScopes: map[string][]string{"twitch": twitchModScopes},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].Moderatable)
+	assert.Equal(t, models.ReasonNotDelegated, caps.Sources[0].Reason)
+}
+
+// Delegating only actions the platform cannot perform is the same dead end as not delegating the
+// platform at all, and must read the same way.
+func TestCapabilities_ActionsUnsupportedByPlatformReadAsNotDelegated(t *testing.T) {
+	auth := &fakeAuthorizer{
+		// Kick has no single-message delete, so a delete-only grant delegates nothing there.
+		access:    moderatorAccess([]string{"delete"}, []string{"kick"}),
+		sources:   []repository.Source{{Platform: "kick", ChannelID: "kickstreamer", ChannelName: "KickStreamer"}},
+		modScopes: map[string][]string{"kick": {models.ScopeKickModeration}},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.Equal(t, models.ReasonNotDelegated, caps.Sources[0].Reason)
+}
+
+// Consent granted for a narrower set than the streamer delegated still reads as "connect": the
+// moderator may have consented for another streamer who delegated less, and re-running consent is
+// the fix they can actually perform.
+func TestCapabilities_ConsentNarrowerThanTheGrantReadsAsNeedsConsent(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:  moderatorAccess([]string{"ban", "unban"}, []string{"twitch"}),
+		sources: twitchSource(),
+		// Delete-only consent: nothing here overlaps ban/unban.
+		modScopes: map[string][]string{"twitch": {models.ScopeTwitchManageMessages}},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].Moderatable)
+	assert.Equal(t, models.ReasonNeedsConsent, caps.Sources[0].Reason)
+}
+
+// Discord has no per-user moderation API, so there is no consent a moderator could grant. Saying
+// "connect your account" would offer a button that goes nowhere.
+func TestCapabilities_DiscordReadsAsNeedsLinkNotConsent(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete"}, []string{"discord"}),
+		sources:   []repository.Source{{Platform: "discord", ChannelID: "123", ChannelName: "#general"}},
+		modScopes: map[string][]string{},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.Equal(t, models.ReasonNeedsDiscordLink, caps.Sources[0].Reason)
+}
+
+// Chat-send is owner-only in v1. The send bar reads can_send straight off the payload, so a true
+// here would hand a volunteer the streamer's voice.
+func TestCapabilities_ModeratorNeverReportsCanSend(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete"}, []string{"twitch"}),
+		sources:   twitchSource(),
+		modScopes: map[string][]string{"twitch": twitchModScopes},
+	}
+	h := modCapsHandler(t, auth)
+	// A send checker that says yes to everything: only the role may stop it.
+	h.SetSendChecker(alwaysSendable{})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodGet, capsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &caps))
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].CanSend, "moderators get no chat-send in v1")
+}
+
+type alwaysSendable struct{}
+
+func (alwaysSendable) CanSend(_ context.Context, _, _, _ string) (bool, error) { return true, nil }
+
+// A scope-lookup failure must not advertise a capability the action path would refuse.
+func TestCapabilities_ModeratorScopeLookupErrorFailsClosed(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:       moderatorAccess([]string{"delete"}, []string{"twitch"}),
+		sources:      twitchSource(),
+		modScopesErr: errors.New("database unavailable"),
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].Moderatable)
+	assert.Equal(t, models.ReasonNeedsConsent, caps.Sources[0].Reason)
+}
+
+// The gate is asked about the OWNER here exactly as it is on the action path, so a moderator with
+// no entitlement of their own still gets controls on a premium streamer's overlay.
+func TestCapabilities_GateIsKeyedOnTheOwner(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete"}, []string{"twitch"}),
+		sources:   twitchSource(),
+		modScopes: map[string][]string{"twitch": twitchModScopes},
+	}
+	h := modCapsHandler(t, auth)
+	h.SetFeatureGate(gateFor{ownerID: true}) // the moderator is deliberately absent
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodGet, capsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &caps))
+	assert.True(t, caps.Enabled)
+	assert.True(t, caps.CanModerate)
+}
+
+// Closing `delegated_moderation` must close the moderator's controls too, or the capability
+// payload would keep advertising actions the action path now refuses.
+func TestCapabilities_DelegationGateClosedReportsCannotModerate(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:    moderatorAccess([]string{"delete"}, []string{"twitch"}),
+		sources:   twitchSource(),
+		modScopes: map[string][]string{"twitch": twitchModScopes},
+	}
+	h := modCapsHandler(t, auth)
+	h.SetFeatureGate(splitGate{moderation: map[string]bool{ownerID: true}})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodGet, capsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &caps))
+	assert.False(t, caps.Enabled)
+	assert.False(t, caps.CanModerate)
+}
+
+// An overlay that does not exist and one the caller holds no role on must produce the identical
+// body, or capabilities becomes the overlay-existence oracle the action path refuses to be.
+func TestCapabilities_UnknownOverlayMatchesNoRole(t *testing.T) {
+	unknown := &fakeAuthorizer{accessErr: repository.ErrOverlayNotFound, sources: twitchSource()}
+	respUnknown := do(newTestRouter(modCapsHandler(t, unknown), modUserID, ""), http.MethodGet, capsPath, "")
+
+	stranger := &fakeAuthorizer{
+		access:  &repository.OverlayAccess{OwnerUserID: ownerID, Role: repository.RoleNone},
+		sources: twitchSource(),
+	}
+	respStranger := do(newTestRouter(modCapsHandler(t, stranger), modUserID, ""), http.MethodGet, capsPath, "")
+
+	assert.Equal(t, respStranger.Code, respUnknown.Code)
+	assert.JSONEq(t, respStranger.Body.String(), respUnknown.Body.String())
+
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(respStranger.Body.Bytes(), &caps))
+	assert.Equal(t, repository.RoleNone, caps.Role)
+	assert.False(t, caps.CanModerate)
+	assert.Empty(t, caps.Sources, "a caller with no role must not learn the overlay's sources")
+}

--- a/services/moderation-service/handler/delegations.go
+++ b/services/moderation-service/handler/delegations.go
@@ -1,0 +1,111 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// HandleListDelegations reports the channels the caller may moderate for someone else.
+//
+// This is the moderator's only route into an overlay they do not own: GET /api/v1/overlays is
+// owner-filtered and has no shared-with-me listing, so without this endpoint an accepted grant is
+// unreachable (ADR-0048).
+//
+// Deliberately ungated. A moderator must be able to see — and therefore understand — a delegation
+// even when the streamer's plan has lapsed; the entitlement shows up as `available: false` on the
+// row, with the streamer's plan named as the cause, never as an upgrade prompt aimed at a
+// volunteer who cannot buy it.
+func (h *GrantHandler) HandleListDelegations(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing user context"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	delegations, err := h.grants.ListDelegationsFor(ctx, userID)
+	if err != nil {
+		h.internalError(c, "list delegations failed", err)
+		return
+	}
+
+	// One gate lookup per distinct owner, not per row: a volunteer often moderates several
+	// overlays for the same streamer, and the answer cannot differ between them.
+	availability := make(map[string]bool, len(delegations))
+	out := models.DelegationList{Delegations: make([]models.Delegation, 0, len(delegations))}
+	for _, d := range delegations {
+		available, cached := availability[d.OwnerUserID]
+		if !cached {
+			available = h.delegationAvailable(ctx, d.OwnerUserID)
+			availability[d.OwnerUserID] = available
+		}
+		out.Delegations = append(out.Delegations, toDelegation(d, available))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// delegationAvailable reports whether the owner's plan currently has delegated moderation open.
+//
+// Fails closed: a gate-lookup error reports unavailable rather than promising a capability the
+// action path would then refuse. The action path asks the same question, so the two agree.
+func (h *GrantHandler) delegationAvailable(ctx context.Context, ownerUserID string) bool {
+	enabled, err := h.gate.DelegationEnabled(ctx, ownerUserID)
+	if err != nil {
+		h.logger.Warn("delegation gate check failed; reporting unavailable",
+			zap.String("owner_user_id", ownerUserID), zap.Error(err))
+		return false
+	}
+	return enabled
+}
+
+// toDelegation maps a repository row to the moderator-facing DTO.
+//
+// The owner's user id is dropped on the way out: the moderator needs the streamer's name, not an
+// identifier that would let them address the streamer's account elsewhere in the API.
+func toDelegation(d repository.Delegation, available bool) models.Delegation {
+	out := models.Delegation{
+		GrantID:          d.GrantID,
+		OverlayID:        d.OverlayID,
+		OverlayName:      d.OverlayName,
+		OwnerDisplayName: d.OwnerDisplayName,
+		Status:           d.Status,
+		Actions:          d.Actions,
+		Platforms:        make([]models.GrantPlatformLeg, 0, len(d.Platforms)),
+		Available:        available,
+		AcceptedAt:       d.AcceptedAt,
+		LastActionAt:     d.LastActionAt,
+	}
+	if out.Actions == nil {
+		out.Actions = []string{}
+	}
+	for _, leg := range d.Platforms {
+		out.Platforms = append(out.Platforms, models.GrantPlatformLeg{
+			Platform:     leg.Platform,
+			Enabled:      leg.Enabled,
+			Verification: leg.Verification,
+			VerifiedAt:   leg.VerifiedAt,
+		})
+	}
+	return out
+}

--- a/services/moderation-service/handler/delegations_test.go
+++ b/services/moderation-service/handler/delegations_test.go
@@ -1,0 +1,243 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// "Channels I moderate" (ADR-0048).
+//
+// GET /api/v1/overlays is owner-filtered, so this listing is the ONLY route an accepted moderator
+// has into an overlay they do not own. Everything here follows from that: it is keyed on the
+// caller alone, it is never feature-gated, and it must keep listing a channel whose grant has been
+// suspended rather than letting it silently vanish.
+
+const delegationsPath = "/api/v1/moderation/delegations"
+
+// delegationHandlerFor builds a grant handler whose store returns the given delegations.
+func delegationHandlerFor(t *testing.T, store *fakeGrantStore, gate FeatureGate) *GrantHandler {
+	t.Helper()
+	h := NewGrantHandler(&fakeAuthorizer{}, store, zap.NewNop())
+	if gate != nil {
+		h.SetFeatureGate(gate)
+	}
+	return h
+}
+
+func listDelegations(t *testing.T, store *fakeGrantStore, gate FeatureGate) models.DelegationList {
+	t.Helper()
+	h := delegationHandlerFor(t, store, gate)
+	resp := do(grantRouter(h, modUserID), http.MethodGet, delegationsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	var out models.DelegationList
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &out))
+	return out
+}
+
+func sampleDelegation() repository.Delegation {
+	accepted := time.Date(2026, 8, 7, 10, 0, 0, 0, time.UTC)
+	return repository.Delegation{
+		GrantID:          "grant-1",
+		OverlayID:        overlayID,
+		OverlayName:      "Main overlay",
+		OwnerUserID:      ownerID,
+		OwnerDisplayName: "SomeStreamer",
+		Status:           models.GrantStatusActive,
+		Actions:          []string{"delete", "timeout"},
+		AcceptedAt:       &accepted,
+		Platforms: []repository.GrantLeg{
+			{Platform: "twitch", Enabled: true, Verification: "unverified"},
+		},
+	}
+}
+
+// The moderator gets the overlay id — without it the grant is unreachable — plus enough context to
+// know whose channel it is.
+func TestDelegations_ListsTheOverlaysAModeratorCanReach(t *testing.T) {
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation()}}
+
+	out := listDelegations(t, store, nil)
+
+	require.Len(t, out.Delegations, 1)
+	d := out.Delegations[0]
+	assert.Equal(t, overlayID, d.OverlayID, "without the overlay id the grant cannot be reached")
+	assert.Equal(t, "Main overlay", d.OverlayName)
+	assert.Equal(t, "SomeStreamer", d.OwnerDisplayName)
+	assert.Equal(t, []string{"delete", "timeout"}, d.Actions)
+	require.Len(t, d.Platforms, 1)
+	assert.Equal(t, "twitch", d.Platforms[0].Platform)
+	assert.True(t, d.Available)
+}
+
+// The listing is keyed on the caller's own id and nothing else: there is no path by which one
+// moderator could enumerate another's channels.
+func TestDelegations_KeyedOnTheCallerAlone(t *testing.T) {
+	store := &fakeGrantStore{}
+
+	listDelegations(t, store, nil)
+
+	assert.Equal(t, []string{modUserID}, store.listedFor)
+}
+
+// An unauthenticated caller has no delegations to look up.
+func TestDelegations_RequiresAUser(t *testing.T) {
+	h := delegationHandlerFor(t, &fakeGrantStore{}, nil)
+
+	resp := do(grantRouter(h, ""), http.MethodGet, delegationsPath, "")
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+}
+
+// An empty list is a list, not a null: the page renders "no channels yet" rather than crashing on
+// a missing array.
+func TestDelegations_EmptyListSerializesAsAnArray(t *testing.T) {
+	h := delegationHandlerFor(t, &fakeGrantStore{}, nil)
+
+	resp := do(grantRouter(h, modUserID), http.MethodGet, delegationsPath, "")
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(t, `{"delegations":[]}`, resp.Body.String())
+}
+
+// The streamer's plan lapsing must not make the channel disappear. It is reported as unavailable,
+// so the moderator can see why they cannot act instead of assuming they were removed.
+func TestDelegations_OwnerOutsideTheCohortIsListedAsUnavailable(t *testing.T) {
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation()}}
+
+	out := listDelegations(t, store, delegationGateFor{}) // nobody is entitled
+
+	require.Len(t, out.Delegations, 1)
+	assert.False(t, out.Delegations[0].Available)
+	assert.Equal(t, overlayID, out.Delegations[0].OverlayID,
+		"an unavailable delegation is still listed — vanishing reads as revocation")
+}
+
+// Availability is the OWNER's entitlement. A moderator's own premium buys them nothing here, and a
+// premium streamer's moderators are available without any of their own.
+func TestDelegations_AvailabilityIsKeyedOnTheOwner(t *testing.T) {
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation()}}
+
+	out := listDelegations(t, store, delegationGateFor{ownerID: true})
+	require.Len(t, out.Delegations, 1)
+	assert.True(t, out.Delegations[0].Available, "a moderator needs no entitlement of their own")
+
+	out = listDelegations(t, store, delegationGateFor{modUserID: true})
+	require.Len(t, out.Delegations, 1)
+	assert.False(t, out.Delegations[0].Available,
+		"the moderator's own premium must not substitute for the streamer's")
+}
+
+// A gate lookup that fails must not promise a capability the action path would then refuse.
+func TestDelegations_GateErrorReportsUnavailable(t *testing.T) {
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation()}}
+
+	out := listDelegations(t, store, erroringGate{})
+
+	require.Len(t, out.Delegations, 1)
+	assert.False(t, out.Delegations[0].Available)
+}
+
+type erroringGate struct{}
+
+func (erroringGate) ModerationEnabled(_ context.Context, _ string) (bool, error) {
+	return false, errors.New("database unavailable")
+}
+
+func (erroringGate) DelegationEnabled(_ context.Context, _ string) (bool, error) {
+	return false, errors.New("database unavailable")
+}
+
+// One gate lookup per distinct owner, not per row. A volunteer moderating several overlays for the
+// same streamer must not turn one page load into one premium query per overlay.
+func TestDelegations_GateIsAskedOncePerOwner(t *testing.T) {
+	second := sampleDelegation()
+	second.GrantID = "grant-2"
+	second.OverlayID = "aaaaaaaa-2222-2222-2222-222222222222"
+	second.OverlayName = "Second overlay"
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation(), second}}
+	gate := &countingGate{enabled: true}
+
+	h := delegationHandlerFor(t, store, gate)
+	resp := do(grantRouter(h, modUserID), http.MethodGet, delegationsPath, "")
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, 1, gate.calls, "both overlays belong to the same streamer")
+}
+
+type countingGate struct {
+	enabled bool
+	calls   int
+}
+
+func (g *countingGate) ModerationEnabled(_ context.Context, _ string) (bool, error) {
+	return g.enabled, nil
+}
+
+func (g *countingGate) DelegationEnabled(_ context.Context, _ string) (bool, error) {
+	g.calls++
+	return g.enabled, nil
+}
+
+// A suspended grant is listed with its status. Hiding it would look identical to revocation, and
+// the moderator would have nothing to ask the streamer about.
+func TestDelegations_SuspendedGrantIsListedWithItsStatus(t *testing.T) {
+	suspended := sampleDelegation()
+	suspended.Status = models.GrantStatusSuspended
+	store := &fakeGrantStore{delegations: []repository.Delegation{suspended}}
+
+	out := listDelegations(t, store, nil)
+
+	require.Len(t, out.Delegations, 1)
+	assert.Equal(t, models.GrantStatusSuspended, out.Delegations[0].Status)
+}
+
+// The moderator learns who delegated to them, not who else did — the payload carries the owner's
+// display name and no user ids at all.
+func TestDelegations_DoesNotLeakUserIdentifiers(t *testing.T) {
+	store := &fakeGrantStore{delegations: []repository.Delegation{sampleDelegation()}}
+	h := delegationHandlerFor(t, store, nil)
+
+	resp := do(grantRouter(h, modUserID), http.MethodGet, delegationsPath, "")
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.NotContains(t, resp.Body.String(), ownerID,
+		"the owner's user id is not the moderator's business")
+}
+
+// A read failure is a 500, not an empty list: silently reporting "you moderate nothing" would send
+// the moderator to ask the streamer about a revocation that never happened.
+func TestDelegations_ReadFailureIsAnError(t *testing.T) {
+	store := &fakeGrantStore{delegateErr: errors.New("database unavailable")}
+	h := delegationHandlerFor(t, store, nil)
+
+	resp := do(grantRouter(h, modUserID), http.MethodGet, delegationsPath, "")
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+}

--- a/services/moderation-service/handler/grants.go
+++ b/services/moderation-service/handler/grants.go
@@ -42,6 +42,9 @@ type GrantStore interface {
 	RevokeAllGrants(ctx context.Context, overlayID, revokedBy string) (int, error)
 	PreviewInvite(ctx context.Context, tokenHash []byte) (repository.InviteDetails, error)
 	AcceptInvite(ctx context.Context, tokenHash []byte, userID string) (repository.InviteDetails, error)
+	// ListDelegationsFor is the mirror of ListGrants: the overlays this user moderates for
+	// someone else, which is the only way an accepted moderator can find them at all.
+	ListDelegationsFor(ctx context.Context, moderatorUserID string) ([]repository.Delegation, error)
 }
 
 // AccessResolver answers who the caller is on an overlay. The grant endpoints need only the role,

--- a/services/moderation-service/handler/grants_test.go
+++ b/services/moderation-service/handler/grants_test.go
@@ -65,6 +65,11 @@ type fakeGrantStore struct {
 	acceptErr   error
 	acceptedFor []string
 	seenHashes  [][]byte
+	delegations []repository.Delegation
+	delegateErr error
+	// listedFor records whose delegations were asked for, so a test can prove the listing is
+	// keyed on the caller and nothing else.
+	listedFor []string
 }
 
 func (f *fakeGrantStore) CreateInvite(_ context.Context, p repository.InviteParams) (repository.Grant, error) {
@@ -116,6 +121,11 @@ func (f *fakeGrantStore) AcceptInvite(_ context.Context, hash []byte, userID str
 	return f.accepted, nil
 }
 
+func (f *fakeGrantStore) ListDelegationsFor(_ context.Context, moderatorUserID string) ([]repository.Delegation, error) {
+	f.listedFor = append(f.listedFor, moderatorUserID)
+	return f.delegations, f.delegateErr
+}
+
 // delegationGateFor reports delegation enabled only for the listed user ids, so a test can prove
 // the gate is asked about the overlay OWNER.
 type delegationGateFor map[string]bool
@@ -163,6 +173,7 @@ func grantRouter(h *GrantHandler, userID string, roles ...string) *gin.Engine {
 	api.DELETE("/overlays/:id/moderators", h.HandleRevokeAll)
 	api.POST("/invites/preview", h.HandlePreviewInvite)
 	api.POST("/invites/accept", h.HandleAcceptInvite)
+	api.GET("/delegations", h.HandleListDelegations)
 	return r
 }
 

--- a/services/moderation-service/handler/moderation.go
+++ b/services/moderation-service/handler/moderation.go
@@ -51,6 +51,10 @@ type Authorizer interface {
 	ResolveOverlayAccess(ctx context.Context, overlayID, callerID string) (repository.OverlayAccess, error)
 	IsModeratableSource(ctx context.Context, overlayID, platform, channelID string) (bool, error)
 	ListModeratableSources(ctx context.Context, overlayID string) ([]repository.Source, error)
+	// ModeratorGrantedScopes reads the scopes on a delegated moderator's OWN credential for a
+	// platform, and whether one exists at all. Never the token itself: the capability answer
+	// needs no decryption.
+	ModeratorGrantedScopes(ctx context.Context, userID, platform string) ([]string, bool, error)
 	// TouchGrantActivity records that a delegated grant was just used, which is what the
 	// dormancy rule reads. A no-op for owner actions, which carry no grant.
 	TouchGrantActivity(ctx context.Context, grantID string) error
@@ -271,7 +275,24 @@ func (h *Handler) HandleUnban(c *gin.Context) {
 	}, nil)
 }
 
+// noRoleCapabilities is the answer for a caller who may not moderate this overlay.
+//
+// The SAME body is returned for "you hold no role here" and "this overlay does not exist", so the
+// endpoint cannot be used to test overlay ids — the action path already takes that care and the
+// capability path must not undo it.
+func noRoleCapabilities() models.Capabilities {
+	return models.Capabilities{
+		Role:    repository.RoleNone,
+		Sources: []models.SourceCapability{},
+	}
+}
+
 // HandleCapabilities reports, per source, which moderation actions the caller can use.
+//
+// Role-aware since ADR-0048: an overlay owner and a delegated moderator both get real source
+// detail, computed from different authorities. The owner's comes from the scopes on their
+// broadcaster credential; the moderator's from what the streamer delegated intersected with the
+// scopes on the moderator's OWN credential.
 func (h *Handler) HandleCapabilities(c *gin.Context) {
 	cl := newCaller(c)
 	if cl.userID == "" {
@@ -279,21 +300,27 @@ func (h *Handler) HandleCapabilities(c *gin.Context) {
 		return
 	}
 	ctx := c.Request.Context()
-	owns, err := h.repo.VerifyOverlayOwnership(ctx, cl.overlayID, cl.userID)
-	if err != nil {
-		h.logger.Error("capabilities: ownership check failed", zap.Error(err))
+
+	access, err := h.repo.ResolveOverlayAccess(ctx, cl.overlayID, cl.userID)
+	switch {
+	case errors.Is(err, repository.ErrOverlayNotFound):
+		c.JSON(http.StatusOK, noRoleCapabilities())
+		return
+	case err != nil:
+		h.logger.Error("capabilities: access resolution failed", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
 		return
 	}
-	// Non-owners get a read-only view: no source detail, no controls.
-	if !owns {
-		c.JSON(http.StatusOK, models.Capabilities{IsOwner: false, Sources: []models.SourceCapability{}})
+	if !access.Authorized() {
+		c.JSON(http.StatusOK, noRoleCapabilities())
 		return
 	}
 
-	// Feature-gate cohort check (ADR-0008). A gate-lookup error fails closed so a
-	// transient DB hiccup never opens the feature to a non-cohort user.
-	enabled, err := h.gate.ModerationEnabled(ctx, cl.userID)
+	// Feature-gate cohort check (ADR-0008), keyed on the OVERLAY OWNER exactly as authorize()
+	// keys it — a premium streamer's moderators moderate for free, and a moderator must never be
+	// told to upgrade a plan that is not theirs. A gate-lookup error fails closed so a transient
+	// DB hiccup never opens the feature to a non-cohort user.
+	enabled, err := h.gateOpenFor(ctx, access)
 	if err != nil {
 		h.logger.Warn("capabilities: feature-gate check failed; treating moderation as disabled", zap.Error(err))
 		enabled = false
@@ -306,11 +333,97 @@ func (h *Handler) HandleCapabilities(c *gin.Context) {
 		return
 	}
 
-	caps := models.Capabilities{IsOwner: true, Enabled: enabled, Sources: make([]models.SourceCapability, 0, len(sources))}
+	caps := models.Capabilities{
+		Role:        access.Role,
+		IsOwner:     access.IsOwner(),
+		Enabled:     enabled,
+		CanModerate: enabled,
+		Sources:     make([]models.SourceCapability, 0, len(sources)),
+	}
+	if !access.IsOwner() {
+		// Only a grant has an action set; an owner's authority is not enumerable this way.
+		caps.DelegatedActions = models.IntersectActions(models.DelegatableActions, access.Actions)
+	}
 	for _, s := range sources {
-		caps.Sources = append(caps.Sources, h.capabilityFor(ctx, cl.userID, s))
+		if access.IsOwner() {
+			caps.Sources = append(caps.Sources, h.capabilityFor(ctx, cl.userID, s))
+			continue
+		}
+		caps.Sources = append(caps.Sources, h.delegatedCapabilityFor(ctx, cl.userID, access, s))
 	}
 	c.JSON(http.StatusOK, caps)
+}
+
+// gateOpenFor answers whether moderation is open for this overlay, keyed on the owner.
+//
+// A delegated moderator needs BOTH keys: closing `delegated_moderation` must stop delegated
+// actions without touching the streamer's own write-path, which is the entire point of it being a
+// second key (ADR-0048).
+func (h *Handler) gateOpenFor(ctx context.Context, access repository.OverlayAccess) (bool, error) {
+	if access.IsOwner() {
+		return h.gate.ModerationEnabled(ctx, access.OwnerUserID)
+	}
+	return h.gate.DelegationEnabled(ctx, access.OwnerUserID)
+}
+
+// delegatedCapabilityFor computes one source's capability for a DELEGATED MODERATOR.
+//
+// Three fail-closed filters, in the order that produces the most actionable answer: what the
+// streamer delegated (only they can widen it), then whether the moderator has connected their own
+// account for that platform (only the moderator can clear that). Chat-send is never reported —
+// moderators get no send in v1, and it is a distinct, higher-trust capability.
+func (h *Handler) delegatedCapabilityFor(
+	ctx context.Context, userID string, access repository.OverlayAccess, s repository.Source,
+) models.SourceCapability {
+	sc := models.SourceCapability{
+		Platform:    s.Platform,
+		ChannelID:   s.ChannelID,
+		ChannelName: s.ChannelName,
+		Actions:     []models.Action{},
+	}
+	if !models.PlatformSupported(s.Platform) {
+		sc.Reason = models.ReasonUnsupportedPlatform
+		return sc
+	}
+	// The grant's platform leg and its action set are separate grants of authority, and a source
+	// the streamer did not hand over is indistinguishable from one where they delegated only
+	// actions this platform cannot perform: both mean "ask the streamer", not "connect your
+	// account".
+	delegated := models.IntersectActions(models.PlatformActions[s.Platform], access.Actions)
+	if !access.MayUsePlatform(s.Platform) || len(delegated) == 0 {
+		sc.Reason = models.ReasonNotDelegated
+		return sc
+	}
+	// Discord's authority is the shared bot plus a link to the moderator's Discord account, not an
+	// OAuth scope they can grant. No such link exists yet, so there is no consent flow to send
+	// them to and the copy must say so rather than offering a dead button.
+	if s.Platform == "discord" {
+		sc.Reason = models.ReasonNeedsDiscordLink
+		return sc
+	}
+
+	scopes, ok, err := h.repo.ModeratorGrantedScopes(ctx, userID, s.Platform)
+	if err != nil {
+		h.logger.Warn("capabilities: moderator scope lookup failed; treating as not connected",
+			zap.String("platform", s.Platform), zap.Error(err))
+		ok = false
+	}
+	if !ok {
+		sc.Reason = models.ReasonNeedsConsent
+		return sc
+	}
+	// The scope→action mapping is already per-platform, so the delegated action set is the only
+	// narrowing left. An empty result means they consented for a narrower set than this streamer
+	// delegated — they may have connected for someone who delegated less — and re-running consent
+	// is exactly the fix, so it reads as "connect" rather than as a refusal.
+	usable := models.IntersectActions(models.ActionsForModeratorScopes(s.Platform, scopes), access.Actions)
+	if len(usable) == 0 {
+		sc.Reason = models.ReasonNeedsConsent
+		return sc
+	}
+	sc.Moderatable = true
+	sc.Actions = usable
+	return sc
 }
 
 // capabilityFor computes one source's capability: unsupported platforms (TikTok) are
@@ -386,8 +499,9 @@ func (h *Handler) authorize(c *gin.Context, cl *caller, platform, channelID stri
 	// moderators moderate for free. Enforced here rather than in middleware so the denial is
 	// audited like every other denial in this service, and so the copy can differ by role —
 	// a delegated moderator must never be pointed at an upgrade page for a plan that is not
-	// theirs to buy.
-	enabled, err := h.gate.ModerationEnabled(ctx, access.OwnerUserID)
+	// theirs to buy. A moderator additionally needs the `delegated_moderation` key, which is what
+	// makes that key a working rollback lever rather than a label on the invite button.
+	enabled, err := h.gateOpenFor(ctx, access)
 	if err != nil {
 		h.logger.Error("moderation gate check failed", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
@@ -406,6 +520,14 @@ func (h *Handler) authorize(c *gin.Context, cl *caller, platform, channelID stri
 	// anything the platform supports.
 	if !access.MayPerform(string(action)) {
 		h.deny(c, *cl, platform, channelID, action, http.StatusForbidden, "this action was not delegated to you")
+		return false
+	}
+
+	// ...and to the platforms whose leg the owner enabled. A separate grant of authority from the
+	// action set: without this check, delegating Twitch would silently delegate every other source
+	// on the overlay, since the action names are shared across platforms.
+	if !access.MayUsePlatform(platform) {
+		h.deny(c, *cl, platform, channelID, action, http.StatusForbidden, "this platform was not delegated to you")
 		return false
 	}
 

--- a/services/moderation-service/handler/moderation_delegation_test.go
+++ b/services/moderation-service/handler/moderation_delegation_test.go
@@ -73,6 +73,7 @@ func TestDelete_DelegatedModeratorIsAuthorized(t *testing.T) {
 		Role:           repository.RoleModerator,
 		GrantID:        "grant-1",
 		Actions:        []string{"delete", "timeout"},
+		Platforms:      []string{"twitch"},
 	}, nil)
 
 	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
@@ -91,7 +92,7 @@ func TestDelete_DelegatedActionStampsGrantActivity(t *testing.T) {
 	auth := &fakeAuthorizer{
 		access: &repository.OverlayAccess{
 			OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleModerator,
-			GrantID: "grant-1", Actions: []string{"delete"},
+			GrantID: "grant-1", Actions: []string{"delete"}, Platforms: []string{"twitch"},
 		},
 		isSource: map[string]bool{"twitch|somestreamer": true},
 	}
@@ -121,7 +122,7 @@ func TestDelete_AStampFailureDoesNotFailTheAction(t *testing.T) {
 	auth := &fakeAuthorizer{
 		access: &repository.OverlayAccess{
 			OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleModerator,
-			GrantID: "grant-1", Actions: []string{"delete"},
+			GrantID: "grant-1", Actions: []string{"delete"}, Platforms: []string{"twitch"},
 		},
 		isSource: map[string]bool{"twitch|somestreamer": true},
 		touchErr: errors.New("database unavailable"),
@@ -140,6 +141,7 @@ func TestDelete_ActionNotDelegatedIsRefused(t *testing.T) {
 		OwnerIsPremium: true,
 		Role:           repository.RoleModerator,
 		Actions:        []string{"timeout"}, // delete withheld
+		Platforms:      []string{"twitch"},
 	}, nil)
 
 	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
@@ -150,6 +152,103 @@ func TestDelete_ActionNotDelegatedIsRefused(t *testing.T) {
 	assert.Equal(t, audit.OutcomeDenied, rec.entries[0].Outcome)
 }
 
+// The per-platform leg is a separate grant of authority from the action set. Without this check,
+// delegating Twitch would silently delegate every other source on the overlay, since the action
+// names are shared across platforms.
+func TestDelete_PlatformNotDelegatedIsRefused(t *testing.T) {
+	h, emitter, rec := delegationHandler(t, repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleModerator,
+		Actions:        []string{"delete"},
+		Platforms:      []string{"kick"}, // Twitch deliberately withheld
+	}, nil)
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	assert.Empty(t, emitter.published)
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, audit.OutcomeDenied, rec.entries[0].Outcome)
+}
+
+// A grant with no enabled leg at all delegates nothing: absence IS disablement (migration 080),
+// so it must fail closed rather than defaulting to every platform the overlay carries.
+func TestDelete_GrantWithNoEnabledLegDelegatesNothing(t *testing.T) {
+	h, emitter, _ := delegationHandler(t, repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleModerator,
+		Actions:        []string{"delete"},
+	}, nil)
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	assert.Empty(t, emitter.published)
+}
+
+// An owner is not narrowed by legs — they hold no grant, so there is nothing to narrow.
+func TestDelete_OwnerIsNotNarrowedByPlatformLegs(t *testing.T) {
+	h, emitter, _ := delegationHandler(t, repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleOwner,
+	}, nil)
+
+	resp := do(newTestRouter(h, ownerID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.NotEmpty(t, emitter.published)
+}
+
+// Closing `delegated_moderation` must stop delegated actions while leaving the streamer's own
+// write-path alone — otherwise the second gate key is a label on the invite button rather than a
+// rollback lever.
+func TestDelete_ClosingTheDelegationGateStopsModeratorsOnly(t *testing.T) {
+	access := repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleModerator,
+		Actions:        []string{"delete"},
+		Platforms:      []string{"twitch"},
+	}
+	// Base moderation open for the owner, delegation closed for everyone.
+	gate := splitGate{moderation: map[string]bool{ownerID: true}}
+
+	hMod, emitter, _ := delegationHandler(t, access, gate)
+	respMod := do(newTestRouter(hMod, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+	assert.Equal(t, http.StatusForbidden, respMod.Code)
+	assert.Empty(t, emitter.published)
+
+	owner := access
+	owner.Role = repository.RoleOwner
+	hOwner, ownerEmitter, _ := delegationHandler(t, owner, gate)
+	respOwner := do(newTestRouter(hOwner, ownerID, ""), http.MethodPost, deletePath(), deleteBody)
+	assert.Equal(t, http.StatusOK, respOwner.Code,
+		"rolling delegation back must not take the streamer's own moderation away")
+	assert.NotEmpty(t, ownerEmitter.published)
+}
+
+// splitGate answers the two gate keys independently, which is what tells a delegation rollback
+// apart from a moderation rollback.
+type splitGate struct {
+	moderation map[string]bool
+	delegation map[string]bool
+}
+
+func (g splitGate) ModerationEnabled(_ context.Context, userID string) (bool, error) {
+	return g.moderation[userID], nil
+}
+
+func (g splitGate) DelegationEnabled(ctx context.Context, userID string) (bool, error) {
+	enabled, err := g.ModerationEnabled(ctx, userID)
+	if err != nil || !enabled {
+		return false, err
+	}
+	return g.delegation[userID], nil
+}
+
 // The premium gate must be asked about the OVERLAY OWNER. A moderator with no entitlement of
 // their own moderates freely on a premium streamer's overlay.
 func TestDelete_GateIsKeyedOnTheOwnerNotTheCaller(t *testing.T) {
@@ -158,6 +257,7 @@ func TestDelete_GateIsKeyedOnTheOwnerNotTheCaller(t *testing.T) {
 		OwnerIsPremium: true,
 		Role:           repository.RoleModerator,
 		Actions:        []string{"delete"},
+		Platforms:      []string{"twitch"},
 	}, gateFor{ownerID: true}) // the moderator is deliberately absent
 
 	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
@@ -174,6 +274,7 @@ func TestDelete_ModeratorCannotSubstituteTheirOwnEntitlement(t *testing.T) {
 		OwnerIsPremium: false,
 		Role:           repository.RoleModerator,
 		Actions:        []string{"delete"},
+		Platforms:      []string{"twitch"},
 	}, gateFor{modUserID: true}) // only the moderator is "premium"
 
 	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
@@ -256,6 +357,7 @@ func TestDelete_DelegatedModeratorCannotReachANonSource(t *testing.T) {
 			OwnerIsPremium: true,
 			Role:           repository.RoleModerator,
 			Actions:        []string{"delete"},
+			Platforms:      []string{"twitch"},
 		},
 		isSource: map[string]bool{}, // nothing is a moderatable source on this overlay
 	}

--- a/services/moderation-service/handler/moderation_test.go
+++ b/services/moderation-service/handler/moderation_test.go
@@ -54,6 +54,10 @@ type fakeAuthorizer struct {
 	// dormancy rule later reads.
 	touchedGrants []string
 	touchErr      error
+	// modScopes are the scopes on the delegated moderator's OWN credential, keyed by platform.
+	// An absent platform means they have not consented for it at all.
+	modScopes    map[string][]string
+	modScopesErr error
 }
 
 func (f *fakeAuthorizer) VerifyOverlayOwnership(context.Context, string, string) (bool, error) {
@@ -91,6 +95,13 @@ func (f *fakeAuthorizer) ListModeratableSources(context.Context, string) ([]repo
 func (f *fakeAuthorizer) TouchGrantActivity(_ context.Context, grantID string) error {
 	f.touchedGrants = append(f.touchedGrants, grantID)
 	return f.touchErr
+}
+func (f *fakeAuthorizer) ModeratorGrantedScopes(_ context.Context, _, platform string) ([]string, bool, error) {
+	if f.modScopesErr != nil {
+		return nil, false, f.modScopesErr
+	}
+	scopes, ok := f.modScopes[platform]
+	return scopes, ok, nil
 }
 
 type fakeEmitter struct{ published []*mpmodels.RawChatMessage }

--- a/services/moderation-service/models/grant.go
+++ b/services/moderation-service/models/grant.go
@@ -52,7 +52,7 @@ var ErrNoActions = errors.New("a grant must delegate at least one action")
 // volunteer moderator needs day to day. Ban and unban stay opt-in.
 var DefaultDelegatedActions = []string{string(ActionDelete), string(ActionTimeout)}
 
-// delegatableActions is the closed allowlist of verbs a grant may carry, in canonical order.
+// DelegatableActions is the closed allowlist of verbs a grant may carry, in canonical order.
 //
 // This is the ONLY admission point for a grant's actions, and it is load-bearing beyond tidiness:
 // ModerationScopesForActions downstream also accepts "engagement", which maps to
@@ -60,9 +60,17 @@ var DefaultDelegatedActions = []string{string(ActionDelete), string(ActionTimeou
 // moderator's consent screen to scopes on their own channel that have nothing to do with
 // moderation (an ADR-0012 regression). Chat send is absent by decision — it is a distinct,
 // higher-trust capability and stays owner-only in v1.
-var delegatableActions = []string{
-	string(ActionDelete), string(ActionTimeout), string(ActionBan), string(ActionUnban),
-}
+var DelegatableActions = []Action{ActionDelete, ActionTimeout, ActionBan, ActionUnban}
+
+// delegatableActions is DelegatableActions as strings, since a grant stores verbs rather than
+// typed actions. Derived rather than restated so the two can never disagree.
+var delegatableActions = func() []string {
+	out := make([]string, 0, len(DelegatableActions))
+	for _, a := range DelegatableActions {
+		out = append(out, string(a))
+	}
+	return out
+}()
 
 // IsDelegatableAction reports whether action may be carried by a delegation grant.
 func IsDelegatableAction(action string) bool {
@@ -272,4 +280,36 @@ type InviteAccepted struct {
 	OwnerDisplayName string             `json:"owner_display_name"`
 	Actions          []string           `json:"actions"`
 	Platforms        []GrantPlatformLeg `json:"platforms"`
+}
+
+// Delegation is one channel a moderator has been handed, as the MODERATOR sees it.
+//
+// This is the mirror image of ModeratorGrant and deliberately not the same type: the owner's view
+// names the moderator, and the moderator's view names the streamer. Nothing here identifies the
+// other moderators on the overlay — a volunteer learns who delegated to them, not who else did.
+type Delegation struct {
+	GrantID          string `json:"grant_id"`
+	OverlayID        string `json:"overlay_id"`
+	OverlayName      string `json:"overlay_name"`
+	OwnerDisplayName string `json:"owner_display_name"`
+	// Status is active or suspended. A suspended grant is listed rather than hidden: dormancy
+	// suspension must read as "ask the streamer to reactivate", not as a channel that silently
+	// vanished.
+	Status    string             `json:"status"`
+	Actions   []string           `json:"actions"`
+	Platforms []GrantPlatformLeg `json:"platforms"`
+	// Available reports whether the streamer's plan currently has delegated moderation open
+	// (ADR-0008, keyed on the owner). When false the moderator is shown the streamer's plan as the
+	// cause — never an upgrade prompt for a plan that is not theirs to buy.
+	Available    bool       `json:"available"`
+	AcceptedAt   *time.Time `json:"accepted_at,omitempty"`
+	LastActionAt *time.Time `json:"last_action_at,omitempty"`
+}
+
+// DelegationList is the "channels I moderate" payload.
+//
+// It is the only way an accepted moderator can reach an overlay at all: GET /api/v1/overlays is
+// owner-filtered, so without this endpoint a grant is unreachable (ADR-0048).
+type DelegationList struct {
+	Delegations []Delegation `json:"delegations"`
 }

--- a/services/moderation-service/models/moderation.go
+++ b/services/moderation-service/models/moderation.go
@@ -30,6 +30,10 @@ const (
 )
 
 // Reasons explaining why a source is not (currently) moderatable.
+//
+// The first two can be reported to either role; the last three only ever describe a delegated
+// moderator's source (ADR-0048), because they are about the grant or about the moderator's own
+// consent rather than about the streamer's credential.
 const (
 	// ReasonUnsupportedPlatform: the platform has no usable moderation API (TikTok).
 	ReasonUnsupportedPlatform = "unsupported_platform"
@@ -37,8 +41,18 @@ const (
 	// this platform/account yet (covers both "never opted in" and "partially granted").
 	// Cleared via the opt-in re-consent flow.
 	ReasonMissingScope = "missing_scope"
-	// ReasonNotOwner: the requester does not own this overlay.
-	ReasonNotOwner = "not_owner"
+	// ReasonNotDelegated: the overlay owner did not delegate this platform to this moderator —
+	// either its leg is disabled (absence IS disablement, migration 080) or none of the granted
+	// actions exist on this platform. Only the streamer can clear it.
+	ReasonNotDelegated = "not_delegated"
+	// ReasonNeedsConsent: the moderator has not yet granted All-Chat their OWN moderation scopes
+	// for this platform. This is the "Connect to moderate" state, and it is the one the moderator
+	// can clear themselves (ADR-0048 defers consent to first use).
+	ReasonNeedsConsent = "needs_consent"
+	// ReasonNeedsDiscordLink: Discord has no per-user moderation API, so the shared bot acts and
+	// All-Chat must know which Discord account the moderator is. No such link exists today, so a
+	// moderator's Discord source always reports this — there is no consent flow to point them at.
+	ReasonNeedsDiscordLink = "needs_discord_link"
 )
 
 // PlatformActions is the moderation support matrix per platform in All-Chat.
@@ -356,15 +370,68 @@ type SourceCapability struct {
 	Actions []Action `json:"actions"`
 }
 
-// Capabilities is the response of the capabilities endpoint: whether the caller
-// owns the overlay, whether the moderation feature gate is open for them, and the
-// per-source moderation capability.
+// Capabilities is the response of the capabilities endpoint: which role the caller holds on the
+// overlay, whether the moderation feature gate is open for it, and the per-source capability.
 type Capabilities struct {
+	// Role is the caller's role: owner, moderator or none (ADR-0048). A caller with no role and a
+	// caller asking about an overlay that does not exist get the identical body, so this must
+	// never be read as evidence that an overlay exists.
+	Role string `json:"role"`
+	// IsOwner is Role == owner, kept as its own field because it is the flag the dashboard has
+	// always branched on and the two must never drift apart.
 	IsOwner bool `json:"is_owner"`
-	// Enabled reports whether the moderation feature gate (ADR-0008) is open for
-	// this user. When false the owner is outside the rollout cohort: the dashboard
-	// hides moderation controls (the action endpoints are independently gated and
-	// would 403). Always false for non-owners.
-	Enabled bool               `json:"enabled"`
-	Sources []SourceCapability `json:"sources"`
+	// Enabled reports whether the moderation feature gate (ADR-0008) is open. It is keyed on the
+	// overlay OWNER, never the caller: a premium streamer's moderators moderate for free, and the
+	// action path decides the same way. False for a caller with no role.
+	Enabled bool `json:"enabled"`
+	// CanModerate is the single flag the UI switches its controls on: the caller holds a role AND
+	// the owner's plan has moderation open. Which actions are actually available per source is
+	// still decided source by source.
+	CanModerate bool `json:"can_moderate"`
+	// DelegatedActions is the grant's action set, present for a moderator only.
+	//
+	// It is what a source's "Connect to moderate" must request scopes for: a source that needs
+	// consent reports no usable actions yet, so without this the consent screen would have to
+	// guess — and guessing high would ask a volunteer for ban scope the streamer never delegated.
+	DelegatedActions []Action           `json:"delegated_actions,omitempty"`
+	Sources          []SourceCapability `json:"sources"`
+}
+
+// ActionsForModeratorScopes maps a delegated moderator's OWN granted scopes to the actions they
+// can perform on a platform.
+//
+// This is the same scope→action mapping the owner path uses; what differs is whose credential the
+// scopes came from. Discord is absent by construction: its authority is the shared bot's guild
+// permissions plus a link to the moderator's Discord account, neither of which is an OAuth scope
+// the moderator grants (see ReasonNeedsDiscordLink).
+func ActionsForModeratorScopes(platform string, scopes []string) []Action {
+	switch platform {
+	case "twitch":
+		return ActionsForTwitchScopes(scopes)
+	case "kick":
+		return ActionsForKickScopes(scopes)
+	case "youtube":
+		return ActionsForYouTubeScopes(scopes)
+	default:
+		return nil
+	}
+}
+
+// IntersectActions returns the actions present in both sets, in the order of the first.
+//
+// A delegated moderator's usable actions are the intersection of what the platform supports, what
+// their own scopes allow, and what the streamer delegated — so this is applied, not assumed, and
+// the result can legitimately be empty.
+func IntersectActions(actions []Action, allowed []string) []Action {
+	permitted := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		permitted[a] = true
+	}
+	out := make([]Action, 0, len(actions))
+	for _, a := range actions {
+		if permitted[string(a)] {
+			out = append(out, a)
+		}
+	}
+	return out
 }

--- a/services/moderation-service/repository/access.go
+++ b/services/moderation-service/repository/access.go
@@ -48,9 +48,12 @@ type OverlayAccess struct {
 	OwnerUserID    string
 	OwnerIsPremium bool
 	Role           string
-	// GrantID and Actions are populated for RoleModerator only.
+	// GrantID, Actions and Platforms are populated for RoleModerator only.
 	GrantID string
 	Actions []string
+	// Platforms are the grant's ENABLED platform legs. An absent row is a disabled leg
+	// (migration 080), so this list is the complete set — never a filter over a default.
+	Platforms []string
 }
 
 // IsOwner reports whether the caller owns the overlay.
@@ -69,6 +72,26 @@ func (a OverlayAccess) MayPerform(action string) bool {
 	case RoleModerator:
 		for _, granted := range a.Actions {
 			if granted == action {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MayUsePlatform reports whether the caller's role permits acting on this platform.
+//
+// The per-platform leg is one of the grant's three fail-closed filters (ADR-0048) and is a
+// separate question from the action set: a streamer who delegates Twitch and Kick to one person
+// and only Discord to another has expressed two different grants, and an action-only check would
+// let either of them act anywhere the overlay has a source. Owners are unrestricted.
+func (a OverlayAccess) MayUsePlatform(platform string) bool {
+	switch a.Role {
+	case RoleOwner:
+		return true
+	case RoleModerator:
+		for _, enabled := range a.Platforms {
+			if enabled == platform {
 				return true
 			}
 		}
@@ -102,7 +125,10 @@ func (r *Repository) ResolveOverlayAccess(ctx context.Context, overlayID, caller
 		            WHEN m.id IS NOT NULL     THEN 'moderator'
 		            ELSE 'none' END,
 		       COALESCE(m.id::text, ''),
-		       COALESCE(m.actions, '{}')
+		       COALESCE(m.actions, '{}'),
+		       ARRAY(SELECT p.platform
+		               FROM overlay_moderator_platforms p
+		              WHERE p.grant_id = m.id AND p.enabled)
 		FROM overlays o
 		JOIN users u ON u.id = o.user_id
 		LEFT JOIN overlay_moderators m
@@ -119,6 +145,7 @@ func (r *Repository) ResolveOverlayAccess(ctx context.Context, overlayID, caller
 		&access.Role,
 		&access.GrantID,
 		&access.Actions,
+		&access.Platforms,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return OverlayAccess{}, ErrOverlayNotFound

--- a/services/moderation-service/repository/access_test.go
+++ b/services/moderation-service/repository/access_test.go
@@ -88,6 +88,56 @@ func TestResolveOverlayAccess(t *testing.T) {
 	})
 }
 
+// The enabled platform legs travel with the role, because the action path needs both in the same
+// round trip: a grant's action set and its platform set are two separate grants of authority, and
+// checking only the first would let a Twitch-only moderator act on every source the overlay has.
+func TestResolveOverlayAccess_PlatformLegs(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	t.Run("only enabled legs are reported", func(t *testing.T) {
+		modID := uuid.New().String()
+		_, err := repo.db.Exec(ctx, `INSERT INTO users (id, is_premium) VALUES ($1, false)`, modID)
+		require.NoError(t, err)
+		grant(t, repo, modID, "active", []string{"delete"}, false)
+
+		var grantID string
+		require.NoError(t, repo.db.QueryRow(ctx,
+			`SELECT id::text FROM overlay_moderators WHERE moderator_user_id = $1`, modID).Scan(&grantID))
+		_, err = repo.db.Exec(ctx, `
+			INSERT INTO overlay_moderator_platforms (grant_id, platform, enabled) VALUES
+			($1, 'twitch', TRUE), ($1, 'kick', FALSE)`, grantID)
+		require.NoError(t, err)
+
+		access, err := repo.ResolveOverlayAccess(ctx, overlayID, modID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"twitch"}, access.Platforms,
+			"a disabled leg is not a delegated platform")
+		assert.True(t, access.MayUsePlatform("twitch"))
+		assert.False(t, access.MayUsePlatform("kick"))
+	})
+
+	t.Run("a grant with no legs delegates no platform", func(t *testing.T) {
+		modID := uuid.New().String()
+		_, err := repo.db.Exec(ctx, `INSERT INTO users (id, is_premium) VALUES ($1, false)`, modID)
+		require.NoError(t, err)
+		grant(t, repo, modID, "active", []string{"delete"}, false)
+
+		access, err := repo.ResolveOverlayAccess(ctx, overlayID, modID)
+		require.NoError(t, err)
+		assert.Empty(t, access.Platforms, "absence is disablement, not a default of everything")
+		assert.False(t, access.MayUsePlatform("twitch"))
+	})
+
+	t.Run("an owner is never narrowed by legs", func(t *testing.T) {
+		access, err := repo.ResolveOverlayAccess(ctx, overlayID, ownerID)
+		require.NoError(t, err)
+		assert.True(t, access.MayUsePlatform("twitch"))
+		assert.True(t, access.MayUsePlatform("discord"))
+	})
+}
+
 func TestResolveOverlayAccess_GrantLifecycle(t *testing.T) {
 	repo, cleanup := setupTestRepo(t)
 	defer cleanup()

--- a/services/moderation-service/repository/delegations.go
+++ b/services/moderation-service/repository/delegations.go
@@ -1,0 +1,165 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Delegation is one overlay a moderator holds a grant on, from the MODERATOR's side.
+//
+// It carries the owner's identity because everything the moderator is shown about entitlement is
+// keyed on the owner, never on themselves (ADR-0048).
+type Delegation struct {
+	GrantID          string
+	OverlayID        string
+	OverlayName      string
+	OwnerUserID      string
+	OwnerDisplayName string
+	Status           string
+	Actions          []string
+	AcceptedAt       *time.Time
+	LastActionAt     *time.Time
+	Platforms        []GrantLeg
+}
+
+// ListDelegationsFor returns the overlays this user may moderate for someone else.
+//
+// Suspended grants are included, not filtered out. A dormancy-suspended grant that simply vanished
+// from the list would look like a revocation to the moderator and give them nothing to act on; it
+// is listed with its status so the UI can say "ask the streamer to reactivate this". Only `active`
+// authorizes anything — ResolveOverlayAccess is the authority there, and it ignores every other
+// status.
+//
+// Pending invites cannot appear: an unredeemed grant has no moderator_user_id yet.
+func (r *Repository) ListDelegationsFor(ctx context.Context, moderatorUserID string) ([]Delegation, error) {
+	// A caller id that is not a UUID cannot match a grant. Normalise rather than letting the cast
+	// fail and surface as a 500.
+	if _, err := uuid.Parse(moderatorUserID); err != nil {
+		return []Delegation{}, nil
+	}
+
+	// Deliberately not restricted to status = 'active', so this does not use the partial index
+	// idx_overlay_moderators_by_mod. That index still serves the authorization path; here the
+	// row count is bounded by the per-overlay cap times the handful of streamers one volunteer
+	// works for, so the scan is not worth a second index.
+	const query = `
+		SELECT m.id::text,
+		       m.overlay_id::text,
+		       o.name,
+		       o.user_id::text,
+		       COALESCE(NULLIF(u.display_name, ''), u.username),
+		       m.status,
+		       m.actions,
+		       m.accepted_at,
+		       m.last_action_at
+		FROM overlay_moderators m
+		JOIN overlays o ON o.id = m.overlay_id
+		JOIN users u    ON u.id = o.user_id
+		WHERE m.moderator_user_id = $1
+		  AND m.revoked_at IS NULL
+		  AND m.status IN ('active', 'suspended')
+		ORDER BY o.name, m.id`
+
+	rows, err := r.db.Query(ctx, query, moderatorUserID)
+	if err != nil {
+		return nil, fmt.Errorf("list delegations: %w", err)
+	}
+	defer rows.Close()
+
+	delegations := make([]Delegation, 0)
+	index := map[string]int{}
+	for rows.Next() {
+		var d Delegation
+		if err := rows.Scan(
+			&d.GrantID, &d.OverlayID, &d.OverlayName, &d.OwnerUserID, &d.OwnerDisplayName,
+			&d.Status, &d.Actions, &d.AcceptedAt, &d.LastActionAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan delegation: %w", err)
+		}
+		index[d.GrantID] = len(delegations)
+		delegations = append(delegations, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate delegations: %w", err)
+	}
+	if len(delegations) == 0 {
+		return delegations, nil
+	}
+
+	legRows, err := r.db.Query(ctx, `
+		SELECT p.grant_id::text, p.platform, p.enabled, p.verification, p.verified_at
+		FROM overlay_moderator_platforms p
+		JOIN overlay_moderators m ON m.id = p.grant_id
+		WHERE m.moderator_user_id = $1
+		  AND m.revoked_at IS NULL
+		  AND m.status IN ('active', 'suspended')
+		ORDER BY p.platform`, moderatorUserID)
+	if err != nil {
+		return nil, fmt.Errorf("list delegation platforms: %w", err)
+	}
+	defer legRows.Close()
+
+	for legRows.Next() {
+		var grantID string
+		var leg GrantLeg
+		if err := legRows.Scan(&grantID, &leg.Platform, &leg.Enabled, &leg.Verification, &leg.VerifiedAt); err != nil {
+			return nil, fmt.Errorf("scan delegation platform: %w", err)
+		}
+		if i, ok := index[grantID]; ok {
+			delegations[i].Platforms = append(delegations[i].Platforms, leg)
+		}
+	}
+	if err := legRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate delegation platforms: %w", err)
+	}
+	return delegations, nil
+}
+
+// ModeratorGrantedScopes returns the scopes on the moderator's OWN credential for a platform, and
+// whether such a credential exists at all.
+//
+// Only granted_scopes is read — never the token — because the capability answer needs no
+// decryption and nothing here should be able to leak a credential. Reading from
+// mod_oauth_credentials rather than the per-channel token tables is the whole point of that table
+// (ADR-0048): the moderator's authority comes from their own account, never from the streamer's
+// stored credential.
+func (r *Repository) ModeratorGrantedScopes(ctx context.Context, userID, platform string) ([]string, bool, error) {
+	if _, err := uuid.Parse(userID); err != nil {
+		return nil, false, nil
+	}
+	const query = `
+		SELECT granted_scopes
+		FROM mod_oauth_credentials
+		WHERE user_id = $1 AND platform = $2`
+
+	var scopes []string
+	err := r.db.QueryRow(ctx, query, userID, platform).Scan(&scopes)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read moderator scopes: %w", err)
+	}
+	return scopes, true, nil
+}

--- a/services/moderation-service/repository/delegations_test.go
+++ b/services/moderation-service/repository/delegations_test.go
@@ -1,0 +1,227 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// "Channels I moderate" (ADR-0048). GET /api/v1/overlays is owner-filtered, so this query is the
+// only thing standing between an accepted moderator and an unreachable grant.
+
+// grantWithLegs creates a grant and enables the named platform legs on it.
+func grantWithLegs(t *testing.T, r *Repository, modID, status string, actions, platforms []string) string {
+	t.Helper()
+	ctx := context.Background()
+	var grantID string
+	err := r.db.QueryRow(ctx,
+		`INSERT INTO overlay_moderators (overlay_id, moderator_user_id, granted_by, status, actions, accepted_at)
+		 VALUES ($1, $2, $3, $4, $5, NOW()) RETURNING id::text`,
+		overlayID, modID, ownerID, status, actions).Scan(&grantID)
+	require.NoError(t, err)
+	for _, p := range platforms {
+		_, err := r.db.Exec(ctx,
+			`INSERT INTO overlay_moderator_platforms (grant_id, platform, enabled) VALUES ($1, $2, TRUE)`,
+			grantID, p)
+		require.NoError(t, err)
+	}
+	return grantID
+}
+
+func TestListDelegationsFor(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	modID := newModerator(t, repo, "A Moderator")
+	grantID := grantWithLegs(t, repo, modID, "active", []string{"delete", "timeout"}, []string{"twitch"})
+
+	delegations, err := repo.ListDelegationsFor(ctx, modID)
+	require.NoError(t, err)
+	require.Len(t, delegations, 1)
+
+	d := delegations[0]
+	assert.Equal(t, grantID, d.GrantID)
+	assert.Equal(t, overlayID, d.OverlayID, "the overlay id is the whole point of this listing")
+	assert.Equal(t, "My Overlay", d.OverlayName)
+	assert.Equal(t, ownerID, d.OwnerUserID)
+	assert.Equal(t, "The Streamer", d.OwnerDisplayName)
+	assert.Equal(t, []string{"delete", "timeout"}, d.Actions)
+	assert.NotNil(t, d.AcceptedAt)
+	require.Len(t, d.Platforms, 1)
+	assert.Equal(t, "twitch", d.Platforms[0].Platform)
+	assert.True(t, d.Platforms[0].Enabled)
+}
+
+// The listing is scoped to the caller. A moderator on one overlay must not see another's.
+func TestListDelegationsFor_ScopedToTheModerator(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mine := newModerator(t, repo, "A Moderator")
+	theirs := newModerator(t, repo, "A Moderator")
+	grantWithLegs(t, repo, mine, "active", []string{"delete"}, []string{"twitch"})
+
+	delegations, err := repo.ListDelegationsFor(ctx, theirs)
+	require.NoError(t, err)
+	assert.Empty(t, delegations, "someone else's grant is not mine to see")
+}
+
+// The owner is not their own moderator: ownership is not a grant, and self-listing would put the
+// streamer's own overlays in a list that means "channels other people handed me".
+func TestListDelegationsFor_OwnerSeesNothing(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	delegations, err := repo.ListDelegationsFor(context.Background(), ownerID)
+	require.NoError(t, err)
+	assert.Empty(t, delegations)
+}
+
+// Which lifecycle states reach the moderator's list. Suspended is included deliberately: a channel
+// that silently vanished would be indistinguishable from a revocation, leaving the moderator with
+// nothing to ask the streamer about.
+func TestListDelegationsFor_LifecycleStates(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		status  string
+		revoked bool
+		listed  bool
+	}{
+		{"active is listed", "active", false, true},
+		{"suspended is listed, so the moderator can ask for reactivation", "suspended", false, true},
+		{"revoked is not listed", "revoked", true, false},
+		{"a revoked_at stamp hides an otherwise active grant", "active", true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			modID := newModerator(t, repo, "A Moderator")
+			grantWithLegs(t, repo, modID, tc.status, []string{"delete"}, []string{"twitch"})
+			if tc.revoked {
+				_, err := repo.db.Exec(ctx,
+					`UPDATE overlay_moderators SET revoked_at = NOW() WHERE moderator_user_id = $1`, modID)
+				require.NoError(t, err)
+			}
+
+			delegations, err := repo.ListDelegationsFor(ctx, modID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.listed, len(delegations) == 1)
+		})
+	}
+}
+
+// A pending invite has no moderator bound to it yet, so it cannot appear in anyone's list — the
+// invite secret is the only thing that reaches it.
+func TestListDelegationsFor_PendingInviteIsUnreachable(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := repo.db.Exec(ctx,
+		`INSERT INTO overlay_moderators (overlay_id, granted_by, status) VALUES ($1, $2, 'pending')`,
+		overlayID, ownerID)
+	require.NoError(t, err)
+
+	modID := newModerator(t, repo, "A Moderator")
+	delegations, err := repo.ListDelegationsFor(ctx, modID)
+	require.NoError(t, err)
+	assert.Empty(t, delegations)
+}
+
+// A disabled leg is still reported, with enabled=false: the moderator's page explains which
+// platforms the streamer has turned on, and an absent row would be indistinguishable from a
+// platform the overlay does not carry.
+func TestListDelegationsFor_ReportsDisabledLegs(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	modID := newModerator(t, repo, "A Moderator")
+	grantID := grantWithLegs(t, repo, modID, "active", []string{"delete"}, []string{"twitch"})
+	_, err := repo.db.Exec(ctx,
+		`INSERT INTO overlay_moderator_platforms (grant_id, platform, enabled) VALUES ($1, 'kick', FALSE)`,
+		grantID)
+	require.NoError(t, err)
+
+	delegations, err := repo.ListDelegationsFor(ctx, modID)
+	require.NoError(t, err)
+	require.Len(t, delegations, 1)
+
+	legs := map[string]bool{}
+	for _, leg := range delegations[0].Platforms {
+		legs[leg.Platform] = leg.Enabled
+	}
+	assert.Equal(t, map[string]bool{"twitch": true, "kick": false}, legs)
+}
+
+// A malformed caller id must not reach Postgres and come back as a 500.
+func TestListDelegationsFor_MalformedUserID(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	delegations, err := repo.ListDelegationsFor(context.Background(), "not-a-uuid")
+	require.NoError(t, err)
+	assert.Empty(t, delegations)
+}
+
+// The moderator's own credential is what authorizes them, so the capability answer reads its
+// scopes — and only its scopes, never a token.
+func TestModeratorGrantedScopes(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	modID := newModerator(t, repo, "A Moderator")
+	_, err := repo.db.Exec(ctx, `
+		INSERT INTO mod_oauth_credentials (user_id, platform, platform_user_id, access_token, granted_scopes)
+		VALUES ($1, 'twitch', '4242', 'encrypted', $2)`,
+		modID, []string{"moderator:manage:chat_messages"})
+	require.NoError(t, err)
+
+	scopes, ok, err := repo.ModeratorGrantedScopes(ctx, modID, "twitch")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, scopes)
+
+	t.Run("a platform they never consented to reports no credential", func(t *testing.T) {
+		_, ok, err := repo.ModeratorGrantedScopes(ctx, modID, "kick")
+		require.NoError(t, err)
+		assert.False(t, ok, "absence must be distinguishable from an empty scope list")
+	})
+
+	t.Run("another user's credential is not visible", func(t *testing.T) {
+		_, ok, err := repo.ModeratorGrantedScopes(ctx, newModerator(t, repo, "A Moderator"), "twitch")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("malformed user id does not surface a database error", func(t *testing.T) {
+		_, ok, err := repo.ModeratorGrantedScopes(ctx, "not-a-uuid", "twitch")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}

--- a/services/moderation-service/repository/repository_test.go
+++ b/services/moderation-service/repository/repository_test.go
@@ -144,6 +144,7 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 		CREATE TABLE users (
 			id UUID PRIMARY KEY,
 			is_premium BOOLEAN NOT NULL DEFAULT false,
+			username VARCHAR(100) NOT NULL DEFAULT '',
 			display_name VARCHAR(100) NOT NULL DEFAULT '',
 			twitch_id VARCHAR(50),
 			kick_id VARCHAR(255),
@@ -175,6 +176,7 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 			platform VARCHAR(20) NOT NULL,
 			platform_user_id VARCHAR(100) NOT NULL,
 			access_token TEXT NOT NULL,
+			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
 			UNIQUE (user_id, platform)
 		);
 		CREATE TABLE overlay_moderators (
@@ -218,7 +220,8 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 
 	// owner is premium (in the rollout cohort); stranger is a non-premium user.
 	_, err = pool.Exec(ctx,
-		`INSERT INTO users (id, is_premium, display_name) VALUES ($1, true, 'The Streamer'), ($2, false, 'A Stranger')`,
+		`INSERT INTO users (id, is_premium, username, display_name) VALUES
+			($1, true, 'thestreamer', 'The Streamer'), ($2, false, 'astranger', 'A Stranger')`,
 		ownerID, strangerID)
 	require.NoError(t, err)
 	_, err = pool.Exec(ctx, `INSERT INTO overlays (id, user_id, name) VALUES ($1, $2, 'My Overlay')`, overlayID, ownerID)


### PR DESCRIPTION
Second slice of ADR-0048. #661 gave a streamer the ability to create a grant; this makes the grant reachable.

## The problem

An accepted delegation was unreachable. `GET /api/v1/overlays` is owner-filtered and there is no shared-with-me listing, so a moderator held a grant with no route into the overlay it applied to. `capabilities` also answered every non-owner with an empty read-only payload, so even reaching the monitor by URL gave them nothing.

## Moderator side

- **`GET /api/v1/moderation/delegations`** — the channels delegated to the caller. Keyed on the caller alone, never gated, and carries no user ids (a volunteer learns who delegated to them, not who else moderates there). `suspended` grants are listed rather than hidden — a channel that vanished would be indistinguishable from a revocation — and a lapsed streamer plan surfaces as `available: false` with the streamer named as the cause, never an upgrade prompt aimed at someone who cannot buy that plan.
- **Role-aware `capabilities`** — `role`, `can_moderate`, and per-source detail computed from what the streamer delegated intersected with the scopes on the moderator's *own* credential. Three new reasons, distinguished by who can clear them: `not_delegated` (the streamer), `needs_consent` (the moderator — the "Connect to moderate" state), `needs_discord_link` (nobody yet). `can_send` is never true for a moderator. A caller with no role and an overlay that does not exist still produce a byte-identical body.
- **UI** — `/moderate`, `/moderate/accept`, a dashboard entry point, and a monitor that renders a moderator's controls plus a per-platform "Connect to moderate". The owner's invite dialog now hands over the redemption link instead of a bare secret, which was not something a streamer could actually send.

## Two authorization gaps closed

Both fail closed, both found while making capabilities agree with `authorize()`:

- The action path enforced the grant's **action set** but not its **platform legs**, so delegating Twitch silently delegated every other source on the overlay (action names are shared across platforms).
- `delegated_moderation` was only checked when creating an invite, so closing it did not stop delegated actions — a label on a button rather than the rollback lever the ADR specifies.

## Known limitation, deliberate

The per-platform legs are still unbuilt: the dispatcher resolves a credential by `(caller, channel)`, so a delegated action fails **closed** with `422 no credential` rather than falling back to the owner's token. The no-fallback invariant holds; the action simply does not work yet. Twitch is next (`moderator_id`/`broadcaster_id` split + the owner-reach anchor).

## Tests

- Go: 10 new capability tests for the moderator payload, 12 for the delegation listing, 4 for the platform-leg and gate enforcement, plus repository coverage against real Postgres (testcontainers) for the listing, the moderator scope read and the new `Platforms` field on `ResolveOverlayAccess`.
- Frontend: 19 component tests across the two new pages, 4 API-layer tests (including "the secret never reaches a URL"), and 5 route-mocked Playwright specs.
- Full `moderation-service` and `api-gateway` suites green; `vitest` 106 files / 904 tests green.