### PR TITLE
feat(moderation): delegated moderators can moderate Twitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ You can also open it from your overlay's settings page (or its preview page) via
 **Your moderators can use it too.** Under **Moderators** in the overlay editor you can invite the
 people who already moderate for you (Premium). You get a private link to send them; they accept it
 with their own All-Chat account, and every channel handed to them shows up under **Channels you
-moderate** (`/moderate`). They act with **their own** platform accounts, so Twitch, YouTube and Kick
-re-check their moderator role on every action and it lands in your native mod log under their name —
-and they never need a plan of their own. Connecting a platform is deferred until the first time they
-moderate on it, and one connection covers every streamer who delegated that platform to them.
+moderate** (`/moderate`). They act with **their own** platform accounts, so Twitch re-checks their
+moderator role on every single action and it lands in your native mod log under their name — never
+yours — and they never need a plan of their own. Connecting an account is deferred until the first
+time they moderate on it, and one connection covers every streamer who delegated that platform to
+them. Twitch is live today; Kick, YouTube and Discord moderation stays with you for now.
 
 ### 3. Customize the look
 

--- a/frontend/src/app/overlay/[id]/view/page.tsx
+++ b/frontend/src/app/overlay/[id]/view/page.tsx
@@ -63,6 +63,7 @@ import {
   buildTimeoutRequest,
   buildUnbanRequest,
   isModerationReauthError,
+  moderationActionCode,
   moderationApi,
 } from '@/lib/api/moderation'
 import type { ChatMessage, DeletionMetadata } from '@/lib/types/message'
@@ -464,6 +465,29 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
   // (granted_scopes may overstate the real grant), so it would fail again on every click.
   const [reauthPrompt, setReauthPrompt] = useState<{ platform: string } | null>(null)
 
+  // Copy for a moderation failure the actor can do something about (ADR-0048). Returns null when
+  // the failure is not one of the delegation-aware ones, so the caller falls back to its own
+  // wording — and to the re-consent banner, which is checked first because it has a CTA.
+  const delegatedFailureMessage = useCallback(
+    (err: unknown, platform: string): string | null => {
+      switch (moderationActionCode(err)) {
+        case 'connect_required':
+          // Consent is deferred to first use, so for a moderator this is the expected first click,
+          // not a fault. The per-source banner already offers the button; this names the reason.
+          return isModerator ? `Connect your own ${platform} account to moderate here` : null
+        case 'owner_channel_unverified':
+          // Only the streamer can fix this, so the copy stops at the cause rather than offering a
+          // button that would do nothing.
+          return `This streamer's ${platform} account isn't connected, so nothing can be moderated here`
+        case 'delegation_unsupported':
+          return `Moderators can't act on ${platform} yet — ask the streamer to handle this one`
+        default:
+          return null
+      }
+    },
+    [isModerator]
+  )
+
   // Apply an optimistic mark + log entry, fire the API, and roll back on error.
   const runModeration = useCallback(
     async (
@@ -500,20 +524,23 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         setItems((prev) =>
           prev.map((it) => (touchedSet.has(it.id) ? { ...it, _moderated: undefined } : it))
         )
+        const delegated = delegatedFailureMessage(err, platform)
         if (isModerationReauthError(err)) {
-          // Actionable failure: the streamer must re-authorize this platform. Show the
+          // Actionable failure: the actor must re-authorize this platform. Show the
           // recovery banner and a toast pointing at it (mirrors the chat-send reauth path).
           setReauthPrompt({ platform })
           toastManager.add({
             title: `${platform} needs you to re-authorize moderation`,
             type: 'error',
           })
+        } else if (delegated !== null) {
+          toastManager.add({ title: delegated, type: 'error' })
         } else {
           toastManager.add({ title: 'Moderation action failed', type: 'error' })
         }
       }
     },
-    []
+    [delegatedFailureMessage]
   )
 
   const handleDelete = useCallback(
@@ -580,18 +607,21 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
         .unbanUser(id, buildUnbanRequest(item))
         .then(() => toastManager.add({ title: `Unbanned ${name}`, type: 'success' }))
         .catch((err) => {
+          const delegated = delegatedFailureMessage(err, item.platform)
           if (isModerationReauthError(err)) {
             setReauthPrompt({ platform: item.platform })
             toastManager.add({
               title: `${item.platform} needs you to re-authorize moderation`,
               type: 'error',
             })
+          } else if (delegated !== null) {
+            toastManager.add({ title: delegated, type: 'error' })
           } else {
             toastManager.add({ title: 'Unban failed', type: 'error' })
           }
         })
     },
-    [id]
+    [id, delegatedFailureMessage]
   )
 
   // Only owners in the rollout cohort get live action callbacks; everyone else

--- a/frontend/src/lib/api/__tests__/moderation.test.ts
+++ b/frontend/src/lib/api/__tests__/moderation.test.ts
@@ -31,6 +31,7 @@ import {
   boundInviteAccount,
   delegationErrorCode,
   isModerationReauthError,
+  moderationActionCode,
   moderationApi,
 } from '@/lib/api/moderation'
 
@@ -163,5 +164,34 @@ describe('moderator-side endpoints', () => {
       '/api/v1/auth/twitch/mod-consent?actions=delete,timeout'
     )
     expect(url).toBe('https://id.twitch.tv/authorize?x')
+  })
+})
+
+// The three action-failure codes (ADR-0048) differ in WHO can fix them, which is the only reason
+// the UI needs to tell them apart: the moderator, the streamer, or nobody yet.
+describe('moderationActionCode', () => {
+  it('reads the code off a failed action', () => {
+    const err = new ApiError(422, 'connect your own twitch account to moderate here', {
+      error: 'connect your own twitch account to moderate here',
+      code: 'connect_required',
+    })
+    expect(moderationActionCode(err)).toBe('connect_required')
+  })
+
+  it('distinguishes the streamer-side failure from the moderator-side one', () => {
+    const owner = new ApiError(403, 'not connected', {
+      error: 'not connected',
+      code: 'owner_channel_unverified',
+    })
+    expect(moderationActionCode(owner)).toBe('owner_channel_unverified')
+  })
+
+  it('is undefined for a plain failure, so callers keep their generic copy', () => {
+    expect(
+      moderationActionCode(
+        new ApiError(502, 'failed to apply moderation', { error: 'failed to apply moderation' })
+      )
+    ).toBeUndefined()
+    expect(moderationActionCode(new TypeError('Failed to fetch'))).toBeUndefined()
   })
 })

--- a/frontend/src/lib/api/moderation.ts
+++ b/frontend/src/lib/api/moderation.ts
@@ -60,6 +60,33 @@ export function isModerationReauthError(err: unknown): boolean {
   return err instanceof ApiError && err.data?.requires_reauth === true
 }
 
+/**
+ * The machine-readable `code` on a failed moderation ACTION (ADR-0048), or undefined.
+ *
+ * Distinct from `delegationErrorCode`, which covers the grant-lifecycle endpoints. These three
+ * describe why a write could not happen, and they differ in who can fix it:
+ *
+ * - `connect_required` — the actor holds no credential for this platform. For a moderator that is
+ *   the deferred-consent state, and the fix is theirs.
+ * - `owner_channel_unverified` — the streamer's own account is not connected, so there is nothing
+ *   on this channel to delegate. Only the streamer can clear it; the moderator gets no CTA.
+ * - `delegation_unsupported` — this platform's delegated path is not built yet.
+ * - `not_moderator_on_platform` — the PLATFORM refused: All-Chat allowed the action and Twitch
+ *   said this person does not moderate that channel. Re-consent cannot fix it, so this must never
+ *   be rendered as a re-authorize prompt; the streamer has to add them in the platform's own tools.
+ */
+export type ModerationActionErrorCode =
+  | 'connect_required'
+  | 'owner_channel_unverified'
+  | 'delegation_unsupported'
+  | 'not_moderator_on_platform'
+
+export function moderationActionCode(err: unknown): ModerationActionErrorCode | undefined {
+  if (!(err instanceof ApiError)) return undefined
+  const code = err.data?.code
+  return typeof code === 'string' ? (code as ModerationActionErrorCode) : undefined
+}
+
 /** Standard success envelope for every moderation POST. */
 export interface ModerationResult {
   status: 'ok'

--- a/migrations/081_moderation_actor_comments.sql
+++ b/migrations/081_moderation_actor_comments.sql
@@ -1,0 +1,23 @@
+-- Migration: 081_moderation_actor_comments
+-- Description: Corrects moderation_actions.actor_user_id's documented meaning (ADR-0048).
+--
+-- Migration 060 defined that column when moderation was owner-only, and its comment asserts the
+-- actor IS the overlay owner. Role-based authorization made that false: a delegated moderator is
+-- the actor, and the owner they acted for lives in on_behalf_of_user_id (migration 080). A comment
+-- that contradicts the data is worse than no comment — anyone auditing "who moderated this
+-- channel?" would read the wrong column and conclude a streamer did something a volunteer did.
+--
+-- Comments only. Migration 060 itself is left untouched: the runner replays every migration on
+-- every pod start, so a shipped file is history and gets corrected forward, not edited.
+--
+-- Idempotent by construction: COMMENT ON replaces whatever was there.
+
+BEGIN;
+
+COMMENT ON COLUMN moderation_actions.actor_user_id IS
+    'The human who performed the action: the overlay owner when they moderate their own overlay, the delegated moderator when one acts (ADR-0048). NOT necessarily the overlay owner (see on_behalf_of_user_id) and NOT necessarily whose credential ran the platform call (see credential_user_id).';
+
+COMMENT ON COLUMN moderation_actions.impersonated_by IS
+    'The real admin when the action was performed under impersonation, else NULL. Deliberately NOT overloaded to express delegation: an admin impersonating a streamer and a moderator acting for one are different events and must stay distinguishable.';
+
+COMMIT;

--- a/migrations/081_moderation_actor_comments_down.sql
+++ b/migrations/081_moderation_actor_comments_down.sql
@@ -1,0 +1,14 @@
+-- Rollback: 081_moderation_actor_comments
+--
+-- Restores migration 060's original wording. That wording is factually wrong under role-based
+-- authorization, so this rollback is only meaningful alongside a rollback of ADR-0048 itself.
+
+BEGIN;
+
+COMMENT ON COLUMN moderation_actions.actor_user_id IS
+    'The overlay owner whose token performed the action.';
+
+COMMENT ON COLUMN moderation_actions.impersonated_by IS
+    'The real admin when the action was performed under impersonation, else NULL.';
+
+COMMIT;

--- a/services/moderation-service/README.md
+++ b/services/moderation-service/README.md
@@ -155,6 +155,41 @@ elevated invite URL). Capability is computed from the bot's effective guild perm
 moderation permissions reports no actions and the dashboard shows the re-invite CTA. A dispatch 403
 (e.g. a channel-level permission overwrite) fails the action — never a false reflect-back.
 
+## Delegated writes (ADR-0048, Twitch)
+
+An owner action and a delegated action differ in exactly one place — which credential performs the
+call and against whose channel — and the dispatcher makes that difference explicit rather than
+inferring it from the caller's id:
+
+| | Owner | Delegated moderator |
+|---|---|---|
+| Token | the owner's broadcaster credential (`users` / `twitch_oauth_tokens`) | the moderator's own credential (`mod_oauth_credentials`) |
+| `broadcaster_id` | their own, from that credential | the **owner-reach anchor** |
+| `moderator_id` | the same id — a streamer is their own moderator | the moderator's `platform_user_id` |
+| Scope pre-check | the owner's `granted_scopes` | the **moderator's** `granted_scopes` |
+
+There is **no fallback** between them. A moderator who has not consented gets `422 connect_required`
+— consent is deferred to first use, so that is the expected first click on a fresh grant — and never
+a call made with the streamer's token.
+
+The **owner-reach anchor** (`tokens.TwitchSource.OwnerTwitchAnchor`) is what stops delegation from
+exceeding what the owner could do themselves: it resolves the numeric broadcaster id from a
+credential row whose login equals the source's `channel_id`. It applies **no scope predicate and
+reads no token** — requiring the owner to hold a moderation scope would deny delegation to exactly
+the streamer who delegates *because* they do not moderate themselves. When it cannot be proven the
+action is refused with `owner_channel_unverified`, and the copy names the streamer: only they can
+fix it.
+
+Twitch itself is the authority on whether the moderator may act. Helix re-checks on every call that
+`moderator_id` is the token's own user and that they moderate `broadcaster_id`; a 403 surfaces as a
+re-consent prompt rather than anything All-Chat cached.
+
+Every write records five identities in `moderation_actions`: who acted, in what role, for whom,
+**whose credential acted** (`credential_user_id` — the machine-checkable proof no fallback
+happened), and the platform id sent as the moderator. Denials carry them too, because "this
+moderator keeps getting refused" is a signal that is invisible if a denial cannot be told apart
+from an owner's.
+
 ## Rollout (feature gate, ADR-0008)
 
 Delegation has its **own** gate key, `delegated_moderation` (seeded `is_premium=TRUE`, migration 080), so
@@ -200,13 +235,13 @@ no redeploy. Locally, non-premium users can either set `users.is_premium=true` o
   resolves the guild from the channel and performs member ops; `handler.DiscordScopeChecker` reports the
   actions the bot's guild permissions allow; the auth-service `GetModerationAuthURL` (elevated invite) +
   `HandleConnect?moderation=true` give an opt-in re-invite that upgrades existing bots in place.
-- **Phase 6 (in progress): delegated moderators** (ADR-0048). Landed so far: role resolution and
-  owner-keyed entitlement; the grant lifecycle; the owner's Moderators panel; the moderator's
-  `/delegations` listing and role-aware `capabilities`; per-platform leg enforcement on the action path.
-  **Not yet landed:** the per-platform legs themselves — the dispatcher still resolves a credential by
-  `(caller, channel)`, so a delegated action currently fails **closed** with `422 no credential` rather
-  than falling back to the owner's token. Twitch is next (`moderator_id`/`broadcaster_id` split + the
-  owner-reach anchor), then Kick, Discord and YouTube, each independently gated.
+- **Phase 6 (in progress): delegated moderators** (ADR-0048). Role resolution and owner-keyed
+  entitlement; the grant lifecycle; the owner's Moderators panel; the moderator's `/delegations`
+  listing and role-aware `capabilities`; per-platform leg enforcement; and the **Twitch leg** — a
+  delegated moderator's Helix write now runs on their own credential (see Delegated writes below).
+  **Kick, Discord and YouTube legs are not built**: a delegated action on those refuses with
+  `delegation_unsupported` rather than falling through to whatever credential the dispatcher would
+  otherwise reach for.
 
 ## Layout
 

--- a/services/moderation-service/audit/store.go
+++ b/services/moderation-service/audit/store.go
@@ -33,13 +33,47 @@ const (
 	OutcomeDenied         = "denied"          // authorization failed (not owner, not a source, etc.)
 	OutcomePlatformError  = "platform_error"  // platform API rejected/failed the action
 	OutcomeReauthRequired = "reauth_required" // owner's token lacks the moderation scope; needs opt-in re-consent
-	OutcomeNoCredential   = "no_credential"   // owner holds no moderator credential for the channel
+	OutcomeNoCredential   = "no_credential"   // the actor holds no moderator credential for the channel
+	// OutcomeOwnerUnverified: the overlay owner cannot be shown to control the channel, so there
+	// was nothing for them to delegate on it (ADR-0048's owner-reach anchor).
+	OutcomeOwnerUnverified = "owner_unverified"
+	// OutcomeNotPlatformModerator: the platform says the delegated moderator does not moderate
+	// that channel. Distinct from a denial: All-Chat allowed it and the platform did not, which is
+	// exactly the authority split the design intends — and a spike of these is one of the signals
+	// that a grant has gone stale.
+	OutcomeNotPlatformModerator = "not_platform_moderator"
+	// OutcomeDelegationUnsupported: a delegated action on a platform whose delegated path is not
+	// built yet. Recorded rather than dropped — it is how a moderator hitting a wall becomes
+	// visible instead of just looking broken.
+	OutcomeDelegationUnsupported = "delegation_unsupported"
 )
 
 // Entry is one audited moderation command.
