### PR TITLE
feat(moderation): Discord member-authority model and live permission read

### DIFF
--- a/services/moderation-service/clients/discord.go
+++ b/services/moderation-service/clients/discord.go
@@ -227,64 +227,163 @@ func (d *DiscordClient) GuildBotPermissions(ctx context.Context, guildID string)
 	if err != nil {
 		return 0, err
 	}
-	memberResp, err := d.do(ctx, http.MethodGet, "/guilds/"+guildID+"/members/"+botID, nil)
+	// The ownership read is skipped deliberately: a bot can never own a guild, so asking
+	// would be a wasted call on the capability path.
+	standing, err := d.memberRoleStanding(ctx, guildID, botID)
 	if err != nil {
-		return 0, fmt.Errorf("discord: member request failed: %w", err)
+		return 0, err
+	}
+	return standing.Permissions, nil
+}
+
+// DiscordMember is one user's live standing in one guild.
+//
+// It mirrors models.DiscordMemberAuthority field for field, and the duplication is
+// deliberate: clients holds no dependency on the domain packages, the same reason
+// models.Actor duplicates repository.Role* rather than importing it. The dispatch layer,
+// which already imports both, does the one-line conversion.
+//
+// The zero value is "not a member", which denies everything — so a caller that ignores an
+// error still fails closed.
+type DiscordMember struct {
+	InGuild        bool
+	IsGuildOwner   bool
+	Permissions    uint64
+	HighestRolePos int
+}
+
+// MemberAuthority reads what one Discord user may do in one guild: their effective
+// guild-level permission bits, the position of their highest role, and whether they own the
+// guild.
+//
+// This is the live read ADR-0048's platform-attested model rests on. Discord never re-checks
+// a delegated moderator — every write authenticates as the shared bot — so this read IS the
+// authorization input, and every failure mode other than "not a member" is returned as an
+// error rather than as a permissive or empty standing.
+//
+// A 404 is an answer, not a failure: it means the user is not in the guild, and it
+// short-circuits before the role and ownership reads, so a stranger costs one call.
+func (d *DiscordClient) MemberAuthority(ctx context.Context, guildID, userID string) (DiscordMember, error) {
+	standing, err := d.memberRoleStanding(ctx, guildID, userID)
+	if err != nil || !standing.InGuild {
+		return standing, err
+	}
+
+	ownerID, err := d.guildOwnerID(ctx, guildID)
+	if err != nil {
+		return DiscordMember{}, err
+	}
+	standing.IsGuildOwner = ownerID != "" && ownerID == userID
+	return standing, nil
+}
+
+// memberRoleStanding reads a member's roles and folds the guild's role definitions into
+// effective permission bits and a highest-role position. It is shared by the bot's own
+// permission check and the general member read so the two computations cannot drift.
+func (d *DiscordClient) memberRoleStanding(ctx context.Context, guildID, userID string) (DiscordMember, error) {
+	memberResp, err := d.do(ctx, http.MethodGet, "/guilds/"+guildID+"/members/"+userID, nil)
+	if err != nil {
+		return DiscordMember{}, fmt.Errorf("discord: member request failed: %w", err)
 	}
 	defer memberResp.Body.Close()
 	switch {
 	case memberResp.StatusCode == http.StatusUnauthorized:
-		return 0, ErrDiscordUnauthorized
+		return DiscordMember{}, ErrDiscordUnauthorized
 	case memberResp.StatusCode == http.StatusForbidden:
-		return 0, ErrDiscordForbidden
+		return DiscordMember{}, ErrDiscordForbidden
 	case memberResp.StatusCode == http.StatusNotFound:
-		// The bot is not a member of the guild — it can do nothing here.
-		return 0, nil
+		// Not a member of the guild — they can do nothing here. Discord answers 404
+		// "Unknown User" for any snowflake that is not a member.
+		return DiscordMember{}, nil
 	case memberResp.StatusCode < 200 || memberResp.StatusCode >= 300:
 		snippet, _ := io.ReadAll(io.LimitReader(memberResp.Body, 512))
-		return 0, fmt.Errorf("discord: get member returned %s: %s", strconv.Itoa(memberResp.StatusCode), string(snippet))
+		return DiscordMember{}, fmt.Errorf("discord: get member returned %s: %s", strconv.Itoa(memberResp.StatusCode), string(snippet))
 	}
 	var member struct {
 		Roles []string `json:"roles"`
 	}
 	if err := json.NewDecoder(memberResp.Body).Decode(&member); err != nil {
-		return 0, fmt.Errorf("discord: decode member: %w", err)
+		return DiscordMember{}, fmt.Errorf("discord: decode member: %w", err)
 	}
 
-	rolesResp, err := d.do(ctx, http.MethodGet, "/guilds/"+guildID+"/roles", nil)
+	roles, err := d.guildRoles(ctx, guildID)
 	if err != nil {
-		return 0, fmt.Errorf("discord: roles request failed: %w", err)
-	}
-	defer rolesResp.Body.Close()
-	if rolesResp.StatusCode < 200 || rolesResp.StatusCode >= 300 {
-		snippet, _ := io.ReadAll(io.LimitReader(rolesResp.Body, 512))
-		return 0, fmt.Errorf("discord: get roles returned %s: %s", strconv.Itoa(rolesResp.StatusCode), string(snippet))
-	}
-	var roles []struct {
-		ID          string `json:"id"`
-		Permissions string `json:"permissions"`
-	}
-	if err := json.NewDecoder(rolesResp.Body).Decode(&roles); err != nil {
-		return 0, fmt.Errorf("discord: decode roles: %w", err)
+		return DiscordMember{}, err
 	}
 
-	// The bot has @everyone (role id == guild id) implicitly, plus its assigned roles.
+	// @everyone (role id == guild id) is implicit — Discord does not list it in a member's
+	// roles — so it is always held, on top of the assigned roles.
 	held := map[string]bool{guildID: true}
 	for _, r := range member.Roles {
 		held[r] = true
 	}
-	var effective uint64
+	standing := DiscordMember{InGuild: true}
 	for _, r := range roles {
 		if !held[r.ID] {
 			continue
 		}
 		bits, perr := strconv.ParseUint(r.Permissions, 10, 64)
 		if perr != nil {
-			return 0, fmt.Errorf("discord: parse role permissions %q: %w", r.Permissions, perr)
+			return DiscordMember{}, fmt.Errorf("discord: parse role permissions %q: %w", r.Permissions, perr)
 		}
-		effective |= bits
+		standing.Permissions |= bits
+		if r.Position > standing.HighestRolePos {
+			standing.HighestRolePos = r.Position
+		}
 	}
-	return effective, nil
+	return standing, nil
+}
+
+// discordRole is one guild role as Discord reports it. Permissions is a decimal string
+// because the bitfield exceeds what JSON numbers represent exactly.
+type discordRole struct {
+	ID          string `json:"id"`
+	Permissions string `json:"permissions"`
+	Position    int    `json:"position"`
+}
+
+// guildRoles lists the guild's role definitions.
+func (d *DiscordClient) guildRoles(ctx context.Context, guildID string) ([]discordRole, error) {
+	resp, err := d.do(ctx, http.MethodGet, "/guilds/"+guildID+"/roles", nil)
+	if err != nil {
+		return nil, fmt.Errorf("discord: roles request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("discord: get roles returned %s: %s", strconv.Itoa(resp.StatusCode), string(snippet))
+	}
+	var roles []discordRole
+	if err := json.NewDecoder(resp.Body).Decode(&roles); err != nil {
+		return nil, fmt.Errorf("discord: decode roles: %w", err)
+	}
+	return roles, nil
+}
+
+// guildOwnerID reads the guild's owner. Ownership implicitly grants every permission and
+// makes a member untouchable by timeout/ban, so it cannot be inferred from permission bits.
+func (d *DiscordClient) guildOwnerID(ctx context.Context, guildID string) (string, error) {
+	resp, err := d.do(ctx, http.MethodGet, "/guilds/"+guildID, nil)
+	if err != nil {
+		return "", fmt.Errorf("discord: guild request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		return "", ErrDiscordUnauthorized
+	case resp.StatusCode == http.StatusForbidden:
+		return "", ErrDiscordForbidden
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("discord: get guild returned %s: %s", strconv.Itoa(resp.StatusCode), string(snippet))
+	}
+	var guild struct {
+		OwnerID string `json:"owner_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&guild); err != nil {
+		return "", fmt.Errorf("discord: decode guild: %w", err)
+	}
+	return guild.OwnerID, nil
 }
 
 // TimeoutMember sets a member's communication_disabled_until to `until` (a future
@@ -337,6 +436,7 @@ func (d *DiscordClient) memberWrite(ctx context.Context, method, path string, bo
 type discordResolverAPI interface {
 	GuildIDForChannel(ctx context.Context, channelID string) (string, error)
 	GuildBotPermissions(ctx context.Context, guildID string) (uint64, error)
+	MemberAuthority(ctx context.Context, guildID, userID string) (DiscordMember, error)
 }
 
 // DiscordGuildResolver caches the two Discord lookups the moderation service makes per
@@ -361,6 +461,14 @@ const (
 	// discordPermsCacheTTL bounds the per-guild effective-permissions entry: short, so a
 	// re-invite that grants moderation permissions is reflected on the dashboard quickly.
 	discordPermsCacheTTL = 5 * time.Minute
+	// discordMemberAuthorityCacheTTL bounds a delegated moderator's standing in a guild.
+	//
+	// This is a SECURITY BOUND, not a tuning knob (ADR-0048). Discord is the one platform
+	// where nothing external re-checks a delegated moderator, and because the GUILD_MEMBERS
+	// privileged intent is off, Discord cannot push us a revocation either. So this TTL is
+	// exactly how long someone the streamer just stripped of their roles keeps being able to
+	// act. Raising it lengthens that window; the ADR fixes the ceiling at 60 seconds.
+	discordMemberAuthorityCacheTTL = 60 * time.Second
 )
 
 // GuildID returns the guild id for a channel, from cache when possible.
@@ -401,4 +509,34 @@ func (r *DiscordGuildResolver) GuildBotPermissions(ctx context.Context, guildID 
 		_ = r.redis.Set(ctx, key, bits, discordPermsCacheTTL).Err()
 	}
 	return bits, nil
+}
+
+// MemberAuthority returns a user's standing in a guild, cached for
+// discordMemberAuthorityCacheTTL — the security bound described on that constant, since the
+// check runs on every delegated action and Discord cannot notify us of a revocation.
+//
+// "Not a member" is cached like any other answer: it is a real standing, and it is the most
+// likely one for a prober, so re-reading it every time would let an attacker drive our
+// Discord API traffic. Errors are never cached — caching one would extend a transient
+// Discord outage into a full TTL of denials.
+func (r *DiscordGuildResolver) MemberAuthority(ctx context.Context, guildID, userID string) (DiscordMember, error) {
+	key := "discord:member:authority:" + guildID + ":" + userID
+	if r.redis != nil {
+		if v, err := r.redis.Get(ctx, key).Bytes(); err == nil && len(v) > 0 {
+			var cached DiscordMember
+			if json.Unmarshal(v, &cached) == nil {
+				return cached, nil
+			}
+		}
+	}
+	standing, err := r.api.MemberAuthority(ctx, guildID, userID)
+	if err != nil {
+		return DiscordMember{}, err
+	}
+	if r.redis != nil {
+		if payload, merr := json.Marshal(standing); merr == nil {
+			_ = r.redis.Set(ctx, key, payload, discordMemberAuthorityCacheTTL).Err()
+		}
+	}
+	return standing, nil
 }

--- a/services/moderation-service/clients/discord_member_test.go
+++ b/services/moderation-service/clients/discord_member_test.go
@@ -1,0 +1,343 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package clients
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// guildFixture describes a fake guild for the member-authority reads: who owns it, which
+// roles exist (id → permissions/position), and which roles each member holds.
+type guildFixture struct {
+	ownerID string
+	roles   string // raw JSON array
+	members map[string]string
+	calls   map[string]int
+}
+
+// newMemberAuthorityServer serves GET /guilds/{g}, /guilds/{g}/members/{u} and
+// /guilds/{g}/roles from a fixture, counting calls per path prefix.
+func newMemberAuthorityServer(t *testing.T, f *guildFixture) *httptest.Server {
+	t.Helper()
+	if f.calls == nil {
+		f.calls = map[string]int{}
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		switch {
+		case p == "/users/@me":
+			f.calls["identity"]++
+			_, _ = w.Write([]byte(`{"id":"bot-1"}`))
+		case strings.HasSuffix(p, "/roles"):
+			f.calls["roles"]++
+			_, _ = w.Write([]byte(f.roles))
+		case strings.Contains(p, "/members/"):
+			f.calls["member"]++
+			uid := p[strings.LastIndex(p, "/")+1:]
+			roles, ok := f.members[uid]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"Unknown User","code":10013}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"roles":` + roles + `}`))
+		case strings.HasPrefix(p, "/guilds/"):
+			f.calls["guild"]++
+			_, _ = w.Write([]byte(`{"id":"g","owner_id":"` + f.ownerID + `"}`))
+		default:
+			t.Errorf("unexpected path %s", p)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+}
+
+// standardGuild: @everyone (id == guild id "g") at position 0 with no permissions; "mods"
+// at 5 with MANAGE_MESSAGES|MODERATE_MEMBERS; "admins" at 9 with ADMINISTRATOR; "unheld"
+// at 20 to prove a role nobody in the fixture holds is never folded in.
+func standardGuild() *guildFixture {
+	return &guildFixture{
+		ownerID: "owner-1",
+		roles: `[{"id":"g","permissions":"0","position":0},
+		         {"id":"mods","permissions":"1099511635968","position":5},
+		         {"id":"admins","permissions":"8","position":9},
+		         {"id":"unheld","permissions":"4","position":20}]`,
+		members: map[string]string{
+			"owner-1": `[]`,
+			"mod-1":   `["mods"]`,
+			"admin-1": `["admins"]`,
+			"both-1":  `["mods","admins"]`,
+			"plain-1": `[]`,
+		},
+	}
+}
+
+func TestDiscordMemberAuthority(t *testing.T) {
+	f := standardGuild()
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+	t.Run("a moderator's bits and highest position", func(t *testing.T) {
+		m, err := c.MemberAuthority(context.Background(), "g", "mod-1")
+		require.NoError(t, err)
+		assert.True(t, m.InGuild)
+		assert.False(t, m.IsGuildOwner)
+		// MANAGE_MESSAGES (8192) | MODERATE_MEMBERS (1<<40) = 1099511635968
+		assert.Equal(t, uint64(8192|(1<<40)), m.Permissions)
+		assert.Equal(t, 5, m.HighestRolePos)
+	})
+
+	t.Run("multiple roles OR their permissions and take the highest position", func(t *testing.T) {
+		m, err := c.MemberAuthority(context.Background(), "g", "both-1")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(8192|(1<<40)|8), m.Permissions)
+		assert.Equal(t, 9, m.HighestRolePos, "highest of the held roles, not the sum or the last seen")
+	})
+
+	t.Run("the guild owner is flagged", func(t *testing.T) {
+		m, err := c.MemberAuthority(context.Background(), "g", "owner-1")
+		require.NoError(t, err)
+		assert.True(t, m.IsGuildOwner)
+		assert.True(t, m.InGuild)
+	})
+
+	t.Run("an @everyone-only member sits at position 0", func(t *testing.T) {
+		m, err := c.MemberAuthority(context.Background(), "g", "plain-1")
+		require.NoError(t, err)
+		assert.True(t, m.InGuild)
+		assert.Equal(t, uint64(0), m.Permissions)
+		assert.Equal(t, 0, m.HighestRolePos)
+	})
+
+	t.Run("a non-member is not in the guild and holds nothing", func(t *testing.T) {
+		m, err := c.MemberAuthority(context.Background(), "g", "stranger")
+		require.NoError(t, err, "404 is an answer, not a failure — it means not a member")
+		assert.False(t, m.InGuild)
+		assert.Equal(t, uint64(0), m.Permissions)
+	})
+}
+
+// TestDiscordMemberAuthority_EveryoneIsAlwaysIncluded: @everyone is implicit — Discord does
+// not list it in a member's roles — so a permission granted to @everyone must still be read.
+func TestDiscordMemberAuthority_EveryoneIsAlwaysIncluded(t *testing.T) {
+	f := &guildFixture{
+		ownerID: "owner-1",
+		roles:   `[{"id":"g","permissions":"8192","position":0}]`,
+		members: map[string]string{"plain-1": `[]`},
+	}
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+	m, err := c.MemberAuthority(context.Background(), "g", "plain-1")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(8192), m.Permissions, "@everyone's id is the guild id and is always held")
+}
+
+// TestDiscordMemberAuthority_NoGuildOrRoleReadWhenNotAMember: a 404 short-circuits, so a
+// stranger costs one call rather than three.
+func TestDiscordMemberAuthority_NoGuildOrRoleReadWhenNotAMember(t *testing.T) {
+	f := standardGuild()
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+	_, err := c.MemberAuthority(context.Background(), "g", "stranger")
+	require.NoError(t, err)
+	assert.Equal(t, 1, f.calls["member"])
+	assert.Zero(t, f.calls["roles"], "no point reading roles for someone who holds none")
+	assert.Zero(t, f.calls["guild"], "no point asking who owns the guild either")
+}
+
+// TestDiscordMemberAuthority_FailsClosed: any error other than a 404 must surface. Discord
+// is the platform with no external backstop, so a swallowed error would become an
+// authorization decision made on no information.
+func TestDiscordMemberAuthority_FailsClosed(t *testing.T) {
+	tests := []struct {
+		name   string
+		failOn string
+		status int
+		wantIs error
+	}{
+		{"unauthorized bot token on the member read", "member", http.StatusUnauthorized, ErrDiscordUnauthorized},
+		{"forbidden on the member read", "member", http.StatusForbidden, ErrDiscordForbidden},
+		{"server error on the member read", "member", http.StatusInternalServerError, nil},
+		{"server error on the roles read", "roles", http.StatusInternalServerError, nil},
+		{"server error on the guild read", "guild", http.StatusBadGateway, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				p := r.URL.Path
+				kind := "guild"
+				switch {
+				case strings.HasSuffix(p, "/roles"):
+					kind = "roles"
+				case strings.Contains(p, "/members/"):
+					kind = "member"
+				}
+				if kind == tc.failOn {
+					w.WriteHeader(tc.status)
+					return
+				}
+				switch kind {
+				case "roles":
+					_, _ = w.Write([]byte(`[{"id":"g","permissions":"0","position":0}]`))
+				case "member":
+					_, _ = w.Write([]byte(`{"roles":[]}`))
+				default:
+					_, _ = w.Write([]byte(`{"owner_id":"owner-1"}`))
+				}
+			}))
+			defer srv.Close()
+			c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+			m, err := c.MemberAuthority(context.Background(), "g", "mod-1")
+			require.Error(t, err, "an unreadable standing must not be reported as a standing")
+			if tc.wantIs != nil {
+				assert.ErrorIs(t, err, tc.wantIs)
+			}
+			assert.False(t, m.InGuild, "the zero value denies everything")
+		})
+	}
+}
+
+// TestDiscordMemberAuthority_MalformedPositionIsAnError: a role position we cannot parse
+// would silently rank a member at 0 and defeat the hierarchy check.
+func TestDiscordMemberAuthority_MalformedPermissionsIsAnError(t *testing.T) {
+	f := &guildFixture{
+		ownerID: "owner-1",
+		roles:   `[{"id":"g","permissions":"not-a-number","position":0}]`,
+		members: map[string]string{"mod-1": `[]`},
+	}
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+	_, err := c.MemberAuthority(context.Background(), "g", "mod-1")
+	require.Error(t, err)
+}
+
+// TestDiscordGuildBotPermissions_SharesTheMemberMachinery: the bot's own permissions are the
+// same computation over the same reads, so the two must not drift. The bot cannot own a
+// guild, so its path skips the ownership read.
+func TestDiscordGuildBotPermissions_SkipsTheGuildOwnerRead(t *testing.T) {
+	f := standardGuild()
+	f.members["bot-1"] = `["mods"]`
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+
+	perms, err := c.GuildBotPermissions(context.Background(), "g")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(8192|(1<<40)), perms)
+	assert.Zero(t, f.calls["guild"], "a bot can never be the guild owner, so that read is waste")
+}
+
+// TestDiscordGuildResolver_MemberAuthorityCacheTTLIsASecurityBound: ADR-0048 makes this TTL
+// a security property — with GUILD_MEMBERS off Discord cannot push us a revocation, so the
+// TTL is exactly how long a removed moderator keeps acting.
+func TestDiscordGuildResolver_MemberAuthorityCacheTTLIsASecurityBound(t *testing.T) {
+	assert.LessOrEqual(t, discordMemberAuthorityCacheTTL.Seconds(), 60.0,
+		"ADR-0048 fixes the delegated-moderator permission cache at 60s or less")
+}
+
+// TestDiscordGuildResolver_MemberAuthorityCached: the check runs on every delegated action,
+// so it must not cost three Discord calls each time — but it must also expire.
+func TestDiscordGuildResolver_MemberAuthorityCached(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	f := standardGuild()
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+	r := NewDiscordGuildResolver(c, rdb)
+
+	for i := 0; i < 3; i++ {
+		m, merr := r.MemberAuthority(context.Background(), "g", "mod-1")
+		require.NoError(t, merr)
+		assert.Equal(t, 5, m.HighestRolePos)
+		assert.True(t, m.InGuild)
+	}
+	assert.Equal(t, 1, f.calls["member"], "the standing is read once then served from cache")
+
+	// Expiry restores the live read — the whole point of the bound.
+	mr.FastForward(discordMemberAuthorityCacheTTL + time.Second)
+	_, err = r.MemberAuthority(context.Background(), "g", "mod-1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, f.calls["member"], "once the TTL lapses the standing is re-read from Discord")
+}
+
+// TestDiscordGuildResolver_MemberAuthorityErrorNotCached: caching a failure would extend a
+// transient Discord outage into a full TTL of denials.
+func TestDiscordGuildResolver_MemberAuthorityErrorNotCached(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+	r := NewDiscordGuildResolver(c, rdb)
+
+	_, err1 := r.MemberAuthority(context.Background(), "g", "mod-1")
+	_, err2 := r.MemberAuthority(context.Background(), "g", "mod-1")
+	require.Error(t, err1)
+	require.Error(t, err2)
+	assert.Equal(t, 2, calls, "an error is not cached; the next call retries")
+}
+
+// TestDiscordGuildResolver_NonMemberIsCached: "not a member" is a real answer and the most
+// likely one for a hostile prober, so it must be cached like any other — but only for the
+// same bounded TTL.
+func TestDiscordGuildResolver_NonMemberIsCached(t *testing.T) {
+	mr, err := miniredis.Run()
+	require.NoError(t, err)
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	f := standardGuild()
+	srv := newMemberAuthorityServer(t, f)
+	defer srv.Close()
+	c := &DiscordClient{httpClient: srv.Client(), botToken: "bot-tok", baseURL: srv.URL}
+	r := NewDiscordGuildResolver(c, rdb)
+
+	for i := 0; i < 3; i++ {
+		m, merr := r.MemberAuthority(context.Background(), "g", "stranger")
+		require.NoError(t, merr)
+		assert.False(t, m.InGuild)
+	}
+	assert.Equal(t, 1, f.calls["member"])
+}

--- a/services/moderation-service/clients/discord_test.go
+++ b/services/moderation-service/clients/discord_test.go
@@ -305,12 +305,15 @@ func TestDiscordMemberWrite_ForbiddenSurfacesSentinel(t *testing.T) {
 // countingResolverAPI records how many times each lookup hits the "API" so the cache
 // test can assert a miss-then-hit.
 type countingResolverAPI struct {
-	guildID    string
-	perms      uint64
-	guildCalls int
-	permsCalls int
-	guildErr   error
-	permsErr   error
+	guildID     string
+	perms       uint64
+	member      DiscordMember
+	guildCalls  int
+	permsCalls  int
+	memberCalls int
+	guildErr    error
+	permsErr    error
+	memberErr   error
 }
 
 func (c *countingResolverAPI) GuildIDForChannel(context.Context, string) (string, error) {
@@ -321,6 +324,11 @@ func (c *countingResolverAPI) GuildIDForChannel(context.Context, string) (string
 func (c *countingResolverAPI) GuildBotPermissions(context.Context, string) (uint64, error) {
 	c.permsCalls++
 	return c.perms, c.permsErr
+}
+
+func (c *countingResolverAPI) MemberAuthority(context.Context, string, string) (DiscordMember, error) {
+	c.memberCalls++
+	return c.member, c.memberErr
 }
 
 func TestDiscordGuildResolver_CachesGuildAndPermissions(t *testing.T) {

--- a/services/moderation-service/models/discord_authority.go
+++ b/services/moderation-service/models/discord_authority.go
@@ -1,0 +1,163 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package models
+
+// Discord's authority model, expressed as pure decisions over a live permission read.
+//
+// Discord is ADR-0048's one "platform-attested" platform: every Discord write authenticates
+// as the shared bot, so no external party ever re-checks a delegated moderator's standing.
+// Whatever these functions decide IS the authorization — there is no platform backstop
+// behind them, which is why the decisions live here as total, table-tested functions rather
+// than as conditionals scattered through a dispatcher.
+//
+// Everything here operates on a DiscordMemberAuthority, which is a *snapshot* of a live
+// read. Its freshness is a security property, not a tuning knob: because the GUILD_MEMBERS
+// privileged intent is off, Discord cannot push us a revocation, so the cache TTL bounds how
+// long a removed moderator keeps acting.
+
+// DiscordPermManageGuild permits managing the guild's settings. Together with ADMINISTRATOR
+// and guild ownership it is what ADR-0048 accepts as proof that the overlay owner controls
+// a guild — the Discord arm of the owner-reach anchor.
+const DiscordPermManageGuild uint64 = 1 << 5
+
+// DiscordPermViewChannel permits seeing a channel. Not a moderation permission; named here
+// so a member who holds only base permissions can be described without a magic number.
+const DiscordPermViewChannel uint64 = 1 << 10
+
+// DiscordMemberAuthority is a point-in-time read of what one Discord user may do in one
+// guild: whether they are a member at all, whether they own the guild, their effective
+// guild-level permission bits (the OR of every role they hold, including @everyone), and
+// the position of their highest role.
+//
+// The zero value is "not in the guild", which denies everything. That default is
+// deliberate: a failed or partial read must never be mistaken for a permissive answer.
+type DiscordMemberAuthority struct {
+	// InGuild is false when Discord answered 404 for this member. Every decision below
+	// returns the denying answer in that case, whatever the other fields hold.
+	InGuild bool
+	// IsGuildOwner short-circuits permissions (an owner implicitly holds all of them) and
+	// makes the member untouchable by member operations.
+	IsGuildOwner bool
+	// Permissions is the effective guild-level bitfield. Channel overwrites are NOT folded
+	// in: they can only further restrict, and Discord enforces them at write time.
+	Permissions uint64
+	// HighestRolePos is the position of the member's highest role. @everyone is position 0,
+	// so a member with no other role sits at 0.
+	HighestRolePos int
+}
+
+// DiscordMemberActions reports the moderation actions this member could perform themselves,
+// natively, in this guild.
+//
+// A non-member gets nothing. The guild owner gets everything: Discord grants an owner every
+// permission implicitly, so reading their bits would understate them.
+func DiscordMemberActions(m DiscordMemberAuthority) []Action {
+	if !m.InGuild {
+		return nil
+	}
+	if m.IsGuildOwner {
+		return []Action{ActionDelete, ActionTimeout, ActionBan, ActionUnban}
+	}
+	return ActionsForDiscordPermissions(m.Permissions)
+}
+
+// DiscordDelegatedActions is the action set a delegated moderator may use in a guild:
+// what the BOT can do intersected with what the MODERATOR could do themselves.
+//
+// Both halves are load-bearing and neither is redundant. The bot performs every write, so
+// its permissions bound what is *possible* — a moderator cannot borrow authority the bot
+// was never invited with. The moderator's own permissions bound what is *permitted* — the
+// point of the intersection is that All-Chat never lets someone do through the bot what
+// Discord would refuse them directly.
+//
+// The result is always non-nil so a caller can serialise it as an empty JSON array rather
+// than null.
+func DiscordDelegatedActions(bot, mod DiscordMemberAuthority) []Action {
+	botActions := DiscordMemberActions(bot)
+	modActions := DiscordMemberActions(mod)
+	permitted := make(map[Action]bool, len(modActions))
+	for _, a := range modActions {
+		permitted[a] = true
+	}
+	out := make([]Action, 0, len(botActions))
+	for _, a := range botActions {
+		if permitted[a] {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// DiscordHierarchyApplies reports whether Discord's role-hierarchy rule governs an action.
+//
+// It governs member operations — timeout and ban — and nothing else. Deleting a message is
+// not a member operation, and an unban target is by definition not a guild member, so
+// neither has a member record to rank. Applying the rule where Discord does not would deny
+// actions a moderator can perform natively, which is its own kind of wrong answer.
+func DiscordHierarchyApplies(a Action) bool {
+	return a == ActionTimeout || a == ActionBan
+}
+
+// DiscordOutranks reports whether actor may perform a member operation on target under
+// Discord's role hierarchy.
+//
+// All-Chat has to evaluate this itself, and that is the whole reason it exists here:
+// Discord hierarchy-gates the *actor*, and on a delegated action the actor is the shared
+// bot, which typically sits above everyone. Without this check a delegated moderator could
+// ban a guild administrator they cannot touch in Discord's own client.
+//
+// The rules, matching Discord: the guild owner outranks everyone and is outranked by
+// nobody; otherwise the actor's highest role must be *strictly* above the target's, so a
+// tie is a refusal. ADMINISTRATOR deliberately does NOT bypass this — on Discord an
+// administrator still cannot act on a member ranked above them.
+func DiscordOutranks(actor, target DiscordMemberAuthority) bool {
+	if !actor.InGuild {
+		return false
+	}
+	// The guild owner can never be the target of a timeout or ban, including by another
+	// owner — a guild has exactly one, so that case cannot arise, but refusing keeps the
+	// rule total rather than leaving a gap for a caller to fall into.
+	if target.IsGuildOwner {
+		return false
+	}
+	if actor.IsGuildOwner {
+		return true
+	}
+	// A target who is not a member holds no roles, so nothing ranks above the actor.
+	if !target.InGuild {
+		return true
+	}
+	return actor.HighestRolePos > target.HighestRolePos
+}
+
+// DiscordOwnerControlsGuild reports whether a member's standing proves they control the
+// guild — the Discord arm of ADR-0048's owner-reach anchor, since delegation must never
+// exceed what the overlay owner could do themselves.
+//
+// Guild ownership, ADMINISTRATOR or MANAGE_GUILD count. Moderation permissions deliberately
+// do not: they prove someone moderates the guild, not that they run it, and the anchor is
+// about control. Note this proves control only — it says nothing about capability, and must
+// never be read as authorizing an action.
+func DiscordOwnerControlsGuild(m DiscordMemberAuthority) bool {
+	if !m.InGuild {
+		return false
+	}
+	if m.IsGuildOwner {
+		return true
+	}
+	return m.Permissions&(DiscordPermAdministrator|DiscordPermManageGuild) != 0
+}

--- a/services/moderation-service/models/discord_authority_test.go
+++ b/services/moderation-service/models/discord_authority_test.go
@@ -1,0 +1,272 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package models_test
+
+import (
+	"testing"
+
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/stretchr/testify/assert"
+)
+
+// Discord is the one platform in ADR-0048 with no external authority behind it: nobody at
+// the platform re-checks a delegated moderator, because every write authenticates as the
+// shared bot. These tests are therefore the authorization check itself, not a convenience
+// layer over one.
+
+func member(perms uint64, pos int) models.DiscordMemberAuthority {
+	return models.DiscordMemberAuthority{InGuild: true, Permissions: perms, HighestRolePos: pos}
+}
+
+func TestDiscordMemberActions(t *testing.T) {
+	tests := []struct {
+		name string
+		m    models.DiscordMemberAuthority
+		want []models.Action
+	}{
+		{
+			name: "not in the guild yields nothing",
+			m:    models.DiscordMemberAuthority{InGuild: false, Permissions: models.DiscordPermAdministrator},
+			want: nil,
+		},
+		{
+			name: "guild owner holds every action regardless of permission bits",
+			m:    models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true, Permissions: 0},
+			want: []models.Action{models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban},
+		},
+		{
+			name: "ADMINISTRATOR short-circuits to every action",
+			m:    member(models.DiscordPermAdministrator, 5),
+			want: []models.Action{models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban},
+		},
+		{
+			name: "MANAGE_MESSAGES alone yields delete only",
+			m:    member(models.DiscordPermManageMessages, 5),
+			want: []models.Action{models.ActionDelete},
+		},
+		{
+			name: "MODERATE_MEMBERS alone yields timeout only",
+			m:    member(models.DiscordPermModerateMembers, 5),
+			want: []models.Action{models.ActionTimeout},
+		},
+		{
+			name: "BAN_MEMBERS yields ban and unban together",
+			m:    member(models.DiscordPermBanMembers, 5),
+			want: []models.Action{models.ActionBan, models.ActionUnban},
+		},
+		{
+			name: "no moderation bits yields nothing",
+			m:    member(models.DiscordPermViewChannel, 5),
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, models.DiscordMemberActions(tc.m))
+		})
+	}
+}
+
+// TestDiscordDelegatedActions_IsBotIntersectModerator pins ADR-0048's rule: the effective
+// set is ActionsForDiscordPermissions(botBits) ∩ ActionsForDiscordPermissions(modBits).
+// Neither side alone is sufficient — the bot performs the write, so its permissions bound
+// what is possible; the moderator's bound what is permitted.
+func TestDiscordDelegatedActions_IsBotIntersectModerator(t *testing.T) {
+	tests := []struct {
+		name     string
+		bot, mod models.DiscordMemberAuthority
+		want     []models.Action
+	}{
+		{
+			name: "both hold everything",
+			bot:  member(models.ModerationBotPermissions, 10),
+			mod:  member(models.ModerationBotPermissions, 5),
+			want: []models.Action{models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban},
+		},
+		{
+			name: "the bot is the ceiling: a moderator cannot exceed what the bot can do",
+			bot:  member(models.DiscordPermManageMessages, 10),
+			mod:  member(models.ModerationBotPermissions, 5),
+			want: []models.Action{models.ActionDelete},
+		},
+		{
+			name: "the moderator is the floor: a permissive bot grants a moderator nothing extra",
+			bot:  member(models.ModerationBotPermissions, 10),
+			mod:  member(models.DiscordPermModerateMembers, 5),
+			want: []models.Action{models.ActionTimeout},
+		},
+		{
+			name: "an ADMINISTRATOR moderator is still bounded by the bot",
+			bot:  member(models.DiscordPermBanMembers, 10),
+			mod:  member(models.DiscordPermAdministrator, 5),
+			want: []models.Action{models.ActionBan, models.ActionUnban},
+		},
+		{
+			name: "a guild-owner moderator is still bounded by the bot",
+			bot:  member(models.DiscordPermManageMessages, 10),
+			mod:  models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true},
+			want: []models.Action{models.ActionDelete},
+		},
+		{
+			name: "disjoint permissions yield nothing",
+			bot:  member(models.DiscordPermManageMessages, 10),
+			mod:  member(models.DiscordPermBanMembers, 5),
+			want: []models.Action{},
+		},
+		{
+			name: "a moderator who left the guild gets nothing even from an ADMINISTRATOR bot",
+			bot:  member(models.DiscordPermAdministrator, 10),
+			mod:  models.DiscordMemberAuthority{InGuild: false, Permissions: models.DiscordPermAdministrator},
+			want: []models.Action{},
+		},
+		{
+			name: "a bot removed from the guild grants nothing to anyone",
+			bot:  models.DiscordMemberAuthority{InGuild: false},
+			mod:  member(models.DiscordPermAdministrator, 5),
+			want: []models.Action{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, models.DiscordDelegatedActions(tc.bot, tc.mod))
+		})
+	}
+}
+
+// TestDiscordHierarchyApplies: Discord hierarchy-gates the ACTOR on member operations, and
+// the bot is always the actor, so All-Chat must apply the gate itself — but only where
+// Discord would. Message deletion is not a member operation, and an unban target is by
+// definition not a member, so neither has a member record to rank.
+func TestDiscordHierarchyApplies(t *testing.T) {
+	assert.True(t, models.DiscordHierarchyApplies(models.ActionTimeout))
+	assert.True(t, models.DiscordHierarchyApplies(models.ActionBan))
+	assert.False(t, models.DiscordHierarchyApplies(models.ActionDelete),
+		"deleting a message is not a member operation; Discord applies no hierarchy check to it")
+	assert.False(t, models.DiscordHierarchyApplies(models.ActionUnban),
+		"an unban target is not a guild member, so there is no member record to rank")
+}
+
+func TestDiscordOutranks(t *testing.T) {
+	tests := []struct {
+		name          string
+		actor, target models.DiscordMemberAuthority
+		want          bool
+		why           string
+	}{
+		{
+			name:   "a strictly higher role outranks",
+			actor:  member(models.DiscordPermBanMembers, 10),
+			target: member(0, 5),
+			want:   true,
+		},
+		{
+			name:   "equal positions do NOT outrank",
+			actor:  member(models.DiscordPermBanMembers, 5),
+			target: member(0, 5),
+			want:   false,
+			why:    "Discord requires strictly greater; a tie means neither can act on the other",
+		},
+		{
+			name:   "a lower role does not outrank",
+			actor:  member(models.DiscordPermBanMembers, 3),
+			target: member(0, 7),
+			want:   false,
+		},
+		{
+			name:   "ADMINISTRATOR does not bypass hierarchy",
+			actor:  member(models.DiscordPermAdministrator, 3),
+			target: member(0, 7),
+			want:   false,
+			why:    "on Discord an administrator still cannot act on a member ranked above them",
+		},
+		{
+			name:   "the guild owner outranks everyone",
+			actor:  models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true, HighestRolePos: 0},
+			target: member(0, 99),
+			want:   true,
+		},
+		{
+			name:   "nobody outranks the guild owner",
+			actor:  member(models.DiscordPermAdministrator, 99),
+			target: models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true, HighestRolePos: 0},
+			want:   false,
+			why:    "the guild owner cannot be timed out or banned by anyone",
+		},
+		{
+			name:   "an owner acting on an owner is still refused",
+			actor:  models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true},
+			target: models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true},
+			want:   false,
+			why:    "a guild has one owner, so this cannot arise; refusing keeps the rule total",
+		},
+		{
+			name:   "an actor outside the guild outranks nobody",
+			actor:  models.DiscordMemberAuthority{InGuild: false, HighestRolePos: 99},
+			target: member(0, 1),
+			want:   false,
+		},
+		{
+			name:   "a target outside the guild is outranked by any member",
+			actor:  member(models.DiscordPermBanMembers, 1),
+			target: models.DiscordMemberAuthority{InGuild: false},
+			want:   true,
+			why:    "a non-member holds no roles, so a timeout/ban of them is not blocked by hierarchy",
+		},
+		{
+			name:   "@everyone-only actor cannot act on an @everyone-only target",
+			actor:  member(models.DiscordPermBanMembers, 0),
+			target: member(0, 0),
+			want:   false,
+			why:    "both sit at position 0, which is a tie, not authority",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, models.DiscordOutranks(tc.actor, tc.target), tc.why)
+		})
+	}
+}
+
+// TestDiscordOwnerControlsGuild covers the owner-reach anchor's Discord predicate: the
+// overlay owner must demonstrably control the guild, which the ADR defines as being the
+// guild owner or holding ADMINISTRATOR or MANAGE_GUILD.
+func TestDiscordOwnerControlsGuild(t *testing.T) {
+	tests := []struct {
+		name string
+		m    models.DiscordMemberAuthority
+		want bool
+	}{
+		{"guild owner controls it", models.DiscordMemberAuthority{InGuild: true, IsGuildOwner: true}, true},
+		{"ADMINISTRATOR controls it", member(models.DiscordPermAdministrator, 1), true},
+		{"MANAGE_GUILD controls it", member(models.DiscordPermManageGuild, 1), true},
+		{"a moderation-only member does not", member(models.ModerationBotPermissions, 1), false},
+		{"a plain member does not", member(models.DiscordPermViewChannel, 1), false},
+		{"someone outside the guild does not, whatever bits we were handed", models.DiscordMemberAuthority{InGuild: false, Permissions: models.DiscordPermAdministrator}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, models.DiscordOwnerControlsGuild(tc.m))
+		})
+	}
+}
+
+// TestDiscordPermManageGuild_BitValue guards the constant against a typo: a wrong bit here
+// would silently widen or narrow who counts as controlling a guild.
+func TestDiscordPermManageGuild_BitValue(t *testing.T) {
+	assert.Equal(t, uint64(1)<<5, models.DiscordPermManageGuild, "MANAGE_GUILD is 1 << 5 (32)")
+	assert.Equal(t, uint64(1)<<10, models.DiscordPermViewChannel, "VIEW_CHANNEL is 1 << 10 (1024)")
+}


