### PR TITLE
feat(moderation): delegated moderators can moderate Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ moderate** (`/moderate`). They act with **their own** platform accounts, so Twit
 moderator role on every single action and it lands in your native mod log under their name — never
 yours — and they never need a plan of their own. Connecting an account is deferred until the first
 time they moderate on it, and one connection covers every streamer who delegated that platform to
-them. Twitch is live today; Kick, YouTube and Discord moderation stays with you for now.
+them. Twitch and Discord are live today; Kick and YouTube moderation stays with you for now.
+
+Discord works a little differently, because Discord has no per-user moderation API: the All-Chat bot
+does the actual deleting and banning, so before it acts for someone it checks that *they* could do it
+themselves. Both of you link your Discord account once (**Settings → Discord**, and **Channels you
+moderate** for them), and from then on a moderator can only do what their own Discord roles allow —
+never more than the bot was invited with, and never to someone ranked above them.
 
 ### 3. Customize the look
 

--- a/docs/adr/0048-delegated-overlay-moderators.md
+++ b/docs/adr/0048-delegated-overlay-moderators.md
@@ -107,6 +107,18 @@ Asymmetry worth recording: only YouTube (`liveChatModerators.insert`, per-broadc
 
 A cached "not a moderator" state is **telemetry, never authorization**. It is surfaced to the streamer and never read in `authorize()`. Reading it would make All-Chat the stale authority the whole design exists to avoid, and one transient 403 would otherwise lock out a legitimate moderator with no self-service recovery.
 
+#### Discord reason codes as built (amendment, 2026-08-11)
+
+Two departures from the table above, both settled while implementing the leg. They change which name a refusal carries, never which refusals happen.
+
+**The three owner-side Discord failures share one code.** The row above names `discord_link_required` for an unlinked owner and `owner_guild_unverified` for a missing `discord_guilds` row; as built, an unlinked owner, a missing row, and an owner who has lost `MANAGE_GUILD` all report **`owner_channel_unverified`** — the platform-agnostic code the Twitch and Kick anchors already use. The reason vocabulary is sorted by *who can clear a state*, and all three are the streamer's alone; three codes for one remediation would have the frontend branch on a distinction it cannot act on differently. `discord_link_required` is therefore reserved for the **moderator**, the one person it names something actionable for.
+
+**Capabilities makes no live Discord read.** The pre-check column above describes the *action* path, which is where it is load-bearing. `GET /capabilities` checks only the two account links and the bot's cached guild permissions, and deliberately does not read the moderator's live standing. Capabilities is advisory everywhere else too — on Twitch it checks the scope and lets Helix decide whether they moderate the channel — and reading Discord per source per dashboard load would put platform traffic behind a caller-supplied overlay id to produce an answer that can go stale before the button is pressed. A capability the moderator turns out not to hold fails at action time with `mod_lacks_permission`, which names the fix.
+
+#### Every proxied route needs an api-gateway entry (2026-08-11)
+
+`services/api-gateway/cmd/main.go` enumerates each proxied path explicitly; there is no prefix forward for `/api/v1/auth/*`. The Discord account-link routes shipped without their gateway entries and were therefore unreachable from the internet — invisible at the time because nothing called them yet. Adding a route to a service is not finished until the gateway forwards it, and "the service registers it" is not testable from outside without that.
+
 ### Credential storage prohibition
 
 A delegated moderator's credential is stored **only** in a dedicated store keyed on the moderator's own identity, never in the existing per-channel credential tables, and never in any row a listener selects from.

--- a/frontend/src/app/moderate/__tests__/page.test.tsx
+++ b/frontend/src/app/moderate/__tests__/page.test.tsx
@@ -28,12 +28,18 @@ import type { Delegation } from '@/lib/types/moderation'
 // reference these before initialization.
 const api = vi.hoisted(() => ({ listDelegations: vi.fn() }))
 const nav = vi.hoisted(() => ({ params: new URLSearchParams() }))
+const discord = vi.hoisted(() => ({
+  getDiscordIdentity: vi.fn(),
+  startDiscordAccountLink: vi.fn(),
+}))
 
 vi.mock('@/lib/api/moderation', async () => {
   const actual =
     await vi.importActual<typeof import('@/lib/api/moderation')>('@/lib/api/moderation')
   return { ...actual, moderationApi: api }
 })
+
+vi.mock('@/lib/api/discord', () => discord)
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => nav.params,
@@ -73,6 +79,7 @@ async function renderPage(delegations: Delegation[]) {
 beforeEach(() => {
   vi.clearAllMocks()
   nav.params = new URLSearchParams()
+  discord.getDiscordIdentity.mockResolvedValue({ linked: true })
 })
 afterEach(cleanup)
 
@@ -163,5 +170,54 @@ describe('channels you moderate', () => {
     await renderPage([delegation()])
 
     expect(await screen.findByText(/did not complete/i)).toBeInTheDocument()
+  })
+})
+
+// The Discord account link (ADR-0048). Discord is the one platform where the prerequisite is an
+// identity rather than an OAuth consent: the shared bot performs every write, so All-Chat has to
+// check the acting human's own server permissions, which needs to know who they are on Discord.
+describe('discord account link', () => {
+  it('asks for the link when a delegation covers discord and none is set', async () => {
+    discord.getDiscordIdentity.mockResolvedValue({ linked: false })
+    await renderPage([
+      delegation({
+        platforms: [{ platform: 'discord', enabled: true, verification: 'unverified' }],
+      }),
+    ])
+
+    expect(await screen.findByRole('button', { name: /link discord/i })).toBeInTheDocument()
+  })
+
+  it('stays quiet when the moderator has already linked', async () => {
+    discord.getDiscordIdentity.mockResolvedValue({ linked: true })
+    await renderPage([
+      delegation({
+        platforms: [{ platform: 'discord', enabled: true, verification: 'unverified' }],
+      }),
+    ])
+
+    await waitFor(() => expect(discord.getDiscordIdentity).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /link discord/i })).not.toBeInTheDocument()
+  })
+
+  // No Discord leg means the link buys them nothing, and an unexplained prompt to hand over an
+  // account identifier is exactly the kind of thing a careful volunteer refuses.
+  it('does not ask when no streamer delegated discord', async () => {
+    discord.getDiscordIdentity.mockResolvedValue({ linked: false })
+    await renderPage([delegation()])
+
+    await waitFor(() => expect(discord.getDiscordIdentity).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /link discord/i })).not.toBeInTheDocument()
+  })
+
+  // One Discord account may back at most one All-Chat account, or a second could inherit the
+  // first's server permissions. Retrying cannot fix it, so the copy must not imply it can.
+  it('explains an already-claimed discord account rather than offering a retry', async () => {
+    nav.params = new URLSearchParams('error=already_linked')
+    await renderPage([delegation()])
+
+    expect(
+      await screen.findByText(/already linked to another All-Chat account/i)
+    ).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/moderate/page.tsx
+++ b/frontend/src/app/moderate/page.tsx
@@ -48,6 +48,7 @@ import { Card } from '@/components/ui/card'
 import { PlatformBadge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
 import { VisuallyHidden } from '@/components/ui/visually-hidden'
+import { getDiscordIdentity, startDiscordAccountLink } from '@/lib/api/discord'
 import { moderationApi } from '@/lib/api/moderation'
 import { DELEGATABLE_ACTIONS, type Delegation, type ModerationAction } from '@/lib/types/moderation'
 
@@ -70,9 +71,22 @@ const PLATFORM_LABELS: Record<string, string> = {
  * than to the overlay because one consent covers every streamer who delegated that
  * platform, so there is no single overlay it belongs to.
  */
-function consentNotice(connected: string | null, error: string | null): string | null {
+function consentNotice(
+  connected: string | null,
+  error: string | null,
+  discordAccount: string | null
+): string | null {
+  // `already_linked` is the one failure worth its own words: that Discord account backs a
+  // different All-Chat account, and no amount of retrying changes it. One Discord identity may
+  // back at most one account, or a second could inherit the first's server permissions.
+  if (error === 'already_linked') {
+    return 'That Discord account is already linked to another All-Chat account. Link a different one, or unlink it from the other account first.'
+  }
   if (error) {
     return 'That connection did not complete. Open a channel below and try again from there.'
+  }
+  if (discordAccount === 'linked') {
+    return 'Discord account linked. All-Chat can now check your own server permissions when you moderate Discord.'
   }
   if (connected) {
     const name = PLATFORM_LABELS[connected] ?? connected
@@ -188,7 +202,11 @@ function DelegationCard({ delegation }: { delegation: Delegation }) {
 
 function ModerateContent() {
   const params = useSearchParams()
-  const notice = consentNotice(params.get('connected'), params.get('error'))
+  const notice = consentNotice(
+    params.get('connected'),
+    params.get('error'),
+    params.get('discord_account')
+  )
 
   const [delegations, setDelegations] = useState<Delegation[] | null>(null)
   const [loadFailed, setLoadFailed] = useState(false)
@@ -223,6 +241,31 @@ function ModerateContent() {
     }
   }, [fetchDelegations])
 
+  // Whether this moderator has linked a Discord account. null = not known yet, and the prompt
+  // stays hidden until it is: offering "link Discord" to someone already linked is noise.
+  const [discordLinked, setDiscordLinked] = useState<boolean | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    getDiscordIdentity()
+      .then((identity) => {
+        if (!cancelled) setDiscordLinked(identity.linked)
+      })
+      .catch(() => {
+        // Unknown, not unlinked: prompting on a failed read would nag someone who is already set up.
+        if (!cancelled) setDiscordLinked(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [notice])
+
+  // Only worth asking for if some streamer actually delegated Discord to them. Discord is the one
+  // platform where the link is the prerequisite rather than an OAuth consent — the shared bot
+  // writes, so All-Chat checks the acting human's own server permissions (ADR-0048).
+  const hasDiscordLeg = (delegations ?? []).some((d) =>
+    d.platforms.some((p) => p.platform === 'discord' && p.enabled)
+  )
+
   return (
     <div className="min-h-screen bg-bg">
       <AppNav />
@@ -239,6 +282,21 @@ function ModerateContent() {
           <div className="mb-6 flex items-start gap-2 rounded-lg border border-border bg-surface-2 px-4 py-3 text-sm text-text-sub">
             <Info className="mt-0.5 size-4 shrink-0 text-text-dim" aria-hidden="true" />
             <span>{notice}</span>
+          </div>
+        )}
+
+        {hasDiscordLeg && discordLinked === false && (
+          <div className="mb-6 flex flex-wrap items-start justify-between gap-3 rounded-lg border border-border bg-surface-2 px-4 py-3 text-sm text-text-sub">
+            <span className="flex items-start gap-2">
+              <Info className="mt-0.5 size-4 shrink-0 text-text-dim" aria-hidden="true" />
+              <span>
+                Link your Discord account to moderate Discord. All-Chat checks your own server
+                permissions before it acts, so it needs to know which Discord account is yours.
+              </span>
+            </span>
+            <Button size="sm" onClick={() => void startDiscordAccountLink('moderate')}>
+              Link Discord
+            </Button>
           </div>
         )}
 

--- a/frontend/src/app/overlay/[id]/view/page.tsx
+++ b/frontend/src/app/overlay/[id]/view/page.tsx
@@ -56,7 +56,7 @@ import { ViewSettingsBar } from '@/components/overlay/ViewSettingsBar'
 import { ResizableSplit } from '@/components/ResizableSplit'
 import { useOverlayStream } from '@/hooks/useOverlayStream'
 import { ApiError } from '@/lib/api/client'
-import { startDiscordModerationReinvite } from '@/lib/api/discord'
+import { startDiscordAccountLink, startDiscordModerationReinvite } from '@/lib/api/discord'
 import {
   buildBanRequest,
   buildDeleteRequest,
@@ -338,6 +338,21 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     []
   )
 
+  // Discord's equivalent of connectAsModerator, and deliberately not the same call: the moderator
+  // grants no scopes and All-Chat keeps no token — it only learns which Discord account they are,
+  // so it can read their own server permissions before acting through the shared bot.
+  const linkDiscordAccount = useCallback(async () => {
+    try {
+      await startDiscordAccountLink('moderate')
+    } catch {
+      toastManager.add({
+        title:
+          'Linking Discord is not available right now. Ask the streamer to moderate there for now.',
+        type: 'error',
+      })
+    }
+  }, [])
+
   // Re-consent when a send fails with `reauth_required` (the streamer's platform
   // send token expired or was revoked). Chat sending requires the advanced-controls
   // grant — Twitch `user:write:chat`, Kick `chat:write`, YouTube force-ssl — which is
@@ -418,6 +433,16 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
     [capabilities]
   )
 
+  // Discord sources waiting on the MODERATOR's own account link. Discord has no per-user
+  // moderation API, so what they must supply is an identity rather than a consent: the shared bot
+  // writes, and All-Chat checks their own server permissions before it will. Deliberately not
+  // merged with needsConsentSources — that banner offers an OAuth consent, and this one a
+  // different flow that grants All-Chat nothing beyond knowing who they are.
+  const needsDiscordLinkSources = useMemo(
+    () => (capabilities?.sources ?? []).filter((s) => s.reason === 'needs_discord_link'),
+    [capabilities]
+  )
+
   // Whether any source can currently send chat from the monitor (gates the send
   // bar). TikTok/Discord have no send path, so only twitch/youtube/kick count.
   const hasSendableSource = useMemo(
@@ -481,6 +506,19 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
           return `This streamer's ${platform} account isn't connected, so nothing can be moderated here`
         case 'delegation_unsupported':
           return `Moderators can't act on ${platform} yet — ask the streamer to handle this one`
+        // Discord's five. The shared bot performs every write there, so All-Chat's own check is
+        // the only authority and these codes carry the entire explanation — which makes naming
+        // the right person to ask the whole job of this copy.
+        case 'discord_link_required':
+          return 'Link your Discord account to moderate here'
+        case 'mod_not_in_guild':
+          return "You're not in this Discord server — ask the streamer to invite you"
+        case 'mod_lacks_permission':
+          return "Your Discord roles don't allow this — ask the streamer for a role that does"
+        case 'mod_below_target':
+          return "Discord's role hierarchy blocks this — your highest role has to sit above theirs"
+        case 'bot_missing_permission':
+          return "The All-Chat bot wasn't given this Discord permission — ask the streamer to re-invite it"
         default:
           return null
       }
@@ -788,6 +826,26 @@ export default function OverlayMonitorView({ params }: { params: Promise<{ id: s
             ) : null}
           </div>
         ))}
+
+      {/* Discord account-link notices. One banner for the whole overlay rather than one per
+          source: the link is per PERSON, not per server, so repeating it per channel would offer
+          the same one-time action several times over. */}
+      {moderationEnabled && isModerator && needsDiscordLinkSources.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs text-text-sub">
+          <Info className="h-3.5 w-3.5 shrink-0 text-text-dim" />
+          <span>
+            Link your Discord account to moderate Discord here — All-Chat checks your own server
+            permissions before acting.
+          </span>
+          <button
+            type="button"
+            onClick={() => void linkDiscordAccount()}
+            className="font-medium text-twitch hover:underline focus-visible:ring-2 focus-visible:ring-twitch focus-visible:outline-none"
+          >
+            Link Discord
+          </button>
+        </div>
+      )}
 
       {/* Missing-scope notices: owner must grant permissions per platform. Owner-only —
           the flow behind it re-consents the STREAMER's broadcaster credential, which is

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -34,8 +34,15 @@ import { VisuallyHidden } from '@/components/ui/visually-hidden'
 import { toastManager } from '@/lib/toast'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { AmbassadorSettingsCard } from '@/components/settings/AmbassadorSettingsCard'
-import { getGuilds, disconnectGuild, startDiscordOAuth } from '@/lib/api/discord'
-import type { DiscordGuild } from '@/lib/api/discord'
+import {
+  getGuilds,
+  disconnectGuild,
+  startDiscordOAuth,
+  getDiscordIdentity,
+  startDiscordAccountLink,
+  unlinkDiscordAccount,
+} from '@/lib/api/discord'
+import type { DiscordGuild, DiscordIdentity } from '@/lib/api/discord'
 
 function SettingsContent() {
   const router = useRouter()
@@ -46,6 +53,8 @@ function SettingsContent() {
   const [guilds, setGuilds] = useState<DiscordGuild[]>([])
   const [guildsLoading, setGuildsLoading] = useState(true)
   const [disconnectTarget, setDisconnectTarget] = useState<DiscordGuild | null>(null)
+  const [identity, setIdentity] = useState<DiscordIdentity | null>(null)
+  const [identityLoading, setIdentityLoading] = useState(true)
   const [restartingGuide, setRestartingGuide] = useState(false)
   const initAuth = useAuthStore((state) => state.init)
   const startOnboarding = useOnboardingStore((state) => state.start)
@@ -92,6 +101,66 @@ function SettingsContent() {
       fetchGuilds()
     }
   }, [searchParams])
+
+  // The account link is fetched separately from the guilds: a user can have servers connected and
+  // no link, or the reverse, and conflating them would hide whichever is missing.
+  //
+  // Keyed on the just-linked marker rather than refetched from the callback effect below, so every
+  // setState here happens in a promise callback: `react-hooks/set-state-in-effect` is a build
+  // error and it follows the call, so an effect must not invoke anything that setStates. When the
+  // marker is cleared from the URL the key flips and this re-reads the freshly linked identity.
+  const justLinked = searchParams.get('discord_account') === 'linked'
+  useEffect(() => {
+    let cancelled = false
+    getDiscordIdentity()
+      .then((data) => {
+        if (!cancelled) setIdentity(data)
+      })
+      .catch(() => {
+        // A failed read is reported as "not linked": the link is an affordance, and offering it
+        // again is harmless, whereas claiming a link we could not confirm is not.
+        if (!cancelled) setIdentity({ linked: false })
+      })
+      .finally(() => {
+        if (!cancelled) setIdentityLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [justLinked])
+
+  // The account-link callback lands here with one of these markers. `already_linked` is the one
+  // needing real copy: it means that Discord account backs a DIFFERENT All-Chat account, which no
+  // amount of retrying fixes — one Discord identity may back at most one account, or a second
+  // account could inherit the first's server permissions.
+  useEffect(() => {
+    if (justLinked) {
+      toastManager.add({ title: 'Discord account linked!', type: 'success' })
+      router.replace('/settings')
+      return
+    }
+    const error = searchParams.get('error')
+    if (!error) return
+    toastManager.add({
+      title:
+        error === 'already_linked'
+          ? 'That Discord account is already linked to another All-Chat account'
+          : 'Could not link your Discord account',
+      description: error === 'already_linked' ? undefined : 'Please try again.',
+      type: 'error',
+    })
+    router.replace('/settings')
+  }, [justLinked, searchParams, router])
+
+  async function handleUnlinkDiscordAccount() {
+    try {
+      await unlinkDiscordAccount()
+      setIdentity({ linked: false })
+      toastManager.add({ title: 'Discord account unlinked', type: 'success' })
+    } catch {
+      toastManager.add({ title: 'Could not unlink your Discord account', type: 'error' })
+    }
+  }
 
   async function handleDisconnectGuild() {
     if (!disconnectTarget) return
@@ -291,6 +360,38 @@ function SettingsContent() {
               </div>
             </div>
           )}
+
+          {/* The Discord ACCOUNT link, kept visually apart from the servers above because it is a
+              different kind of thing: those record which servers this account controls, this
+              records who you are on Discord. Moderation needs both — Discord has no per-user
+              moderation API, so the shared bot writes and All-Chat checks real people's server
+              permissions itself (ADR-0048). No token is kept. */}
+          <div className="mt-6 border-t border-border pt-4">
+            <h3 className="text-sm font-semibold text-text">Your Discord account</h3>
+            {identityLoading ? (
+              <div role="status" className="mt-3">
+                <VisuallyHidden>Loading your Discord account link</VisuallyHidden>
+                <Skeleton className="h-9 w-full" />
+              </div>
+            ) : (
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm text-text-sub">
+                  {identity?.linked
+                    ? `Linked as ${identity.discord_username ?? 'your Discord account'}. Needed so moderators can act on your Discord servers.`
+                    : 'Not linked. Link it to let moderators you invite act on your Discord servers.'}
+                </p>
+                {identity?.linked ? (
+                  <Button variant="outline" onClick={handleUnlinkDiscordAccount}>
+                    Unlink
+                  </Button>
+                ) : (
+                  <Button onClick={() => void startDiscordAccountLink('settings')}>
+                    Link Discord account
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
         </Card>
 
         {/* Danger zone */}

--- a/frontend/src/components/overlay/ModerationControls.tsx
+++ b/frontend/src/components/overlay/ModerationControls.tsx
@@ -86,6 +86,9 @@ export function ModerationControls({
   const showDelete = disabled || can('delete')
   const showUserActions = disabled || hasUserActions
 
+  // Each string names what stands in the way, and where the reader can act, who to ask. Sending
+  // someone at a fix that is not theirs to make is the failure mode the reason vocabulary exists
+  // to prevent (ADR-0048).
   const disabledReason = !platformSupported
     ? `${platformLabel(item.platform)} has no moderation API`
     : !capability
@@ -94,7 +97,13 @@ export function ModerationControls({
         ? 'Grant moderation permissions to enable mod actions'
         : capability.reason === 'unsupported_platform'
           ? `${platformLabel(item.platform)} has no moderation API`
-          : 'Moderation is unavailable for this source'
+          : capability.reason === 'needs_discord_link'
+            ? 'Link your Discord account to moderate here'
+            : capability.reason === 'owner_channel_unverified'
+              ? "This streamer's Discord account isn't connected, so nothing can be moderated here"
+              : capability.reason === 'bot_missing_permission'
+                ? "The All-Chat bot wasn't given this Discord permission — ask the streamer to re-invite it"
+                : 'Moderation is unavailable for this source'
 
   const closeAfter = (fn: () => void) => () => {
     fn()

--- a/frontend/src/lib/api/discord.ts
+++ b/frontend/src/lib/api/discord.ts
@@ -70,7 +70,7 @@ export async function startDiscordOAuth(): Promise<void> {
 // Unlike Twitch/Kick/YouTube this is a bot RE-INVITE, not an OAuth re-consent.
 export async function startDiscordModerationReinvite(): Promise<void> {
   const data = await apiClient.get<{ bot_invite_url: string }>(
-    '/api/v1/auth/discord/connect?moderation=true',
+    '/api/v1/auth/discord/connect?moderation=true'
   )
   if (data.bot_invite_url) {
     safeExternalRedirect(data.bot_invite_url)
@@ -80,7 +80,46 @@ export async function startDiscordModerationReinvite(): Promise<void> {
 export async function updateSourceConfig(
   overlayId: string,
   sourceId: string,
-  config: DiscordSourceConfig,
+  config: DiscordSourceConfig
 ): Promise<void> {
   return apiClient.patch<void>(`/api/v1/overlays/${overlayId}/sources/${sourceId}`, { config })
+}
+
+/**
+ * The Discord ACCOUNT link (ADR-0048) — which Discord user an All-Chat account is.
+ *
+ * Distinct from the guild routes above, and the distinction is the point: those record which
+ * SERVERS a streamer connected, this records a PERSON. Discord moderation needs both, because
+ * Discord has no per-user moderation API — the shared bot performs every write, so All-Chat has to
+ * check the acting human's own server permissions, which needs their snowflake.
+ *
+ * No OAuth token is retained: the `identify` grant is used once, at link time, and discarded.
+ */
+export interface DiscordIdentity {
+  linked: boolean
+  discord_user_id?: string
+  /** Display only. Discord usernames are mutable; never identify anyone by this. */
+  discord_username?: string
+  linked_at?: string
+}
+
+/** Where to send the browser after linking. An allowlisted KEY, never a path — the server owns
+ *  the mapping, so this cannot become an open redirect. */
+export type DiscordLinkReturn = 'settings' | 'moderate'
+
+export async function getDiscordIdentity(): Promise<DiscordIdentity> {
+  return apiClient.get<DiscordIdentity>('/api/v1/auth/discord/identity')
+}
+
+export async function startDiscordAccountLink(returnTo: DiscordLinkReturn): Promise<void> {
+  const data = await apiClient.get<{ auth_url: string }>(
+    `/api/v1/auth/discord/identity/connect?return=${returnTo}`
+  )
+  if (data.auth_url) {
+    safeExternalRedirect(data.auth_url)
+  }
+}
+
+export async function unlinkDiscordAccount(): Promise<void> {
+  return apiClient.delete('/api/v1/auth/discord/identity')
 }

--- a/frontend/src/lib/api/moderation.ts
+++ b/frontend/src/lib/api/moderation.ts
@@ -63,8 +63,8 @@ export function isModerationReauthError(err: unknown): boolean {
 /**
  * The machine-readable `code` on a failed moderation ACTION (ADR-0048), or undefined.
  *
- * Distinct from `delegationErrorCode`, which covers the grant-lifecycle endpoints. These three
- * describe why a write could not happen, and they differ in who can fix it:
+ * Distinct from `delegationErrorCode`, which covers the grant-lifecycle endpoints. These describe
+ * why a write could not happen, and they differ in who can fix it:
  *
  * - `connect_required` — the actor holds no credential for this platform. For a moderator that is
  *   the deferred-consent state, and the fix is theirs.
@@ -74,12 +74,33 @@ export function isModerationReauthError(err: unknown): boolean {
  * - `not_moderator_on_platform` — the PLATFORM refused: All-Chat allowed the action and Twitch
  *   said this person does not moderate that channel. Re-consent cannot fix it, so this must never
  *   be rendered as a re-authorize prompt; the streamer has to add them in the platform's own tools.
+ *
+ * The last five are Discord's. They exist as separate codes because Discord has no per-user
+ * moderation API: the shared bot performs every write, so no platform message comes back to
+ * explain a refusal and this code IS the explanation. Only `discord_link_required` is the
+ * moderator's own to clear.
+ *
+ * - `discord_link_required` — the moderator has not linked a Discord account, so their server
+ *   permissions cannot be read. Theirs to fix, and NOT the same as `connect_required`: the link
+ *   stores no token and runs through a different flow.
+ * - `mod_not_in_guild` — they are not a member of the server. The streamer invites them.
+ * - `mod_lacks_permission` — their Discord roles do not carry the permission, and All-Chat will
+ *   not let them do through the bot what Discord would refuse them directly.
+ * - `mod_below_target` — Discord's role hierarchy refused it. Nothing about All-Chat is wrong here;
+ *   Discord's own client would refuse it too.
+ * - `bot_missing_permission` — the bot was never invited with the permission, so nobody can borrow
+ *   it. Cleared by re-inviting the bot, never by an OAuth re-consent.
  */
 export type ModerationActionErrorCode =
   | 'connect_required'
   | 'owner_channel_unverified'
   | 'delegation_unsupported'
   | 'not_moderator_on_platform'
+  | 'discord_link_required'
+  | 'mod_not_in_guild'
+  | 'mod_lacks_permission'
+  | 'mod_below_target'
+  | 'bot_missing_permission'
 
 export function moderationActionCode(err: unknown): ModerationActionErrorCode | undefined {
   if (!(err instanceof ApiError)) return undefined

--- a/frontend/src/lib/types/moderation.ts
+++ b/frontend/src/lib/types/moderation.ts
@@ -35,10 +35,18 @@ export type ModerationAction = 'delete' | 'timeout' | 'ban' | 'unban'
 /**
  * Why a source cannot be moderated, when `moderatable` is false.
  *
- * The first two can describe either role. The last three only ever describe a
- * delegated moderator's source (ADR-0048), and they differ in who can clear
- * them: `not_delegated` needs the streamer, `needs_consent` needs the
- * moderator, and `needs_discord_link` needs neither — nothing can clear it yet.
+ * The first two can describe either role; the rest only ever describe a delegated
+ * moderator's source (ADR-0048). Sort them by WHO CAN CLEAR THEM, because that is
+ * what the copy has to branch on — an unclearable instruction is worse than none:
+ *
+ * - the moderator themselves: `needs_consent`, `needs_discord_link`
+ * - the streamer: `not_delegated`, `owner_channel_unverified`,
+ *   `bot_missing_permission`
+ * - nobody: `unsupported_platform`
+ *
+ * `needs_discord_link` and `owner_channel_unverified` can both be caused by the
+ * same missing thing — a Discord account link — and are kept apart precisely
+ * because one is the reader's to fix and the other is not.
  */
 export type ModerationUnavailableReason =
   | 'unsupported_platform'
@@ -46,6 +54,8 @@ export type ModerationUnavailableReason =
   | 'not_delegated'
   | 'needs_consent'
   | 'needs_discord_link'
+  | 'owner_channel_unverified'
+  | 'bot_missing_permission'
 
 /** The caller's role on an overlay's moderation write-path. */
 export type ModerationRole = 'owner' | 'moderator' | 'none'

--- a/services/api-gateway/cmd/main.go
+++ b/services/api-gateway/cmd/main.go
@@ -671,6 +671,14 @@ func main() {
 		protectedAPI.GET("/auth/guilds/:guild_id/channels", proxyHandler.ForwardRequest)
 		protectedAPI.DELETE("/auth/guilds/:guild_id", proxyHandler.ForwardRequest)
 
+		// Discord ACCOUNT link (ADR-0048) — which Discord user an All-Chat account is, as
+		// opposed to which servers it controls. Needed because Discord has no per-user
+		// moderation API: the shared bot performs every write, so All-Chat verifies the acting
+		// human's own guild permissions, which requires their snowflake.
+		protectedAPI.GET("/auth/discord/identity/connect", proxyHandler.ForwardRequest)
+		protectedAPI.GET("/auth/discord/identity", proxyHandler.ForwardRequest)
+		protectedAPI.DELETE("/auth/discord/identity", proxyHandler.ForwardRequest)
+
 		// Viewer protected routes
 		protectedAPI.GET("/auth/viewer/me", proxyHandler.ForwardRequest)
 		// AuthCookieForward so the handler can blacklist the viewer token on logout

--- a/services/moderation-service/README.md
+++ b/services/moderation-service/README.md
@@ -28,11 +28,18 @@ applies (`MODERATION_RATE_PER_MIN`, default 30/min).
 `capabilities` is role-aware (ADR-0048): `role` is `owner` / `moderator` / `none`, and `can_moderate` is
 the single flag the UI switches controls on. An owner's per-source answer comes from the scopes on their
 broadcaster credential; a **moderator's** comes from what the streamer delegated intersected with the
-scopes on the moderator's *own* credential, so `reason` gains three moderator-only values that differ in
+scopes on the moderator's *own* credential, so `reason` gains moderator-only values that differ in
 who can clear them: `not_delegated` (only the streamer can), `needs_consent` (only the moderator can —
-this is the "Connect to moderate" state) and `needs_discord_link` (nobody yet; Discord has no per-user
-moderation API and All-Chat holds no Discord identity for a user). `can_send` is never true for a
+this is the "Connect to moderate" state), `needs_discord_link` (the moderator — they must link their
+Discord account, since the shared bot acts and All-Chat checks *their* server permissions),
+`owner_channel_unverified` (only the streamer — on Discord, they have not linked their own account) and
+`bot_missing_permission` (only the streamer — the bot needs re-inviting with moderation permissions).
+`can_send` is never true for a
 moderator: chat send is a distinct, higher-trust capability and stays owner-only in v1.
+
+The Discord answer deliberately makes **no live permission read**: it checks the two account links and
+the bot's cached guild permissions, and leaves the moderator's own standing to the action path. That
+mirrors Twitch, where capabilities checks the scope and Helix decides whether they moderate the channel.
 `delegated_actions` echoes the grant's action set so a `needs_consent` source can request scopes for
 exactly what was delegated rather than guessing high.
 
@@ -153,9 +160,12 @@ the "opt-in" is the bot **re-invite** (`GET /api/v1/auth/discord/connect?moderat
 elevated invite URL). Capability is computed from the bot's effective guild permissions (delete⇐
 `MANAGE_MESSAGES`, timeout⇐`MODERATE_MEMBERS`, ban/unban⇐`BAN_MEMBERS`), so a bot invited without the
 moderation permissions reports no actions and the dashboard shows the re-invite CTA. A dispatch 403
-(e.g. a channel-level permission overwrite) fails the action — never a false reflect-back.
+(e.g. a channel-level permission overwrite) fails the action — never a false reflect-back. A delegated
+moderator additionally needs a Discord **account link** (`GET /api/v1/auth/discord/identity/connect`),
+which grants All-Chat no scopes and stores no token: it only records which Discord account they are, so
+their own server permissions can be checked. See "The Discord leg" below.
 
-## Delegated writes (ADR-0048, Twitch)
+## Delegated writes (ADR-0048, Twitch + Discord)
 
 An owner action and a delegated action differ in exactly one place — which credential performs the
 call and against whose channel — and the dispatcher makes that difference explicit rather than
@@ -189,6 +199,26 @@ Every write records five identities in `moderation_actions`: who acted, in what 
 happened), and the platform id sent as the moderator. Denials carry them too, because "this
 moderator keeps getting refused" is a signal that is invisible if a denial cannot be told apart
 from an owner's.
+
+### The Discord leg
+
+Discord has no per-user moderation API. The shared bot performs every write, so unlike Twitch there is
+no token to hand over and **nothing external re-checks the moderator** — All-Chat's own decision *is* the
+authorization. `dispatch/discord.go` therefore checks, failing closed on any read error:
+
+1. the **owner-reach anchor** — a `discord_guilds` row for (owner, guild), on owner and delegated
+   actions alike, plus (delegated only) a live read showing the owner still holds
+   `owner ∥ ADMINISTRATOR ∥ MANAGE_GUILD`;
+2. the **moderator's Discord identity** (`discord_identities`, migration 083), without which their
+   permissions cannot be read at all;
+3. the **`bot ∩ moderator` action intersection** — the bot bounds what is possible, the moderator what
+   is permitted, so nobody does through the bot what Discord would refuse them directly;
+4. **role hierarchy** for timeout and ban only, because Discord hierarchy-gates the *actor* and the
+   actor is the bot, which typically outranks everyone.
+
+The member-standing cache TTL (60s, `clients/discord.go`) is a **security bound, not a tuning knob**:
+the `GUILD_MEMBERS` intent is off, so Discord cannot push us a revocation, and that TTL is exactly how
+long a moderator whose roles were just stripped keeps acting.
 
 ## Rollout (feature gate, ADR-0008)
 
@@ -237,9 +267,10 @@ no redeploy. Locally, non-premium users can either set `users.is_premium=true` o
   `HandleConnect?moderation=true` give an opt-in re-invite that upgrades existing bots in place.
 - **Phase 6 (in progress): delegated moderators** (ADR-0048). Role resolution and owner-keyed
   entitlement; the grant lifecycle; the owner's Moderators panel; the moderator's `/delegations`
-  listing and role-aware `capabilities`; per-platform leg enforcement; and the **Twitch leg** — a
-  delegated moderator's Helix write now runs on their own credential (see Delegated writes below).
-  **Kick, Discord and YouTube legs are not built**: a delegated action on those refuses with
+  listing and role-aware `capabilities`; per-platform leg enforcement; the **Twitch leg** — a
+  delegated moderator's Helix write now runs on their own credential (see Delegated writes below) —
+  and the **Discord leg**, which works differently on purpose (see below).
+  **Kick and YouTube legs are not built**: a delegated action on those refuses with
   `delegation_unsupported` rather than falling through to whatever credential the dispatcher would
   otherwise reach for.
 

--- a/services/moderation-service/audit/store.go
+++ b/services/moderation-service/audit/store.go
@@ -46,6 +46,25 @@ const (
 	// built yet. Recorded rather than dropped — it is how a moderator hitting a wall becomes
 	// visible instead of just looking broken.
 	OutcomeDelegationUnsupported = "delegation_unsupported"
+	// The Discord refusals. They are kept apart rather than collapsed into OutcomeDenied because
+	// on Discord no platform message accompanies a refusal — All-Chat's own check is the only
+	// authority (ADR-0048), so the audit row is the entire record of WHY something was refused,
+	// and the five causes have five different remedies.
+	//
+	// OutcomeDiscordLinkRequired: the moderator has no Discord account linked, so their guild
+	// permissions could not be read at all.
+	OutcomeDiscordLinkRequired = "discord_link_required"
+	// OutcomeModNotInGuild: the moderator is not a member of the guild.
+	OutcomeModNotInGuild = "mod_not_in_guild"
+	// OutcomeModLacksPermission: the moderator is in the guild but could not perform the action
+	// themselves, so All-Chat refused to lend them the bot's authority.
+	OutcomeModLacksPermission = "mod_lacks_permission"
+	// OutcomeModBelowTarget: Discord's role hierarchy refused the member operation. Worth its own
+	// value because a run of these against one target is what an escalation attempt looks like.
+	OutcomeModBelowTarget = "mod_below_target"
+	// OutcomeBotMissingPermission: the bot was never invited with the permission, so nobody can
+	// borrow it. Distinct from a platform 403 on the owner path: this one is known before any call.
+	OutcomeBotMissingPermission = "bot_missing_permission"
 )
 
 // Entry is one audited moderation command.

--- a/services/moderation-service/cmd/main.go
+++ b/services/moderation-service/cmd/main.go
@@ -193,11 +193,16 @@ func main() {
 	if cfg.DiscordBotToken != "" {
 		discordClient := clients.NewDiscordClient(cfg.DiscordBotToken)
 		discordGuilds := clients.NewDiscordGuildResolver(discordClient, redisClient)
-		dispatchers["discord"] = dispatch.NewDiscord(discordClient, discordGuilds, log)
+		// The repository answers the owner-reach anchor and the Discord account links. It is a
+		// constructor argument rather than an opt-in setter because on Discord nothing external
+		// re-checks a delegated moderator (ADR-0048): without the store the dispatcher can check
+		// nothing, and "cannot check" must never degrade into acting with the streamer's full
+		// guild authority.
+		dispatchers["discord"] = dispatch.NewDiscord(discordClient, discordGuilds, repo, log)
 		// The resolver caches both the channel→guild map AND the per-guild effective
 		// permissions, so the capability endpoint stays cheap on dashboard load.
 		scopeCheckers["discord"] = handler.NewDiscordScopeChecker(discordGuilds, discordGuilds, log)
-		log.Info("Discord moderation enabled (delete/timeout/ban/unban, bot REST)")
+		log.Info("Discord moderation enabled (delete/timeout/ban/unban, bot REST, owner + delegated moderator)")
 	} else {
 		log.Warn("DISCORD_BOT_TOKEN not set; Discord moderation runs in dry-run")
 	}

--- a/services/moderation-service/dispatch/discord.go
+++ b/services/moderation-service/dispatch/discord.go
@@ -37,61 +37,220 @@ type discordAPI interface {
 	UnbanMember(ctx context.Context, guildID, userID string) error
 }
 
-// discordGuildResolver maps a channel id to its guild id (clients.DiscordGuildResolver).
+// discordGuildResolver answers the three cached Discord reads authorization needs: which guild a
+// channel belongs to, what the bot may do there, and what one member may do there.
+// (*clients.DiscordGuildResolver satisfies it.)
 type discordGuildResolver interface {
 	GuildID(ctx context.Context, channelID string) (string, error)
+	GuildBotPermissions(ctx context.Context, guildID string) (uint64, error)
+	MemberAuthority(ctx context.Context, guildID, userID string) (clients.DiscordMember, error)
 }
 
-// Discord dispatches moderation (delete + member ban/timeout/unban) to the Discord bot
-// REST API. Unlike Twitch it resolves no per-user credential and performs no OAuth scope
-// pre-check or token refresh: authority is the shared bot token, and the only failure
-// mode that needs a human is the bot missing a moderation permission (MANAGE_MESSAGES /
-// MODERATE_MEMBERS / BAN_MEMBERS) — fixed by RE-INVITING the bot with the elevated
-// permissions, not by an OAuth re-consent. Such failures are returned as dispatch errors
-// so the handler responds 502 and does NOT emit a reflect-back (the action did not land).
-// The capability endpoint reports the bot's real permissions, so the dashboard normally
-// shows the re-invite prompt before a 403 can happen here.
+// discordAuthorityStore is the database half of the Discord authority model: who someone is on
+// Discord, and which guilds the overlay owner connected. (*repository.Repository satisfies it.)
+type discordAuthorityStore interface {
+	DiscordIdentity(ctx context.Context, userID string) (string, bool, error)
+	DiscordGuildConnectedBy(ctx context.Context, userID, guildID string) (bool, error)
+}
+
+// Discord dispatches moderation (delete + member ban/timeout/unban) to the Discord bot REST API.
+//
+// It is the one dispatcher that resolves no per-user credential: Discord has no per-user
+// moderation API, so every write authenticates as the shared bot whoever asked for it. That makes
+// this file's authorization checks load-bearing in a way no other dispatcher's are — ADR-0048 calls
+// the model "platform-attested", meaning Discord attests the facts (via live bot-token reads) and
+// All-Chat alone decides on them. Twitch/Kick/YouTube re-check a moderator's role on every call and
+// will refuse an action we wrongly allowed; here nothing will.
+//
+// Two consequences run through everything below. Every read that feeds the decision fails CLOSED,
+// because a swallowed error would be an authorization decision made on no information. And the
+// role-hierarchy rule is enforced here rather than left to Discord: Discord hierarchy-gates the
+// *actor*, and the actor is always the bot, which typically outranks everyone in the guild.
+//
+// A bot permission the guild never granted still surfaces as a dispatch error (502, no
+// reflect-back) on the owner path, fixed by RE-INVITING the bot rather than by an OAuth
+// re-consent; on the delegated path the bot's ceiling is known before the call and refuses cleanly.
 type Discord struct {
 	api    discordAPI
 	guilds discordGuildResolver
+	store  discordAuthorityStore
 	logger *zap.Logger
 }
 
-// NewDiscord wires a Discord dispatcher over the bot REST client and a channel→guild
-// resolver.
-func NewDiscord(api discordAPI, guilds discordGuildResolver, logger *zap.Logger) *Discord {
-	return &Discord{api: api, guilds: guilds, logger: logger}
+// NewDiscord wires a Discord dispatcher over the bot REST client, the cached guild/member
+// resolver, and the store that answers the owner anchor and the Discord account links.
+//
+// store is a constructor parameter rather than an opt-in setter (as Twitch's mod source is)
+// because on Discord it is not an enhancement: without it nothing can be checked, and "cannot
+// check" must never degrade into "act with the streamer's full guild authority". A nil store
+// therefore refuses every action rather than allowing any.
+func NewDiscord(api discordAPI, guilds discordGuildResolver, store discordAuthorityStore, logger *zap.Logger) *Discord {
+	return &Discord{api: api, guilds: guilds, store: store, logger: logger}
 }
 
-// Dispatch performs a Discord moderation action. delete is channel-scoped; timeout/ban/
-// unban are guild-scoped, so the guild id is resolved from the channel id first.
+// Dispatch authorizes and performs a Discord moderation action.
+//
+// delete is channel-scoped and the member ops are guild-scoped, but authority is per-guild for all
+// of them, so the guild is resolved first in every case — that resolution is also the ADR's
+// requirement that a source's channel actually belong to the guild being anchored against.
 func (d *Discord) Dispatch(ctx context.Context, actor models.Actor, action models.Action, req models.DispatchRequest) (models.DispatchResult, error) {
 	if req.Platform != "discord" {
 		return models.DispatchResult{Outcome: models.DispatchDryRun}, nil
 	}
-
-	// Discord is the one platform where refusing delegation is load-bearing rather than tidy.
-	// Every other dispatcher acts with the caller's own credential, so a moderator without one
-	// simply fails; here the actor is always the shared bot, which holds the streamer's full
-	// guild authority. Without this refusal a delegated action would execute with that authority
-	// and no check that the moderator holds any of it — All-Chat's own check is the ONLY
-	// authority on Discord, and it is not built yet (ADR-0048 Phase 2).
-	if actor.IsModerator() {
-		return models.DispatchResult{Outcome: models.DispatchDelegationUnsupported}, nil
+	if d.store == nil {
+		// A wiring bug, not a user state: loud, and refusing.
+		return models.DispatchResult{}, errors.New("discord authority store not wired; refusing rather than acting with the bot's guild authority")
 	}
 
-	if action == models.ActionDelete {
-		return d.result(action, req.ChannelID, d.api.DeleteMessage(ctx, req.ChannelID, req.NativeMessageID))
-	}
-
-	// Member ops need the guild id. Resolution failure that is a permission/visibility
-	// problem maps to the re-invite path; anything else is a transient dispatch error.
 	guildID, err := d.guilds.GuildID(ctx, req.ChannelID)
 	if err != nil {
 		return d.result(action, req.ChannelID, fmt.Errorf("resolve guild for channel: %w", err))
 	}
 
+	res, authorized, err := d.authorize(ctx, actor, action, guildID, req)
+	if err != nil || !authorized {
+		return res, err
+	}
+	return d.perform(ctx, action, guildID, req)
+}
+
+// authorize decides whether this actor may perform this action in this guild. A false second
+// return means the decision is already made and res carries it; an error means a read failed and
+// nothing may be inferred.
+func (d *Discord) authorize(
+	ctx context.Context, actor models.Actor, action models.Action, guildID string, req models.DispatchRequest,
+) (models.DispatchResult, bool, error) {
+	// The owner-reach anchor, on both paths: nothing delegated may exceed what the overlay owner
+	// could do themselves, and an owner may only act on a guild they actually connected. The row
+	// is itself platform-attested — Discord only lets someone add a bot where they hold Manage
+	// Server — so on the owner path it is the whole anchor (ADR-0048, "Discord anchor strength").
+	connected, err := d.store.DiscordGuildConnectedBy(ctx, actor.OwnerUserID, guildID)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read owner guild anchor: %w", err)
+	}
+	if !connected {
+		return models.DispatchResult{Outcome: models.DispatchOwnerUnverified}, false, nil
+	}
+	if !actor.IsModerator() {
+		return models.DispatchResult{}, true, nil
+	}
+
+	// Everything from here is the delegated path, ordered so that the most actionable answer wins
+	// when several checks would fail: the streamer's own blockers first (they gate every moderator
+	// on the overlay), then this moderator's.
+	if res, ok, err := d.ownerStillControlsGuild(ctx, actor.OwnerUserID, guildID); err != nil || !ok {
+		return res, false, err
+	}
+
+	modSnowflake, linked, err := d.store.DiscordIdentity(ctx, actor.UserID)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read moderator discord identity: %w", err)
+	}
+	if !linked {
+		// The one Discord blocker the moderator can clear themselves. Consent is deferred to first
+		// use, so this is the normal state of a fresh grant rather than a fault.
+		return models.DispatchResult{Outcome: models.DispatchModNotLinked}, false, nil
+	}
+
+	mod, err := d.memberAuthority(ctx, guildID, modSnowflake)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read moderator guild standing: %w", err)
+	}
+	if !mod.InGuild {
+		return models.DispatchResult{Outcome: models.DispatchModNotInGuild}, false, nil
+	}
+
+	// The bot bounds what is POSSIBLE, the moderator what is PERMITTED, and neither half is
+	// redundant: a moderator cannot borrow authority the bot was never invited with, and All-Chat
+	// must never let someone do through the bot what Discord would refuse them directly.
+	botBits, err := d.guilds.GuildBotPermissions(ctx, guildID)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read bot guild permissions: %w", err)
+	}
+	// The bot's own hierarchy position is deliberately not read: it bounds nothing here, because
+	// Discord enforces the actor's hierarchy itself and the actor IS the bot. A bot cannot own a
+	// guild either, and if one somehow did, reading only its permission bits understates it —
+	// which errs toward refusal.
+	bot := models.DiscordMemberAuthority{InGuild: true, Permissions: botBits}
+	if !models.ActionsInclude(models.DiscordDelegatedActions(bot, mod), action) {
+		// Which side is missing it decides who is told to do what: re-invite the bot, or give the
+		// moderator a role. The bot is reported first when both are missing, since no moderator can
+		// perform an action the bot cannot.
+		if !models.ActionsInclude(models.DiscordMemberActions(bot), action) {
+			d.logger.Warn("discord delegated action refused: the bot lacks the permission",
+				zap.String("action", string(action)), zap.String("guild_id", guildID))
+			return models.DispatchResult{Outcome: models.DispatchBotMissingPermission}, false, nil
+		}
+		return models.DispatchResult{Outcome: models.DispatchModLacksPermission}, false, nil
+	}
+
+	if !models.DiscordHierarchyApplies(action) {
+		// Delete is not a member operation and an unban target is by definition not a member, so
+		// neither has a member record to rank. Ranking them anyway would deny actions the
+		// moderator can perform natively.
+		return models.DispatchResult{}, true, nil
+	}
+	target, err := d.memberAuthority(ctx, guildID, req.TargetUserID)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read target guild standing: %w", err)
+	}
+	if !models.DiscordOutranks(mod, target) {
+		return models.DispatchResult{Outcome: models.DispatchModBelowTarget}, false, nil
+	}
+	return models.DispatchResult{}, true, nil
+}
+
+// ownerStillControlsGuild is the delegated path's live half of the anchor. The connected-guild row
+// records that the owner controlled the guild when they invited the bot; only this read notices
+// they have since lost that standing, which matters precisely because a third party is about to
+// act on the strength of the owner's reach.
+//
+// An owner who has never linked a Discord account cannot be read at all. That is an owner-side
+// blocker — only the streamer can clear it — so it reports as owner-unverified rather than sending
+// the moderator to a link flow that would change nothing.
+func (d *Discord) ownerStillControlsGuild(ctx context.Context, ownerUserID, guildID string) (models.DispatchResult, bool, error) {
+	ownerSnowflake, linked, err := d.store.DiscordIdentity(ctx, ownerUserID)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read owner discord identity: %w", err)
+	}
+	if !linked {
+		return models.DispatchResult{Outcome: models.DispatchOwnerUnverified}, false, nil
+	}
+	owner, err := d.memberAuthority(ctx, guildID, ownerSnowflake)
+	if err != nil {
+		return models.DispatchResult{}, false, fmt.Errorf("read owner guild standing: %w", err)
+	}
+	if !models.DiscordOwnerControlsGuild(owner) {
+		d.logger.Warn("discord delegation refused: the overlay owner no longer controls the guild",
+			zap.String("guild_id", guildID), zap.String("owner_user_id", ownerUserID))
+		return models.DispatchResult{Outcome: models.DispatchOwnerUnverified}, false, nil
+	}
+	return models.DispatchResult{}, true, nil
+}
+
+// memberAuthority reads a member's live standing and converts it into the domain type the decision
+// functions take. clients deliberately holds no dependency on models — the same reason models.Actor
+// duplicates repository.Role* — so the one-line conversion lives here, in the layer importing both.
+func (d *Discord) memberAuthority(ctx context.Context, guildID, userID string) (models.DiscordMemberAuthority, error) {
+	m, err := d.guilds.MemberAuthority(ctx, guildID, userID)
+	if err != nil {
+		return models.DiscordMemberAuthority{}, err
+	}
+	return models.DiscordMemberAuthority{
+		InGuild:        m.InGuild,
+		IsGuildOwner:   m.IsGuildOwner,
+		Permissions:    m.Permissions,
+		HighestRolePos: m.HighestRolePos,
+	}, nil
+}
+
+// perform makes the authorized call. No Discord result is reported back as attribution: the shared
+// bot is always the actor, so there is no per-user credential and no platform moderator id, and
+// claiming either would put a fiction in the audit row.
+func (d *Discord) perform(ctx context.Context, action models.Action, guildID string, req models.DispatchRequest) (models.DispatchResult, error) {
 	switch action {
+	case models.ActionDelete:
+		return d.result(action, req.ChannelID, d.api.DeleteMessage(ctx, req.ChannelID, req.NativeMessageID))
 	case models.ActionTimeout:
 		until := time.Now().Add(time.Duration(req.DurationSeconds) * time.Second)
 		return d.result(action, req.ChannelID, d.api.TimeoutMember(ctx, guildID, req.TargetUserID, until))

--- a/services/moderation-service/dispatch/discord_delegated_test.go
+++ b/services/moderation-service/dispatch/discord_delegated_test.go
@@ -1,0 +1,443 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/caesar/all-chat/services/moderation-service/clients"
+	"github.com/caesar/all-chat/services/moderation-service/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Delegated moderation on Discord (ADR-0048's platform-attested leg).
+//
+// Every other dispatcher can lean on the platform: it hands over the moderator's own token and
+// Twitch/Kick/YouTube re-check the role on every call. Discord has no per-user moderation API, so
+// the shared bot performs the write and NOTHING external re-checks anything. Whatever these tests
+// pin down IS the authorization — there is no backstop behind it, which is why the denial cases
+// here are as load-bearing as the success case.
+
+// modUserID and ownerUserID are shared with the Twitch delegated tests (twitch_delegated_test.go).
+const (
+	guildID    = "guild-1"
+	ownerSnow  = "100"
+	modSnow    = "200"
+	targetSnow = "300"
+)
+
+// fakeDiscordStore answers the two database reads the delegated path needs.
+type fakeDiscordStore struct {
+	identities map[string]string // all-chat user id -> discord snowflake
+	guilds     map[string]string // all-chat user id -> the one guild they connected
+	identErr   error
+	guildErr   error
+}
+
+func (f *fakeDiscordStore) DiscordIdentity(_ context.Context, userID string) (string, bool, error) {
+	if f.identErr != nil {
+		return "", false, f.identErr
+	}
+	snowflake, ok := f.identities[userID]
+	return snowflake, ok, nil
+}
+
+func (f *fakeDiscordStore) DiscordGuildConnectedBy(_ context.Context, userID, gid string) (bool, error) {
+	if f.guildErr != nil {
+		return false, f.guildErr
+	}
+	return f.guilds[userID] == gid, nil
+}
+
+// fakeAuthorityResolver is a guild resolver that also answers live permission reads.
+type fakeAuthorityResolver struct {
+	guildID  string
+	guildErr error
+
+	botPerms   uint64
+	botErr     error
+	botCalls   int
+	members    map[string]clients.DiscordMember // snowflake -> standing
+	memberErr  error
+	memberCall map[string]int
+}
+
+func (f *fakeAuthorityResolver) GuildID(_ context.Context, _ string) (string, error) {
+	return f.guildID, f.guildErr
+}
+
+func (f *fakeAuthorityResolver) GuildBotPermissions(_ context.Context, _ string) (uint64, error) {
+	f.botCalls++
+	return f.botPerms, f.botErr
+}
+
+func (f *fakeAuthorityResolver) MemberAuthority(_ context.Context, _, userID string) (clients.DiscordMember, error) {
+	if f.memberCall == nil {
+		f.memberCall = map[string]int{}
+	}
+	f.memberCall[userID]++
+	if f.memberErr != nil {
+		return clients.DiscordMember{}, f.memberErr
+	}
+	return f.members[userID], nil
+}
+
+// fullyAuthorized is the happy path every denial test perturbs exactly one field of: the owner
+// controls the guild, the bot holds every moderation permission, and the moderator holds them too
+// and outranks the target.
+func fullyAuthorized() (*fakeDiscordStore, *fakeAuthorityResolver) {
+	store := &fakeDiscordStore{
+		identities: map[string]string{ownerUserID: ownerSnow, modUserID: modSnow},
+		guilds:     map[string]string{ownerUserID: guildID},
+	}
+	resolver := &fakeAuthorityResolver{
+		guildID:  guildID,
+		botPerms: models.ModerationBotPermissions,
+		members: map[string]clients.DiscordMember{
+			ownerSnow:  {InGuild: true, IsGuildOwner: true},
+			modSnow:    {InGuild: true, Permissions: models.ModerationBotPermissions, HighestRolePos: 5},
+			targetSnow: {InGuild: true, HighestRolePos: 1},
+		},
+	}
+	return store, resolver
+}
+
+func delegatedDispatcher(api *fakeDiscordAPI, store *fakeDiscordStore, resolver *fakeAuthorityResolver) *Discord {
+	return NewDiscord(api, resolver, store, zap.NewNop())
+}
+
+func delegatedActor() models.Actor { return moderator(modUserID, ownerUserID) }
+
+func banRequest() models.DispatchRequest {
+	return models.DispatchRequest{Platform: "discord", ChannelID: "chan-1", TargetUserID: targetSnow}
+}
+
+func TestDiscordDelegated_PerformsWhenEveryCheckPasses(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, 1, api.banCalls)
+	assert.Equal(t, guildID, api.guildID)
+	assert.Equal(t, targetSnow, api.targetID)
+}
+
+// The shared bot is the actor on every Discord write, so there is no per-user credential and no
+// platform moderator id to report. Claiming otherwise would put a fiction in the audit row that an
+// auditor reads as the no-fallback proof.
+func TestDiscordDelegated_ReportsNoCredentialAttribution(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Empty(t, res.CredentialUserID, "no per-user credential acts on Discord")
+	assert.Empty(t, res.PlatformActorID, "nothing is sent as a platform moderator id")
+}
+
+func TestDiscordDelegated_UnlinkedModeratorIsRefused(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	delete(store.identities, modUserID)
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchModNotLinked, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// Two different people can be un-linked, and only one of them can fix it. Telling a volunteer to
+// link their Discord account when it is the streamer who has not is a dead end.
+func TestDiscordDelegated_UnlinkedOwnerReadsAsOwnerUnverified(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	delete(store.identities, ownerUserID)
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchOwnerUnverified, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+func TestDiscordDelegated_GuildTheOwnerNeverConnectedIsRefused(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	store.guilds[ownerUserID] = "some-other-guild"
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchOwnerUnverified, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// The row proves the owner controlled the guild at invite time; the live read is what notices they
+// have since lost that standing. On the delegated path both are required (ADR-0048, "Discord
+// anchor strength") — a third party is acting on the strength of the owner's reach.
+func TestDiscordDelegated_OwnerWhoLostControlOfTheGuildIsRefused(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[ownerSnow] = clients.DiscordMember{InGuild: true, Permissions: models.DiscordPermViewChannel}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchOwnerUnverified, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+func TestDiscordDelegated_ModeratorNotInGuildIsRefused(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[modSnow] = clients.DiscordMember{} // Discord answered 404
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchModNotInGuild, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// The whole point of the bot ∩ moderator intersection: All-Chat must never let someone do through
+// the bot what Discord would refuse them directly.
+func TestDiscordDelegated_ModeratorWithoutThePermissionCannotBorrowTheBots(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[modSnow] = clients.DiscordMember{
+		InGuild: true, Permissions: models.DiscordPermManageMessages, HighestRolePos: 5,
+	}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchModLacksPermission, res.Outcome)
+	assert.Zero(t, api.banCalls, "the bot holds BAN_MEMBERS, but the moderator does not")
+}
+
+// The bot's permissions are the ceiling, so a moderator who holds everything is still bounded by
+// what the bot was invited with — and the remedy is the streamer re-inviting it, not a re-consent.
+func TestDiscordDelegated_BotCeilingBoundsAnAdministratorModerator(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.botPerms = models.DiscordPermManageMessages
+	resolver.members[modSnow] = clients.DiscordMember{
+		InGuild: true, Permissions: models.DiscordPermAdministrator, HighestRolePos: 5,
+	}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchBotMissingPermission, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// Discord hierarchy-gates the ACTOR, and the actor here is the bot, which typically sits above
+// everyone. Without our own check a delegated moderator could ban a member they cannot touch in
+// Discord's own client.
+func TestDiscordDelegated_HierarchyRefusesBanOnAHigherMember(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[targetSnow] = clients.DiscordMember{InGuild: true, HighestRolePos: 9}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchModBelowTarget, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// Discord requires strictly-greater, and @everyone is position 0 — so two role-less members
+// cannot act on each other.
+func TestDiscordDelegated_HierarchyTieRefuses(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[modSnow] = clients.DiscordMember{
+		InGuild: true, Permissions: models.ModerationBotPermissions, HighestRolePos: 3,
+	}
+	resolver.members[targetSnow] = clients.DiscordMember{InGuild: true, HighestRolePos: 3}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionTimeout,
+		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: targetSnow, DurationSeconds: 60})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchModBelowTarget, res.Outcome)
+	assert.Zero(t, api.timeoutCalls)
+}
+
+// Hierarchy governs member operations only. Applying it to a delete would deny an action the
+// moderator can perform natively, which is its own kind of wrong answer.
+func TestDiscordDelegated_HierarchyDoesNotGateDelete(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	resolver.members[targetSnow] = clients.DiscordMember{InGuild: true, HighestRolePos: 99}
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionDelete,
+		models.DispatchRequest{Platform: "discord", ChannelID: "chan-1", NativeMessageID: "msg-1"})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, 1, api.deleteCalls)
+	assert.Zero(t, resolver.memberCall[targetSnow], "a delete target has no member record to rank")
+}
+
+// An unban target is by definition not a guild member, so there is nothing to rank there either.
+func TestDiscordDelegated_HierarchyDoesNotGateUnban(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionUnban,
+		models.DispatchRequest{Platform: "discord", ChannelID: "c", TargetUserID: targetSnow})
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, 1, api.unbanCalls)
+}
+
+// On the one platform with no external backstop, a swallowed error is an authorization decision
+// made on no information. Every read that feeds the decision must fail closed instead.
+func TestDiscordDelegated_EveryReadFailureFailsClosed(t *testing.T) {
+	cases := []struct {
+		name     string
+		sabotage func(*fakeDiscordStore, *fakeAuthorityResolver)
+	}{
+		{"guild resolution", func(_ *fakeDiscordStore, r *fakeAuthorityResolver) {
+			r.guildErr = errors.New("discord down")
+		}},
+		{"identity lookup", func(s *fakeDiscordStore, _ *fakeAuthorityResolver) {
+			s.identErr = errors.New("db down")
+		}},
+		{"owner guild-row lookup", func(s *fakeDiscordStore, _ *fakeAuthorityResolver) {
+			s.guildErr = errors.New("db down")
+		}},
+		{"member authority read", func(_ *fakeDiscordStore, r *fakeAuthorityResolver) {
+			r.memberErr = errors.New("discord down")
+		}},
+		{"bot permission read", func(_ *fakeDiscordStore, r *fakeAuthorityResolver) {
+			r.botErr = errors.New("discord down")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &fakeDiscordAPI{}
+			store, resolver := fullyAuthorized()
+			tc.sabotage(store, resolver)
+			d := delegatedDispatcher(api, store, resolver)
+
+			res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+			require.Error(t, err, "a read failure must never be read as permission")
+			assert.NotEqual(t, models.DispatchPerformed, res.Outcome)
+			assert.Zero(t, api.banCalls)
+		})
+	}
+}
+
+// Every action goes through authorization, not just the member ops. On Discord the bot holds the
+// streamer's full guild authority, so a single unchecked verb would hand it to whoever asked.
+func TestDiscordDelegated_NoActionReachesTheBotUnauthorized(t *testing.T) {
+	for _, action := range []models.Action{
+		models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban,
+	} {
+		t.Run(string(action), func(t *testing.T) {
+			api := &fakeDiscordAPI{}
+			store, resolver := fullyAuthorized()
+			delete(store.identities, modUserID)
+			d := delegatedDispatcher(api, store, resolver)
+
+			res, err := d.Dispatch(context.Background(), delegatedActor(), action,
+				models.DispatchRequest{
+					Platform: "discord", ChannelID: "c", NativeMessageID: "m",
+					TargetUserID: targetSnow, DurationSeconds: 60,
+				})
+
+			require.NoError(t, err)
+			assert.Equal(t, models.DispatchModNotLinked, res.Outcome)
+			assert.Zero(t, api.deleteCalls+api.timeoutCalls+api.banCalls+api.unbanCalls,
+				"the bot must not act for an unauthorized moderator")
+		})
+	}
+}
+
+// A dispatcher wired without the store cannot check anything, and on Discord "cannot check" must
+// never degrade into "act with the bot's full guild authority".
+func TestDiscordDelegated_NoStoreRefusesRatherThanActs(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	_, resolver := fullyAuthorized()
+	d := NewDiscord(api, resolver, nil, zap.NewNop())
+
+	res, err := d.Dispatch(context.Background(), delegatedActor(), models.ActionBan, banRequest())
+
+	require.Error(t, err)
+	assert.NotEqual(t, models.DispatchPerformed, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// The owner path keeps the anchor too, at the strength ADR-0048 fixes for it: the discord_guilds
+// row, and no live read. A streamer acting on a guild they never connected is refused.
+func TestDiscordOwner_AnchorRequiresTheConnectedGuild(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	store.guilds[ownerUserID] = "some-other-guild"
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), owner(ownerUserID), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchOwnerUnverified, res.Outcome)
+	assert.Zero(t, api.banCalls)
+}
+
+// The row alone anchors an owner action. Requiring the live read here would have switched Discord
+// moderation off for every existing Discord streamer until each completed a new account link, to
+// re-prove something Discord already attested at invite time.
+func TestDiscordOwner_NeedsNoDiscordLinkAndNoLiveRead(t *testing.T) {
+	api := &fakeDiscordAPI{}
+	store, resolver := fullyAuthorized()
+	delete(store.identities, ownerUserID)
+	d := delegatedDispatcher(api, store, resolver)
+
+	res, err := d.Dispatch(context.Background(), owner(ownerUserID), models.ActionBan, banRequest())
+
+	require.NoError(t, err)
+	assert.Equal(t, models.DispatchPerformed, res.Outcome)
+	assert.Equal(t, 1, api.banCalls)
+	assert.Empty(t, resolver.memberCall, "no live permission read on the owner path")
+	assert.Zero(t, resolver.botCalls, "and no bot-ceiling pre-check either")
+}

--- a/services/moderation-service/dispatch/discord_test.go
+++ b/services/moderation-service/dispatch/discord_test.go
@@ -64,7 +64,9 @@ func (f *fakeDiscordAPI) UnbanMember(_ context.Context, guildID, userID string) 
 	return f.err
 }
 
-// fakeGuildResolver maps any channel to guildID (or returns err).
+// fakeGuildResolver maps any channel to guildID (or returns err). The live permission reads are
+// the delegated path's business and are exercised in discord_delegated_test.go; here they answer
+// nothing, which is enough because the owner path performs neither.
 type fakeGuildResolver struct {
 	guildID string
 	err     error
@@ -76,8 +78,28 @@ func (f *fakeGuildResolver) GuildID(_ context.Context, _ string) (string, error)
 	return f.guildID, f.err
 }
 
+func (f *fakeGuildResolver) GuildBotPermissions(_ context.Context, _ string) (uint64, error) {
+	return 0, errors.New("no live permission read is expected on the owner path")
+}
+
+func (f *fakeGuildResolver) MemberAuthority(_ context.Context, _, _ string) (clients.DiscordMember, error) {
+	return clients.DiscordMember{}, errors.New("no live member read is expected on the owner path")
+}
+
+// ownerAnchorStore satisfies the owner-reach anchor for any guild: these tests are about the
+// dispatch mechanics, and the anchor itself is exercised in discord_delegated_test.go.
+type ownerAnchorStore struct{}
+
+func (ownerAnchorStore) DiscordIdentity(_ context.Context, _ string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (ownerAnchorStore) DiscordGuildConnectedBy(_ context.Context, _, _ string) (bool, error) {
+	return true, nil
+}
+
 func newDiscordDispatcher(api *fakeDiscordAPI, guilds *fakeGuildResolver) *Discord {
-	return NewDiscord(api, guilds, zap.NewNop())
+	return NewDiscord(api, guilds, ownerAnchorStore{}, zap.NewNop())
 }
 
 func TestDiscordDispatch_NonDiscordIsDryRun(t *testing.T) {
@@ -100,7 +122,8 @@ func TestDiscordDispatch_DeletePerformed(t *testing.T) {
 	assert.Equal(t, 1, api.deleteCalls)
 	assert.Equal(t, "chan-1", api.channelID)
 	assert.Equal(t, "msg-1", api.msgID, "the Discord native message id (snowflake) is the delete target")
-	assert.Zero(t, guilds.calls, "delete is channel-scoped and needs no guild resolution")
+	assert.Equal(t, 1, guilds.calls,
+		"the write is channel-scoped but authority is per-guild, so even a delete resolves the guild to anchor against")
 }
 
 func TestDiscordDispatch_BanResolvesGuildAndPerforms(t *testing.T) {
@@ -169,30 +192,25 @@ func TestDiscordDispatch_GuildResolutionFailureIsError(t *testing.T) {
 	assert.Zero(t, api.banCalls, "no ban is attempted when the guild cannot be resolved")
 }
 
-// Discord is the one platform where refusing delegation is load-bearing rather than tidy.
-//
-// Everywhere else the actor supplies their own credential, so an unconsented moderator simply
-// fails. Here the actor is always the shared bot, holding the streamer's full guild authority —
-// so without this refusal a delegated action would execute with that authority and no check that
-// the moderator holds any of it. All-Chat's own check is the ONLY authority on Discord, and it is
-// not built yet.
-func TestDiscord_DelegatedActionNeverReachesTheSharedBot(t *testing.T) {
+// The owner path performs no live permission read at all, on any action. That is ADR-0048's
+// anchor-strength decision made checkable: the connected-guild row alone anchors an owner, and
+// adding a live read here would have switched Discord moderation off for every existing Discord
+// streamer until each completed a new account link.
+func TestDiscordDispatch_OwnerPathMakesNoLivePermissionRead(t *testing.T) {
 	for _, action := range []models.Action{
 		models.ActionDelete, models.ActionTimeout, models.ActionBan, models.ActionUnban,
 	} {
 		t.Run(string(action), func(t *testing.T) {
 			api := &fakeDiscordAPI{}
-			guilds := &fakeGuildResolver{guildID: "g1"}
-			d := newDiscordDispatcher(api, guilds)
+			// This resolver errors on every live read, so any attempt to make one fails the test
+			// rather than passing silently.
+			d := newDiscordDispatcher(api, &fakeGuildResolver{guildID: "g1"})
 
-			res, err := d.Dispatch(context.Background(), moderator("mod", "own"), action,
-				models.DispatchRequest{Platform: "discord", ChannelID: "c", NativeMessageID: "m", TargetUserID: "42"})
+			res, err := d.Dispatch(context.Background(), owner("u1"), action,
+				models.DispatchRequest{Platform: "discord", ChannelID: "c", NativeMessageID: "m", TargetUserID: "42", DurationSeconds: 60})
 
 			require.NoError(t, err)
-			assert.Equal(t, models.DispatchDelegationUnsupported, res.Outcome)
-			assert.Zero(t, api.deleteCalls+api.timeoutCalls+api.banCalls+api.unbanCalls,
-				"the bot must not act for a delegated moderator")
-			assert.Zero(t, guilds.calls, "not even the guild lookup should run")
+			assert.Equal(t, models.DispatchPerformed, res.Outcome)
 		})
 	}
 }

--- a/services/moderation-service/handler/capabilities_delegation_test.go
+++ b/services/moderation-service/handler/capabilities_delegation_test.go
@@ -170,18 +170,98 @@ func TestCapabilities_ConsentNarrowerThanTheGrantReadsAsNeedsConsent(t *testing.
 	assert.Equal(t, models.ReasonNeedsConsent, caps.Sources[0].Reason)
 }
 
-// Discord has no per-user moderation API, so there is no consent a moderator could grant. Saying
-// "connect your account" would offer a button that goes nowhere.
+func discordSource() []repository.Source {
+	return []repository.Source{{Platform: "discord", ChannelID: "123", ChannelName: "#general"}}
+}
+
+// Discord has no per-user moderation API, so what a moderator must supply is not a consent but an
+// identity: the shared bot writes, and All-Chat checks their own server permissions. Saying
+// "connect your account" would point them at an OAuth flow that grants nothing usable.
 func TestCapabilities_DiscordReadsAsNeedsLinkNotConsent(t *testing.T) {
 	auth := &fakeAuthorizer{
 		access:    moderatorAccess([]string{"delete"}, []string{"discord"}),
-		sources:   []repository.Source{{Platform: "discord", ChannelID: "123", ChannelName: "#general"}},
+		sources:   discordSource(),
 		modScopes: map[string][]string{},
 	}
 
 	caps := modCaps(t, auth)
 
 	require.Len(t, caps.Sources, 1)
+	assert.Equal(t, models.ReasonNeedsDiscordLink, caps.Sources[0].Reason)
+}
+
+// The same missing thing — a Discord account link — has two subjects, and only one of them is the
+// person reading this. A moderator told to link their account when it is the STREAMER who has not
+// would link it and see nothing change.
+func TestCapabilities_UnlinkedOwnerIsNotTheModeratorsProblemToFix(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:            moderatorAccess([]string{"delete"}, []string{"discord"}),
+		sources:           discordSource(),
+		discordIdentities: map[string]string{modUserID: "200"}, // the moderator linked; the owner did not
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.Equal(t, models.ReasonOwnerChannelUnverified, caps.Sources[0].Reason)
+	assert.False(t, caps.Sources[0].Moderatable)
+}
+
+// With both linked, the answer is what the BOT can do in that guild narrowed to what the streamer
+// delegated. The moderator's own server permissions are checked at action time, not here — exactly
+// as on Twitch, where capabilities checks the scope and the platform decides the rest.
+func TestCapabilities_LinkedDiscordReportsTheDelegatedBotIntersection(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:            moderatorAccess([]string{"delete", "ban"}, []string{"discord"}),
+		sources:           discordSource(),
+		discordIdentities: map[string]string{modUserID: "200", ownerID: "100"},
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.True(t, caps.Sources[0].Moderatable)
+	assert.Empty(t, caps.Sources[0].Reason)
+	// modCapsHandler's scope checker reports the full set as the bot's permissions, so the grant
+	// is the only narrowing left.
+	assert.ElementsMatch(t, []models.Action{models.ActionDelete, models.ActionBan}, caps.Sources[0].Actions)
+}
+
+// A bot invited without the permissions the grant covers cannot lend them to anyone, and only the
+// streamer can fix it — by re-inviting the bot, never by any re-consent.
+func TestCapabilities_DiscordBotWithoutThePermissionsReadsAsReinvite(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:            moderatorAccess([]string{"ban"}, []string{"discord"}),
+		sources:           discordSource(),
+		discordIdentities: map[string]string{modUserID: "200", ownerID: "100"},
+	}
+	// A bot holding only MANAGE_MESSAGES: it can delete, and the grant covers only ban.
+	h := New(auth, &fakeEmitter{}, &fakeRecorder{}, fakeScopes{actions: []models.Action{models.ActionDelete}},
+		DryRunDispatcher{}, zap.NewNop())
+
+	resp := do(newTestRouter(h, modUserID, ""), http.MethodGet, capsPath, "")
+	require.Equal(t, http.StatusOK, resp.Code)
+	var caps models.Capabilities
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &caps))
+
+	require.Len(t, caps.Sources, 1)
+	assert.Equal(t, models.ReasonBotMissingPermission, caps.Sources[0].Reason)
+	assert.False(t, caps.Sources[0].Moderatable)
+}
+
+// A lookup failure must not advertise a capability the action path would refuse. On Discord that
+// matters more than elsewhere: nothing downstream re-checks it on our behalf.
+func TestCapabilities_DiscordIdentityLookupErrorFailsClosed(t *testing.T) {
+	auth := &fakeAuthorizer{
+		access:          moderatorAccess([]string{"delete"}, []string{"discord"}),
+		sources:         discordSource(),
+		discordIdentErr: errors.New("db down"),
+	}
+
+	caps := modCaps(t, auth)
+
+	require.Len(t, caps.Sources, 1)
+	assert.False(t, caps.Sources[0].Moderatable)
 	assert.Equal(t, models.ReasonNeedsDiscordLink, caps.Sources[0].Reason)
 }
 

--- a/services/moderation-service/handler/moderation.go
+++ b/services/moderation-service/handler/moderation.go
@@ -55,6 +55,11 @@ type Authorizer interface {
 	// platform, and whether one exists at all. Never the token itself: the capability answer
 	// needs no decryption.
 	ModeratorGrantedScopes(ctx context.Context, userID, platform string) ([]string, bool, error)
+	// DiscordIdentity reports whether a user has linked a Discord account, and which one. It is
+	// Discord's analogue of the credential lookup above: the shared bot performs every write, so
+	// what a Discord source needs from a person is not a token but an identity to check their
+	// server permissions against (ADR-0048).
+	DiscordIdentity(ctx context.Context, userID string) (string, bool, error)
 	// TouchGrantActivity records that a delegated grant was just used, which is what the
 	// dormancy rule reads. A no-op for owner actions, which carry no grant.
 	TouchGrantActivity(ctx context.Context, grantID string) error
@@ -172,6 +177,26 @@ const (
 	// codeNotPlatformModerator: the platform says the caller does not moderate that channel. The
 	// fix is on the platform, not in All-Chat.
 	codeNotPlatformModerator = "not_moderator_on_platform"
+	// The Discord refusals (ADR-0048). Discord has no per-user moderation API, so no platform
+	// message comes back to explain a refusal — these codes are the whole explanation, and they
+	// are separate because the remedies are separate PEOPLE's jobs. Only the first is the
+	// moderator's own to clear.
+	//
+	// codeDiscordLinkRequired: the moderator has not linked a Discord account, so there is no
+	// snowflake to read their guild permissions against. Not folded into connect_required: that
+	// means a missing OAuth credential, whereas the Discord link deliberately stores no token, so
+	// it is a different flow the UI has to send them to.
+	codeDiscordLinkRequired = "discord_link_required"
+	// codeModNotInGuild: the moderator is not a member of the Discord server.
+	codeModNotInGuild = "mod_not_in_guild"
+	// codeModLacksPermission: they are in the server but their roles do not carry this permission,
+	// and All-Chat will not let them do through the bot what Discord would refuse them directly.
+	codeModLacksPermission = "mod_lacks_permission"
+	// codeModBelowTarget: Discord's role hierarchy refuses the member operation.
+	codeModBelowTarget = "mod_below_target"
+	// codeBotMissingPermission: the bot was never invited with the permission, so nobody can
+	// borrow it. Cleared by re-inviting the bot — never by an OAuth re-consent.
+	codeBotMissingPermission = "bot_missing_permission"
 )
 
 // unauthorizedDenials counts refusals of callers who hold no role on the overlay.
@@ -410,12 +435,8 @@ func (h *Handler) delegatedCapabilityFor(
 		sc.Reason = models.ReasonNotDelegated
 		return sc
 	}
-	// Discord's authority is the shared bot plus a link to the moderator's Discord account, not an
-	// OAuth scope they can grant. No such link exists yet, so there is no consent flow to send
-	// them to and the copy must say so rather than offering a dead button.
 	if s.Platform == "discord" {
-		sc.Reason = models.ReasonNeedsDiscordLink
-		return sc
+		return h.discordDelegatedCapabilityFor(ctx, userID, access, s, sc)
 	}
 
 	scopes, ok, err := h.repo.ModeratorGrantedScopes(ctx, userID, s.Platform)
@@ -435,6 +456,66 @@ func (h *Handler) delegatedCapabilityFor(
 	usable := models.IntersectActions(models.ActionsForModeratorScopes(s.Platform, scopes), access.Actions)
 	if len(usable) == 0 {
 		sc.Reason = models.ReasonNeedsConsent
+		return sc
+	}
+	sc.Moderatable = true
+	sc.Actions = usable
+	return sc
+}
+
+// discordDelegatedCapabilityFor computes one DISCORD source's capability for a delegated moderator.
+//
+// Discord needs its own branch because what a person must supply here is not an OAuth credential
+// but an identity: the shared bot performs every write, so All-Chat checks the acting human's own
+// server permissions instead of handing over their token. Two people therefore have to be linked,
+// and the whole value of saying so is that only one of them can fix each case — a volunteer told to
+// link their Discord account when it is the streamer who has not is a dead end.
+//
+// What this deliberately does NOT do is read the moderator's live guild permissions. Capabilities
+// is advisory (ADR-0048: a cached moderator state is telemetry, never authorization) and the action
+// path is the authority — exactly as on Twitch, where capabilities checks the scope and Helix
+// decides whether they moderate the channel. Reading them here would also put Discord API traffic
+// on every dashboard load, driven by a caller-supplied overlay id, to produce an answer that can go
+// stale before the button is pressed.
+func (h *Handler) discordDelegatedCapabilityFor(
+	ctx context.Context, userID string, access repository.OverlayAccess,
+	s repository.Source, sc models.SourceCapability,
+) models.SourceCapability {
+	// The moderator's own link first: it is the one blocker on this list they can clear.
+	if _, linked, err := h.repo.DiscordIdentity(ctx, userID); err != nil || !linked {
+		if err != nil {
+			h.logger.Warn("capabilities: discord identity lookup failed; treating as not linked",
+				zap.String("platform", s.Platform), zap.Error(err))
+		}
+		sc.Reason = models.ReasonNeedsDiscordLink
+		return sc
+	}
+	// The owner's link is what proves they still control the guild on a delegated action, so
+	// without it nothing on this source is delegable. Only the streamer can clear it, which is why
+	// it does not read as "link your Discord account" — the moderator would be linking the wrong
+	// account and nothing would change.
+	if _, linked, err := h.repo.DiscordIdentity(ctx, access.OwnerUserID); err != nil || !linked {
+		if err != nil {
+			h.logger.Warn("capabilities: owner discord identity lookup failed; treating as unverified",
+				zap.String("platform", s.Platform), zap.Error(err))
+		}
+		sc.Reason = models.ReasonOwnerChannelUnverified
+		return sc
+	}
+
+	// The bot's permissions in this guild are the ceiling for everyone, so they bound what can be
+	// offered. The moderator's own permissions narrow it further at action time.
+	botActions, err := h.scopes.GrantedActions(ctx, userID, s.Platform, s.ChannelID)
+	if err != nil {
+		h.logger.Warn("capabilities: discord bot permission lookup failed; reporting no actions",
+			zap.String("channel_id", s.ChannelID), zap.Error(err))
+		botActions = nil
+	}
+	usable := models.IntersectActions(botActions, access.Actions)
+	if len(usable) == 0 {
+		// The bot was invited without the permissions this grant covers. Re-inviting it is the
+		// streamer's job, and it is the same wall the action path reports as bot_missing_permission.
+		sc.Reason = models.ReasonBotMissingPermission
 		return sc
 	}
 	sc.Moderatable = true
@@ -645,6 +726,50 @@ func (h *Handler) execute(c *gin.Context, cl caller, action models.Action, dreq 
 		c.JSON(http.StatusUnprocessableEntity, gin.H{
 			"error": "moderators cannot act on " + dreq.Platform + " yet — ask the streamer to handle this one",
 			"code":  codeDelegationUnsupported,
+		})
+		return
+	case models.DispatchModNotLinked:
+		// The one Discord refusal the moderator can clear themselves, so it is the one that gets a
+		// 422 and copy addressed to them.
+		e.Outcome = audit.OutcomeDiscordLinkRequired
+		h.record(ctx, e)
+		c.JSON(http.StatusUnprocessableEntity, gin.H{
+			"error": "link your Discord account to moderate here — All-Chat checks your own server permissions before acting",
+			"code":  codeDiscordLinkRequired,
+		})
+		return
+	case models.DispatchModNotInGuild:
+		e.Outcome = audit.OutcomeModNotInGuild
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "you're not a member of this Discord server — ask the streamer to invite you",
+			"code":  codeModNotInGuild,
+		})
+		return
+	case models.DispatchModLacksPermission:
+		e.Outcome = audit.OutcomeModLacksPermission
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "your Discord roles don't allow this — ask the streamer to give you a role that can",
+			"code":  codeModLacksPermission,
+		})
+		return
+	case models.DispatchModBelowTarget:
+		// Naming the rule matters: this refusal looks arbitrary otherwise, and it is the one case
+		// where nothing about All-Chat is wrong — Discord would refuse it in its own client too.
+		e.Outcome = audit.OutcomeModBelowTarget
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "Discord's role hierarchy blocks this — your highest role has to sit above theirs",
+			"code":  codeModBelowTarget,
+		})
+		return
+	case models.DispatchBotMissingPermission:
+		e.Outcome = audit.OutcomeBotMissingPermission
+		h.record(ctx, e)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": "the All-Chat bot wasn't given this permission — ask the streamer to re-invite it with moderation permissions",
+			"code":  codeBotMissingPermission,
 		})
 		return
 	case models.DispatchReauthRequired:

--- a/services/moderation-service/handler/moderation_actor_test.go
+++ b/services/moderation-service/handler/moderation_actor_test.go
@@ -206,3 +206,84 @@ func TestExecute_NoCredentialCopyDiffersByRole(t *testing.T) {
 		assert.Contains(t, body["error"], "do not hold moderator credentials")
 	})
 }
+
+// The five Discord refusals (ADR-0048's platform-attested leg).
+//
+// Discord is the one platform where All-Chat's own check is the only authority, so its refusals
+// have no platform message behind them — this mapping IS the explanation the person gets. What
+// each case must get right is WHO is told to do something: a volunteer sent to fix a permission
+// only the streamer controls has been given a dead end, which is the failure mode the whole reason
+// vocabulary exists to prevent.
+func TestExecute_DiscordRefusalsNameTheRightFixer(t *testing.T) {
+	cases := []struct {
+		name     string
+		outcome  models.DispatchOutcome
+		status   int
+		code     string
+		audited  string
+		mentions string
+	}{
+		{
+			name: "moderator has not linked Discord", outcome: models.DispatchModNotLinked,
+			status: http.StatusUnprocessableEntity, code: codeDiscordLinkRequired,
+			audited: audit.OutcomeDiscordLinkRequired, mentions: "your",
+		},
+		{
+			name: "moderator is not in the guild", outcome: models.DispatchModNotInGuild,
+			status: http.StatusForbidden, code: codeModNotInGuild,
+			audited: audit.OutcomeModNotInGuild, mentions: "streamer",
+		},
+		{
+			name: "moderator lacks the Discord permission", outcome: models.DispatchModLacksPermission,
+			status: http.StatusForbidden, code: codeModLacksPermission,
+			audited: audit.OutcomeModLacksPermission, mentions: "streamer",
+		},
+		{
+			name: "role hierarchy refuses", outcome: models.DispatchModBelowTarget,
+			status: http.StatusForbidden, code: codeModBelowTarget,
+			audited: audit.OutcomeModBelowTarget, mentions: "role",
+		},
+		{
+			name: "the bot was never given the permission", outcome: models.DispatchBotMissingPermission,
+			status: http.StatusForbidden, code: codeBotMissingPermission,
+			audited: audit.OutcomeBotMissingPermission, mentions: "re-invite",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, _, rec := actorHandler(t, delegatedAccess(), models.DispatchResult{Outcome: tc.outcome})
+
+			resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+			assert.Equal(t, tc.status, resp.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+			assert.Equal(t, tc.code, body["code"])
+			assert.Contains(t, body["error"], tc.mentions, "the copy must name the person who can fix it")
+			assert.NotContains(t, body, "requires_reauth",
+				"no Discord refusal is fixed by an OAuth re-consent — the link stores no token and guild permissions are not scopes")
+			require.Len(t, rec.entries, 1, "a refusal is audited, never silently dropped")
+			assert.Equal(t, tc.audited, rec.entries[0].Outcome)
+			assert.Equal(t, repository.RoleModerator, rec.entries[0].ActorRole)
+		})
+	}
+}
+
+// No refusal may emit the reflect-back: the message is still there on Discord, and hiding it in the
+// overlay would tell the streamer an action landed that never did.
+func TestExecute_DiscordRefusalsEmitNoReflectBack(t *testing.T) {
+	for _, outcome := range []models.DispatchOutcome{
+		models.DispatchModNotLinked, models.DispatchModNotInGuild, models.DispatchModLacksPermission,
+		models.DispatchModBelowTarget, models.DispatchBotMissingPermission,
+	} {
+		access := delegatedAccess()
+		auth := &fakeAuthorizer{access: &access, isSource: map[string]bool{"twitch|somestreamer": true}}
+		emitter := &fakeEmitter{}
+		h := New(auth, emitter, &fakeRecorder{}, NoScopeChecker{}, &fakeDispatcher{res: models.DispatchResult{Outcome: outcome}}, zap.NewNop())
+
+		resp := do(newTestRouter(h, modUserID, ""), http.MethodPost, deletePath(), deleteBody)
+
+		require.NotEqual(t, http.StatusOK, resp.Code)
+		assert.Empty(t, emitter.published, "a refused action must not be reflected back as if it had landed")
+	}
+}

--- a/services/moderation-service/handler/moderation_test.go
+++ b/services/moderation-service/handler/moderation_test.go
@@ -58,6 +58,10 @@ type fakeAuthorizer struct {
 	// An absent platform means they have not consented for it at all.
 	modScopes    map[string][]string
 	modScopesErr error
+	// discordIdentities are the users who have linked a Discord account, keyed by user id. An
+	// absent user has not linked one — the state every user is in until they run the link flow.
+	discordIdentities map[string]string
+	discordIdentErr   error
 }
 
 func (f *fakeAuthorizer) VerifyOverlayOwnership(context.Context, string, string) (bool, error) {
@@ -102,6 +106,14 @@ func (f *fakeAuthorizer) ModeratorGrantedScopes(_ context.Context, _, platform s
 	}
 	scopes, ok := f.modScopes[platform]
 	return scopes, ok, nil
+}
+
+func (f *fakeAuthorizer) DiscordIdentity(_ context.Context, userID string) (string, bool, error) {
+	if f.discordIdentErr != nil {
+		return "", false, f.discordIdentErr
+	}
+	snowflake, ok := f.discordIdentities[userID]
+	return snowflake, ok, nil
 }
 
 type fakeEmitter struct{ published []*mpmodels.RawChatMessage }

--- a/services/moderation-service/models/moderation.go
+++ b/services/moderation-service/models/moderation.go
@@ -50,9 +50,20 @@ const (
 	// can clear themselves (ADR-0048 defers consent to first use).
 	ReasonNeedsConsent = "needs_consent"
 	// ReasonNeedsDiscordLink: Discord has no per-user moderation API, so the shared bot acts and
-	// All-Chat must know which Discord account the moderator is. No such link exists today, so a
-	// moderator's Discord source always reports this — there is no consent flow to point them at.
+	// All-Chat must know which Discord account the MODERATOR is before it will check their server
+	// permissions. Theirs to clear, via the Discord account link.
 	ReasonNeedsDiscordLink = "needs_discord_link"
+	// ReasonOwnerChannelUnverified: the overlay OWNER cannot be shown to control this channel, so
+	// there is nothing for them to delegate on it (ADR-0048's owner-reach anchor). Kept apart from
+	// ReasonNeedsDiscordLink even though the same missing thing — a Discord account link — can
+	// cause both: the moderator can clear one and only the streamer can clear the other, and
+	// pointing a volunteer at a link flow that would change nothing is the dead end this whole
+	// vocabulary exists to avoid. Matches the action path's owner_channel_unverified code.
+	ReasonOwnerChannelUnverified = "owner_channel_unverified"
+	// ReasonBotMissingPermission: the All-Chat bot was invited to this Discord server without the
+	// permissions this grant covers, so nobody can borrow them. Cleared by the streamer
+	// re-inviting the bot — never by any OAuth re-consent, which cannot touch guild permissions.
+	ReasonBotMissingPermission = "bot_missing_permission"
 )
 
 // PlatformActions is the moderation support matrix per platform in All-Chat.
@@ -76,8 +87,14 @@ var PlatformActions = map[string][]Action{
 
 // SupportsAction reports whether the platform supports the given moderation action.
 func SupportsAction(platform string, a Action) bool {
-	for _, supported := range PlatformActions[platform] {
-		if supported == a {
+	return ActionsInclude(PlatformActions[platform], a)
+}
+
+// ActionsInclude reports whether an action set contains an action. The sets it is asked about are
+// at most four elements long, so a linear scan is the whole implementation.
+func ActionsInclude(actions []Action, a Action) bool {
+	for _, candidate := range actions {
+		if candidate == a {
 			return true
 		}
 	}
@@ -355,6 +372,38 @@ const (
 	// always the shared bot: without this, a delegated action would execute with the bot's full
 	// guild authority and no check that the moderator holds any of it.
 	DispatchDelegationUnsupported
+
+	// The four outcomes below are Discord's, and they exist because Discord is the one platform
+	// where no external party re-checks a delegated moderator (ADR-0048's platform-attested
+	// model). Everywhere else a refusal comes back from the platform and needs no vocabulary of
+	// its own; here All-Chat is the authority, so each way its own check can refuse has to be
+	// nameable — otherwise a volunteer is told "it didn't work" with no route to a fix, and the
+	// fixes genuinely differ.
+
+	// DispatchModNotLinked: the acting moderator has not linked a Discord account, so there is no
+	// snowflake to read their guild permissions against. Theirs to clear, and the only Discord
+	// outcome that is — which is why it is not folded into DispatchNoCredential: that one means a
+	// missing OAuth *credential*, and the Discord link deliberately stores no token at all, so the
+	// remedy is a different flow.
+	DispatchModNotLinked
+	// DispatchModNotInGuild: Discord answered 404 for the moderator in that guild. They are not a
+	// member, so they hold no permissions there and All-Chat must not lend them the bot's. Only
+	// the streamer can clear it, by inviting them to the server.
+	DispatchModNotInGuild
+	// DispatchModLacksPermission: the moderator is in the guild but could not perform this action
+	// themselves. The bot could — that is the point of the intersection: All-Chat never lets
+	// someone do through the bot what Discord would refuse them directly. The streamer clears it
+	// by giving them a role that carries the permission.
+	DispatchModLacksPermission
+	// DispatchModBelowTarget: Discord's role hierarchy refuses this member operation, because the
+	// moderator's highest role does not sit strictly above the target's. All-Chat has to evaluate
+	// this itself: Discord hierarchy-gates the *actor*, and on a delegated action the actor is the
+	// bot, which typically outranks everyone.
+	DispatchModBelowTarget
+	// DispatchBotMissingPermission: the bot itself was never invited with the permission this
+	// action needs, so no moderator can borrow it. The streamer clears it by re-inviting the bot —
+	// never an OAuth re-consent, which cannot touch guild permissions.
+	DispatchBotMissingPermission
 )
 
 // DispatchResult is what a Dispatcher reports back to the handler.

--- a/services/moderation-service/repository/discord.go
+++ b/services/moderation-service/repository/discord.go
@@ -1,0 +1,86 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// The database half of ADR-0048's Discord leg.
+//
+// Discord is the one platform where nothing external re-checks a delegated moderator: every write
+// authenticates as the shared bot, so All-Chat's own decision IS the authorization. These two reads
+// are its non-live inputs — who someone is on Discord, and whether the overlay owner ever connected
+// the guild being acted in. Both answer "no" rather than erroring on an input that cannot match a
+// row, because a 500 on the authorization path is a worse failure than a denial.
+
+// DiscordIdentity returns the Discord snowflake linked to an All-Chat account, and whether such a
+// link exists at all.
+//
+// Needed for both roles and for different reasons: a delegated moderator's snowflake is what their
+// live guild permissions are read against — the check that stands in for the platform's own — and
+// the overlay owner's is what proves they still control the guild on a delegated action.
+//
+// The table holds no OAuth token, so there is nothing here that could leak a credential: the
+// `identify` grant is used once, at link time, and discarded.
+func (r *Repository) DiscordIdentity(ctx context.Context, userID string) (string, bool, error) {
+	// A caller id that is not a UUID cannot match a row. Normalise rather than letting the cast
+	// fail and surface as a 500.
+	if _, err := uuid.Parse(userID); err != nil {
+		return "", false, nil
+	}
+	const query = `SELECT discord_user_id FROM discord_identities WHERE user_id = $1`
+
+	var discordUserID string
+	err := r.db.QueryRow(ctx, query, userID).Scan(&discordUserID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read discord identity: %w", err)
+	}
+	return discordUserID, true, nil
+}
+
+// DiscordGuildConnectedBy reports whether this user connected the All-Chat bot to this guild — the
+// Discord arm of ADR-0048's owner-reach anchor.
+//
+// The row is not a weak stand-in for a live permission read: Discord only lets someone add a bot to
+// a guild where they hold Manage Server, so a `discord_guilds` row IS Discord's own record that the
+// user controlled that guild at invite time. What it cannot see is a later loss of standing, which
+// is why a delegated action additionally requires the live read (ADR-0048, "Discord anchor
+// strength") and an owner action does not.
+//
+// Scoped to the user, never to the guild alone: a row belonging to a different streamer would
+// otherwise let one overlay's delegation reach another's guild.
+func (r *Repository) DiscordGuildConnectedBy(ctx context.Context, userID, guildID string) (bool, error) {
+	if _, err := uuid.Parse(userID); err != nil {
+		return false, nil
+	}
+	const query = `SELECT EXISTS (SELECT 1 FROM discord_guilds WHERE user_id = $1 AND guild_id = $2)`
+
+	var connected bool
+	if err := r.db.QueryRow(ctx, query, userID, guildID).Scan(&connected); err != nil {
+		return false, fmt.Errorf("check discord guild connection: %w", err)
+	}
+	return connected, nil
+}

--- a/services/moderation-service/repository/discord_test.go
+++ b/services/moderation-service/repository/discord_test.go
@@ -1,0 +1,89 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two Discord reads the delegated dispatch path needs (ADR-0048). Both are inputs to an
+// authorization decision that no platform re-checks afterwards, so both must fail closed on
+// every path that is not an unambiguous match.
+
+func TestDiscordIdentity(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	snowflake, found, err := repo.DiscordIdentity(ctx, ownerID)
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, ownerDiscordID, snowflake)
+
+	_, found, err = repo.DiscordIdentity(ctx, strangerID)
+	require.NoError(t, err)
+	assert.False(t, found, "a user who never linked Discord reports not-found, not an error")
+}
+
+// A malformed id must not reach the UUID cast and surface as a 500. It cannot match a row, so
+// the honest answer is "not linked".
+func TestDiscordIdentity_NonUUIDIsNotLinked(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	_, found, err := repo.DiscordIdentity(context.Background(), "not-a-uuid")
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func TestDiscordGuildConnectedBy(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	connected, err := repo.DiscordGuildConnectedBy(ctx, ownerID, ownerGuildID)
+	require.NoError(t, err)
+	assert.True(t, connected, "the owner invited the bot to this guild, which is Discord's own attestation of control")
+
+	connected, err = repo.DiscordGuildConnectedBy(ctx, ownerID, "some-other-guild")
+	require.NoError(t, err)
+	assert.False(t, connected, "a guild the owner never connected must not anchor anything")
+}
+
+// The anchor is what stops one streamer's delegation reaching another streamer's guild, so a
+// row belonging to somebody else must not satisfy it.
+func TestDiscordGuildConnectedBy_IsScopedToTheUser(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	connected, err := repo.DiscordGuildConnectedBy(context.Background(), strangerID, ownerGuildID)
+	require.NoError(t, err)
+	assert.False(t, connected, "another user's guild row must never anchor this user's reach")
+}
+
+func TestDiscordGuildConnectedBy_NonUUIDIsNotConnected(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	connected, err := repo.DiscordGuildConnectedBy(context.Background(), "not-a-uuid", ownerGuildID)
+	require.NoError(t, err)
+	assert.False(t, connected)
+}

--- a/services/moderation-service/repository/repository_test.go
+++ b/services/moderation-service/repository/repository_test.go
@@ -35,6 +35,10 @@ const (
 	// adminActor stands in for an admin acting on the grant lifecycle; revoked_by carries no
 	// foreign key precisely so the trail survives the actor's account.
 	adminActor = "99999999-9999-9999-9999-999999999999"
+	// The owner's Discord side: the snowflake their account is linked to, and a guild they
+	// invited the bot to. Both anchor the Discord leg of delegation (ADR-0048).
+	ownerDiscordID = "300000000000000001"
+	ownerGuildID   = "877203185700339742"
 )
 
 func TestVerifyOverlayOwnership(t *testing.T) {
@@ -214,7 +218,21 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 			verified_at TIMESTAMP,
 			last_denied_at TIMESTAMP,
 			PRIMARY KEY (grant_id, platform)
-		);`
+		);
+		CREATE TABLE discord_guilds (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			guild_id VARCHAR(30) NOT NULL,
+			guild_name VARCHAR(255) NOT NULL,
+			UNIQUE (user_id, guild_id)
+		);
+		CREATE TABLE discord_identities (
+			user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+			discord_user_id VARCHAR(30) NOT NULL,
+			discord_username VARCHAR(255)
+		);
+		CREATE UNIQUE INDEX uq_discord_identities_discord_user_id
+			ON discord_identities (discord_user_id);`
 	_, err = pool.Exec(ctx, schema)
 	require.NoError(t, err)
 
@@ -231,6 +249,17 @@ func setupTestRepo(t *testing.T) (*Repository, func()) {
 		($1, 'twitch', 'somestreamer', 'SomeStreamer'),
 		($1, 'tiktok', 'tiktokuser', 'TikTokUser'),
 		($1, 'shared_overlay', 'some-share-id', 'A Friend')`, overlayID)
+	require.NoError(t, err)
+
+	// The owner's Discord side: one linked account and one connected guild. The stranger has
+	// neither, so the "not linked" and "not connected" branches have a real subject too.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO discord_identities (user_id, discord_user_id, discord_username) VALUES ($1, $2, 'thestreamer')`,
+		ownerID, ownerDiscordID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO discord_guilds (user_id, guild_id, guild_name) VALUES ($1, $2, 'The Guild')`,
+		ownerID, ownerGuildID)
 	require.NoError(t, err)
 
 	return New(pool), func() {


### PR DESCRIPTION
Completes ADR-0048's Discord leg — the last platform-attested one, and the one that works differently on purpose.

Twitch/Kick/YouTube hand over the moderator's own token and let the platform re-check their role on every call. **Discord has no per-user moderation API**: the shared bot performs every write, so nothing external re-checks anything and All-Chat's own decision *is* the authorization. That is why `dispatch/discord.go` has refused every delegated action until now — without a check of its own, a delegated action would have run with the streamer's full guild authority and no evidence the moderator held any of it.

## What the dispatcher checks

Guild resolved from the channel first (which is also the ADR's requirement that a source's channel actually belong to the guild being anchored against), then, **failing closed on every read error**:

1. **Owner-reach anchor** — a `discord_guilds` row for (owner, guild) on *both* paths, plus, on the delegated path only, a live read showing the owner still satisfies `owner ∥ ADMINISTRATOR ∥ MANAGE_GUILD`. That asymmetry is the anchor-strength decision already recorded in the ADR: the row is itself platform-attested, since Discord only lets someone add a bot where they hold Manage Server.
2. **The moderator's Discord identity**, without which their permissions cannot be read at all.
3. **`DiscordDelegatedActions(bot, mod)`** — the bot bounds what is *possible*, the moderator what is *permitted*, so nobody does through the bot what Discord would refuse them directly.
4. **`DiscordOutranks`** for timeout and ban only. Discord hierarchy-gates the *actor*, and the actor is the bot, which typically outranks everyone.

The decisions were already table-tested in `models` (#685) and the account link already existed (#686); this is the wiring, plus the two repository reads moderation-service was missing.

The store is a **constructor argument** rather than an opt-in setter (as Twitch's mod source is), because on Discord it is not an enhancement: a nil store refuses everything instead of quietly acting as the streamer.

## Five refusals, five remedies

They get their own outcomes, codes and audit values rather than collapsing into `denied`. On Discord no platform message accompanies a refusal, so the code *is* the explanation — and only `discord_link_required` is the moderator's own to clear; the rest are the streamer's.

## Two departures from the ADR's reason table (amended there, with reasoning)

- **The three owner-side failures share one code.** Unlinked owner, missing row, and lost `MANAGE_GUILD` all report the existing `owner_channel_unverified` rather than splitting into `discord_link_required`/`owner_guild_unverified`. The vocabulary is sorted by *who can clear a state*, and all three are the streamer's alone.
- **Capabilities makes no live Discord read.** It checks the two account links and the bot's cached permissions and leaves the moderator's own standing to the action path — exactly as Twitch's capabilities checks the scope and lets Helix decide whether they moderate the channel.

## Also fixes a live gap in #686

`api-gateway` enumerates every proxied path explicitly, and the Discord account-link routes shipped **without their gateway entries**, so all three were unreachable from the internet (verified in prod: `/api/v1/auth/discord/identity` → 404 while `/auth/discord/connect` → 401). Invisible at the time because nothing called them yet; the frontend affordance here is the first caller.

## Frontend

The link affordance both roles need (streamer in Settings, moderator on `/moderate` and from the monitor's per-source banner), copy for the new reasons and codes, and the `already_linked` case spelled out — that Discord account backs a *different* All-Chat account, which no amount of retrying fixes.

## Testing

- `moderation-service`: all packages green (`repository` 389s, `tokens` 347s, `audit` 49s — testcontainers). New: delegated dispatch (happy path + every denial + a fail-closed case per read + all four verbs), the two repository reads, the handler's outcome→code→audit mapping, and the capabilities branches.
- Frontend: `tsc`, `eslint`, `prettier`, `vitest` clean. `settings/page.tsx` keeps its two pre-existing `set-state-in-effect` errors; the new effects use the promise-callback form and add none.

Note `npm-audit (frontend)` is red repo-wide (dompurify/postcss) and unrelated.