+//
+// Five identities are kept distinguishable forever (ADR-0048), because a delegated action has
+// more of them than an owner action does and collapsing any pair would destroy the trail:
+// who acted, in what role, for whom, with whose credential, and as which platform id.
 type Entry struct {
-	OverlayID       string
-	ActorUserID     string // effective identity whose token acts (the overlay owner)
+	OverlayID string
+	// ActorUserID is the human who performed the action — the owner when they moderate their own
+	// overlay, the delegated moderator when one acts. It is NOT necessarily whose credential ran
+	// the platform call (see CredentialUserID) and NOT necessarily the overlay owner.
+	ActorUserID string
+	// ActorRole is owner | moderator. Empty on legacy rows, where the actor was always the owner.
+	ActorRole string
+	// OnBehalfOfUserID is the overlay owner the action was performed for. Equals ActorUserID when
+	// the owner acted themselves.
+	OnBehalfOfUserID string
+	// CredentialUserID is whose OAuth token actually performed the platform call. This is the
+	// machine-checkable proof that a delegated action never fell back to the owner's credential:
+	// for a delegated row it must equal ActorUserID, never OnBehalfOfUserID. Empty where no
+	// per-user credential acts (Discord's shared bot, and dry runs).
+	CredentialUserID string
+	// PlatformActorID is the id sent as the platform's moderator field, so a row can be
+	// reconciled against the platform's own moderator log.
+	PlatformActorID string
+	// GrantID is the delegation the action was performed under. Empty for an owner action.
+	GrantID         string
 	ImpersonatedBy  string // real admin when acting under impersonation; "" otherwise
 	Platform        string
 	ChannelID       string
@@ -62,14 +96,15 @@ func New(db *pgxpool.Pool) *Store {
 }
 
 // Record inserts one audit row. Optional string fields are stored as NULL when
-// empty (notably impersonated_by, which is a UUID column and must be NULL — not the
-// empty string — for non-impersonated actions).
+// empty (notably impersonated_by and the ADR-0048 attribution columns, which are UUID columns and
+// must be NULL — not the empty string — when they do not apply).
 func (s *Store) Record(ctx context.Context, e Entry) error {
 	const query = `
 		INSERT INTO moderation_actions
 			(overlay_id, actor_user_id, impersonated_by, platform, channel_id, action,
-			 target_user_id, target_message_id, reason, outcome, platform_status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
+			 target_user_id, target_message_id, reason, outcome, platform_status,
+			 actor_role, on_behalf_of_user_id, credential_user_id, platform_actor_id, grant_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
 	_, err := s.db.Exec(ctx, query,
 		e.OverlayID,
 		e.ActorUserID,
@@ -82,6 +117,11 @@ func (s *Store) Record(ctx context.Context, e Entry) error {
 		nullIfEmpty(e.Reason),
 		e.Outcome,
 		nullIfEmpty(e.PlatformStatus),
+		nullIfEmpty(e.ActorRole),
+		nullIfEmpty(e.OnBehalfOfUserID),
+		nullIfEmpty(e.CredentialUserID),
+		nullIfEmpty(e.PlatformActorID),
+		nullIfEmpty(e.GrantID),
 	)
 	if err != nil {
 		return fmt.Errorf("record moderation action: %w", err)

--- a/services/moderation-service/audit/store_test.go
+++ b/services/moderation-service/audit/store_test.go
@@ -121,22 +121,29 @@ func setupAuditDB(t *testing.T) (*Store, *pgxpool.Pool, func()) {
 	pool, err := pgxpool.New(ctx, "postgres://testuser:testpass@"+host+":"+port.Port()+"/testdb?sslmode=disable")
 	require.NoError(t, err)
 
-	// Matches migrations/060_moderation_actions.sql.
+	// Matches migrations/060_moderation_actions.sql plus 080's attribution columns. Those are
+	// UUID columns, which is what makes the empty-string-to-NULL mapping load-bearing rather
+	// than cosmetic: an owner action carries no grant, and "" would be a cast error.
 	const schema = `
 		CREATE TABLE moderation_actions (
-			id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-			overlay_id        UUID NOT NULL,
-			actor_user_id     UUID NOT NULL,
-			impersonated_by   UUID,
-			platform          VARCHAR(50)  NOT NULL,
-			channel_id        VARCHAR(100) NOT NULL,
-			action            VARCHAR(20)  NOT NULL,
-			target_user_id    VARCHAR(100),
-			target_message_id VARCHAR(200),
-			reason            TEXT,
-			outcome           VARCHAR(30)  NOT NULL,
-			platform_status   TEXT,
-			created_at        TIMESTAMP NOT NULL DEFAULT NOW()
+			id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			overlay_id           UUID NOT NULL,
+			actor_user_id        UUID NOT NULL,
+			impersonated_by      UUID,
+			platform             VARCHAR(50)  NOT NULL,
+			channel_id           VARCHAR(100) NOT NULL,
+			action               VARCHAR(20)  NOT NULL,
+			target_user_id       VARCHAR(100),
+			target_message_id    VARCHAR(200),
+			reason               TEXT,
+			outcome              VARCHAR(30)  NOT NULL,
+			platform_status      TEXT,
+			actor_role           VARCHAR(24),
+			on_behalf_of_user_id UUID,
+			credential_user_id   UUID,
+			platform_actor_id    VARCHAR(100),
+			grant_id             UUID,
+			created_at           TIMESTAMP NOT NULL DEFAULT NOW()
 		);`
 	_, err = pool.Exec(ctx, schema)
 	require.NoError(t, err)
@@ -145,4 +152,77 @@ func setupAuditDB(t *testing.T) (*Store, *pgxpool.Pool, func()) {
 		pool.Close()
 		_ = container.Terminate(ctx)
 	}
+}
+
+// The five identities (ADR-0048). A delegated action has more of them than an owner action does,
+// and collapsing any pair destroys the trail the streamer needs to answer "who did this?".
+func TestRecord_DelegatedActionKeepsFiveIdentitiesDistinct(t *testing.T) {
+	store, pool, cleanup := setupAuditDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const modID = "33333333-3333-4333-8333-333333333333"
+	const grantID = "44444444-4444-4444-8444-444444444444"
+
+	err := store.Record(ctx, Entry{
+		OverlayID:        overlay,
+		ActorUserID:      modID,
+		ActorRole:        "moderator",
+		OnBehalfOfUserID: ownerID,
+		CredentialUserID: modID,
+		PlatformActorID:  "777",
+		GrantID:          grantID,
+		Platform:         "twitch",
+		ChannelID:        "somestreamer",
+		Action:           "delete",
+		Outcome:          OutcomeSuccess,
+	})
+	require.NoError(t, err)
+
+	var actor, role, onBehalf, credential, platformActor, grant string
+	err = pool.QueryRow(ctx, `
+		SELECT actor_user_id, actor_role, on_behalf_of_user_id, credential_user_id,
+		       platform_actor_id, grant_id
+		FROM moderation_actions WHERE overlay_id=$1`, overlay).
+		Scan(&actor, &role, &onBehalf, &credential, &platformActor, &grant)
+	require.NoError(t, err)
+
+	assert.Equal(t, modID, actor, "the human who pressed the button")
+	assert.Equal(t, "moderator", role)
+	assert.Equal(t, ownerID, onBehalf, "the streamer the action was performed for")
+	assert.Equal(t, modID, credential,
+		"the moderator's OWN token acted — this column is the proof there was no fallback")
+	assert.NotEqual(t, ownerID, credential)
+	assert.Equal(t, "777", platformActor, "reconcilable against Twitch's own mod log")
+	assert.Equal(t, grantID, grant)
+}
+
+// An owner action leaves the delegation columns NULL rather than restating the owner in each,
+// so "was this delegated?" stays answerable with a single IS NOT NULL.
+func TestRecord_OwnerActionLeavesDelegationColumnsNull(t *testing.T) {
+	store, pool, cleanup := setupAuditDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	err := store.Record(ctx, Entry{
+		OverlayID:        overlay,
+		ActorUserID:      ownerID,
+		ActorRole:        "owner",
+		OnBehalfOfUserID: ownerID,
+		CredentialUserID: ownerID,
+		PlatformActorID:  "9001",
+		Platform:         "twitch",
+		ChannelID:        "somestreamer",
+		Action:           "ban",
+		Outcome:          OutcomeSuccess,
+	})
+	require.NoError(t, err)
+
+	var grant *string
+	var role string
+	err = pool.QueryRow(ctx, `SELECT grant_id, actor_role FROM moderation_actions WHERE overlay_id=$1`, overlay).
+		Scan(&grant, &role)
+	require.NoError(t, err)
+	assert.Nil(t, grant, "an owner acts by ownership, not under a grant")
+	assert.Equal(t, "owner", role)
 }

--- a/services/moderation-service/clients/twitch.go
+++ b/services/moderation-service/clients/twitch.go
@@ -46,8 +46,13 @@ var (
 
 const defaultHelixBaseURL = "https://api.twitch.tv/helix"
 
-// TwitchClient calls Twitch Helix moderation endpoints. For own-channel moderation the
-// broadcaster is also the moderator (moderator_id == broadcaster_id).
+// TwitchClient calls Twitch Helix moderation endpoints.
+//
+// Every call takes broadcasterID and moderatorID separately. They are equal when a streamer
+// moderates their own channel, and different when a delegated moderator acts (ADR-0048) — and
+// Helix re-checks on every call that moderatorID is the token's own user and that they are a
+// moderator of broadcasterID. That check is the authority the whole delegation design rests on,
+// so these must never be collapsed back into one parameter.
 type TwitchClient struct {
 	httpClient *http.Client
 	clientID   string
@@ -65,10 +70,10 @@ func NewTwitchClient(clientID string) *TwitchClient {
 
 // DeleteMessage removes a single chat message.
 // DELETE /helix/moderation/chat — scope moderator:manage:chat_messages.
-func (t *TwitchClient) DeleteMessage(ctx context.Context, token, broadcasterID, nativeMessageID string) error {
+func (t *TwitchClient) DeleteMessage(ctx context.Context, token, broadcasterID, moderatorID, nativeMessageID string) error {
 	q := url.Values{
 		"broadcaster_id": {broadcasterID},
-		"moderator_id":   {broadcasterID},
+		"moderator_id":   {moderatorID},
 		"message_id":     {nativeMessageID},
 	}
 	return t.do(ctx, http.MethodDelete, "/moderation/chat?"+q.Encode(), token, nil)
@@ -76,32 +81,32 @@ func (t *TwitchClient) DeleteMessage(ctx context.Context, token, broadcasterID, 
 
 // TimeoutUser removes a user's messages for durationSeconds.
 // POST /helix/moderation/bans with a duration — scope moderator:manage:banned_users.
-func (t *TwitchClient) TimeoutUser(ctx context.Context, token, broadcasterID, targetUserID string, durationSeconds int, reason string) error {
-	return t.ban(ctx, token, broadcasterID, targetUserID, &durationSeconds, reason)
+func (t *TwitchClient) TimeoutUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID string, durationSeconds int, reason string) error {
+	return t.ban(ctx, token, broadcasterID, moderatorID, targetUserID, &durationSeconds, reason)
 }
 
 // BanUser permanently bans a user.
 // POST /helix/moderation/bans without a duration — scope moderator:manage:banned_users.
-func (t *TwitchClient) BanUser(ctx context.Context, token, broadcasterID, targetUserID, reason string) error {
-	return t.ban(ctx, token, broadcasterID, targetUserID, nil, reason)
+func (t *TwitchClient) BanUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID, reason string) error {
+	return t.ban(ctx, token, broadcasterID, moderatorID, targetUserID, nil, reason)
 }
 
 // UnbanUser lifts a ban or timeout.
 // DELETE /helix/moderation/bans — scope moderator:manage:banned_users.
-func (t *TwitchClient) UnbanUser(ctx context.Context, token, broadcasterID, targetUserID string) error {
+func (t *TwitchClient) UnbanUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID string) error {
 	q := url.Values{
 		"broadcaster_id": {broadcasterID},
-		"moderator_id":   {broadcasterID},
+		"moderator_id":   {moderatorID},
 		"user_id":        {targetUserID},
 	}
 	return t.do(ctx, http.MethodDelete, "/moderation/bans?"+q.Encode(), token, nil)
 }
 
 // ban posts to /moderation/bans; a non-nil duration makes it a timeout.
-func (t *TwitchClient) ban(ctx context.Context, token, broadcasterID, targetUserID string, durationSeconds *int, reason string) error {
+func (t *TwitchClient) ban(ctx context.Context, token, broadcasterID, moderatorID, targetUserID string, durationSeconds *int, reason string) error {
 	q := url.Values{
 		"broadcaster_id": {broadcasterID},
-		"moderator_id":   {broadcasterID},
+		"moderator_id":   {moderatorID},
 	}
 	data := map[string]any{"user_id": targetUserID}
 	if durationSeconds != nil {

--- a/services/moderation-service/clients/twitch_test.go
+++ b/services/moderation-service/clients/twitch_test.go
@@ -64,7 +64,7 @@ func TestDeleteMessage(t *testing.T) {
 	c, done := newTestClient(t, http.StatusNoContent, &got)
 	defer done()
 
-	err := c.DeleteMessage(context.Background(), "tok", "12345", "msg-1")
+	err := c.DeleteMessage(context.Background(), "tok", "12345", "12345", "msg-1")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, got.method)
 	assert.Equal(t, "/moderation/chat", got.path)
@@ -80,7 +80,7 @@ func TestBanUser_PermanentOmitsDuration(t *testing.T) {
 	c, done := newTestClient(t, http.StatusOK, &got)
 	defer done()
 
-	err := c.BanUser(context.Background(), "tok", "12345", "999", "spam")
+	err := c.BanUser(context.Background(), "tok", "12345", "12345", "999", "spam")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, got.method)
 	assert.Equal(t, "/moderation/bans", got.path)
@@ -97,7 +97,7 @@ func TestTimeoutUser_IncludesDuration(t *testing.T) {
 	c, done := newTestClient(t, http.StatusOK, &got)
 	defer done()
 
-	err := c.TimeoutUser(context.Background(), "tok", "12345", "999", 600, "cool down")
+	err := c.TimeoutUser(context.Background(), "tok", "12345", "12345", "999", 600, "cool down")
 	require.NoError(t, err)
 	data := got.body["data"].(map[string]any)
 	assert.Equal(t, float64(600), data["duration"], "timeout must carry the duration (seconds)")
@@ -109,7 +109,7 @@ func TestUnbanUser(t *testing.T) {
 	c, done := newTestClient(t, http.StatusNoContent, &got)
 	defer done()
 
-	err := c.UnbanUser(context.Background(), "tok", "12345", "999")
+	err := c.UnbanUser(context.Background(), "tok", "12345", "12345", "999")
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, got.method)
 	assert.Equal(t, "/moderation/bans", got.path)
@@ -127,7 +127,7 @@ func TestStatusMapping(t *testing.T) {
 	for _, tc := range cases {
 		var got capturedRequest
 		c, done := newTestClient(t, tc.status, &got)
-		err := c.BanUser(context.Background(), "tok", "1", "2", "")
+		err := c.BanUser(context.Background(), "tok", "1", "1", "2", "")
 		assert.ErrorIs(t, err, tc.want, "status %d", tc.status)
 		done()
 	}
@@ -136,8 +136,55 @@ func TestStatusMapping(t *testing.T) {
 	var got capturedRequest
 	c, done := newTestClient(t, http.StatusInternalServerError, &got)
 	defer done()
-	err := c.BanUser(context.Background(), "tok", "1", "2", "")
+	err := c.BanUser(context.Background(), "tok", "1", "1", "2", "")
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, ErrUnauthorized)
 	assert.NotErrorIs(t, err, ErrForbidden)
+}
+
+// A delegated moderator's write is the whole point of the moderator_id/broadcaster_id split
+// (ADR-0048): Helix re-checks that moderator_id is the token's own user and that they moderate
+// broadcaster_id, which is the authority All-Chat cannot and must not replicate. Collapsing these
+// back into one parameter would either act as the streamer or fail every delegated call.
+func TestDelegatedWriteSendsDistinctModeratorID(t *testing.T) {
+	t.Run("delete", func(t *testing.T) {
+		var got capturedRequest
+		c, done := newTestClient(t, http.StatusNoContent, &got)
+		defer done()
+
+		require.NoError(t, c.DeleteMessage(context.Background(), "mod-tok", "12345", "777", "msg-1"))
+		assert.Equal(t, "12345", got.query["broadcaster_id"], "the channel being moderated")
+		assert.Equal(t, "777", got.query["moderator_id"], "the moderator's own id, not the streamer's")
+		assert.Equal(t, "Bearer mod-tok", got.auth, "the moderator's own token performs the call")
+	})
+
+	t.Run("ban", func(t *testing.T) {
+		var got capturedRequest
+		c, done := newTestClient(t, http.StatusOK, &got)
+		defer done()
+
+		require.NoError(t, c.BanUser(context.Background(), "mod-tok", "12345", "777", "999", ""))
+		assert.Equal(t, "12345", got.query["broadcaster_id"])
+		assert.Equal(t, "777", got.query["moderator_id"])
+	})
+
+	t.Run("unban", func(t *testing.T) {
+		var got capturedRequest
+		c, done := newTestClient(t, http.StatusNoContent, &got)
+		defer done()
+
+		require.NoError(t, c.UnbanUser(context.Background(), "mod-tok", "12345", "777", "999"))
+		assert.Equal(t, "12345", got.query["broadcaster_id"])
+		assert.Equal(t, "777", got.query["moderator_id"])
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		var got capturedRequest
+		c, done := newTestClient(t, http.StatusOK, &got)
+		defer done()
+
+		require.NoError(t, c.TimeoutUser(context.Background(), "mod-tok", "12345", "777", "999", 60, ""))
+		assert.Equal(t, "12345", got.query["broadcaster_id"])
+		assert.Equal(t, "777", got.query["moderator_id"])
+	})
 }

--- a/services/moderation-service/cmd/main.go
+++ b/services/moderation-service/cmd/main.go
@@ -137,11 +137,17 @@ func main() {
 	default:
 		twitchSource := tokens.NewTwitchSource(dbPool, cipher, cfg.TwitchClientID, cfg.TwitchClientSecret)
 		twitchClient := clients.NewTwitchClient(cfg.TwitchClientID)
-		dispatchers["twitch"] = dispatch.NewTwitch(twitchSource, twitchClient, log)
+		twitchDispatcher := dispatch.NewTwitch(twitchSource, twitchClient, log)
+		// Delegated moderation (ADR-0048): a moderator acts with their OWN credential, read from
+		// mod_oauth_credentials and never from the streamer's rows. Without this the dispatcher
+		// refuses delegated Twitch actions outright rather than falling back to the owner's
+		// token — the refusal, not the fallback, is the invariant.
+		twitchDispatcher.SetModSource(tokens.NewModTwitchSource(dbPool, cipher, cfg.TwitchClientID, cfg.TwitchClientSecret))
+		dispatchers["twitch"] = twitchDispatcher
 		twitchScopes := tokens.NewTwitchScopeChecker(twitchSource)
 		scopeCheckers["twitch"] = twitchScopes
 		sendCheckers["twitch"] = twitchScopes
-		log.Info("Twitch moderation enabled (real Helix calls)")
+		log.Info("Twitch moderation enabled (real Helix calls, owner + delegated moderator)")
 	}
 
 	// Kick (timeout/ban/unban; no single-message delete) uses the broadcaster's own

--- a/services/moderation-service/dispatch/discord.go
+++ b/services/moderation-service/dispatch/discord.go
@@ -65,9 +65,19 @@ func NewDiscord(api discordAPI, guilds discordGuildResolver, logger *zap.Logger)
 
 // Dispatch performs a Discord moderation action. delete is channel-scoped; timeout/ban/
 // unban are guild-scoped, so the guild id is resolved from the channel id first.
-func (d *Discord) Dispatch(ctx context.Context, _ string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+func (d *Discord) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if req.Platform != "discord" {
 		return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
+	}
+
+	// Discord is the one platform where refusing delegation is load-bearing rather than tidy.
+	// Every other dispatcher acts with the caller's own credential, so a moderator without one
+	// simply fails; here the actor is always the shared bot, which holds the streamer's full
+	// guild authority. Without this refusal a delegated action would execute with that authority
+	// and no check that the moderator holds any of it — All-Chat's own check is the ONLY
+	// authority on Discord, and it is not built yet (ADR-0048 Phase 2).
+	if actor.IsModerator() {
+		return models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
 	}
 
 	if action == models.ActionDelete {

--- a/services/moderation-service/dispatch/discord_test.go
+++ b/services/moderation-service/dispatch/discord_test.go
@@ -83,7 +83,7 @@ func newDiscordDispatcher(api *fakeDiscordAPI, guilds *fakeGuildResolver) *Disco
 func TestDiscordDispatch_NonDiscordIsDryRun(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	d := newDiscordDispatcher(api, &fakeGuildResolver{})
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchDryRun, res.Outcome)
 	assert.Zero(t, api.deleteCalls)
@@ -93,7 +93,7 @@ func TestDiscordDispatch_DeletePerformed(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	guilds := &fakeGuildResolver{guildID: "g"}
 	d := newDiscordDispatcher(api, guilds)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete,
 		models.DispatchRequest{Platform: "discord", ChannelID: "chan-1", NativeMessageID: "msg-1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -107,7 +107,7 @@ func TestDiscordDispatch_BanResolvesGuildAndPerforms(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	guilds := &fakeGuildResolver{guildID: "guild-42"}
 	d := newDiscordDispatcher(api, guilds)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan,
 		models.DispatchRequest{Platform: "discord", ChannelID: "chan-1", TargetUserID: "member-7"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -120,7 +120,7 @@ func TestDiscordDispatch_TimeoutSetsFutureUntil(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	guilds := &fakeGuildResolver{guildID: "g"}
 	d := newDiscordDispatcher(api, guilds)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionTimeout,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionTimeout,
 		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: "u", DurationSeconds: 600})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -132,7 +132,7 @@ func TestDiscordDispatch_UnbanPerformed(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	guilds := &fakeGuildResolver{guildID: "g"}
 	d := newDiscordDispatcher(api, guilds)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionUnban,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionUnban,
 		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: "u"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -142,7 +142,7 @@ func TestDiscordDispatch_UnbanPerformed(t *testing.T) {
 func TestDiscordDispatch_ForbiddenIsError(t *testing.T) {
 	api := &fakeDiscordAPI{err: clients.ErrDiscordForbidden}
 	d := newDiscordDispatcher(api, &fakeGuildResolver{guildID: "g"})
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete,
 		models.DispatchRequest{Platform: "discord", ChannelID: "c", NativeMessageID: "m"})
 	require.Error(t, err, "a missing bot permission must fail the dispatch so no reflect-back fires")
 	assert.NotEqual(t, models.DispatchPerformed, res.Outcome)
@@ -152,7 +152,7 @@ func TestDiscordDispatch_ForbiddenIsError(t *testing.T) {
 func TestDiscordDispatch_BanForbiddenSurfacesReinvite(t *testing.T) {
 	api := &fakeDiscordAPI{err: clients.ErrDiscordForbidden}
 	d := newDiscordDispatcher(api, &fakeGuildResolver{guildID: "g"})
-	_, err := d.Dispatch(context.Background(), "u1", models.ActionBan,
+	_, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan,
 		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: "u"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, clients.ErrDiscordForbidden)
@@ -163,8 +163,36 @@ func TestDiscordDispatch_GuildResolutionFailureIsError(t *testing.T) {
 	api := &fakeDiscordAPI{}
 	guilds := &fakeGuildResolver{err: errors.New("channel gone")}
 	d := newDiscordDispatcher(api, guilds)
-	_, err := d.Dispatch(context.Background(), "u1", models.ActionBan,
+	_, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan,
 		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: "u"})
 	require.Error(t, err)
 	assert.Zero(t, api.banCalls, "no ban is attempted when the guild cannot be resolved")
+}
+
+// Discord is the one platform where refusing delegation is load-bearing rather than tidy.
+//
+// Everywhere else the actor supplies their own credential, so an unconsented moderator simply
+// fails. Here the actor is always the shared bot, holding the streamer's full guild authority —
+// so without this refusal a delegated action would execute with that authority and no check that
+// the moderator holds any of it. All-Chat's own check is the ONLY authority on Discord, and it is
+// not built yet.
+func TestDiscord_DelegatedActionNeverReachesTheSharedBot(t *testing.T) {
+	for _, action := range []models.Action{
+		models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			api := &fakeDiscordAPI{}
+			guilds := &fakeGuildResolver{guildID: "g1"}
+			d := newDiscordDispatcher(api, guilds)
+
+			res, err := d.Dispatch(context.Background(), moderator("mod", "own"), action,
+				models.DispatchRequest{Platform: "discord", ChannelID: "c", NativeMessageID: "m", TargetUserID: "42"})
+
+			require.NoError(t, err)
+			assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
+			assert.Zero(t, api.deleteCalls+api.timeoutCalls+api.banCalls+api.unbanCalls,
+				"the bot must not act for a delegated moderator")
+			assert.Zero(t, guilds.calls, "not even the guild lookup should run")
+		})
+	}
 }

--- a/services/moderation-service/dispatch/kick.go
+++ b/services/moderation-service/dispatch/kick.go
@@ -61,12 +61,19 @@ func NewKick(src kickTokenSource, api kickAPI, logger *zap.Logger) *Kick {
 // Dispatch resolves the owner's Kick credential, verifies it carries the moderation
 // scope, refreshes it if expired, and calls the Kick API — retrying once after a
 // reactive refresh on 401.
-func (d *Kick) Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+func (d *Kick) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if req.Platform != "kick" {
 		return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 	}
+	// The delegated path for this platform is not built yet (ADR-0048 gates each leg
+	// independently). Refuse explicitly: resolving by the caller's id happens to find nothing for
+	// a moderator today, but relying on that coincidence would turn any future change to
+	// credential selection into a silent privilege escalation.
+	if actor.IsModerator() {
+		return models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
+	}
 
-	cred, err := d.tokens.Resolve(ctx, userID, req.ChannelID)
+	cred, err := d.tokens.Resolve(ctx, actor.UserID, req.ChannelID)
 	if errors.Is(err, tokens.ErrNoCredential) {
 		return models.DispatchResult{Outcome: models.DispatchNoCredential}, nil
 	}

--- a/services/moderation-service/dispatch/kick_test.go
+++ b/services/moderation-service/dispatch/kick_test.go
@@ -102,7 +102,7 @@ func kickCredWith(scopes ...string) *tokens.KickCredential {
 func TestKickDispatch_NonKickIsDryRun(t *testing.T) {
 	api := &fakeKickAPI{}
 	d := NewKick(&fakeKickTokens{}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchDryRun, res.Outcome)
 	assert.Zero(t, api.calls)
@@ -111,7 +111,7 @@ func TestKickDispatch_NonKickIsDryRun(t *testing.T) {
 func TestKickDispatch_NoCredential(t *testing.T) {
 	api := &fakeKickAPI{}
 	d := NewKick(&fakeKickTokens{resolveErr: tokens.ErrNoCredential}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchNoCredential, res.Outcome)
 	assert.Zero(t, api.calls)
@@ -120,7 +120,7 @@ func TestKickDispatch_NoCredential(t *testing.T) {
 func TestKickDispatch_MissingScopePreCheckSkipsAPICall(t *testing.T) {
 	api := &fakeKickAPI{}
 	d := NewKick(&fakeKickTokens{cred: kickCredWith("user:read")}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeKickModeration}, res.MissingScopes)
@@ -130,7 +130,7 @@ func TestKickDispatch_MissingScopePreCheckSkipsAPICall(t *testing.T) {
 func TestKickDispatch_BanPerformed(t *testing.T) {
 	api := &fakeKickAPI{results: []error{nil}}
 	d := NewKick(&fakeKickTokens{cred: kickCredWith(models.ScopeKickModeration)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, "ban", api.method)
@@ -141,7 +141,7 @@ func TestKickDispatch_BanPerformed(t *testing.T) {
 func TestKickDispatch_TimeoutThreadsDuration(t *testing.T) {
 	api := &fakeKickAPI{results: []error{nil}}
 	d := NewKick(&fakeKickTokens{cred: kickCredWith(models.ScopeKickModeration)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionTimeout,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionTimeout,
 		models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42", DurationSeconds: 600})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -156,7 +156,7 @@ func TestKickDispatch_UnauthorizedRefreshesAndRetries(t *testing.T) {
 		onRefresh: func(c *tokens.KickCredential) { c.AccessToken = "tok2" },
 	}
 	d := NewKick(src, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, 1, src.refreshes, "a 401 triggers exactly one reactive refresh")
@@ -166,8 +166,24 @@ func TestKickDispatch_UnauthorizedRefreshesAndRetries(t *testing.T) {
 func TestKickDispatch_ForbiddenIsReauthWithScope(t *testing.T) {
 	api := &fakeKickAPI{results: []error{clients.ErrKickForbidden}}
 	d := NewKick(&fakeKickTokens{cred: kickCredWith(models.ScopeKickModeration)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeKickModeration}, res.MissingScopes)
+}
+
+// Kick's delegated leg is not built (ADR-0048 gates each independently). The refusal is explicit
+// rather than relying on the caller-keyed credential lookup happening to find nothing: any future
+// change to credential selection would otherwise become a silent privilege escalation.
+func TestKick_DelegatedActionIsRefused(t *testing.T) {
+	tok := &fakeKickTokens{cred: kickCredWith(models.ScopeKickModeration)}
+	api := &fakeKickAPI{}
+	d := NewKick(tok, api, zap.NewNop())
+
+	res, err := d.Dispatch(context.Background(), moderator("mod", "own"), models.ActionBan,
+		models.DispatchRequest{Platform: "kick", ChannelID: "c", TargetUserID: "42"})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
+	assert.Zero(t, api.calls, "no platform call, and no credential resolution either")
 }

--- a/services/moderation-service/dispatch/multi.go
+++ b/services/moderation-service/dispatch/multi.go
@@ -25,7 +25,7 @@ import (
 // PlatformDispatcher performs the real moderation call for a single platform.
 // *Twitch, *Discord, *Kick, and *YouTube each satisfy it.
 type PlatformDispatcher interface {
-	Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error)
+	Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error)
 }
 
 // Multi routes a platform-agnostic moderation command to the dispatcher registered for
@@ -44,9 +44,16 @@ func NewMulti(byPlatform map[string]PlatformDispatcher) *Multi {
 }
 
 // Dispatch routes by req.Platform.
-func (m *Multi) Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+func (m *Multi) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if d, ok := m.byPlatform[req.Platform]; ok && d != nil {
-		return d.Dispatch(ctx, userID, action, req)
+		return d.Dispatch(ctx, actor, action, req)
+	}
+	// No dispatcher for this platform in this deployment. Dry-run is the safe answer for an
+	// owner (reflect-back only, nothing happened upstream), but for a delegated moderator it
+	// would report success for an action nobody performed, on a platform whose delegated path
+	// does not exist — so that is refused instead.
+	if actor.IsModerator() {
+		return models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
 	}
 	return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 }

--- a/services/moderation-service/dispatch/multi_test.go
+++ b/services/moderation-service/dispatch/multi_test.go
@@ -30,7 +30,7 @@ type recordingDispatcher struct {
 	calls    int
 }
 
-func (r *recordingDispatcher) Dispatch(_ context.Context, _ string, _ models.Action, _ models.DispatchRequest) (models.DispatchResult, error) {
+func (r *recordingDispatcher) Dispatch(_ context.Context, _ models.Actor, _ models.Action, _ models.DispatchRequest) (models.DispatchResult, error) {
 	r.calls++
 	return models.DispatchResult{Outcome: models.DispatchPerformed, PlatformStatus: r.platform}, nil
 }
@@ -40,7 +40,7 @@ func TestMulti_RoutesByPlatform(t *testing.T) {
 	discord := &recordingDispatcher{platform: "discord"}
 	m := NewMulti(map[string]PlatformDispatcher{"twitch": twitch, "discord": discord})
 
-	res, err := m.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "discord"})
+	res, err := m.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "discord"})
 	require.NoError(t, err)
 	assert.Equal(t, "discord", res.PlatformStatus, "request routed to the discord dispatcher")
 	assert.Equal(t, 1, discord.calls)
@@ -51,8 +51,48 @@ func TestMulti_UnregisteredPlatformIsDryRun(t *testing.T) {
 	twitch := &recordingDispatcher{platform: "twitch"}
 	m := NewMulti(map[string]PlatformDispatcher{"twitch": twitch})
 
-	res, err := m.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "kick"})
+	res, err := m.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "kick"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchDryRun, res.Outcome, "an unconfigured platform falls back to dry-run reflect-back")
 	assert.Zero(t, twitch.calls)
+}
+
+// owner builds an Actor for a streamer moderating their own overlay — the role every test in
+// this package used implicitly before delegation existed.
+func owner(userID string) models.Actor {
+	return models.Actor{UserID: userID, Role: models.RoleOwner, OwnerUserID: userID}
+}
+
+// moderator builds an Actor for a delegated moderator acting on ownerID's overlay.
+func moderator(userID, ownerID string) models.Actor {
+	return models.Actor{
+		UserID: userID, Role: models.RoleModerator, OwnerUserID: ownerID, GrantID: "grant-1",
+	}
+}
+
+// Delegation is gated per platform (ADR-0048 Phase 2), and each unbuilt leg must REFUSE rather
+// than fall through. The reasons differ by platform but the requirement does not.
+func TestDelegatedActionsAreRefusedOnUnbuiltLegs(t *testing.T) {
+	t.Run("unregistered platform is not a dry run for a moderator", func(t *testing.T) {
+		// For an owner, dry-run means "reflect back, nothing happened upstream". For a moderator
+		// it would report success for an action nobody performed on a platform with no delegated
+		// path at all.
+		m := NewMulti(map[string]PlatformDispatcher{})
+
+		res, err := m.Dispatch(context.Background(), moderator("mod", "own"), models.ActionDelete,
+			models.DispatchRequest{Platform: "tiktok"})
+
+		require.NoError(t, err)
+		assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
+	})
+
+	t.Run("an owner still gets the dry run", func(t *testing.T) {
+		m := NewMulti(map[string]PlatformDispatcher{})
+
+		res, err := m.Dispatch(context.Background(), owner("u1"), models.ActionDelete,
+			models.DispatchRequest{Platform: "tiktok"})
+
+		require.NoError(t, err)
+		assert.Equal(t, models.DispatchDryRun, res.Outcome)
+	})
 }

--- a/services/moderation-service/dispatch/twitch.go
+++ b/services/moderation-service/dispatch/twitch.go
@@ -38,106 +38,245 @@ import (
 // so a foreseeable expiry does not cost the user a failed first attempt.
 const refreshLeadTime = 5 * time.Minute
 
-// twitchTokenSource resolves and refreshes broadcaster credentials.
-// *tokens.TwitchSource satisfies it; an interface keeps dispatch unit-testable.
+// twitchTokenSource resolves and refreshes broadcaster credentials, and answers the owner-reach
+// anchor. *tokens.TwitchSource satisfies it; an interface keeps dispatch unit-testable.
 type twitchTokenSource interface {
 	Resolve(ctx context.Context, userID, channelID string) (*tokens.TwitchCredential, error)
 	Refresh(ctx context.Context, cred *tokens.TwitchCredential) error
+	// OwnerTwitchAnchor proves the overlay OWNER controls a channel and yields the numeric
+	// broadcaster id. It applies no scope predicate and reads no token: an owner who delegates
+	// precisely because they do not moderate themselves must still be able to delegate.
+	OwnerTwitchAnchor(ctx context.Context, ownerUserID, channelID string) (string, error)
+}
+
+// modTokenSource resolves and refreshes a delegated moderator's OWN Twitch credential.
+// *tokens.ModTwitchSource satisfies it.
+type modTokenSource interface {
+	Resolve(ctx context.Context, userID string) (*tokens.ModCredential, error)
+	Refresh(ctx context.Context, userID string, cred *tokens.ModCredential) error
 }
 
 // twitchAPI is the subset of clients.TwitchClient the dispatcher calls.
 type twitchAPI interface {
-	DeleteMessage(ctx context.Context, token, broadcasterID, nativeMessageID string) error
-	TimeoutUser(ctx context.Context, token, broadcasterID, targetUserID string, durationSeconds int, reason string) error
-	BanUser(ctx context.Context, token, broadcasterID, targetUserID, reason string) error
-	UnbanUser(ctx context.Context, token, broadcasterID, targetUserID string) error
+	DeleteMessage(ctx context.Context, token, broadcasterID, moderatorID, nativeMessageID string) error
+	TimeoutUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID string, durationSeconds int, reason string) error
+	BanUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID, reason string) error
+	UnbanUser(ctx context.Context, token, broadcasterID, moderatorID, targetUserID string) error
 }
 
 // Twitch dispatches moderation commands to the Twitch Helix API. Platforms other
 // than Twitch report DispatchDryRun (their clients ship in later phases).
 type Twitch struct {
 	tokens twitchTokenSource
+	mod    modTokenSource // nil ⇒ delegation unsupported for this deployment
 	api    twitchAPI
 	logger *zap.Logger
 }
 
-// NewTwitch wires a Twitch dispatcher.
+// NewTwitch wires a Twitch dispatcher for owner actions only.
 func NewTwitch(src twitchTokenSource, api twitchAPI, logger *zap.Logger) *Twitch {
 	return &Twitch{tokens: src, api: api, logger: logger}
 }
 
-// Dispatch resolves the owner's Twitch credential, verifies it carries the scope the
-// action needs, refreshes it if expired, and calls Helix — retrying once after a
-// reactive refresh on 401. Authorization (ownership, source membership) has already
-// happened in the handler.
-func (d *Twitch) Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+// SetModSource enables delegated moderation (ADR-0048). Until it is called, a delegated action is
+// refused rather than falling back to the owner's credential — the refusal is the invariant, not
+// an oversight.
+func (d *Twitch) SetModSource(src modTokenSource) { d.mod = src }
+
+// twitchCall is one resolved Twitch write: whose token, against which channel, as which
+// moderator. Building it is the whole difference between an owner action and a delegated one;
+// everything after it — scope pre-check, refresh, retry, error mapping — is identical.
+type twitchCall struct {
+	accessToken   string
+	broadcasterID string
+	moderatorID   string
+	scopes        []string
+	expiresAt     time.Time
+	// credentialUserID is whose token this is, reported back as the proof that a delegated action
+	// used the moderator's own credential and not the owner's.
+	credentialUserID string
+	// refresh renews this credential in place, whichever store it came from.
+	refresh func(ctx context.Context) error
+}
+
+// Dispatch resolves the acting human's own Twitch credential, verifies it carries the scope the
+// action needs, refreshes it if expired, and calls Helix — retrying once after a reactive refresh
+// on 401. Authorization (role, grant, source membership) has already happened in the handler.
+//
+// For a delegated moderator the credential is theirs, and the channel comes from the owner-reach
+// anchor. There is deliberately no fallback between the two: if the moderator has not consented,
+// the action fails rather than quietly running as the streamer.
+func (d *Twitch) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if req.Platform != "twitch" {
 		// No client for this platform yet — keep the reflect-back-only dry run.
 		return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 	}
 
-	cred, err := d.tokens.Resolve(ctx, userID, req.ChannelID)
-	if errors.Is(err, tokens.ErrNoCredential) {
-		return models.DispatchResult{Outcome: models.DispatchNoCredential}, nil
-	}
-	if err != nil {
-		return models.DispatchResult{}, fmt.Errorf("resolve twitch credential: %w", err)
+	call, result, err := d.resolveCall(ctx, actor, req)
+	if err != nil || call == nil {
+		return result, err
 	}
 
 	// Scope pre-check: fail fast (no API call) when the token cannot perform the
 	// action, surfacing exactly the scope the opt-in re-consent must request.
 	need := models.RequiredTwitchScope(action)
-	if need != "" && !hasScope(cred.GrantedScopes, need) {
+	if need != "" && !hasScope(call.scopes, need) {
 		return models.DispatchResult{Outcome: models.DispatchReauthRequired, MissingScopes: []string{need}}, nil
 	}
 
 	// Proactive refresh: token-refresh-service keeps tokens fresh, but refresh here
 	// too if expiry is imminent so we don't spend the first attempt on a 401.
-	if !cred.ExpiresAt.IsZero() && time.Until(cred.ExpiresAt) < refreshLeadTime {
-		if err := d.tokens.Refresh(ctx, cred); err != nil {
+	if !call.expiresAt.IsZero() && time.Until(call.expiresAt) < refreshLeadTime {
+		if err := call.refresh(ctx); err != nil {
 			d.logger.Warn("proactive token refresh failed; attempting with current token",
 				zap.String("channel_id", req.ChannelID), zap.Error(err))
 		}
 	}
 
-	err = d.call(ctx, action, cred, req)
+	proof := models.DispatchResult{
+		CredentialUserID: call.credentialUserID,
+		PlatformActorID:  call.moderatorID,
+	}
+
+	err = d.call(ctx, action, call, req)
 	if errors.Is(err, clients.ErrUnauthorized) {
 		// Reactive refresh + single retry: the token expired between refresh cycles.
-		if rerr := d.tokens.Refresh(ctx, cred); rerr != nil {
+		if rerr := call.refresh(ctx); rerr != nil {
 			d.logger.Warn("reactive token refresh failed", zap.String("channel_id", req.ChannelID), zap.Error(rerr))
-			return models.DispatchResult{Outcome: models.DispatchReauthRequired, PlatformStatus: "token refresh failed"}, nil
+			proof.Outcome = models.DispatchReauthRequired
+			proof.PlatformStatus = "token refresh failed"
+			return proof, nil
 		}
-		err = d.call(ctx, action, cred, req)
+		err = d.call(ctx, action, call, req)
 	}
 
 	switch {
 	case err == nil:
-		return models.DispatchResult{Outcome: models.DispatchPerformed}, nil
+		proof.Outcome = models.DispatchPerformed
+		return proof, nil
 	case errors.Is(err, clients.ErrForbidden):
-		// Token is valid but lacks the scope (or moderator privilege) — re-consent.
-		missing := []string{}
-		if need != "" {
-			missing = []string{need}
+		// Helix accepted the token and refused the action. For a delegated moderator that is
+		// almost never about scope — the pre-check above already confirmed the scope is present —
+		// so it is Twitch answering the question the whole design defers to it: this person is not
+		// a moderator of this channel. Reporting it as "re-authorize" would loop a volunteer
+		// through a consent screen that cannot fix anything; the remediation is the streamer
+		// modding them on Twitch.
+		if actor.IsModerator() && need != "" {
+			proof.Outcome = models.DispatchNotPlatformModerator
+			proof.PlatformStatus = "forbidden"
+			return proof, nil
 		}
-		return models.DispatchResult{Outcome: models.DispatchReauthRequired, MissingScopes: missing, PlatformStatus: "forbidden"}, nil
+		// Owner path unchanged: a broadcaster is always a moderator of their own channel, so a
+		// 403 there really is about the grant.
+		if need != "" {
+			proof.MissingScopes = []string{need}
+		}
+		proof.Outcome = models.DispatchReauthRequired
+		proof.PlatformStatus = "forbidden"
+		return proof, nil
 	case errors.Is(err, clients.ErrUnauthorized):
-		return models.DispatchResult{Outcome: models.DispatchReauthRequired, PlatformStatus: "unauthorized after refresh"}, nil
+		proof.Outcome = models.DispatchReauthRequired
+		proof.PlatformStatus = "unauthorized after refresh"
+		return proof, nil
 	default:
-		return models.DispatchResult{}, err
+		// An unexpected failure still carries the attribution: "which credential did we try?" is
+		// exactly the question a failed delegated action raises, and dropping it here would leave
+		// the audit row unable to answer it.
+		return proof, err
 	}
 }
 
+// resolveCall builds the credential + channel pair for this actor. A non-nil DispatchResult with
+// a nil call means the dispatch is already decided (no credential, owner unverified, delegation
+// unsupported).
+func (d *Twitch) resolveCall(ctx context.Context, actor models.Actor, req models.DispatchRequest) (*twitchCall, models.DispatchResult, error) {
+	if !actor.IsModerator() {
+		cred, err := d.tokens.Resolve(ctx, actor.UserID, req.ChannelID)
+		if errors.Is(err, tokens.ErrNoCredential) {
+			return nil, models.DispatchResult{Outcome: models.DispatchNoCredential}, nil
+		}
+		if err != nil {
+			return nil, models.DispatchResult{}, fmt.Errorf("resolve twitch credential: %w", err)
+		}
+		// A streamer moderating their own channel IS the moderator, so Helix gets the same id
+		// twice. This is the one case where they legitimately coincide.
+		call := &twitchCall{
+			accessToken:      cred.AccessToken,
+			broadcasterID:    cred.BroadcasterID,
+			moderatorID:      cred.BroadcasterID,
+			scopes:           cred.GrantedScopes,
+			expiresAt:        cred.ExpiresAt,
+			credentialUserID: actor.UserID,
+		}
+		// The refresh writes the new token back onto the call, not just onto the credential:
+		// the retry after a 401 reads from the call, so a snapshot taken at construction would
+		// silently retry with the same expired token.
+		call.refresh = func(ctx context.Context) error {
+			if err := d.tokens.Refresh(ctx, cred); err != nil {
+				return err
+			}
+			call.accessToken, call.expiresAt = cred.AccessToken, cred.ExpiresAt
+			return nil
+		}
+		return call, models.DispatchResult{}, nil
+	}
+
+	if d.mod == nil {
+		return nil, models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
+	}
+
+	// The owner-reach anchor first: delegation never exceeds what the owner could do themselves,
+	// and this is also the only honest source of the broadcaster id — the moderator's credential
+	// knows nothing about the streamer's channel.
+	broadcasterID, err := d.tokens.OwnerTwitchAnchor(ctx, actor.OwnerUserID, req.ChannelID)
+	if errors.Is(err, tokens.ErrOwnerChannelUnverified) {
+		return nil, models.DispatchResult{Outcome: models.DispatchOwnerUnverified}, nil
+	}
+	if err != nil {
+		return nil, models.DispatchResult{}, fmt.Errorf("resolve owner anchor: %w", err)
+	}
+
+	cred, err := d.mod.Resolve(ctx, actor.UserID)
+	if errors.Is(err, tokens.ErrNoCredential) {
+		// They have not consented for Twitch yet. Consent is deferred to first use, so this is
+		// the normal state of a fresh grant, not a fault.
+		return nil, models.DispatchResult{Outcome: models.DispatchNoCredential}, nil
+	}
+	if err != nil {
+		return nil, models.DispatchResult{}, fmt.Errorf("resolve moderator twitch credential: %w", err)
+	}
+
+	call := &twitchCall{
+		accessToken:   cred.AccessToken,
+		broadcasterID: broadcasterID,
+		moderatorID:   cred.PlatformUserID,
+		scopes:        cred.GrantedScopes,
+		expiresAt:     cred.ExpiresAt,
+		// The moderator's own id, never the owner's. This is the field an auditor reads to
+		// confirm the no-fallback invariant held.
+		credentialUserID: actor.UserID,
+	}
+	call.refresh = func(ctx context.Context) error {
+		if err := d.mod.Refresh(ctx, actor.UserID, cred); err != nil {
+			return err
+		}
+		call.accessToken, call.expiresAt = cred.AccessToken, cred.ExpiresAt
+		return nil
+	}
+	return call, models.DispatchResult{}, nil
+}
+
 // call routes an action to the matching Helix endpoint.
-func (d *Twitch) call(ctx context.Context, action models.Action, cred *tokens.TwitchCredential, req models.DispatchRequest) error {
+func (d *Twitch) call(ctx context.Context, action models.Action, c *twitchCall, req models.DispatchRequest) error {
 	switch action {
 	case models.ActionDelete:
-		return d.api.DeleteMessage(ctx, cred.AccessToken, cred.BroadcasterID, req.NativeMessageID)
+		return d.api.DeleteMessage(ctx, c.accessToken, c.broadcasterID, c.moderatorID, req.NativeMessageID)
 	case models.ActionTimeout:
-		return d.api.TimeoutUser(ctx, cred.AccessToken, cred.BroadcasterID, req.TargetUserID, req.DurationSeconds, req.Reason)
+		return d.api.TimeoutUser(ctx, c.accessToken, c.broadcasterID, c.moderatorID, req.TargetUserID, req.DurationSeconds, req.Reason)
 	case models.ActionBan:
-		return d.api.BanUser(ctx, cred.AccessToken, cred.BroadcasterID, req.TargetUserID, req.Reason)
+		return d.api.BanUser(ctx, c.accessToken, c.broadcasterID, c.moderatorID, req.TargetUserID, req.Reason)
 	case models.ActionUnban:
-		return d.api.UnbanUser(ctx, cred.AccessToken, cred.BroadcasterID, req.TargetUserID)
+		return d.api.UnbanUser(ctx, c.accessToken, c.broadcasterID, c.moderatorID, req.TargetUserID)
 	default:
 		return fmt.Errorf("dispatch: unsupported twitch action %q", action)
 	}

--- a/services/moderation-service/dispatch/twitch_delegated_test.go
+++ b/services/moderation-service/dispatch/twitch_delegated_test.go
@@ -1,0 +1,255 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/moderation-service/clients"
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/tokens"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// The delegated Twitch write path (ADR-0048).
+//
+// One invariant dominates every test here: a delegated action runs on the MODERATOR's own
+// credential against the OWNER's channel, with **no fallback** between them. If the moderator has
+// not consented, the action fails — it must never quietly run as the streamer, which would put the
+// streamer's name in their own mod log for something they did not do and would make the platform's
+// per-call moderator check meaningless.
+
+const (
+	modUserID   = "mod-user"
+	ownerUserID = "owner-user"
+)
+
+// modCredWith builds a moderator credential whose platform id is deliberately different from any
+// broadcaster id used in these tests.
+func modCredWith(scopes ...string) *tokens.ModCredential {
+	return &tokens.ModCredential{
+		AccessToken:    "mod-tok",
+		RefreshToken:   "mod-ref",
+		PlatformUserID: "777",
+		GrantedScopes:  scopes,
+		ExpiresAt:      time.Now().Add(time.Hour), // far future: no proactive refresh
+	}
+}
+
+// delegatedTwitch wires a dispatcher with both credential stores.
+func delegatedTwitch(t *testing.T, own *fakeTokens, mod *fakeModTokens, api *fakeAPI) *Twitch {
+	t.Helper()
+	d := NewTwitch(own, api, zap.NewNop())
+	if mod != nil {
+		d.SetModSource(mod)
+	}
+	return d
+}
+
+func deleteReq() models.DispatchRequest {
+	return models.DispatchRequest{Platform: "twitch", ChannelID: "somestreamer", NativeMessageID: "m1"}
+}
+
+// The whole point: the moderator's token, the owner's channel, the moderator's id as moderator_id.
+func TestDelegated_UsesTheModeratorsOwnCredentialAgainstTheOwnersChannel(t *testing.T) {
+	own := &fakeTokens{anchor: "9001", cred: credWith(models.ScopeTwitchManageMessages)}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageMessages)}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, mod, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, []string{"mod-tok"}, api.tokensSeen, "the moderator's own token performs the call")
+	assert.Equal(t, "9001", api.broadcaster, "the channel is the owner's, from the anchor")
+	assert.Equal(t, "777", api.moderator, "moderator_id is the moderator, never the broadcaster")
+	assert.Equal(t, []string{modUserID}, mod.resolvedFor)
+}
+
+// The owner's credential must not be touched on a delegated action — not as a fallback, not as a
+// source of the token, not at all. Only the anchor may consult the owner, and it reads no token.
+func TestDelegated_NeverReachesForTheOwnersCredential(t *testing.T) {
+	// The owner holds a perfectly good credential; if any code path preferred it, this passes
+	// where it must fail.
+	own := &fakeTokens{anchor: "9001", cred: credWith(models.ScopeTwitchManageMessages)}
+	mod := &fakeModTokens{resolveErr: tokens.ErrNoCredential}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, mod, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchNoCredential, res.Outcome,
+		"an unconsented moderator fails; it must not fall back to the streamer's token")
+	assert.Zero(t, api.calls, "nothing may be sent to Helix")
+}
+
+// The anchor is asked about the OWNER, not the caller. Asking about the moderator would let anyone
+// with a grant act on any channel they happen to hold a credential for.
+func TestDelegated_AnchorIsResolvedAgainstTheOwner(t *testing.T) {
+	own := &fakeTokens{anchor: "9001"}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageMessages)}
+	d := delegatedTwitch(t, own, mod, &fakeAPI{})
+
+	_, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{ownerUserID + "|somestreamer"}, own.anchorFor)
+}
+
+// Delegation never exceeds what the owner could do themselves: if the owner cannot be shown to
+// control the channel, there is nothing on it to delegate.
+func TestDelegated_OwnerWithoutAnchorBlocksTheAction(t *testing.T) {
+	own := &fakeTokens{anchorErr: tokens.ErrOwnerChannelUnverified}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageMessages)}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, mod, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchOwnerUnverified, res.Outcome)
+	assert.Zero(t, api.calls)
+	assert.Empty(t, mod.resolvedFor, "the anchor fails first; no credential is even read")
+}
+
+// The scope pre-check reads the MODERATOR's scopes. Reading the owner's would advertise actions
+// the moderator never consented to and burn a Helix call to discover it.
+func TestDelegated_ScopePreCheckReadsTheModeratorsScopes(t *testing.T) {
+	// The owner holds the delete scope; the moderator does not.
+	own := &fakeTokens{anchor: "9001", cred: credWith(models.ScopeTwitchManageMessages)}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageBannedUsers)}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, mod, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
+	assert.Equal(t, []string{models.ScopeTwitchManageMessages}, res.MissingScopes)
+	assert.Zero(t, api.calls)
+}
+
+// A 401 refreshes the MODERATOR's credential and retries with the new token — the same recovery
+// the owner path gets, against the moderator's own row.
+func TestDelegated_UnauthorizedRefreshesTheModeratorsTokenAndRetries(t *testing.T) {
+	own := &fakeTokens{anchor: "9001"}
+	mod := &fakeModTokens{
+		cred:      modCredWith(models.ScopeTwitchManageMessages),
+		onRefresh: func(c *tokens.ModCredential) { c.AccessToken = "mod-tok2" },
+	}
+	api := &fakeAPI{results: []error{clients.ErrUnauthorized, nil}}
+	d := delegatedTwitch(t, own, mod, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, 1, mod.refreshes)
+	assert.Equal(t, []string{"mod-tok", "mod-tok2"}, api.tokensSeen, "the retry uses the refreshed token")
+}
+
+// The proof columns are what an auditor reads to confirm no-fallback held. They must name the
+// moderator, never the owner.
+func TestDelegated_ReportsWhoseCredentialActed(t *testing.T) {
+	own := &fakeTokens{anchor: "9001"}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageMessages)}
+	d := delegatedTwitch(t, own, mod, &fakeAPI{})
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, modUserID, res.CredentialUserID)
+	assert.NotEqual(t, ownerUserID, res.CredentialUserID)
+	assert.Equal(t, "777", res.PlatformActorID)
+}
+
+// An owner action reports its own attribution too, and the ids coincide legitimately there.
+func TestOwnerAction_ReportsItsOwnCredential(t *testing.T) {
+	own := &fakeTokens{cred: credWith(models.ScopeTwitchManageMessages)}
+	d := delegatedTwitch(t, own, &fakeModTokens{}, &fakeAPI{})
+
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, "u1", res.CredentialUserID)
+	assert.Equal(t, "9001", res.PlatformActorID, "the streamer is their own moderator")
+	assert.Empty(t, own.anchorFor, "an owner action needs no anchor — ownership is the anchor")
+}
+
+// A deployment without the moderator credential store refuses delegated actions rather than
+// falling through to whatever the owner path would have done.
+func TestDelegated_WithoutAModSourceIsRefused(t *testing.T) {
+	own := &fakeTokens{anchor: "9001", cred: credWith(models.ScopeTwitchManageMessages)}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, nil, api)
+
+	res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
+	assert.Zero(t, api.calls)
+}
+
+// An anchor lookup that errors for an unexpected reason is an error, not a silent allow.
+func TestDelegated_AnchorErrorIsNotAnAllow(t *testing.T) {
+	own := &fakeTokens{anchorErr: errors.New("database unavailable")}
+	mod := &fakeModTokens{cred: modCredWith(models.ScopeTwitchManageMessages)}
+	api := &fakeAPI{}
+	d := delegatedTwitch(t, own, mod, api)
+
+	_, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), models.ActionDelete, deleteReq())
+
+	require.Error(t, err)
+	assert.Zero(t, api.calls)
+}
+
+// Every delegatable action carries the split, not just delete.
+func TestDelegated_AllActionsCarryTheModeratorID(t *testing.T) {
+	cases := []struct {
+		action models.Action
+		req    models.DispatchRequest
+	}{
+		{models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"}},
+		{models.ActionTimeout, models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42", DurationSeconds: 60}},
+		{models.ActionBan, models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42"}},
+		{models.ActionUnban, models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.action), func(t *testing.T) {
+			own := &fakeTokens{anchor: "9001"}
+			mod := &fakeModTokens{cred: modCredWith(
+				models.ScopeTwitchManageMessages, models.ScopeTwitchManageBannedUsers)}
+			api := &fakeAPI{}
+			d := delegatedTwitch(t, own, mod, api)
+
+			res, err := d.Dispatch(context.Background(), moderator(modUserID, ownerUserID), tc.action, tc.req)
+
+			require.NoError(t, err)
+			assert.Equal(t, models.DispatchPerformed, res.Outcome)
+			assert.Equal(t, "9001", api.broadcaster)
+			assert.Equal(t, "777", api.moderator)
+		})
+	}
+}

--- a/services/moderation-service/dispatch/twitch_test.go
+++ b/services/moderation-service/dispatch/twitch_test.go
@@ -35,6 +35,47 @@ type fakeTokens struct {
 	refreshErr error
 	refreshes  int
 	onRefresh  func(*tokens.TwitchCredential) // mutate cred to simulate a successful refresh
+	// anchor is the broadcaster id the owner-reach anchor resolves; anchorErr overrides it.
+	anchor    string
+	anchorErr error
+	anchorFor []string // the (owner, channel) pairs the anchor was asked about
+}
+
+func (f *fakeTokens) OwnerTwitchAnchor(_ context.Context, ownerUserID, channelID string) (string, error) {
+	f.anchorFor = append(f.anchorFor, ownerUserID+"|"+channelID)
+	if f.anchorErr != nil {
+		return "", f.anchorErr
+	}
+	return f.anchor, nil
+}
+
+// fakeModTokens stands in for a delegated moderator's OWN credential store.
+type fakeModTokens struct {
+	cred        *tokens.ModCredential
+	resolveErr  error
+	refreshErr  error
+	refreshes   int
+	resolvedFor []string
+	onRefresh   func(*tokens.ModCredential)
+}
+
+func (f *fakeModTokens) Resolve(_ context.Context, userID string) (*tokens.ModCredential, error) {
+	f.resolvedFor = append(f.resolvedFor, userID)
+	if f.resolveErr != nil {
+		return nil, f.resolveErr
+	}
+	return f.cred, nil
+}
+
+func (f *fakeModTokens) Refresh(_ context.Context, _ string, cred *tokens.ModCredential) error {
+	f.refreshes++
+	if f.refreshErr != nil {
+		return f.refreshErr
+	}
+	if f.onRefresh != nil {
+		f.onRefresh(cred)
+	}
+	return nil
 }
 
 func (f *fakeTokens) Resolve(context.Context, string, string) (*tokens.TwitchCredential, error) {
@@ -62,14 +103,15 @@ type fakeAPI struct {
 	tokensSeen  []string
 	method      string
 	broadcaster string
+	moderator   string
 	target      string
 	msgID       string
 	duration    int
 }
 
-func (f *fakeAPI) next(token, broadcaster string) error {
+func (f *fakeAPI) next(token, broadcaster, moderator string) error {
 	f.tokensSeen = append(f.tokensSeen, token)
-	f.broadcaster = broadcaster
+	f.broadcaster, f.moderator = broadcaster, moderator
 	var err error
 	if f.calls < len(f.results) {
 		err = f.results[f.calls]
@@ -78,21 +120,21 @@ func (f *fakeAPI) next(token, broadcaster string) error {
 	return err
 }
 
-func (f *fakeAPI) DeleteMessage(_ context.Context, token, b, msgID string) error {
+func (f *fakeAPI) DeleteMessage(_ context.Context, token, b, m, msgID string) error {
 	f.method, f.msgID = "delete", msgID
-	return f.next(token, b)
+	return f.next(token, b, m)
 }
-func (f *fakeAPI) TimeoutUser(_ context.Context, token, b, target string, dur int, _ string) error {
+func (f *fakeAPI) TimeoutUser(_ context.Context, token, b, m, target string, dur int, _ string) error {
 	f.method, f.target, f.duration = "timeout", target, dur
-	return f.next(token, b)
+	return f.next(token, b, m)
 }
-func (f *fakeAPI) BanUser(_ context.Context, token, b, target, _ string) error {
+func (f *fakeAPI) BanUser(_ context.Context, token, b, m, target, _ string) error {
 	f.method, f.target = "ban", target
-	return f.next(token, b)
+	return f.next(token, b, m)
 }
-func (f *fakeAPI) UnbanUser(_ context.Context, token, b, target string) error {
+func (f *fakeAPI) UnbanUser(_ context.Context, token, b, m, target string) error {
 	f.method, f.target = "unban", target
-	return f.next(token, b)
+	return f.next(token, b, m)
 }
 
 func credWith(scopes ...string) *tokens.TwitchCredential {
@@ -108,7 +150,7 @@ func credWith(scopes ...string) *tokens.TwitchCredential {
 func TestDispatch_NonTwitchIsDryRun(t *testing.T) {
 	api := &fakeAPI{}
 	d := NewTwitch(&fakeTokens{}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "kick", ChannelID: "c"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "kick", ChannelID: "c"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchDryRun, res.Outcome)
 	assert.Zero(t, api.calls, "no platform call for an unimplemented platform")
@@ -117,7 +159,7 @@ func TestDispatch_NonTwitchIsDryRun(t *testing.T) {
 func TestDispatch_NoCredential(t *testing.T) {
 	api := &fakeAPI{}
 	d := NewTwitch(&fakeTokens{resolveErr: tokens.ErrNoCredential}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchNoCredential, res.Outcome)
 	assert.Zero(t, api.calls)
@@ -127,7 +169,7 @@ func TestDispatch_MissingScopePreCheckSkipsAPICall(t *testing.T) {
 	api := &fakeAPI{}
 	// Token has banned-users scope but the action is delete (needs manage:chat_messages).
 	d := NewTwitch(&fakeTokens{cred: credWith(models.ScopeTwitchManageBannedUsers)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeTwitchManageMessages}, res.MissingScopes)
@@ -137,7 +179,7 @@ func TestDispatch_MissingScopePreCheckSkipsAPICall(t *testing.T) {
 func TestDispatch_DeletePerformed(t *testing.T) {
 	api := &fakeAPI{results: []error{nil}}
 	d := NewTwitch(&fakeTokens{cred: credWith(models.ScopeTwitchManageMessages)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, 1, api.calls)
@@ -150,7 +192,7 @@ func TestDispatch_DeletePerformed(t *testing.T) {
 func TestDispatch_TimeoutThreadsDuration(t *testing.T) {
 	api := &fakeAPI{results: []error{nil}}
 	d := NewTwitch(&fakeTokens{cred: credWith(models.ScopeTwitchManageBannedUsers)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionTimeout,
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionTimeout,
 		models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42", DurationSeconds: 600})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
@@ -166,7 +208,7 @@ func TestDispatch_UnauthorizedRefreshesAndRetries(t *testing.T) {
 		onRefresh: func(c *tokens.TwitchCredential) { c.AccessToken = "tok2" },
 	}
 	d := NewTwitch(src, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, 1, src.refreshes, "a 401 triggers exactly one reactive refresh")
@@ -178,7 +220,7 @@ func TestDispatch_UnauthorizedRefreshFailsIsReauth(t *testing.T) {
 	api := &fakeAPI{results: []error{clients.ErrUnauthorized}}
 	src := &fakeTokens{cred: credWith(models.ScopeTwitchManageMessages), refreshErr: assertErr("refresh dead")}
 	d := NewTwitch(src, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, 1, api.calls, "no retry when the refresh fails")
@@ -188,7 +230,7 @@ func TestDispatch_ForbiddenIsReauthWithScope(t *testing.T) {
 	api := &fakeAPI{results: []error{clients.ErrForbidden}}
 	// Token claims the scope locally, but Twitch rejects (e.g. not actually a moderator).
 	d := NewTwitch(&fakeTokens{cred: credWith(models.ScopeTwitchManageBannedUsers)}, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "twitch", ChannelID: "c", TargetUserID: "42"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeTwitchManageBannedUsers}, res.MissingScopes)
@@ -200,7 +242,7 @@ func TestDispatch_ProactiveRefreshNearExpiry(t *testing.T) {
 	cred.ExpiresAt = time.Now().Add(time.Minute) // within the lead time
 	src := &fakeTokens{cred: cred}
 	d := NewTwitch(src, api, zap.NewNop())
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionDelete, models.DispatchRequest{Platform: "twitch", ChannelID: "c", NativeMessageID: "m1"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, 1, src.refreshes, "an imminent expiry triggers a proactive refresh")

--- a/services/moderation-service/dispatch/youtube.go
+++ b/services/moderation-service/dispatch/youtube.go
@@ -69,15 +69,22 @@ func NewYouTube(src youtubeTokenSource, api youtubeAPI, liveChat liveChatResolve
 }
 
 // Dispatch bans a user from a channel's live chat.
-func (d *YouTube) Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+func (d *YouTube) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if req.Platform != "youtube" {
 		return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
+	}
+	// The delegated path for this platform is not built yet (ADR-0048 gates each leg
+	// independently). Refuse explicitly: resolving by the caller's id happens to find nothing for
+	// a moderator today, but relying on that coincidence would turn any future change to
+	// credential selection into a silent privilege escalation.
+	if actor.IsModerator() {
+		return models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
 	}
 	if action != models.ActionBan {
 		return models.DispatchResult{}, fmt.Errorf("dispatch: unsupported youtube action %q", action)
 	}
 
-	cred, err := d.tokens.Resolve(ctx, userID, req.ChannelID)
+	cred, err := d.tokens.Resolve(ctx, actor.UserID, req.ChannelID)
 	if errors.Is(err, tokens.ErrNoCredential) {
 		return models.DispatchResult{Outcome: models.DispatchNoCredential}, nil
 	}

--- a/services/moderation-service/dispatch/youtube_test.go
+++ b/services/moderation-service/dispatch/youtube_test.go
@@ -111,7 +111,7 @@ func banReq() models.DispatchRequest {
 func TestYouTubeDispatch_NonYouTubeIsDryRun(t *testing.T) {
 	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{}, api, fakeLiveChat{id: "lc"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, models.DispatchRequest{Platform: "twitch"})
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, models.DispatchRequest{Platform: "twitch"})
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchDryRun, res.Outcome)
 	assert.Zero(t, api.calls)
@@ -121,7 +121,7 @@ func TestYouTubeDispatch_NonYouTubeIsDryRun(t *testing.T) {
 func TestYouTubeDispatch_NoCredential(t *testing.T) {
 	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{resolveErr: tokens.ErrNoCredential}, api, fakeLiveChat{id: "lc"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchNoCredential, res.Outcome)
 	assert.Zero(t, q.reserves)
@@ -130,7 +130,7 @@ func TestYouTubeDispatch_NoCredential(t *testing.T) {
 func TestYouTubeDispatch_MissingScopeSkipsEverything(t *testing.T) {
 	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{cred: ytCredWith("https://www.googleapis.com/auth/youtube.readonly")}, api, fakeLiveChat{id: "lc"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeYouTubeModeration}, res.MissingScopes)
@@ -141,7 +141,7 @@ func TestYouTubeDispatch_MissingScopeSkipsEverything(t *testing.T) {
 func TestYouTubeDispatch_NotLiveIsErrorNoQuota(t *testing.T) {
 	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{err: clients.ErrYouTubeNotLive}, q)
-	_, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	_, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.Error(t, err)
 	assert.Zero(t, q.reserves, "no quota reserved when there is no live chat to ban in")
 	assert.Zero(t, api.calls)
@@ -150,7 +150,7 @@ func TestYouTubeDispatch_NotLiveIsErrorNoQuota(t *testing.T) {
 func TestYouTubeDispatch_QuotaExhausted(t *testing.T) {
 	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: false}
 	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{id: "lc"}, q)
-	_, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	_, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.Error(t, err)
 	assert.Equal(t, 1, q.reserves)
 	assert.Zero(t, api.calls, "no API call when the reservation is refused")
@@ -159,7 +159,7 @@ func TestYouTubeDispatch_QuotaExhausted(t *testing.T) {
 func TestYouTubeDispatch_BanPerformedConfirmsQuota(t *testing.T) {
 	api, q := &fakeYTAPI{results: []error{nil}}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{id: "lc-1"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, "lc-1", api.liveChat)
@@ -173,7 +173,7 @@ func TestYouTubeDispatch_UnauthorizedRefreshesAndRetries(t *testing.T) {
 	q := &fakeQuota{reserveOK: true}
 	src := &fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration), onRefresh: func(c *tokens.YouTubeCredential) { c.AccessToken = "tok2" }}
 	d := newYT(src, api, fakeLiveChat{id: "lc"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchPerformed, res.Outcome)
 	assert.Equal(t, 1, src.refreshes)
@@ -185,7 +185,7 @@ func TestYouTubeDispatch_UnauthorizedRefreshesAndRetries(t *testing.T) {
 func TestYouTubeDispatch_ForbiddenRollsBackQuota(t *testing.T) {
 	api, q := &fakeYTAPI{results: []error{clients.ErrYouTubeForbidden}}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{id: "lc"}, q)
-	res, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	res, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.NoError(t, err)
 	assert.Equal(t, models.DispatchReauthRequired, res.Outcome)
 	assert.Equal(t, []string{models.ScopeYouTubeModeration}, res.MissingScopes)
@@ -196,7 +196,22 @@ func TestYouTubeDispatch_ForbiddenRollsBackQuota(t *testing.T) {
 func TestYouTubeDispatch_OtherErrorRollsBack(t *testing.T) {
 	api, q := &fakeYTAPI{results: []error{errors.New("boom")}}, &fakeQuota{reserveOK: true}
 	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{id: "lc"}, q)
-	_, err := d.Dispatch(context.Background(), "u1", models.ActionBan, banReq())
+	_, err := d.Dispatch(context.Background(), owner("u1"), models.ActionBan, banReq())
 	require.Error(t, err)
 	assert.Equal(t, 1, q.rollbacks)
+}
+
+// YouTube's delegated leg is not built, and its write path is permanent-ban-only besides —
+// handing a volunteer permanent-ban-only would be a moderation-safety problem, so the refusal is
+// explicit rather than incidental.
+func TestYouTube_DelegatedActionIsRefused(t *testing.T) {
+	api, q := &fakeYTAPI{}, &fakeQuota{reserveOK: true}
+	d := newYT(&fakeYTTokens{cred: ytCredWith(models.ScopeYouTubeModeration)}, api, fakeLiveChat{id: "lc"}, q)
+
+	res, err := d.Dispatch(context.Background(), moderator("mod", "own"), models.ActionBan, banReq())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
+	assert.Zero(t, api.calls)
+	assert.Zero(t, q.reserves, "no quota is spent on an action that cannot happen")
 }

--- a/services/moderation-service/handler/moderation.go
+++ b/services/moderation-service/handler/moderation.go
@@ -93,7 +93,7 @@ func (NoScopeChecker) GrantedActions(context.Context, string, string, string) ([
 // emits the reflect-back event). The error return is reserved for unexpected /
 // transient failures (mapped to 502).
 type Dispatcher interface {
-	Dispatch(ctx context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error)
+	Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error)
 }
 
 // DryRunDispatcher performs no platform calls; every dispatch is a dry run. Used in
@@ -101,7 +101,7 @@ type Dispatcher interface {
 type DryRunDispatcher struct{}
 
 // Dispatch always reports a dry run.
-func (DryRunDispatcher) Dispatch(context.Context, string, models.Action, models.DispatchRequest) (models.DispatchResult, error) {
+func (DryRunDispatcher) Dispatch(context.Context, models.Actor, models.Action, models.DispatchRequest) (models.DispatchResult, error) {
 	return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 }
 
@@ -157,6 +157,22 @@ func (h *Handler) SetSendChecker(s SendChecker) { h.send = s }
 // notAuthorizedMsg is used for BOTH "you have no role on this overlay" and "this overlay does
 // not exist", so the two are indistinguishable to a caller probing overlay ids.
 const notAuthorizedMsg = "not authorized for this overlay"
+
+// Machine-readable codes on the action endpoints' failure bodies. The frontend switches on these
+// rather than on the prose, which differs by role and is free to change.
+const (
+	// codeConnectRequired: the actor holds no credential for this platform. For a moderator that
+	// is the deferred-consent state, and the fix is theirs to perform.
+	codeConnectRequired = "connect_required"
+	// codeOwnerUnverified: the overlay owner cannot be shown to control this channel, so there is
+	// nothing to delegate on it. Only the owner can clear it.
+	codeOwnerUnverified = "owner_channel_unverified"
+	// codeDelegationUnsupported: this platform's delegated path is not built yet.
+	codeDelegationUnsupported = "delegation_unsupported"
+	// codeNotPlatformModerator: the platform says the caller does not moderate that channel. The
+	// fix is on the platform, not in All-Chat.
+	codeNotPlatformModerator = "not_moderator_on_platform"
+)
 
 // unauthorizedDenials counts refusals of callers who hold no role on the overlay.
 //
@@ -562,8 +578,24 @@ func (h *Handler) execute(c *gin.Context, cl caller, action models.Action, dreq 
 	e.OverlayID = cl.overlayID
 	e.ActorUserID = cl.userID
 	e.ImpersonatedBy = cl.impersonatedBy
+	// Five identities must stay distinguishable forever (ADR-0048): the human who acted, their
+	// role, the owner they acted for, whose credential actually acted, and the platform id we
+	// sent as the moderator. The last two come back from the dispatcher, because only it knows
+	// which credential it reached for — asserting them here would document an intention rather
+	// than record a fact.
+	e.ActorRole = cl.access.Role
+	e.OnBehalfOfUserID = cl.access.OwnerUserID
+	e.GrantID = cl.access.GrantID
 
-	res, err := h.dispatch.Dispatch(ctx, cl.userID, action, dreq)
+	actor := models.Actor{
+		UserID:      cl.userID,
+		Role:        cl.access.Role,
+		OwnerUserID: cl.access.OwnerUserID,
+		GrantID:     cl.access.GrantID,
+	}
+	res, err := h.dispatch.Dispatch(ctx, actor, action, dreq)
+	e.CredentialUserID = res.CredentialUserID
+	e.PlatformActorID = res.PlatformActorID
 	if err != nil {
 		h.logger.Error("platform dispatch failed", zap.Error(err), zap.String("action", e.Action))
 		e.Outcome = audit.OutcomePlatformError
@@ -577,7 +609,43 @@ func (h *Handler) execute(c *gin.Context, cl caller, action models.Action, dreq 
 	case models.DispatchNoCredential:
 		e.Outcome = audit.OutcomeNoCredential
 		h.record(ctx, e)
-		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "you do not hold moderator credentials for this channel"})
+		// The copy differs by role because the remedy does: a streamer is not the broadcaster of
+		// this channel, whereas a moderator simply has not connected their own account yet —
+		// which is the expected state of a fresh grant, since consent is deferred to first use.
+		msg := "you do not hold moderator credentials for this channel"
+		if actor.IsModerator() {
+			msg = "connect your own " + dreq.Platform + " account to moderate here"
+		}
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": msg, "code": codeConnectRequired})
+		return
+	case models.DispatchOwnerUnverified:
+		// Delegation never exceeds what the owner could do themselves. Only the owner can fix
+		// this, so the copy names them and gives the moderator nothing to attempt.
+		e.Outcome = audit.OutcomeOwnerUnverified
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "this streamer's " + dreq.Platform + " account is not connected, so nothing can be delegated on this channel",
+			"code":  codeOwnerUnverified,
+		})
+		return
+	case models.DispatchNotPlatformModerator:
+		// The platform refused, not All-Chat. Pointing this at a re-consent screen would loop a
+		// volunteer through a flow that cannot fix it — the streamer has to mod them there.
+		e.Outcome = audit.OutcomeNotPlatformModerator
+		e.PlatformStatus = res.PlatformStatus
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": dreq.Platform + " says you're not a moderator of this channel — ask the streamer to add you in " + dreq.Platform + "'s own tools",
+			"code":  codeNotPlatformModerator,
+		})
+		return
+	case models.DispatchDelegationUnsupported:
+		e.Outcome = audit.OutcomeDelegationUnsupported
+		h.record(ctx, e)
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error": "moderators cannot act on " + dreq.Platform + " yet — ask the streamer to handle this one",
+			"code":  codeDelegationUnsupported,
+		})
 		return
 	case models.DispatchReauthRequired:
 		e.Outcome = audit.OutcomeReauthRequired
@@ -646,16 +714,23 @@ func (h *Handler) denyUnauthorized(c *gin.Context, cl caller, reason string) {
 }
 
 // deny audits an authorization failure (when the caller is known) and responds.
+//
+// The role and the overlay owner are recorded here too, not only on successes: "a delegated
+// moderator was repeatedly refused" is one of the signals that a grant has gone wrong, and it is
+// invisible if a denial cannot be told apart from an owner's.
 func (h *Handler) deny(c *gin.Context, cl caller, platform, channelID string, action models.Action, status int, msg string) {
 	h.record(c.Request.Context(), audit.Entry{
-		OverlayID:      cl.overlayID,
-		ActorUserID:    cl.userID,
-		ImpersonatedBy: cl.impersonatedBy,
-		Platform:       platform,
-		ChannelID:      channelID,
-		Action:         string(action),
-		Outcome:        audit.OutcomeDenied,
-		PlatformStatus: msg,
+		OverlayID:        cl.overlayID,
+		ActorUserID:      cl.userID,
+		ActorRole:        cl.access.Role,
+		OnBehalfOfUserID: cl.access.OwnerUserID,
+		GrantID:          cl.access.GrantID,
+		ImpersonatedBy:   cl.impersonatedBy,
+		Platform:         platform,
+		ChannelID:        channelID,
+		Action:           string(action),
+		Outcome:          audit.OutcomeDenied,
+		PlatformStatus:   msg,
 	})
 	c.JSON(status, gin.H{"error": msg})
 }

--- a/services/moderation-service/handler/moderation_actor_test.go
+++ b/services/moderation-service/handler/moderation_actor_test.go
@@ -1,0 +1,208 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/caesar/all-chat/services/moderation-service/audit"
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/caesar/all-chat/services/moderation-service/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// What the handler hands the dispatcher, and what it records about the result (ADR-0048).
+//
+// The handler is where the resolved role becomes the Actor the dispatcher branches on, and where
+// the dispatcher's report of *whose credential acted* becomes an audit row. Both are load-bearing:
+// an Actor missing its owner id would send the anchor looking at the wrong account, and an audit
+// row missing credential_user_id would lose the only machine-checkable proof of no-fallback.
+
+// actorHandler wires a handler whose dispatcher records the Actor it was given.
+func actorHandler(t *testing.T, access repository.OverlayAccess, res models.DispatchResult) (*Handler, *fakeDispatcher, *fakeRecorder) {
+	t.Helper()
+	auth := &fakeAuthorizer{
+		access:   &access,
+		isSource: map[string]bool{"twitch|somestreamer": true},
+	}
+	disp := &fakeDispatcher{res: res}
+	rec := &fakeRecorder{}
+	return New(auth, &fakeEmitter{}, rec, NoScopeChecker{}, disp, zap.NewNop()), disp, rec
+}
+
+func delegatedAccess() repository.OverlayAccess {
+	return repository.OverlayAccess{
+		OwnerUserID:    ownerID,
+		OwnerIsPremium: true,
+		Role:           repository.RoleModerator,
+		GrantID:        "grant-1",
+		Actions:        []string{"delete"},
+		Platforms:      []string{"twitch"},
+	}
+}
+
+// The Actor carries the OWNER's id, not just the caller's: the owner-reach anchor is resolved
+// against it, and pointing that at the moderator would let anyone with a grant act on any channel
+// they happen to hold a credential for.
+func TestExecute_ActorCarriesRoleOwnerAndGrant(t *testing.T) {
+	h, disp, _ := actorHandler(t, delegatedAccess(), models.DispatchResult{Outcome: models.DispatchPerformed})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, modUserID, disp.gotActor.UserID, "the human who pressed the button")
+	assert.Equal(t, repository.RoleModerator, disp.gotActor.Role)
+	assert.Equal(t, ownerID, disp.gotActor.OwnerUserID, "whose channel is being moderated")
+	assert.Equal(t, "grant-1", disp.gotActor.GrantID)
+}
+
+// An owner action names itself on both sides — there is no third party — and carries no grant.
+func TestExecute_OwnerActorIsItsOwnPrincipal(t *testing.T) {
+	access := repository.OverlayAccess{OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleOwner}
+	h, disp, _ := actorHandler(t, access, models.DispatchResult{Outcome: models.DispatchPerformed})
+
+	resp := do(newTestRouter(h, ownerID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, ownerID, disp.gotActor.UserID)
+	assert.Equal(t, ownerID, disp.gotActor.OwnerUserID)
+	assert.Empty(t, disp.gotActor.GrantID)
+}
+
+// credential_user_id comes from the dispatcher rather than being asserted here, because only the
+// dispatcher knows which credential it actually reached for. Recording an assumption instead
+// would turn the proof into a restatement of intent.
+func TestExecute_AuditRecordsWhoseCredentialActed(t *testing.T) {
+	h, _, rec := actorHandler(t, delegatedAccess(), models.DispatchResult{
+		Outcome:          models.DispatchPerformed,
+		CredentialUserID: modUserID,
+		PlatformActorID:  "777",
+	})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Len(t, rec.entries, 1)
+	e := rec.entries[0]
+	assert.Equal(t, modUserID, e.ActorUserID)
+	assert.Equal(t, repository.RoleModerator, e.ActorRole)
+	assert.Equal(t, ownerID, e.OnBehalfOfUserID)
+	assert.Equal(t, modUserID, e.CredentialUserID, "the moderator's own token acted")
+	assert.NotEqual(t, ownerID, e.CredentialUserID)
+	assert.Equal(t, "777", e.PlatformActorID)
+	assert.Equal(t, "grant-1", e.GrantID)
+}
+
+// A denial is audited with the same attribution. "This moderator keeps getting refused" is one of
+// the signals that a grant has gone wrong, and it is invisible if a denial cannot be told apart
+// from an owner's.
+func TestDeny_RecordsTheRoleAndTheOwner(t *testing.T) {
+	access := delegatedAccess()
+	access.Actions = []string{"timeout"} // delete withheld
+	h, _, rec := actorHandler(t, access, models.DispatchResult{})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	require.Equal(t, http.StatusForbidden, resp.Code)
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, audit.OutcomeDenied, rec.entries[0].Outcome)
+	assert.Equal(t, repository.RoleModerator, rec.entries[0].ActorRole)
+	assert.Equal(t, ownerID, rec.entries[0].OnBehalfOfUserID)
+	assert.Equal(t, "grant-1", rec.entries[0].GrantID)
+}
+
+// The owner-reach anchor failing is the owner's problem to fix, so the copy names them and gives
+// the moderator nothing to attempt. It is audited, not silently dropped.
+func TestExecute_OwnerUnverifiedIsRefusedAndAudited(t *testing.T) {
+	h, _, rec := actorHandler(t, delegatedAccess(), models.DispatchResult{Outcome: models.DispatchOwnerUnverified})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.Equal(t, codeOwnerUnverified, body["code"])
+	assert.Contains(t, body["error"], "streamer")
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, audit.OutcomeOwnerUnverified, rec.entries[0].Outcome)
+}
+
+// The platform's own refusal is surfaced as something the streamer can act on, not as a consent
+// prompt the moderator would run in circles on.
+func TestExecute_NotAPlatformModeratorPointsAtTheStreamer(t *testing.T) {
+	h, _, rec := actorHandler(t, delegatedAccess(), models.DispatchResult{
+		Outcome: models.DispatchNotPlatformModerator, PlatformStatus: "forbidden",
+	})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusForbidden, resp.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.Equal(t, codeNotPlatformModerator, body["code"])
+	assert.NotContains(t, body, "requires_reauth", "re-consent cannot fix this")
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, audit.OutcomeNotPlatformModerator, rec.entries[0].Outcome)
+}
+
+// A platform whose delegated leg is not built must refuse rather than report success. Audited
+// too, so a moderator hitting the wall is visible rather than just looking broken.
+func TestExecute_DelegationUnsupportedIsRefusedAndAudited(t *testing.T) {
+	h, _, rec := actorHandler(t, delegatedAccess(), models.DispatchResult{Outcome: models.DispatchDelegationUnsupported})
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.Equal(t, codeDelegationUnsupported, body["code"])
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, audit.OutcomeDelegationUnsupported, rec.entries[0].Outcome)
+}
+
+// "No credential" reads differently by role: a streamer is not the broadcaster of this channel,
+// whereas a moderator simply has not connected their own account — the expected state of a fresh
+// grant, since consent is deferred to first use.
+func TestExecute_NoCredentialCopyDiffersByRole(t *testing.T) {
+	t.Run("moderator is told to connect", func(t *testing.T) {
+		h, _, _ := actorHandler(t, delegatedAccess(), models.DispatchResult{Outcome: models.DispatchNoCredential})
+
+		resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+		assert.Equal(t, codeConnectRequired, body["code"])
+		assert.Contains(t, body["error"], "connect")
+	})
+
+	t.Run("owner is told they are not the broadcaster", func(t *testing.T) {
+		access := repository.OverlayAccess{OwnerUserID: ownerID, OwnerIsPremium: true, Role: repository.RoleOwner}
+		h, _, _ := actorHandler(t, access, models.DispatchResult{Outcome: models.DispatchNoCredential})
+
+		resp := do(newTestRouter(h, ownerID, ""), http.MethodPost, deletePath(), deleteBody)
+
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+		assert.Contains(t, body["error"], "do not hold moderator credentials")
+	})
+}

--- a/services/moderation-service/handler/moderation_test.go
+++ b/services/moderation-service/handler/moderation_test.go
@@ -145,13 +145,15 @@ type fakeDispatcher struct {
 	err       error
 	calls     int
 	gotUserID string
+	gotActor  models.Actor
 	gotAction models.Action
 	gotReq    models.DispatchRequest
 }
 
-func (f *fakeDispatcher) Dispatch(_ context.Context, userID string, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
+func (f *fakeDispatcher) Dispatch(_ context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	f.calls++
-	f.gotUserID = userID
+	f.gotUserID = actor.UserID
+	f.gotActor = actor
 	f.gotAction = action
 	f.gotReq = req
 	return f.res, f.err

--- a/services/moderation-service/models/moderation.go
+++ b/services/moderation-service/models/moderation.go
@@ -281,6 +281,37 @@ func RequiredDiscordPermission(a Action) uint64 {
 	}
 }
 
+// Actor is who is performing a moderation action, and on whose behalf.
+//
+// It travels with every dispatch because *whose credential acts* is the load-bearing
+// question of ADR-0048, and it must never be inferred from the caller's id alone: an owner acts
+// with their own broadcaster credential, a delegated moderator with their own moderator
+// credential against the OWNER's channel, and there is no fallback between them. Passing this
+// explicitly is what makes a dispatcher that ignores the distinction a compile-time change rather
+// than a silent one.
+type Actor struct {
+	// UserID is the human who pressed the button, and whose credential must perform the call.
+	UserID string
+	// Role is RoleOwner or RoleModerator as resolved on the overlay.
+	Role string
+	// OwnerUserID is the overlay owner the action is performed for. Equals UserID when the owner
+	// acts themselves; for a moderator it is whose channel is being moderated, and it is the only
+	// identity the owner-reach anchor may be resolved against.
+	OwnerUserID string
+	// GrantID is the delegation the moderator is acting under. Empty for an owner.
+	GrantID string
+}
+
+// IsModerator reports whether a delegated moderator is acting.
+func (a Actor) IsModerator() bool { return a.Role == RoleModerator }
+
+// Roles an Actor can hold. These mirror repository.Role* — duplicated rather than imported
+// because models must not depend on the repository (the dependency runs the other way).
+const (
+	RoleOwner     = "owner"
+	RoleModerator = "moderator"
+)
+
 // DispatchRequest carries the identifiers a platform moderation call needs. It is
 // the platform-agnostic input the handler hands to a Dispatcher.
 type DispatchRequest struct {
@@ -304,9 +335,26 @@ const (
 	// DispatchReauthRequired: the owner's token lacks the required scope (or the
 	// platform rejected it as unauthorized). The handler returns 403 + missing_scopes.
 	DispatchReauthRequired
-	// DispatchNoCredential: the owner holds no moderator credential for this channel.
+	// DispatchNoCredential: the actor holds no moderator credential for this channel.
 	// The handler returns 422.
 	DispatchNoCredential
+	// DispatchOwnerUnverified: the overlay owner cannot prove they control this channel, so
+	// there is nothing for them to delegate (ADR-0048's owner-reach anchor). Delegation never
+	// exceeds what the owner could do themselves. The handler returns 403 with copy aimed at the
+	// OWNER — reconnecting their account is the fix, and the moderator cannot perform it.
+	DispatchOwnerUnverified
+	// DispatchNotPlatformModerator: the platform accepted the credential and refused the action
+	// because this person is not a moderator of that channel. Only reported for a delegated
+	// moderator, and only once the scope pre-check has already passed — which is what makes the
+	// inference sound. It is the platform answering the question ADR-0048 defers to it, and the
+	// remediation is the streamer adding them in the platform's own tools, never a re-consent.
+	DispatchNotPlatformModerator
+	// DispatchDelegationUnsupported: this platform's delegated path is not built yet, so a
+	// delegated action must be refused rather than fall through to whatever credential the
+	// dispatcher would otherwise use. Load-bearing for Discord in particular, where the actor is
+	// always the shared bot: without this, a delegated action would execute with the bot's full
+	// guild authority and no check that the moderator holds any of it.
+	DispatchDelegationUnsupported
 )
 
 // DispatchResult is what a Dispatcher reports back to the handler.
@@ -314,6 +362,13 @@ type DispatchResult struct {
 	Outcome        DispatchOutcome
 	MissingScopes  []string // populated on DispatchReauthRequired
 	PlatformStatus string   // platform detail for the audit row
+	// CredentialUserID is whose OAuth token actually performed the call, and PlatformActorID the
+	// id sent as the platform's moderator field. Together they are the machine-checkable proof
+	// that a delegated action never fell back to the owner's credential (ADR-0048), which is why
+	// they are reported back rather than assumed by the handler. Both are empty where no per-user
+	// credential acts — Discord, where the shared bot is always the actor, and dry runs.
+	CredentialUserID string
+	PlatformActorID  string
 }
 
 // PlatformSupported reports whether the platform has any moderation support at all.

--- a/services/moderation-service/tokens/mod.go
+++ b/services/moderation-service/tokens/mod.go
@@ -1,0 +1,150 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package tokens
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// A delegated moderator's OWN platform credential (ADR-0048).
+//
+// Read from mod_oauth_credentials and nowhere else. That table is keyed on the MODERATOR, never
+// on a channel, and the separation is not fastidiousness: the listeners select chat-reading
+// credentials by channel with no user scoping (`twitch-eventsub-listener/channels/manager.go`
+// matches `LOWER(twitch_login) = LOWER(channel_id)`), so a moderator-scoped row in those tables
+// would become a candidate INGEST credential and could silently break chat on a real channel.
+
+// ModCredential is a delegated moderator's decrypted credential for one platform.
+//
+// PlatformUserID is deliberately not called BroadcasterID. It is the id sent as the platform's
+// *moderator* field, and the entire correctness of the delegated write path is that the two are
+// different values: the broadcaster is the overlay owner's channel, resolved separately through
+// the owner-reach anchor.
+type ModCredential struct {
+	AccessToken    string
+	RefreshToken   string
+	PlatformUserID string
+	GrantedScopes  []string
+	ExpiresAt      time.Time
+}
+
+// ModTwitchSource resolves and refreshes a delegated moderator's own Twitch credential.
+type ModTwitchSource struct {
+	db      *pgxpool.Pool
+	cipher  Cipher
+	refresh *twitchRefresher
+}
+
+// NewModTwitchSource builds a source over mod_oauth_credentials. clientID/clientSecret are the
+// All-Chat Twitch application credentials used for the refresh grant.
+func NewModTwitchSource(db *pgxpool.Pool, cipher Cipher, clientID, clientSecret string) *ModTwitchSource {
+	return &ModTwitchSource{
+		db:      db,
+		cipher:  cipher,
+		refresh: newTwitchRefresher(clientID, clientSecret),
+	}
+}
+
+// Resolve returns the moderator's decrypted Twitch credential.
+//
+// It is keyed on the moderator alone — no channel — because Twitch's moderation scopes are
+// role-based rather than channel-scoped: one consent serves every streamer who delegated Twitch
+// to them. ErrNoCredential means they have not consented yet, which is the normal state of a
+// fresh grant (consent is deferred to first use) rather than an error condition.
+func (s *ModTwitchSource) Resolve(ctx context.Context, userID string) (*ModCredential, error) {
+	const query = `
+		SELECT access_token, refresh_token, COALESCE(token_expires_at, TIMESTAMP 'epoch'),
+		       granted_scopes, platform_user_id
+		FROM mod_oauth_credentials
+		WHERE user_id = $1 AND platform = 'twitch'`
+
+	var encAccess, encRefresh, platformUserID string
+	var expiresAt time.Time
+	var scopes []string
+	err := s.db.QueryRow(ctx, query, userID).Scan(&encAccess, &encRefresh, &expiresAt, &scopes, &platformUserID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNoCredential
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve moderator twitch credential: %w", err)
+	}
+
+	access, err := s.cipher.DecryptString(encAccess)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt moderator access token: %w", err)
+	}
+	refresh, err := s.cipher.DecryptString(encRefresh)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt moderator refresh token: %w", err)
+	}
+
+	return &ModCredential{
+		AccessToken:    access,
+		RefreshToken:   refresh,
+		PlatformUserID: platformUserID,
+		GrantedScopes:  scopes,
+		ExpiresAt:      expiresAt,
+	}, nil
+}
+
+// Refresh exchanges the moderator's refresh token for a new access token and writes the
+// re-encrypted pair back to their own row.
+//
+// token-refresh-service keeps these fresh on a schedule (#656); this is the proactive/reactive
+// path for the moment of use, so a token that lapsed between cycles does not cost the moderator a
+// failed action. granted_scopes is left untouched — it is owned by the consent flow, and a
+// refresh grant never widens it.
+func (s *ModTwitchSource) Refresh(ctx context.Context, userID string, cred *ModCredential) error {
+	if cred.RefreshToken == "" {
+		return errors.New("tokens: no moderator refresh token available")
+	}
+
+	refreshed, err := s.refresh.exchange(ctx, cred.RefreshToken)
+	if err != nil {
+		return err
+	}
+
+	encAccess, err := s.cipher.EncryptString(refreshed.accessToken)
+	if err != nil {
+		return fmt.Errorf("encrypt refreshed moderator access token: %w", err)
+	}
+	encRefresh, err := s.cipher.EncryptString(refreshed.refreshToken)
+	if err != nil {
+		return fmt.Errorf("encrypt refreshed moderator refresh token: %w", err)
+	}
+
+	// Scoped to (user, platform) rather than a row id: the table's UNIQUE(user_id, platform)
+	// makes that exact, and it cannot address another moderator's row by accident.
+	const update = `
+		UPDATE mod_oauth_credentials
+		SET access_token = $1, refresh_token = $2, token_expires_at = $3, updated_at = NOW()
+		WHERE user_id = $4 AND platform = 'twitch'`
+	if _, err := s.db.Exec(ctx, update, encAccess, encRefresh, refreshed.expiresAt, userID); err != nil {
+		return fmt.Errorf("persist refreshed moderator token: %w", err)
+	}
+
+	cred.AccessToken = refreshed.accessToken
+	cred.RefreshToken = refreshed.refreshToken
+	cred.ExpiresAt = refreshed.expiresAt
+	return nil
+}

--- a/services/moderation-service/tokens/mod_test.go
+++ b/services/moderation-service/tokens/mod_test.go
@@ -1,0 +1,220 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package tokens
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The delegated moderator's own credential, and the owner-reach anchor (ADR-0048).
+//
+// These are the two halves of a delegated write: the moderator supplies the token and the
+// moderator_id, the owner supplies the broadcaster_id — and neither may substitute for the other.
+
+func TestModResolve_ReturnsTheModeratorsOwnCredential(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	cred, err := src.Resolve(context.Background(), modUser)
+
+	require.NoError(t, err)
+	assert.Equal(t, "modAcc", cred.AccessToken, "decrypted, not the stored ciphertext")
+	assert.Equal(t, "modRef", cred.RefreshToken)
+	assert.Equal(t, "7007", cred.PlatformUserID, "the id sent as moderator_id")
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, cred.GrantedScopes)
+}
+
+// Keyed on the moderator alone, with no channel: Twitch's moderation scopes are role-based, so
+// one consent serves every streamer who delegated Twitch to them.
+func TestModResolve_IsNotScopedToAChannel(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	first, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+	second, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+	assert.Equal(t, first.AccessToken, second.AccessToken)
+}
+
+// Not having consented yet is the normal state of a fresh grant (consent is deferred to first
+// use), so it is a sentinel the dispatcher can act on rather than an error.
+func TestModResolve_NoConsentIsNoCredential(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	_, err := src.Resolve(context.Background(), strangerD)
+
+	assert.ErrorIs(t, err, ErrNoCredential)
+}
+
+// A streamer's own broadcaster credential is NOT a moderator credential. They live in different
+// tables on purpose, and reading across would reintroduce the fallback the design forbids.
+func TestModResolve_DoesNotSeeBroadcasterCredentials(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	// userA holds a perfectly good broadcaster credential and no moderator credential.
+	_, err := src.Resolve(context.Background(), userA)
+
+	assert.ErrorIs(t, err, ErrNoCredential)
+}
+
+func TestModRefresh_PersistsToTheModeratorsOwnRow(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		assert.Equal(t, "modRef", r.Form.Get("refresh_token"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"modAcc2","refresh_token":"modRef2","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	src.refresh.tokenURL = srv.URL
+
+	cred, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+
+	require.NoError(t, src.Refresh(context.Background(), modUser, cred))
+	assert.Equal(t, "modAcc2", cred.AccessToken)
+	assert.Equal(t, "modRef2", cred.RefreshToken)
+	assert.WithinDuration(t, time.Now().Add(time.Hour), cred.ExpiresAt, time.Minute)
+
+	reread, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+	assert.Equal(t, "modAcc2", reread.AccessToken, "re-encrypted and persisted")
+	assert.Equal(t, "modRef2", reread.RefreshToken)
+}
+
+// The scopes are owned by the consent flow; a refresh grant never widens them, so it must not
+// touch them either.
+func TestModRefresh_LeavesGrantedScopesAlone(t *testing.T) {
+	_, cipher, pool, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+	src := NewModTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"b","expires_in":3600}`))
+	}))
+	defer srv.Close()
+	src.refresh.tokenURL = srv.URL
+
+	cred, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+	require.NoError(t, src.Refresh(context.Background(), modUser, cred))
+
+	reread, err := src.Resolve(context.Background(), modUser)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"moderator:manage:chat_messages"}, reread.GrantedScopes)
+}
+
+// --- Owner-reach anchor ------------------------------------------------------
+
+// The anchor yields the numeric broadcaster id for a channel the owner controls. A Twitch
+// source's channel_id IS the login, which is what makes this answerable.
+func TestOwnerAnchor_ResolvesTheBroadcasterID(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	id, err := src.OwnerTwitchAnchor(context.Background(), userA, "streamerA")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1001", id)
+}
+
+func TestOwnerAnchor_IsCaseInsensitive(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	id, err := src.OwnerTwitchAnchor(context.Background(), userA, "StReAmErA")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1001", id)
+}
+
+// A linked (non-primary-login) Twitch account proves control just as well — the streamer connected
+// it, which is the whole claim being made.
+func TestOwnerAnchor_AcceptsALinkedCredential(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	id, err := src.OwnerTwitchAnchor(context.Background(), userB, "streamerB")
+
+	require.NoError(t, err)
+	assert.Equal(t, "2002", id)
+}
+
+// ADR-0016's preference, so the anchor and the owner's own credential resolution never disagree
+// about which id a channel has.
+func TestOwnerAnchor_PrefersTheUsersRow(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	id, err := src.OwnerTwitchAnchor(context.Background(), userC, "dualstreamer")
+
+	require.NoError(t, err)
+	assert.Equal(t, "3003", id, "the users row wins over a stale linked row")
+}
+
+// The anchor is about a specific owner. Another account's credential for the same channel proves
+// nothing about this one — otherwise any user could lend their channel to someone else's overlay.
+func TestOwnerAnchor_IsScopedToTheOwner(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	_, err := src.OwnerTwitchAnchor(context.Background(), strangerD, "streamerA")
+
+	assert.ErrorIs(t, err, ErrOwnerChannelUnverified)
+}
+
+func TestOwnerAnchor_UnknownChannelIsUnverified(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	_, err := src.OwnerTwitchAnchor(context.Background(), userA, "some-channel-they-do-not-own")
+
+	assert.ErrorIs(t, err, ErrOwnerChannelUnverified)
+}
+
+// The anchor proves CONTROL, never capability. Requiring a moderation scope would deny delegation
+// to exactly the streamer who delegates because they do not moderate themselves — and userB's
+// linked credential deliberately carries only banned-users scope, not the delete scope.
+func TestOwnerAnchor_AppliesNoScopePredicate(t *testing.T) {
+	src, _, _, cleanup := setupTokenSourceWithPool(t)
+	defer cleanup()
+
+	// userB holds no moderator:manage:chat_messages anywhere, yet still anchors the channel.
+	id, err := src.OwnerTwitchAnchor(context.Background(), userB, "streamerB")
+
+	require.NoError(t, err)
+	assert.Equal(t, "2002", id)
+}