### PR DESCRIPTION
> Stacked on #684. Review that first; this PR's diff is only the second commit.

## Why this is its own PR

Discord is ADR-0048's one **platform-attested** platform: every Discord write authenticates as the shared bot, so nothing external ever re-checks a delegated moderator. Whatever All-Chat decides **is** the authorization — there is no platform backstop behind it.

That makes this the highest-consequence logic in the whole delegation feature, so it lands on its own, fully table-tested, **before** anything is wired to it. `dispatch/discord.go` still returns `DispatchDelegationUnsupported`, so this PR changes no behaviour for anyone.

## The decisions (`models/discord_authority.go`)

| Function | Rule | Why it is not obvious |
|---|---|---|
| `DiscordMemberActions` | guild owner ⇒ every action; `ADMINISTRATOR` ⇒ every action; non-member ⇒ nothing | Discord grants an owner all permissions *implicitly*, so reading their bits would understate them |
| `DiscordDelegatedActions` | `bot ∩ moderator` | The bot bounds what is **possible**, the moderator bounds what is **permitted**. Nobody may do through the bot what Discord would refuse them directly |
| `DiscordOutranks` | strictly-greater highest role position | Ties **refuse**. `ADMINISTRATOR` does **not** bypass hierarchy. The guild owner outranks everyone and is outranked by nobody |
| `DiscordHierarchyApplies` | timeout + ban only | Deleting a message is not a member operation, and an unban target is not a member — neither has a member record to rank. Applying it there would deny actions a moderator can perform natively |
| `DiscordOwnerControlsGuild` | ownership ∥ `ADMINISTRATOR` ∥ `MANAGE_GUILD` | The Discord arm of the owner-reach anchor. Moderation permissions deliberately do **not** count: they prove someone moderates a guild, not that they run it |

