### PR TITLE
feat(discord): link an All-Chat account to a Discord user account

### DIFF
--- a/docs/adr/0048-delegated-overlay-moderators.md
+++ b/docs/adr/0048-delegated-overlay-moderators.md
@@ -73,9 +73,24 @@ The anchor proves **control only**. It must never require the owner to hold a mo
 | **Twitch** | The owner holds a Twitch credential row whose login equals the source's `channel_id` (a Twitch source's `channel_id` *is* the login). The row also yields the numeric `broadcaster_id` the write needs. `users` branch (`auth_provider='twitch'`) preferred over `twitch_oauth_tokens` (ADR-0016), **no scope predicate**. | 403 `owner_channel_unverified`; the Twitch leg of every grant on that overlay is unusable. Remediation targets the **owner** ("reconnect your Twitch account"), surfaced in the owner's UI. |
 | **Kick** | Same shape: `users.kick_id` (Kick-login) or `kick_oauth_tokens.kick_user_id`, yielding the numeric `broadcaster_user_id`. `kick_user_id IS NOT NULL` is mandatory — it is NULL on legacy listener-only rows (migration 062). | 403 `owner_channel_unverified`. Load-bearing beyond authorization: this is the **only** legitimate source of `broadcaster_user_id`. |
 | **YouTube** | A `youtube_oauth_tokens` row for the owner and **exactly** the source's `channel_id` — that column is only ever written from `channels?mine=true` with the owner's own token. The `users`-row fallback used elsewhere is **forbidden as an anchor**: it is channel-agnostic and would match any channel id. | 403 `owner_channel_unverified`. A non-trivial existing population may fail this; measure before opening the gate. |
-| **Discord** | Both required: a `discord_guilds` row for (owner, guild) — migration 035, `UNIQUE(user_id, guild_id)`, written by the bot-invite callback — **and** a live bot-token read showing the owner's own Discord member permissions in that guild satisfy `owner_id ∥ ADMINISTRATOR ∥ MANAGE_GUILD`. Plus the source's `channel_id` must actually resolve to that guild. | Owner not Discord-linked → 403 `discord_link_required`. Row missing → 403 `owner_guild_unverified`. Live-check error → **fail closed**; no stamp-based bypass. |
+| **Discord** | Both required: a `discord_guilds` row for (owner, guild) — migration 035, `UNIQUE(user_id, guild_id)`, written by the bot-invite callback — **and** a live bot-token read showing the owner's own Discord member permissions in that guild satisfy `owner_id ∥ ADMINISTRATOR ∥ MANAGE_GUILD`. Plus the source's `channel_id` must actually resolve to that guild. **Amended 2026-08-10 — see "Discord anchor strength" below: the live read is required on delegated actions only.** | Owner not Discord-linked → 403 `discord_link_required`. Row missing → 403 `owner_guild_unverified`. Live-check error → **fail closed**; no stamp-based bypass. |
 | **TikTok** | n/a — no moderation API on any TikTok product. Absent from `PlatformActions` by design; reported `unsupported_platform`, never a fake button. | — |
 | **shared_overlay** | n/a — stays non-moderatable. Owner-only authorization made "a recipient must not moderate the original streamer's channel" true by construction; role-based authorization does not, so the existing `platform <> 'shared_overlay'` predicates become security-critical and get an explicit regression test. | — |
+
+#### Discord anchor strength (amendment, 2026-08-10)
+
+The anchor's two halves apply asymmetrically on Discord, decided when the leg was implemented:
+
+| Path | What must hold |
+|---|---|
+| **Owner** action | The `discord_guilds` row for (owner, guild). |
+| **Delegated** action | The row **and** a live `DiscordOwnerControlsGuild` read of the owner's own member permissions. |
+
+The reason is that the row is not a weak substitute for the live read — it is itself platform-attested. Discord only lets someone add a bot to a guild where they hold **Manage Server**, so a `discord_guilds` row *is* Discord's own record that the owner controlled that guild at invite time. What the row cannot see is a later loss of that standing, which is what the live read adds.
+
+That staleness matters on the delegated path, where a third party acts on the strength of the owner's reach, and matters far less on the owner path, where a stale row grants the owner authority over a guild they themselves connected. Set against that: the live read needs the owner's Discord **user id**, which no existing streamer has — the bot-invite flow never captured one — so requiring it on the owner path would switch Discord moderation off for **every** current Discord streamer until each completed a new account link. Disabling a working feature to re-prove something Discord already attested is the worse trade.
+
+So the anchor still applies to owner actions, as the original rule requires; only its strength differs by path. The unlinked-owner case does surface on the delegated path, where the moderator is told the streamer must link their Discord account — remediation aimed at the owner, per the anchor-failure UX decision below.
 
 ### Moderator-status verification model
 

--- a/migrations/083_discord_identities.sql
+++ b/migrations/083_discord_identities.sql
@@ -1,0 +1,64 @@
+-- Migration: 083_discord_identities
+-- Description: Links an All-Chat account to a Discord USER account (ADR-0048, Discord leg).
+--
+-- Why a new table rather than a column on users, and why it does not already exist: the only
+-- Discord flow All-Chat has ever run is a `scope=bot` guild invite, whose callback returns a
+-- guild_id and no user identity at all. So `discord_guilds` records which SERVERS a streamer
+-- connected while All-Chat has never known WHO any user is on Discord.
+--
+-- The Discord leg of delegated moderation cannot work without that. Discord has no per-user
+-- moderation API, so the shared bot performs every write and All-Chat must itself verify the
+-- acting human's guild permissions -- which requires their Discord user id. The overlay owner's
+-- id is needed too, to prove they control the guild the moderator would act in.
+--
+-- Idempotent throughout: the migration runner re-applies every migration on each pod start, so
+-- a non-idempotent statement would crash-loop fresh pods.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS discord_identities (
+    -- One Discord account per All-Chat user, hence the PK rather than a surrogate id.
+    user_id          UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    -- Discord snowflake. VARCHAR, not BIGINT: snowflakes are 64-bit unsigned and every Discord
+    -- API surface exchanges them as strings, matching discord_guilds.guild_id.
+    discord_user_id  VARCHAR(30)  NOT NULL,
+    -- Display only, for "you are linked as <name>" copy. Discord usernames are mutable, so this
+    -- is refreshed on every re-link and must never be used to identify anyone.
+    discord_username VARCHAR(255),
+    linked_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- A Discord account may back at most ONE All-Chat account, and this is a security control, not
+-- hygiene: without it a second All-Chat user could claim someone else's Discord identity and
+-- inherit their guild permissions on every delegated action. A re-link attempt by a different
+-- All-Chat user must fail loudly here rather than silently take the identity over.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_discord_identities_discord_user_id
+    ON discord_identities (discord_user_id);
+
+COMMENT ON TABLE discord_identities IS
+    'Links an All-Chat user to their Discord user account (ADR-0048). Required because Discord '
+    'has no per-user moderation API: the shared bot performs every write, so All-Chat must '
+    'verify the acting human''s own guild permissions, which needs their Discord snowflake. '
+    'Holds no OAuth token -- the identify grant is used once, at link time, and discarded.';
+
+COMMENT ON COLUMN discord_identities.discord_user_id IS
+    'Discord snowflake, globally unique across All-Chat accounts so one Discord identity can '
+    'never be claimed by two users.';
+
+COMMENT ON COLUMN discord_identities.discord_username IS
+    'Display only. Discord usernames are mutable; never identify a user by this.';
+
+-- Reuse the shared updated_at trigger function if this database has it (it is created by the
+-- early migrations); skip silently otherwise so a partially-migrated database still applies.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at_column') THEN
+        DROP TRIGGER IF EXISTS update_discord_identities_updated_at ON discord_identities;
+        CREATE TRIGGER update_discord_identities_updated_at
+            BEFORE UPDATE ON discord_identities
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;
+
+COMMIT;

--- a/migrations/083_discord_identities_down.sql
+++ b/migrations/083_discord_identities_down.sql
@@ -1,0 +1,12 @@
+-- Rollback: 083_discord_identities
+--
+-- Drops the Discord account links. Users who had linked must re-run the identify consent after a
+-- roll-forward; nothing else is affected, since no other table references this one and the
+-- Discord bot-invite flow (discord_guilds) is independent of it.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS update_discord_identities_updated_at ON discord_identities;
+DROP TABLE IF EXISTS discord_identities;
+
+COMMIT;

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -414,6 +414,12 @@ func main() {
 			protected.GET("/guilds", discordHandler.HandleGetGuilds)
 			protected.GET("/guilds/:guild_id/channels", discordHandler.HandleGetGuildChannels)
 			protected.DELETE("/guilds/:guild_id", discordHandler.HandleDisconnect)
+			// Discord ACCOUNT link (ADR-0048): which Discord user this All-Chat account is.
+			// Separate from the guild routes above — those record servers, this records a person,
+			// and Discord moderation needs both. Shares the /discord/callback redirect_uri.
+			protected.GET("/discord/identity/connect", discordHandler.HandleIdentityConnect)
+			protected.GET("/discord/identity", discordHandler.HandleGetIdentity)
+			protected.DELETE("/discord/identity", discordHandler.HandleDeleteIdentity)
 		}
 	}
 