--- a/services/moderation-service/tokens/source.go
+++ b/services/moderation-service/tokens/source.go
@@ -177,48 +177,16 @@ func (s *TwitchSource) Refresh(ctx context.Context, cred *TwitchCredential) erro
 		return errors.New("tokens: no refresh token available")
 	}
 
-	form := url.Values{
-		"client_id":     {s.clientID},
-		"client_secret": {s.clientSecret},
-		"grant_type":    {"refresh_token"},
-		"refresh_token": {cred.RefreshToken},
+	refresher := &twitchRefresher{
+		httpClient: s.httpClient, clientID: s.clientID, clientSecret: s.clientSecret, tokenURL: s.tokenURL,
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.tokenURL, strings.NewReader(form.Encode()))
+	refreshed, err := refresher.exchange(ctx, cred.RefreshToken)
 	if err != nil {
-		return fmt.Errorf("build refresh request: %w", err)
+		return err
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	newRefresh, newExpiry := refreshed.refreshToken, refreshed.expiresAt
 
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("twitch token refresh request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("twitch token refresh returned %s: %s", strconv.Itoa(resp.StatusCode), string(snippet))
-	}
-
-	var tr struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		ExpiresIn    int    `json:"expires_in"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
-		return fmt.Errorf("decode refresh response: %w", err)
-	}
-	if tr.AccessToken == "" {
-		return errors.New("twitch token refresh returned an empty access token")
-	}
-
-	// Twitch may rotate the refresh token; keep the old one if it didn't.
-	newRefresh := tr.RefreshToken
-	if newRefresh == "" {
-		newRefresh = cred.RefreshToken
-	}
-	newExpiry := time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
-
-	encAccess, err := s.cipher.EncryptString(tr.AccessToken)
+	encAccess, err := s.cipher.EncryptString(refreshed.accessToken)
 	if err != nil {
 		return fmt.Errorf("encrypt refreshed access token: %w", err)
 	}
@@ -240,8 +208,133 @@ func (s *TwitchSource) Refresh(ctx context.Context, cred *TwitchCredential) erro
 		return fmt.Errorf("persist refreshed token: %w", err)
 	}
 
-	cred.AccessToken = tr.AccessToken
+	cred.AccessToken = refreshed.accessToken
 	cred.RefreshToken = newRefresh
 	cred.ExpiresAt = newExpiry
 	return nil
+}
+
+// ErrOwnerChannelUnverified reports that the overlay owner cannot prove they control a channel.
+//
+// The owner-reach anchor (ADR-0048): delegation never exceeds what the owner could do themselves,
+// so a moderator may only act on a channel the owner demonstrably controls. It proves **control
+// only** — never that the owner holds a moderation scope, a live token or premium. Requiring any
+// of those would deny delegation to exactly the streamer who delegates *because* they do not
+// moderate themselves.
+var ErrOwnerChannelUnverified = errors.New("tokens: overlay owner cannot be shown to control this channel")
+
+// ownerAnchorQuery mirrors resolveQuery's UNION and ADR-0016 preference, minus the two things the
+// anchor must not care about: it selects no token material and applies no scope predicate.
+const ownerAnchorQuery = `
+	SELECT broadcaster_id
+	FROM (
+		SELECT u.twitch_id AS broadcaster_id, 1 AS pri
+		FROM users u
+		WHERE u.id = $1
+		  AND u.auth_provider = 'twitch'
+		  AND LOWER(u.username) = LOWER($2)
+		  AND u.twitch_id IS NOT NULL
+		UNION ALL
+		SELECT t.twitch_user_id AS broadcaster_id, 2 AS pri
+		FROM twitch_oauth_tokens t
+		WHERE t.user_id = $1
+		  AND LOWER(t.twitch_login) = LOWER($2)
+	) c
+	ORDER BY c.pri ASC
+	LIMIT 1`
+
+// OwnerTwitchAnchor returns the numeric Twitch broadcaster id for a channel the overlay owner
+// controls, or ErrOwnerChannelUnverified.
+//
+// A Twitch source's channel_id IS the login, which is what makes this answerable: the owner holds
+// a credential row whose login equals it. The numeric id it yields is the `broadcaster_id` the
+// delegated write needs — the moderator's own credential supplies only the `moderator_id`.
+func (s *TwitchSource) OwnerTwitchAnchor(ctx context.Context, ownerUserID, channelID string) (string, error) {
+	var broadcasterID string
+	err := s.db.QueryRow(ctx, ownerAnchorQuery, ownerUserID, channelID).Scan(&broadcasterID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrOwnerChannelUnverified
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve owner twitch anchor: %w", err)
+	}
+	if broadcasterID == "" {
+		return "", ErrOwnerChannelUnverified
+	}
+	return broadcasterID, nil
+}
+
+// twitchRefresher performs the Twitch OAuth refresh grant. Shared by the broadcaster and the
+// delegated-moderator credential sources: the exchange is identical, only the row it is written
+// back to differs, and duplicating it would let the two drift.
+type twitchRefresher struct {
+	httpClient   *http.Client
+	clientID     string
+	clientSecret string
+	tokenURL     string
+}
+
+func newTwitchRefresher(clientID, clientSecret string) *twitchRefresher {
+	return &twitchRefresher{
+		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		tokenURL:     defaultTwitchTokenURL,
+	}
+}
+
+// refreshedToken is one successful refresh-grant response, normalized.
+type refreshedToken struct {
+	accessToken  string
+	refreshToken string
+	expiresAt    time.Time
+}
+
+// exchange trades a refresh token for a fresh access token.
+func (r *twitchRefresher) exchange(ctx context.Context, refreshToken string) (refreshedToken, error) {
+	form := url.Values{
+		"client_id":     {r.clientID},
+		"client_secret": {r.clientSecret},
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return refreshedToken{}, fmt.Errorf("build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return refreshedToken{}, fmt.Errorf("twitch token refresh request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return refreshedToken{}, fmt.Errorf("twitch token refresh returned %s: %s",
+			strconv.Itoa(resp.StatusCode), string(snippet))
+	}
+
+	var tr struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return refreshedToken{}, fmt.Errorf("decode refresh response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return refreshedToken{}, errors.New("twitch token refresh returned an empty access token")
+	}
+
+	// Twitch may rotate the refresh token; keep the old one if it didn't.
+	rotated := tr.RefreshToken
+	if rotated == "" {
+		rotated = refreshToken
+	}
+	return refreshedToken{
+		accessToken:  tr.AccessToken,
+		refreshToken: rotated,
+		expiresAt:    time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second),
+	}, nil
 }

--- a/services/moderation-service/tokens/source_test.go
+++ b/services/moderation-service/tokens/source_test.go
@@ -36,6 +36,7 @@ const (
 	userB     = "22222222-bbbb-2222-2222-222222222222" // youtube-login, linked twitch
 	userC     = "33333333-cccc-3333-3333-333333333333" // has BOTH a users row and a linked row
 	strangerD = "44444444-dddd-4444-4444-444444444444"
+	modUser   = "55555555-eeee-5555-5555-555555555555" // a delegated moderator, owns no channel
 )
 
 func TestResolve_UsersRowCredential(t *testing.T) {
@@ -155,6 +156,14 @@ func TestRefresh_KeepsOldRefreshTokenWhenResponseOmitsIt(t *testing.T) {
 // AES cipher used to encrypt the seeded tokens.
 func setupTokenSource(t *testing.T) (*TwitchSource, Cipher, func()) {
 	t.Helper()
+	src, cipher, _, cleanup := setupTokenSourceWithPool(t)
+	return src, cipher, cleanup
+}
+
+// setupTokenSourceWithPool is setupTokenSource plus the pool, for the delegated-moderator
+// credential store — which lives in its own table and needs its own seeding.
+func setupTokenSourceWithPool(t *testing.T) (*TwitchSource, Cipher, *pgxpool.Pool, func()) {
+	t.Helper()
 	ctx := context.Background()
 
 	aes, err := encryption.NewAESEncryptor([]byte("0123456789abcdef0123456789abcdef"))
@@ -208,6 +217,19 @@ func setupTokenSource(t *testing.T) (*TwitchSource, Cipher, func()) {
 			token_expires_at TIMESTAMP NOT NULL,
 			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
 			updated_at TIMESTAMP DEFAULT NOW()
+		);
+		CREATE TABLE mod_oauth_credentials (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL,
+			platform VARCHAR(20) NOT NULL,
+			platform_user_id VARCHAR(100) NOT NULL,
+			platform_login VARCHAR(200),
+			access_token TEXT NOT NULL,
+			refresh_token TEXT,
+			token_expires_at TIMESTAMP,
+			granted_scopes TEXT[] NOT NULL DEFAULT '{}',
+			updated_at TIMESTAMP DEFAULT NOW(),
+			UNIQUE (user_id, platform)
 		);`
 	_, err = pool.Exec(ctx, schema)
 	require.NoError(t, err)
@@ -244,8 +266,18 @@ func setupTokenSource(t *testing.T) (*TwitchSource, Cipher, func()) {
 		userC, enc("accC-linked"), enc("refC2"), exp, []string{"moderator:manage:banned_users"})
 	require.NoError(t, err)
 
+	// modUser: a volunteer who has consented to moderate, and owns no channel of their own.
+	_, err = pool.Exec(ctx, `INSERT INTO users (id, username, auth_provider, access_token, refresh_token, token_expires_at)
+		VALUES ($1,'volunteer','twitch',$2,$3,$4)`, modUser, enc("ignored"), enc("ignored"), exp)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `INSERT INTO mod_oauth_credentials
+		(user_id, platform, platform_user_id, platform_login, access_token, refresh_token, token_expires_at, granted_scopes)
+		VALUES ($1,'twitch','7007','volunteer',$2,$3,$4,$5)`,
+		modUser, enc("modAcc"), enc("modRef"), exp, []string{"moderator:manage:chat_messages"})
+	require.NoError(t, err)
+
 	src := NewTwitchSource(pool, cipher, "test-client-id", "test-client-secret")
-	return src, cipher, func() {
+	return src, cipher, pool, func() {
 		pool.Close()
 		_ = container.Terminate(ctx)
 	}


### PR DESCRIPTION
Third slice of ADR-0048, and the one that makes the feature real. #661 let a streamer create a grant; #662 let the moderator reach the overlay; this lets them act.

## The split

`clients/twitch.go` hardcoded `moderator_id == broadcaster_id` at all four call sites. Correct for a streamer moderating their own channel, wrong for everyone else — and it is the exact parameter Twitch re-checks on every call to decide whether the caller may moderate. That check is the authority this design defers to instead of replicating, so collapsing the two either acts as the streamer or fails every delegated call.

A delegated write now resolves in two halves that cannot substitute for each other:

| | Owner | Delegated moderator |
|---|---|---|
| Token | the owner's broadcaster credential | the moderator's own (`mod_oauth_credentials`) |
| `broadcaster_id` | their own | the **owner-reach anchor** |
| `moderator_id` | the same id | the moderator's `platform_user_id` |
| Scope pre-check | the owner's scopes | the **moderator's** scopes |

The **owner-reach anchor** applies no scope predicate and reads no token — requiring the owner to hold a moderation scope would deny delegation to exactly the streamer who delegates *because* they do not moderate themselves.

## Failure modes, each pointing at whoever can fix it

- `connect_required` (422) — the moderator has not consented yet. The expected first click on a fresh grant, since consent is deferred to first use. **Never** a call made with the streamer's token.
- `owner_channel_unverified` (403) — the streamer's account isn't connected, so there is nothing on this channel to delegate. Copy names them; the moderator gets no CTA.
- `not_moderator_on_platform` (403) — Twitch refused *after* the scope pre-check passed, so it is not about scope: it is Twitch saying they don't moderate this channel. Surfacing this as "re-authorize" would loop a volunteer through a consent screen that cannot fix anything.
- `delegation_unsupported` (422) — Kick/Discord/YouTube legs are not built.

## A live hole closed

Every unbuilt leg now **refuses** delegated actions instead of falling through. For Kick and YouTube that is defense in depth — resolving by the caller's id happens to find nothing today. **For Discord it was a real hole**: the actor there is always the shared bot, holding the streamer's full guild authority, so a delegated Discord action would have executed with it and no check that the moderator held any of it. All-Chat's own check is the only authority on Discord and it is not built yet. Reachable since role-based authz landed in #654; blast radius zero (0 grants in prod).

`Dispatcher.Dispatch` now takes `models.Actor` rather than a user id, so a dispatcher that ignores the role is a compile error rather than a silent fallback.

## Audit

Migration 080 added five attribution columns and nothing wrote them. Now every row carries who acted, in what role, for whom, **whose credential acted**, and the platform id sent as moderator. `credential_user_id` comes back *from the dispatcher* rather than being asserted by the handler — only the dispatcher knows which credential it reached for, and recording an assumption would make the no-fallback proof a restatement of intent. Denials carry it too: "this moderator keeps getting refused" is invisible if a denial can't be told from an owner's. Migration 081 corrects migration 060's comment, which still asserted `actor_user_id` is the overlay owner.

## Tests

- 13 delegated-dispatch tests, including "never reaches for the owner's credential" (the owner holds a perfectly good one throughout) and the anchor being resolved against the owner rather than the caller.
- Discord refusal covered for all four actions, asserting not even the guild lookup runs.
- Client tests for the split on every endpoint; audit tests against real Postgres for the five identities; `tokens` tests against real Postgres for the moderator store and the anchor (including "applies no scope predicate").
- A refactor bug caught by the pre-existing `TestDispatch_UnauthorizedRefreshesAndRetries`: the 401 retry read a token snapshot taken before the refresh. Fixed; the refresh now writes back onto the resolved call.
- Full `moderation-service` suite green; `vitest` 106 files / 907 tests green; migration-rerun test green with 081.

Kick, Discord and YouTube legs remain unbuilt.