`DiscordOutranks` is the one All-Chat is *forced* to implement: Discord hierarchy-gates the **actor**, and on a delegated action the actor is the bot, which typically sits above everyone. Without it a delegated moderator could ban a guild administrator they cannot touch in Discord's own client.

The zero value of `DiscordMemberAuthority` is "not in the guild", so a caller that ignores an error still fails closed.

## The live read (`clients/discord.go`)

`MemberAuthority(guild, user)` reads effective bits, highest role position and guild ownership.

- A **404 is an answer** ("not a member"), not a failure, and short-circuits before the role and ownership reads — a stranger costs one call instead of three.
- Every **other** failure surfaces as an error. On the platform with no external backstop, a swallowed error would be an authorization decision made on no information.
- `GuildBotPermissions` now shares the same role-folding machinery, so the bot and member computations cannot drift, and skips the ownership read since a bot can never own a guild.

## The 60-second TTL is a security bound

Asserted as one, not merely documented:

```go
assert.LessOrEqual(t, discordMemberAuthorityCacheTTL.Seconds(), 60.0,
    "ADR-0048 fixes the delegated-moderator permission cache at 60s or less")
```

With `GUILD_MEMBERS` off, Discord cannot push us a revocation, so this TTL is exactly how long a moderator whose roles were just stripped keeps acting. "Not a member" is cached like any other answer so a prober cannot drive our Discord API traffic; errors are never cached, since caching one would extend a transient Discord outage into a full TTL of denials.

## Tests

Table tests cover the cases ADR-0048 asks for: owner short-circuit, `ADMINISTRATOR`, `@everyone`-only, multi-role OR, position ties, 404 ⇒ deny, bot ∩ moderator in both directions, hierarchy denying timeout/ban while allowing delete, and fail-closed on each of the three reads independently.

Full `moderation-service` suite green, including the testcontainer `repository`/`tokens`/`audit` suites.

## Note on layering

`clients.DiscordMember` duplicates `models.DiscordMemberAuthority` field for field rather than importing it, for the same reason `models.Actor` already duplicates `repository.Role*`: `clients` holds no dependency on the domain packages. `dispatch`, which imports both, will do the one-line conversion.