--- a/services/auth-service/handlers/data_export.go
+++ b/services/auth-service/handlers/data_export.go
@@ -18,10 +18,12 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.uber.org/zap"
 )
@@ -40,6 +42,17 @@ type DataExportResponse struct {
 	// delegated moderation to, and overlays delegated to this user. Both are personal data about
 	// the exporting user, and neither is derivable from the sections above.
 	Delegations []DataExportDelegation `json:"moderation_delegations,omitempty"`
+	// DiscordAccount is the linked Discord identity (migration 083). A third-party account
+	// identifier is personal data in its own right and is not derivable from Guilds, which records
+	// servers rather than people.
+	DiscordAccount *DataExportDiscordAccount `json:"discord_account,omitempty"`
+}
+
+// DataExportDiscordAccount is the Discord user account linked to this All-Chat account.
+type DataExportDiscordAccount struct {
+	DiscordUserID   string    `json:"discord_user_id"`
+	DiscordUsername string    `json:"discord_username,omitempty"`
+	LinkedAt        time.Time `json:"linked_at"`
 }
 
 // DataExportDelegation is one delegated-moderation grant, from whichever side the exporting user
@@ -155,6 +168,7 @@ func (h *AuthHandler) HandleDataExport(c *gin.Context) {
 	export.Overlays = fetchOverlays(ctx, db, uid, h.logger)
 	export.Viewers = fetchViewerSessions(ctx, db, uid, h.logger)
 	export.Guilds = fetchGuilds(ctx, db, uid, h.logger)
+	export.DiscordAccount = fetchDiscordAccount(ctx, db, uid, h.logger)
 	export.Messages = fetchMessages(ctx, db, uid, h.logger)
 	export.Delegations = fetchDelegations(ctx, db, uid, h.logger)
 
@@ -247,6 +261,27 @@ func fetchGuilds(ctx context.Context, db *pgxpool.Pool, userID string, log *zap.
 		out = append(out, g)
 	}
 	return out
+}
+
+// fetchDiscordAccount returns the linked Discord identity, or nil when the user has not linked
+// one. Absence is the common case and is not an error.
+func fetchDiscordAccount(ctx context.Context, db *pgxpool.Pool, userID string, log *zap.Logger) *DataExportDiscordAccount {
+	var acc DataExportDiscordAccount
+	var username *string
+	err := db.QueryRow(ctx, `
+		SELECT discord_user_id, discord_username, linked_at
+		FROM discord_identities
+		WHERE user_id = $1`, userID).Scan(&acc.DiscordUserID, &username, &acc.LinkedAt)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			log.Warn("Data export: failed to fetch discord account", zap.Error(err))
+		}
+		return nil
+	}
+	if username != nil {
+		acc.DiscordUsername = *username
+	}
+	return &acc
 }
 
 // fetchDelegations returns every delegated-moderation grant the user is a party to, in both

--- a/services/auth-service/handlers/discord.go
+++ b/services/auth-service/handlers/discord.go
@@ -41,6 +41,10 @@ type DiscordOAuthProvider interface {
 	ExchangeCode(ctx context.Context, code string) (*oauth2.Token, error)
 	CheckBotPermissions(ctx context.Context, guildID string) ([]string, error)
 	GetGuildInfo(ctx context.Context, guildID string) (*oauth.GuildInfo, error)
+	// GetIdentityAuthURL and GetIdentity drive the account link (ADR-0048) — a user OAuth flow
+	// asking only `identify`, distinct from the bot invite above.
+	GetIdentityAuthURL(state string) string
+	GetIdentity(ctx context.Context, accessToken string) (*oauth.DiscordIdentity, error)
 }
 
 // DiscordGuildRepo is the interface for guild persistence (allows mocking in tests).
@@ -50,6 +54,10 @@ type DiscordGuildRepo interface {
 	ListGuildsByUser(ctx context.Context, userID string) ([]*models.DiscordGuild, error)
 	GetGuild(ctx context.Context, userID, guildID string) (*models.DiscordGuild, error)
 	DeleteDiscordSourcesByGuildID(ctx context.Context, guildID string) error
+	// Discord ACCOUNT links, as opposed to the guild records above (migration 083).
+	UpsertIdentity(ctx context.Context, userID, discordUserID, discordUsername string) error
+	GetIdentity(ctx context.Context, userID string) (*models.DiscordIdentity, error)
+	DeleteIdentity(ctx context.Context, userID string) error
 }
 
 // stateStorer abstracts Redis state key operations for testability.
@@ -196,6 +204,11 @@ func (h *DiscordHandler) HandleConnect(c *gin.Context) {
 // It validates the CSRF state from Redis, exchanges the code, checks bot permissions,
 // and stores the guild in the database. If the bot lacks required permissions, it returns
 // 403 Forbidden with a human-readable error listing the missing permissions.
+//
+// Two different Discord flows land here, because they share one registered redirect_uri: the bot
+// invite and the account link (ADR-0048). Which one this is comes from the SERVER-SIDE state
+// value, never from a query parameter — a client that could pick the branch could redirect an
+// invite's code into the link path or vice versa.
 // Route: GET /discord/callback (PUBLIC — no JWT)
 func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -204,13 +217,13 @@ func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 	guildID := c.Query("guild_id")
 	guildName := c.Query("guild_name")
 
-	if state == "" || code == "" || guildID == "" {
+	if state == "" || code == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required parameters"})
 		return
 	}
 
 	// Validate CSRF state — retrieve and delete atomically
-	userID, err := h.stateStore.Get(ctx, state)
+	stored, err := h.stateStore.Get(ctx, state)
 	if err != nil {
 		h.log.Warn("discord: invalid or expired OAuth state", zap.String("state", state), zap.Error(err))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid or expired state"})
@@ -219,6 +232,19 @@ func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 	// Delete state regardless of subsequent outcome
 	if delErr := h.stateStore.Del(ctx, state); delErr != nil {
 		h.log.Warn("discord: failed to delete OAuth state", zap.Error(delErr))
+	}
+
+	flow := parseDiscordFlowState(stored)
+	if flow.Kind == discordFlowIdentity {
+		h.completeIdentityLink(c, flow, code)
+		return
+	}
+	userID := flow.UserID
+
+	// Only the bot invite carries a guild; the account link never does.
+	if guildID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required parameters"})
+		return
 	}
 
 	// Exchange code for token (stored for audit only — not used for subsequent calls)
@@ -307,9 +333,9 @@ type discordChannel struct {
 
 // channelCategory is the response category object grouping text channels.
 type channelCategory struct {
-	ID       string              `json:"id"`
-	Name     string              `json:"name"`
-	Channels []channelSummary    `json:"channels"`
+	ID       string           `json:"id"`
+	Name     string           `json:"name"`
+	Channels []channelSummary `json:"channels"`
 }
 
 // channelSummary is the minimal channel data returned to the frontend.

--- a/services/auth-service/handlers/discord_identity.go
+++ b/services/auth-service/handlers/discord_identity.go
@@ -1,0 +1,245 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// The Discord ACCOUNT LINK, as opposed to the bot invite in discord.go.
+//
+// All-Chat has always known which Discord *servers* a streamer connected and never who any user
+// is on Discord, because the only Discord flow it ran was a `scope=bot` invite whose callback
+// returns a guild_id and no identity. ADR-0048's Discord leg cannot work without the identity:
+// Discord has no per-user moderation API, so the shared bot performs every write and All-Chat
+// must itself read the acting human's guild permissions — which needs their snowflake.
+//
+// Both roles need one. A delegated moderator's own permissions are the check; the overlay owner's
+// prove they control the guild being moderated in.
+
+// discordFlowIdentity marks a state issued for the account-link flow.
+const discordFlowIdentity = "identity"
+
+// discordFlowState is what the shared callback must know about a flow it did not start. It lives
+// in the state VALUE (server-side, in Redis) rather than in a query parameter: a client able to
+// choose the branch could feed a bot invite's code into the link path, or the reverse.
+type discordFlowState struct {
+	// Kind is discordFlowIdentity for an account link. Empty means the bot invite.
+	Kind string `json:"kind,omitempty"`
+	// UserID is the authenticated user who started the flow.
+	UserID string `json:"user_id"`
+	// Return is an allowlisted key naming where to send the browser afterwards — a key, never a
+	// URL, so this can never become an open redirect.
+	Return string `json:"return,omitempty"`
+}
+
+// discordReturnPaths is the closed allowlist of post-link destinations. A streamer links from
+// settings; a delegated moderator links from the channels-I-moderate area and has no reason to
+// end up in someone else's settings.
+var discordReturnPaths = map[string]string{
+	"settings": "/settings",
+	"moderate": "/moderate",
+}
+
+const defaultDiscordReturn = "settings"
+
+// encodeDiscordFlowState renders a flow state for the state store.
+func encodeDiscordFlowState(f discordFlowState) (string, error) {
+	payload, err := json.Marshal(f)
+	if err != nil {
+		return "", fmt.Errorf("encode discord flow state: %w", err)
+	}
+	return string(payload), nil
+}
+
+// parseDiscordFlowState reads a stored state value.
+//
+// A bare user id (the pre-ADR-0048 format) is a bot invite. That fallback is not decoration: state
+// entries live for ten minutes, so an invite already in flight when this deploy rolls must still
+// complete rather than fail on an unrecognised state.
+func parseDiscordFlowState(stored string) discordFlowState {
+	if !strings.HasPrefix(strings.TrimSpace(stored), "{") {
+		return discordFlowState{UserID: stored}
+	}
+	var f discordFlowState
+	if err := json.Unmarshal([]byte(stored), &f); err != nil {
+		// Unparseable JSON is not a bot invite either — return an empty state so the caller's
+		// user-id check rejects it rather than acting for a user we cannot name.
+		return discordFlowState{}
+	}
+	return f
+}
+
+// HandleIdentityConnect starts the Discord account link and returns the consent URL.
+//
+// Route: GET /discord/identity/connect?return=settings|moderate (JWT required)
+func (h *DiscordHandler) HandleIdentityConnect(c *gin.Context) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := fmt.Sprintf("%v", userIDRaw)
+
+	returnKey := c.Query("return")
+	if _, ok := discordReturnPaths[returnKey]; !ok {
+		returnKey = defaultDiscordReturn
+	}
+
+	state, err := generateRandomString(32)
+	if err != nil {
+		h.log.Error("discord identity: failed to generate state", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+	stored, err := encodeDiscordFlowState(discordFlowState{
+		Kind:   discordFlowIdentity,
+		UserID: userID,
+		Return: returnKey,
+	})
+	if err != nil {
+		h.log.Error("discord identity: failed to encode state", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+	if err := h.stateStore.Set(c.Request.Context(), state, stored, 10*time.Minute); err != nil {
+		h.log.Error("discord identity: failed to store OAuth state", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"auth_url": h.oauth.GetIdentityAuthURL(state)})
+}
+
+// completeIdentityLink finishes the account link. Called from the shared callback once the stored
+// state has identified this as the link flow.
+//
+// Failures redirect with an error code rather than rendering JSON: the user is in a browser
+// mid-OAuth, and the frontend owns the copy for each case.
+func (h *DiscordHandler) completeIdentityLink(c *gin.Context, flow discordFlowState, code string) {
+	ctx := c.Request.Context()
+	if flow.UserID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid or expired state"})
+		return
+	}
+
+	token, err := h.oauth.ExchangeCode(ctx, code)
+	if err != nil {
+		h.log.Error("discord identity: code exchange failed", zap.Error(err))
+		h.redirectIdentity(c, flow.Return, "error=exchange_failed")
+		return
+	}
+
+	identity, err := h.oauth.GetIdentity(ctx, token.AccessToken)
+	if err != nil {
+		h.log.Error("discord identity: identity read failed", zap.Error(err))
+		h.redirectIdentity(c, flow.Return, "error=identity_unavailable")
+		return
+	}
+
+	switch err := h.repo.UpsertIdentity(ctx, flow.UserID, identity.ID, identity.Username); {
+	case errors.Is(err, repository.ErrDiscordIdentityClaimed):
+		// Deliberately distinguishable: the remedy is a human one (unlink it on the other
+		// account, or link the right Discord account here), and a generic failure would send the
+		// user round the consent loop forever.
+		h.log.Warn("discord identity: account already linked to another user",
+			zap.String("user_id", flow.UserID))
+		h.redirectIdentity(c, flow.Return, "error=already_linked")
+		return
+	case err != nil:
+		h.log.Error("discord identity: failed to store link", zap.String("user_id", flow.UserID), zap.Error(err))
+		h.redirectIdentity(c, flow.Return, "error=save_failed")
+		return
+	}
+
+	// The identify grant has done its one job. It is not stored: All-Chat never acts as the user
+	// on Discord — every write is the bot — so retaining the token would be a credential held for
+	// no purpose.
+	h.log.Info("discord identity: linked", zap.String("user_id", flow.UserID))
+	h.redirectIdentity(c, flow.Return, "discord_account=linked")
+}
+
+// redirectIdentity sends the browser back to the allowlisted return path with a result marker.
+func (h *DiscordHandler) redirectIdentity(c *gin.Context, returnKey, query string) {
+	path, ok := discordReturnPaths[returnKey]
+	if !ok {
+		path = discordReturnPaths[defaultDiscordReturn]
+	}
+	c.Redirect(http.StatusFound, strings.TrimSuffix(h.frontendURL, "/")+path+"?"+query)
+}
+
+// HandleGetIdentity reports whether the caller has linked a Discord account.
+//
+// Route: GET /discord/identity (JWT required)
+func (h *DiscordHandler) HandleGetIdentity(c *gin.Context) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := fmt.Sprintf("%v", userIDRaw)
+
+	identity, err := h.repo.GetIdentity(c.Request.Context(), userID)
+	if errors.Is(err, repository.ErrNotFound) {
+		c.JSON(http.StatusOK, gin.H{"linked": false})
+		return
+	}
+	if err != nil {
+		h.log.Error("discord identity: lookup failed", zap.String("user_id", userID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"linked":           true,
+		"discord_user_id":  identity.DiscordUserID,
+		"discord_username": identity.DiscordUsername,
+		"linked_at":        identity.LinkedAt,
+	})
+}
+
+// HandleDeleteIdentity unlinks the caller's Discord account. Idempotent.
+//
+// Allowed even while Discord moderation grants exist: the moderation path resolves the identity
+// live and fails closed without one, so the effect is simply that Discord moderation stops
+// working for this user — the right outcome for someone withdrawing the link.
+//
+// Route: DELETE /discord/identity (JWT required)
+func (h *DiscordHandler) HandleDeleteIdentity(c *gin.Context) {
+	userIDRaw, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := fmt.Sprintf("%v", userIDRaw)
+
+	if err := h.repo.DeleteIdentity(c.Request.Context(), userID); err != nil {
+		h.log.Error("discord identity: unlink failed", zap.String("user_id", userID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+	h.log.Info("discord identity: unlinked", zap.String("user_id", userID))
+	c.JSON(http.StatusOK, gin.H{"unlinked": true})
+}

--- a/services/auth-service/handlers/discord_identity_test.go
+++ b/services/auth-service/handlers/discord_identity_test.go
@@ -1,0 +1,318 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/models"
+	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// identityHandler builds a DiscordHandler with a usable in-memory state store.
+func identityHandler(o *mockDiscordOAuth, r *mockDiscordRepo) *DiscordHandler {
+	return newTestDiscordHandlerNoRedis(o, r, "https://allch.at")
+}
+
+// authed runs a request through a gin context that already carries a user id.
+func authed(h *DiscordHandler, method, target, userID string, fn func(*DiscordHandler, *gin.Context)) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, target, nil)
+	if userID != "" {
+		c.Set("user_id", userID)
+	}
+	fn(h, c)
+	return w
+}
+
+func TestHandleIdentityConnect_ReturnsTheIdentifyURLAndStoresAnIdentityState(t *testing.T) {
+	o, r := &mockDiscordOAuth{}, &mockDiscordRepo{}
+	h := identityHandler(o, r)
+	store := h.stateStore.(*memStateStore)
+
+	w := authed(h, http.MethodGet, "/discord/identity/connect?return=moderate", "user-1",
+		(*DiscordHandler).HandleIdentityConnect)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Contains(t, body["auth_url"], "scope=identify")
+
+	require.Len(t, store.states, 1, "exactly one state is issued")
+	for _, stored := range store.states {
+		flow := parseDiscordFlowState(stored)
+		assert.Equal(t, discordFlowIdentity, flow.Kind)
+		assert.Equal(t, "user-1", flow.UserID)
+		assert.Equal(t, "moderate", flow.Return)
+	}
+}
+
+// TestHandleIdentityConnect_RejectsAnUnknownReturn: the return target is an allowlisted KEY, so a
+// caller-supplied path can never become an open redirect.
+func TestHandleIdentityConnect_RejectsAnUnknownReturn(t *testing.T) {
+	h := identityHandler(&mockDiscordOAuth{}, &mockDiscordRepo{})
+	store := h.stateStore.(*memStateStore)
+
+	w := authed(h, http.MethodGet, "/discord/identity/connect?return=https://evil.example/steal", "user-1",
+		(*DiscordHandler).HandleIdentityConnect)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	for _, stored := range store.states {
+		assert.Equal(t, defaultDiscordReturn, parseDiscordFlowState(stored).Return,
+			"an unrecognised return key falls back to the default rather than being honoured")
+	}
+}
+
+func TestHandleIdentityConnect_RequiresAuth(t *testing.T) {
+	h := identityHandler(&mockDiscordOAuth{}, &mockDiscordRepo{})
+	w := authed(h, http.MethodGet, "/discord/identity/connect", "", (*DiscordHandler).HandleIdentityConnect)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// callback drives the shared callback with a pre-seeded state.
+func callback(t *testing.T, h *DiscordHandler, stored, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	require.NoError(t, h.stateStore.Set(context.Background(), "st-1", stored, time.Minute))
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/discord/callback?state=st-1"+query, nil)
+	h.HandleCallback(c)
+	return w
+}
+
+func identityState(t *testing.T, userID, returnKey string) string {
+	t.Helper()
+	stored, err := encodeDiscordFlowState(discordFlowState{Kind: discordFlowIdentity, UserID: userID, Return: returnKey})
+	require.NoError(t, err)
+	return stored
+}
+
+func TestCallback_IdentityFlowStoresTheLinkAndRedirects(t *testing.T) {
+	o := &mockDiscordOAuth{
+		exchangeToken: &oauth2.Token{AccessToken: "user-token"},
+		identity:      &oauth.DiscordIdentity{ID: "42424242", Username: "volunteer"},
+	}
+	r := &mockDiscordRepo{}
+	h := identityHandler(o, r)
+
+	w := callback(t, h, identityState(t, "user-1", "moderate"), "&code=abc")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://allch.at/moderate?discord_account=linked", w.Header().Get("Location"))
+	assert.True(t, r.upsertIdentityCalled)
+	assert.Equal(t, "user-1", r.upsertIdentityUser)
+	assert.Equal(t, "42424242", r.upsertIdentityDiscID)
+	assert.False(t, r.upsertCalled, "an account link must never create a guild record")
+}
+
+// TestCallback_IdentityFlowNeedsNoGuildID is the fork's whole point: an identify callback carries
+// no guild_id, and the old handler rejected any callback without one.
+func TestCallback_IdentityFlowNeedsNoGuildID(t *testing.T) {
+	o := &mockDiscordOAuth{exchangeToken: &oauth2.Token{AccessToken: "t"}}
+	r := &mockDiscordRepo{}
+	h := identityHandler(o, r)
+
+	w := callback(t, h, identityState(t, "user-1", "settings"), "&code=abc")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.True(t, r.upsertIdentityCalled)
+}
+
+// TestCallback_BotInviteStillRequiresAGuildID: the fork must not loosen the invite branch.
+func TestCallback_BotInviteStillRequiresAGuildID(t *testing.T) {
+	h := identityHandler(&mockDiscordOAuth{exchangeToken: &oauth2.Token{}}, &mockDiscordRepo{})
+
+	w := callback(t, h, "user-1", "&code=abc")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestCallback_LegacyBareUserIDStateIsStillABotInvite: state entries live ten minutes, so an
+// invite already in flight when this change deploys must still complete.
+func TestCallback_LegacyBareUserIDStateIsStillABotInvite(t *testing.T) {
+	o := &mockDiscordOAuth{exchangeToken: &oauth2.Token{}}
+	r := &mockDiscordRepo{}
+	h := identityHandler(o, r)
+
+	w := callback(t, h, "user-1", "&code=abc&guild_id=g-1")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.True(t, r.upsertCalled, "the guild is stored, as before")
+	assert.False(t, r.upsertIdentityCalled, "and no identity is invented for it")
+}
+
+// TestCallback_FlowKindComesFromServerStateNotTheQuery: a client that could pick the branch could
+// redirect a bot invite's code into the link path. Passing guild_id on an identity state must not
+// turn it into an invite, and the reverse must not turn an invite into a link.
+func TestCallback_FlowKindComesFromServerStateNotTheQuery(t *testing.T) {
+	t.Run("guild_id cannot promote an identity state to a bot invite", func(t *testing.T) {
+		o := &mockDiscordOAuth{exchangeToken: &oauth2.Token{}}
+		r := &mockDiscordRepo{}
+		h := identityHandler(o, r)
+
+		callback(t, h, identityState(t, "user-1", "settings"), "&code=abc&guild_id=someone-elses-guild")
+
+		assert.False(t, r.upsertCalled, "no guild record may be created from an identity state")
+		assert.True(t, r.upsertIdentityCalled)
+	})
+
+	t.Run("an invite state is never treated as a link", func(t *testing.T) {
+		o := &mockDiscordOAuth{exchangeToken: &oauth2.Token{}}
+		r := &mockDiscordRepo{}
+		h := identityHandler(o, r)
+
+		callback(t, h, "user-1", "&code=abc&guild_id=g-1")
+
+		assert.False(t, r.upsertIdentityCalled)
+	})
+}
+
+func TestCallback_IdentityFlowFailureRedirectsWithACode(t *testing.T) {
+	tests := []struct {
+		name    string
+		oauth   *mockDiscordOAuth
+		repo    *mockDiscordRepo
+		wantErr string
+	}{
+		{
+			name:    "code exchange failed",
+			oauth:   &mockDiscordOAuth{exchangeErr: errors.New("boom")},
+			repo:    &mockDiscordRepo{},
+			wantErr: "error=exchange_failed",
+		},
+		{
+			name:    "identity unreadable",
+			oauth:   &mockDiscordOAuth{exchangeToken: &oauth2.Token{}, identityErr: errors.New("boom")},
+			repo:    &mockDiscordRepo{},
+			wantErr: "error=identity_unavailable",
+		},
+		{
+			name:    "already linked to another All-Chat user",
+			oauth:   &mockDiscordOAuth{exchangeToken: &oauth2.Token{}},
+			repo:    &mockDiscordRepo{upsertIdentityErr: repository.ErrDiscordIdentityClaimed},
+			wantErr: "error=already_linked",
+		},
+		{
+			name:    "storage failed",
+			oauth:   &mockDiscordOAuth{exchangeToken: &oauth2.Token{}},
+			repo:    &mockDiscordRepo{upsertIdentityErr: errors.New("db down")},
+			wantErr: "error=save_failed",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := identityHandler(tc.oauth, tc.repo)
+
+			w := callback(t, h, identityState(t, "user-1", "moderate"), "&code=abc")
+
+			assert.Equal(t, http.StatusFound, w.Code, "the user is mid-OAuth in a browser, so failures redirect")
+			loc := w.Header().Get("Location")
+			assert.True(t, strings.HasPrefix(loc, "https://allch.at/moderate?"), "back where they started: %s", loc)
+			assert.Contains(t, loc, tc.wantErr)
+		})
+	}
+}
+
+// TestCallback_IdentityStateWithoutAUserIsRejected: an unparseable or user-less state must not act
+// for a user we cannot name.
+func TestCallback_IdentityStateWithoutAUserIsRejected(t *testing.T) {
+	r := &mockDiscordRepo{}
+	h := identityHandler(&mockDiscordOAuth{exchangeToken: &oauth2.Token{}}, r)
+
+	w := callback(t, h, `{"kind":"identity"}`, "&code=abc")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.False(t, r.upsertIdentityCalled)
+}
+
+func TestParseDiscordFlowState_UnparseableJSONNamesNobody(t *testing.T) {
+	flow := parseDiscordFlowState(`{"kind":`)
+	assert.Empty(t, flow.UserID, "a broken state must not fall back to treating the blob as a user id")
+	assert.Empty(t, flow.Kind)
+}
+
+func TestHandleGetIdentity(t *testing.T) {
+	t.Run("unlinked", func(t *testing.T) {
+		h := identityHandler(&mockDiscordOAuth{}, &mockDiscordRepo{})
+		w := authed(h, http.MethodGet, "/discord/identity", "user-1", (*DiscordHandler).HandleGetIdentity)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, false, body["linked"])
+		assert.NotContains(t, body, "discord_user_id")
+	})
+
+	t.Run("linked", func(t *testing.T) {
+		r := &mockDiscordRepo{getIdentity: &models.DiscordIdentity{
+			UserID: "user-1", DiscordUserID: "42424242", DiscordUsername: "volunteer", LinkedAt: time.Now().UTC(),
+		}}
+		h := identityHandler(&mockDiscordOAuth{}, r)
+		w := authed(h, http.MethodGet, "/discord/identity", "user-1", (*DiscordHandler).HandleGetIdentity)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		assert.Equal(t, true, body["linked"])
+		assert.Equal(t, "42424242", body["discord_user_id"])
+		assert.Equal(t, "volunteer", body["discord_username"])
+	})
+
+	t.Run("lookup failure is not reported as unlinked", func(t *testing.T) {
+		r := &mockDiscordRepo{getIdentityErr: errors.New("db down")}
+		h := identityHandler(&mockDiscordOAuth{}, r)
+		w := authed(h, http.MethodGet, "/discord/identity", "user-1", (*DiscordHandler).HandleGetIdentity)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code,
+			"reporting unlinked would show a Connect button to someone already linked")
+	})
+}
+
+func TestHandleDeleteIdentity(t *testing.T) {
+	r := &mockDiscordRepo{}
+	h := identityHandler(&mockDiscordOAuth{}, r)
+
+	w := authed(h, http.MethodDelete, "/discord/identity", "user-1", (*DiscordHandler).HandleDeleteIdentity)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, r.deleteIdentityCalled)
+}
+
+func TestHandleDeleteIdentity_RequiresAuth(t *testing.T) {
+	r := &mockDiscordRepo{}
+	h := identityHandler(&mockDiscordOAuth{}, r)
+
+	w := authed(h, http.MethodDelete, "/discord/identity", "", (*DiscordHandler).HandleDeleteIdentity)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.False(t, r.deleteIdentityCalled)
+}

--- a/services/auth-service/handlers/discord_test.go
+++ b/services/auth-service/handlers/discord_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/caesar/all-chat/services/auth-service/models"
 	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/caesar/all-chat/services/auth-service/repository"
 	"github.com/gin-gonic/gin"
 	"golang.org/x/oauth2"
 )
@@ -39,6 +40,10 @@ type mockDiscordOAuth struct {
 	missingPerms     []string
 	checkPermsErr    error
 	checkPermsCalled bool
+	// Account-link flow (ADR-0048).
+	identity     *oauth.DiscordIdentity
+	identityErr  error
+	identityAuth string
 }
 
 func (m *mockDiscordOAuth) GetAuthURL(state string) string {
@@ -65,17 +70,64 @@ func (m *mockDiscordOAuth) GetGuildInfo(_ context.Context, guildID string) (*oau
 	return &oauth.GuildInfo{Name: "Guild " + guildID, Icon: ""}, nil
 }
 
+func (m *mockDiscordOAuth) GetIdentityAuthURL(state string) string {
+	if m.identityAuth != "" {
+		return m.identityAuth
+	}
+	return "https://discord.com/oauth2/authorize?client_id=test&scope=identify&state=" + state
+}
+
+func (m *mockDiscordOAuth) GetIdentity(_ context.Context, _ string) (*oauth.DiscordIdentity, error) {
+	if m.identityErr != nil {
+		return nil, m.identityErr
+	}
+	if m.identity != nil {
+		return m.identity, nil
+	}
+	return &oauth.DiscordIdentity{ID: "198569499228766208", Username: "volunteer"}, nil
+}
+
 type mockDiscordRepo struct {
-	upsertCalled                      bool
-	upsertErr                         error
-	deleteCalled                      bool
-	deleteErr                         error
-	deleteSourcesCalled               bool
-	deleteSourcesErr                  error
-	listGuilds                        []*models.DiscordGuild
-	listErr                           error
-	getGuild                          *models.DiscordGuild
-	getErr                            error
+	upsertCalled        bool
+	upsertErr           error
+	deleteCalled        bool
+	deleteErr           error
+	deleteSourcesCalled bool
+	deleteSourcesErr    error
+	listGuilds          []*models.DiscordGuild
+	listErr             error
+	getGuild            *models.DiscordGuild
+	getErr              error
+	// Account-link flow (ADR-0048).
+	upsertIdentityCalled bool
+	upsertIdentityUser   string
+	upsertIdentityDiscID string
+	upsertIdentityErr    error
+	getIdentity          *models.DiscordIdentity
+	getIdentityErr       error
+	deleteIdentityCalled bool
+	deleteIdentityErr    error
+}
+
+func (m *mockDiscordRepo) UpsertIdentity(_ context.Context, userID, discordUserID, _ string) error {
+	m.upsertIdentityCalled = true
+	m.upsertIdentityUser, m.upsertIdentityDiscID = userID, discordUserID
+	return m.upsertIdentityErr
+}
+
+func (m *mockDiscordRepo) GetIdentity(_ context.Context, _ string) (*models.DiscordIdentity, error) {
+	if m.getIdentityErr != nil {
+		return nil, m.getIdentityErr
+	}
+	if m.getIdentity == nil {
+		return nil, repository.ErrNotFound
+	}
+	return m.getIdentity, nil
+}
+
+func (m *mockDiscordRepo) DeleteIdentity(_ context.Context, _ string) error {
+	m.deleteIdentityCalled = true
+	return m.deleteIdentityErr
 }
 
 func (m *mockDiscordRepo) UpsertGuild(_ context.Context, _ *models.DiscordGuild) error {
@@ -354,9 +406,9 @@ func TestHandleDiscordDisconnect_APIFailure(t *testing.T) {
 	icon := "icon123"
 	mockRepo := &mockDiscordRepo{
 		getGuild: &models.DiscordGuild{
-			ID:      "1",
-			UserID:  "user-1",
-			GuildID: "guild-111",
+			ID:        "1",
+			UserID:    "user-1",
+			GuildID:   "guild-111",
 			GuildName: "Test Server",
 			GuildIcon: &icon,
 		},

--- a/services/auth-service/models/discord_guild.go
+++ b/services/auth-service/models/discord_guild.go
@@ -24,8 +24,27 @@ import "time"
 type DiscordGuild struct {
 	ID          string    `json:"id"`
 	UserID      string    `json:"user_id"`
-	GuildID     string    `json:"guild_id"`   // Discord Snowflake ID — always string
+	GuildID     string    `json:"guild_id"` // Discord Snowflake ID — always string
 	GuildName   string    `json:"guild_name"`
 	GuildIcon   *string   `json:"guild_icon"` // nullable CDN hash
 	ConnectedAt time.Time `json:"connected_at"`
+}
+
+// DiscordIdentity links an All-Chat account to a Discord USER account (migration 083, ADR-0048).
+//
+// Distinct from DiscordGuild, which records which SERVERS a streamer connected: the bot-invite
+// flow returns a guild and no user identity, so this is the only place All-Chat learns who
+// someone is on Discord. It is required because Discord has no per-user moderation API — the
+// shared bot performs every write, so verifying that the acting human may moderate means reading
+// *their* guild permissions, which needs their snowflake.
+//
+// No OAuth token is held: the identify grant is used once, at link time, and discarded.
+type DiscordIdentity struct {
+	UserID string `json:"user_id"`
+	// DiscordUserID is a Snowflake — always a string, for the reason on DiscordGuild.GuildID.
+	DiscordUserID string `json:"discord_user_id"`
+	// DiscordUsername is display only. Discord usernames are mutable, so never identify a user
+	// by this; refreshed on every re-link.
+	DiscordUsername string    `json:"discord_username"`
+	LinkedAt        time.Time `json:"linked_at"`
 }

--- a/services/auth-service/oauth/discord.go
+++ b/services/auth-service/oauth/discord.go
@@ -41,7 +41,6 @@ const (
 	PermViewChannel        uint64 = 1024  // 0x400
 	PermSendMessages       uint64 = 2048  // 0x800
 	PermReadMessageHistory uint64 = 65536 // 0x10000
-	RequiredBotPermissions uint64 = PermViewChannel | PermSendMessages | PermReadMessageHistory // 68608
 
 	// Moderation permission bits, requested ONLY through the opt-in moderation re-invite
 	// (ADR-0017) — never bundled into the base listener invite. MANAGE_MESSAGES → delete,
@@ -49,6 +48,13 @@ const (
 	PermManageMessages  uint64 = 1 << 13 // 8192
 	PermBanMembers      uint64 = 1 << 2  // 4
 	PermModerateMembers uint64 = 1 << 40
+)
+
+// Derived permission sets. Kept out of the bit-value block above so neither declaration has to
+// pad its trailing comments to the width of the longest expression.
+const (
+	// RequiredBotPermissions is the base listener invite: read and write chat, nothing more (68608).
+	RequiredBotPermissions uint64 = PermViewChannel | PermSendMessages | PermReadMessageHistory
 	// ModerationBotPermissions is the elevated permission set the moderation re-invite
 	// URL requests: the base listener permissions plus the moderation permissions.
 	ModerationBotPermissions uint64 = RequiredBotPermissions | PermManageMessages | PermBanMembers | PermModerateMembers
@@ -104,6 +110,74 @@ func (d *DiscordOAuth) GetAuthURL(state string) string {
 // controls once the capability endpoint reports the new permissions.
 func (d *DiscordOAuth) GetModerationAuthURL(state string) string {
 	return d.inviteURL(state, ModerationBotPermissions)
+}
+
+// GetIdentityAuthURL returns the Discord **account link** URL: a normal user OAuth flow
+// requesting `identify` and nothing else.
+//
+// This is a different flow from every other Discord URL here. The invite flows ask a server
+// admin to add a bot and come back with a guild_id; this asks a person which Discord account is
+// theirs, and comes back with nothing else at all. All-Chat needs it because Discord has no
+// per-user moderation API: the shared bot performs every write, so verifying that the acting
+// human may moderate requires knowing who they are on Discord (ADR-0048).
+//
+// `identify` alone, per ADR-0012: not `guilds` (All-Chat learns guilds from the bot's own view),
+// not `email`, and emphatically not `bot`. It reuses the registered bot-invite redirect_uri, so
+// linking needs no change in the Discord developer dashboard; the callback tells the two flows
+// apart from server-side state, never from a query parameter.
+func (d *DiscordOAuth) GetIdentityAuthURL(state string) string {
+	params := url.Values{}
+	params.Set("client_id", d.clientID)
+	params.Set("scope", "identify")
+	params.Set("state", state)
+	params.Set("redirect_uri", d.redirectURL)
+	params.Set("response_type", "code")
+	return discordAuthBase + "?" + params.Encode()
+}
+
+// DiscordIdentity is who a user is on Discord: the snowflake All-Chat stores, plus a display
+// name for copy. No token is retained — the identify grant is used once and discarded.
+type DiscordIdentity struct {
+	ID       string
+	Username string
+}
+
+// GetIdentity reads the Discord account behind an `identify` access token.
+//
+// The token is a USER token, so it authenticates with `Bearer`. Sending the bot token here would
+// return the bot's own identity and link every user to the same account, which is why this does
+// not share a helper with the bot-token reads.
+func (d *DiscordOAuth) GetIdentity(ctx context.Context, accessToken string) (*DiscordIdentity, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", d.apiBase+"/users/@me", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create identity request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("User-Agent", discordUserAgent)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("identity request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discord identity returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var self struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	}
+	if err := json.Unmarshal(body, &self); err != nil {
+		return nil, fmt.Errorf("failed to decode discord identity: %w", err)
+	}
+	// A 200 with no id must fail here rather than be stored: a link to the empty snowflake would
+	// make every later permission read answer "not a member", an unexplainable dead end.
+	if self.ID == "" {
+		return nil, fmt.Errorf("discord identity carried no user id")
+	}
+	return &DiscordIdentity{ID: self.ID, Username: self.Username}, nil
 }
 
 // inviteURL builds a bot invite URL requesting the given permission bitfield.

--- a/services/auth-service/oauth/discord_identity_test.go
+++ b/services/auth-service/oauth/discord_identity_test.go
@@ -1,0 +1,133 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The identify flow is a genuinely different Discord flow from the bot invite, and the two must
+// not be conflated: the invite asks a server admin to add a bot and returns a guild_id, while
+// this asks a person who they are and returns nothing else at all.
+
+// TestGetIdentityAuthURL_RequestsIdentifyOnly is the least-privilege guard (ADR-0012). A
+// volunteer moderator is being asked only "which Discord account are you"; anything more on that
+// screen — guilds, email, or the bot scope — would be a scope grab.
+func TestGetIdentityAuthURL_RequestsIdentifyOnly(t *testing.T) {
+	d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb")
+
+	raw := d.GetIdentityAuthURL("state-1")
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	q := u.Query()
+
+	assert.Equal(t, "identify", q.Get("scope"), "identify and nothing else")
+	assert.Equal(t, "code", q.Get("response_type"))
+	assert.Equal(t, "client-id", q.Get("client_id"))
+	assert.Equal(t, "state-1", q.Get("state"))
+	assert.Equal(t, "https://example.com/cb", q.Get("redirect_uri"),
+		"the identify flow reuses the registered bot-invite redirect_uri, so linking needs no Discord dashboard change")
+	assert.Empty(t, q.Get("permissions"), "a permission bitfield belongs to the bot invite, not to an identity link")
+}
+
+// TestGetIdentityAuthURL_IsNotTheBotInvite: the two URLs must differ in scope, or a user would be
+// shown a server picker when asked to identify themselves.
+func TestGetIdentityAuthURL_IsNotTheBotInvite(t *testing.T) {
+	d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb")
+
+	identity, err := url.Parse(d.GetIdentityAuthURL("s"))
+	require.NoError(t, err)
+	invite, err := url.Parse(d.GetAuthURL("s"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "identify", identity.Query().Get("scope"))
+	assert.Equal(t, "bot", invite.Query().Get("scope"))
+}
+
+func TestGetIdentity(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+		_, _ = w.Write([]byte(`{"id":"198569499228766208","username":"volunteer","global_name":"A Volunteer"}`))
+	}))
+	defer srv.Close()
+	d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb")
+	d.apiBase = srv.URL
+
+	id, err := d.GetIdentity(context.Background(), "user-access-token")
+	require.NoError(t, err)
+	assert.Equal(t, "198569499228766208", id.ID)
+	assert.Equal(t, "volunteer", id.Username)
+	assert.Equal(t, "/users/@me", gotPath)
+	assert.Equal(t, "Bearer user-access-token", gotAuth,
+		"an identify grant is a USER token and uses Bearer; only the bot token uses the Bot scheme")
+}
+
+// TestGetIdentity_RejectsAnEmptyID: a 200 with no id would otherwise be stored as a link to the
+// empty snowflake, which every permission read would then answer "not a member" for — an
+// unexplainable dead end rather than a failure at link time.
+func TestGetIdentity_RejectsAnEmptyID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"username":"nameless"}`))
+	}))
+	defer srv.Close()
+	d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb")
+	d.apiBase = srv.URL
+
+	_, err := d.GetIdentity(context.Background(), "tok")
+	require.Error(t, err)
+}
+
+func TestGetIdentity_PropagatesFailure(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusInternalServerError} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		}))
+		d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb")
+		d.apiBase = srv.URL
+
+		_, err := d.GetIdentity(context.Background(), "tok")
+		require.Error(t, err, "status %d must not yield a silent empty identity", status)
+		srv.Close()
+	}
+}
+
+// TestGetIdentity_DoesNotUseTheBotToken pins the separation: the bot token must never be sent on
+// the identify read, or the "identity" returned would be the bot's own and every user would link
+// to the same account.
+func TestGetIdentity_DoesNotUseTheBotToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"id":"1","username":"u"}`))
+	}))
+	defer srv.Close()
+	d := NewDiscordOAuth("client-id", "secret", "https://example.com/cb").WithBotToken("the-bot-token")
+	d.apiBase = srv.URL
+
+	_, err := d.GetIdentity(context.Background(), "the-user-token")
+	require.NoError(t, err)
+	assert.NotContains(t, gotAuth, "the-bot-token")
+	assert.Equal(t, "Bearer the-user-token", gotAuth)
+}

--- a/services/auth-service/repository/discord_repo.go
+++ b/services/auth-service/repository/discord_repo.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/caesar/all-chat/services/auth-service/models"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -120,6 +121,74 @@ func (r *DiscordRepository) DeleteDiscordSourcesByGuildID(ctx context.Context, g
 	`, guildID)
 	if err != nil {
 		return fmt.Errorf("DeleteDiscordSourcesByGuildID: %w", err)
+	}
+	return nil
+}
+
+// ErrDiscordIdentityClaimed reports that the Discord account is already linked to a DIFFERENT
+// All-Chat user. It is a distinct error rather than a generic failure because the remedy is a
+// human one: unlink it on the other account, or link the right Discord account here.
+var ErrDiscordIdentityClaimed = errors.New("discord account already linked to another All-Chat user")
+
+// UpsertIdentity records which Discord account belongs to an All-Chat user (migration 083).
+//
+// Re-linking the SAME All-Chat user is allowed and overwrites — someone may link a different
+// Discord account, or refresh a changed username. Linking a Discord account another All-Chat user
+// already holds violates the unique index and returns ErrDiscordIdentityClaimed rather than
+// silently taking the identity over: that would let the second account inherit the first's guild
+// permissions on every delegated moderation action.
+func (r *DiscordRepository) UpsertIdentity(ctx context.Context, userID, discordUserID, discordUsername string) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO discord_identities (user_id, discord_user_id, discord_username)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (user_id)
+		DO UPDATE SET discord_user_id  = EXCLUDED.discord_user_id,
+		              discord_username = EXCLUDED.discord_username,
+		              updated_at       = NOW()
+	`, userID, discordUserID, discordUsername)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		// 23505 unique_violation can only be uq_discord_identities_discord_user_id here: the
+		// user_id conflict is handled above.
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDiscordIdentityClaimed
+		}
+		return fmt.Errorf("UpsertIdentity: %w", err)
+	}
+	return nil
+}
+
+// GetIdentity returns the Discord account linked to an All-Chat user, or ErrNotFound.
+func (r *DiscordRepository) GetIdentity(ctx context.Context, userID string) (*models.DiscordIdentity, error) {
+	identity := &models.DiscordIdentity{}
+	var username *string
+	err := r.db.QueryRow(ctx, `
+		SELECT user_id, discord_user_id, discord_username, linked_at
+		FROM discord_identities
+		WHERE user_id = $1
+	`, userID).Scan(&identity.UserID, &identity.DiscordUserID, &username, &identity.LinkedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("GetIdentity: %w", err)
+	}
+	if username != nil {
+		identity.DiscordUsername = *username
+	}
+	return identity, nil
+}
+
+// DeleteIdentity unlinks a user's Discord account. Idempotent: a missing row is not an error, so
+// an unlink is safe to retry.
+//
+// Unlinking is deliberately allowed even while Discord grants exist. The moderation path resolves
+// the identity live and fails closed without one, so the effect is that Discord moderation stops
+// working for that user — the correct outcome for someone withdrawing the link.
+func (r *DiscordRepository) DeleteIdentity(ctx context.Context, userID string) error {
+	_, err := r.db.Exec(ctx, `DELETE FROM discord_identities WHERE user_id = $1`, userID)
+	if err != nil {
+		return fmt.Errorf("DeleteIdentity: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
> Stacked on #685 (which is stacked on #684). Review those first; this PR's diff is only the third commit.

## Why this is needed at all

ADR-0048's Discord leg cannot be built without it. All-Chat has always known which Discord **servers** a streamer connected and **never who any user is on Discord** — the only Discord flow it has ever run is a `scope=bot` guild invite, whose callback returns a `guild_id` and no identity.

But Discord has no per-user moderation API. The shared bot performs every write, so verifying that the acting human may moderate means reading **their** guild permissions — which needs their snowflake. Both roles need one:

- a delegated moderator's own permissions **are** the check;
- the overlay owner's prove they control the guild being moderated in.

## Migration 083

`discord_identities`, keyed on `user_id` (one Discord account per All-Chat user), with a **UNIQUE index on `discord_user_id`**.

That index is a security control, not hygiene: without it a second All-Chat user could claim someone else's Discord identity and inherit their guild permissions on every delegated action. The repository surfaces the collision as `ErrDiscordIdentityClaimed` rather than a generic failure, because the remedy is a human one — a generic error would send the user round the consent loop forever.

Verified against `TestMigrationsSurviveRerun` (the runner replays every migration on each pod start).

## Least privilege

`identify` and nothing else — not `guilds` (All-Chat learns guilds from the bot's own view), not `email`, and not `bot`. Per ADR-0012, with a test asserting the URL carries no `permissions` bitfield and differs from the bot invite.

**No token is retained.** All-Chat never acts as the user on Discord — every write is the bot — so keeping the grant would be a credential held for no purpose.

## The callback fork is the security-sensitive part

The link reuses the registered `/discord/callback` `redirect_uri`, so it needs no change in the Discord developer dashboard. That means one callback now serves two flows, and which one it is comes from the **server-side state value, never a query parameter** — a client able to pick the branch could redirect a bot invite's code into the link path, or the reverse.

Tested in both directions:

| Case | Asserted |
|---|---|
| `guild_id` passed alongside an identity state | no guild record is created |
| an invite state | never treated as a link |
| bare-user-id state (the old format) | still a bot invite — an invite in flight when this deploys still completes |
| invite branch | still requires `guild_id` |
| unparseable state | names nobody; rejected rather than acting for a user we cannot identify |

The post-link destination is an allowlisted **key**, never a caller-supplied path, so it cannot become an open redirect. A streamer links from settings; a delegated moderator from `/moderate`.

## DSGVO

The export gains a `discord_account` section: a third-party account identifier is personal data in its own right and is not derivable from the `guilds` section. Deletion is already covered by `ON DELETE CASCADE`.

## Risk

**Nothing consumes the link yet** — `dispatch/discord.go` still returns `DispatchDelegationUnsupported` — so this changes no behaviour for anyone. The endpoints exist; the frontend affordance and the moderation wiring follow.

## ADR amendment

ADR-0048 gains the anchor-strength decision this leg needs: on Discord the `discord_guilds` row anchors **owner** actions, and the live `MANAGE_GUILD` read is required only on **delegated** ones.

The row is not a weak substitute for the live read. Discord only lets someone add a bot to a guild where they hold **Manage Server**, so the row is Discord's own attestation that the owner controlled that guild at invite time. What it cannot see is a *later* loss of standing — which matters when a third party acts on the owner's reach, and much less when the owner acts on a guild they connected themselves.

Requiring the live read on the owner path would have switched Discord moderation off for **every existing Discord streamer** until each completed a new account link, to re-prove something Discord already attested. The anchor still applies to owner actions, as the original rule requires; only its strength differs by path.

## Tests

Full `auth-service` suite green (`handlers`, `oauth`, `repository` incl. testcontainers). New coverage: the identify URL's scope, `Bearer`-not-`Bot` on the identity read, an empty id rejected at link time, all four link failure modes redirecting with distinct codes, both fork directions, the return-key allowlist, and get/delete including "a lookup failure must not report *unlinked*" (which would show a Connect button to someone already linked).

## Also

Splits `oauth.RequiredBotPermissions` into its own `const` block — gofmt aligns trailing comments to the widest expression in a block, which was padding the neighbouring bit values into illegibility.