### PR TITLE
feat(tiktok): surface coin chests as Activity & Events entries

### DIFF
--- a/frontend/src/app/overlays/[id]/events/page.tsx
+++ b/frontend/src/app/overlays/[id]/events/page.tsx
@@ -57,6 +57,7 @@ interface EventSettings {
   enable_tiktok_gifts: boolean
   enable_tiktok_follows: boolean
   enable_tiktok_shares: boolean
+  enable_tiktok_treasure_chests: boolean
   // System
   enable_token_warnings: boolean
   // Settings
@@ -458,6 +459,11 @@ export default function EventSettingsPage({ params }: { params: Promise<{ id: st
                       key: 'enable_tiktok_shares',
                       label: 'Shares',
                       desc: 'Stream shares to other platforms',
+                    },
+                    {
+                      key: 'enable_tiktok_treasure_chests',
+                      label: 'Coin Chests',
+                      desc: 'Treasure boxes of coins dropped by viewers',
                     },
                   ].map(({ key, label, desc }) => (
                     <EventToggle

--- a/frontend/src/components/overlay/CompactEvent.tsx
+++ b/frontend/src/components/overlay/CompactEvent.tsx
@@ -54,6 +54,7 @@ const EVENT_TITLE: Partial<Record<EventType, string>> = {
   follow: 'Follow',
   like_aggregate: 'Likes',
   share: 'Share',
+  treasure_chest: 'Coin Chest',
   message_deleted: 'Message Deleted',
   user_banned: 'User Banned',
   token_expiration_warning: 'Auth Warning',

--- a/frontend/src/components/overlay/EventContent.tsx
+++ b/frontend/src/components/overlay/EventContent.tsx
@@ -82,6 +82,8 @@ export function EventContent({ message }: { message: ChatMessage }) {
         return '👍'
       case 'share':
         return '🔗'
+      case 'treasure_chest':
+        return '🪙'
       case 'member_milestone':
         return '🎂'
       case 'membership_gift':
@@ -152,6 +154,8 @@ export function EventContent({ message }: { message: ChatMessage }) {
         return 'Likes!'
       case 'share':
         return 'Stream Shared!'
+      case 'treasure_chest':
+        return 'Coin Chest!'
       case 'token_expiration_warning': {
         const platform = (event.metadata?.platform as string) || 'Platform'
         return `${platform.charAt(0).toUpperCase() + platform.slice(1)} Authentication Error`

--- a/frontend/src/components/overlay/ObservabilitySummary.tsx
+++ b/frontend/src/components/overlay/ObservabilitySummary.tsx
@@ -43,6 +43,7 @@ const EVENT_TOGGLES: Array<{ key: keyof EventSettings; label: string }> = [
   { key: 'enable_tiktok_gifts', label: 'TikTok Gifts' },
   { key: 'enable_tiktok_follows', label: 'TikTok Follows' },
   { key: 'enable_tiktok_shares', label: 'TikTok Shares' },
+  { key: 'enable_tiktok_treasure_chests', label: 'TikTok Coin Chests' },
   { key: 'enable_token_warnings', label: 'Token Warnings' },
 ]
 

--- a/frontend/src/components/overlay/__tests__/ActivityPanel.test.tsx
+++ b/frontend/src/components/overlay/__tests__/ActivityPanel.test.tsx
@@ -77,6 +77,16 @@ describe('ActivityPanel', () => {
     expect(text.indexOf('Chat cleared')).toBeLessThan(text.indexOf('Subscription'))
   })
 
+  it('labels a TikTok coin chest instead of falling back to the generic badge', () => {
+    // CompactEvent keeps its own title map, separate from EventContent's switch —
+    // a missing entry silently degrades the badge to 'Event' in this very panel.
+    const item = eventItem('e2', 'treasure_chest', '2026-05-31T10:03:00.000Z')
+    item.platform = 'tiktok'
+    render(<ActivityPanel events={[item]} system={[]} moderationLog={[]} />)
+    expect(screen.getByText('Coin Chest')).toBeInTheDocument()
+    expect(screen.queryByText('Event')).not.toBeInTheDocument()
+  })
+
   it('renders system notices from the system bucket', () => {
     const system = [eventItem('s1', 'source_permission_error', '2026-05-31T10:01:00.000Z')]
     render(<ActivityPanel events={[]} system={system} moderationLog={[]} />)

--- a/frontend/src/components/overlay/__tests__/EventContent.test.tsx
+++ b/frontend/src/components/overlay/__tests__/EventContent.test.tsx
@@ -203,3 +203,23 @@ describe('EventContent — Twitch chat notices (ADR-0046)', () => {
     expect(screen.getByText('Some brand-new Twitch notice')).toBeInTheDocument()
   })
 })
+
+describe('EventContent — TikTok events', () => {
+  it('renders a coin chest with its own icon and title, not the generic fallback', () => {
+    render(<EventContent message={eventMessage('treasure_chest', { coins: 20, can_open: 1 })} />)
+    expect(screen.getByText('Coin Chest!')).toBeInTheDocument()
+    expect(screen.getByText('🪙')).toBeInTheDocument()
+    // Regression guard: a case missing from either switch renders "✨ Event!" instead.
+    expect(screen.queryByText('Event!')).not.toBeInTheDocument()
+    expect(screen.queryByText('✨')).not.toBeInTheDocument()
+  })
+
+  it('shows the coin amount from the event value pill, not twice', () => {
+    const msg = eventMessage('treasure_chest', { coins: 20, can_open: 1 })
+    msg.event!.value = { amount: 20, currency: 'coins', display_text: '20 coins' }
+    render(<EventContent message={msg} />)
+    // The normalizer's display_text is the only place the coin count is printed — `coins`
+    // is deliberately absent from the numeric-metadata footer to avoid a duplicate.
+    expect(screen.getAllByText('20 coins')).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/overlay/__tests__/ObservabilitySummary.test.tsx
+++ b/frontend/src/components/overlay/__tests__/ObservabilitySummary.test.tsx
@@ -65,6 +65,7 @@ function eventSettings(over: Partial<EventSettings> = {}): EventSettings {
     enable_tiktok_gifts: false,
     enable_tiktok_follows: false,
     enable_tiktok_shares: false,
+    enable_tiktok_treasure_chests: true,
     enable_token_warnings: true,
     tiktok_like_aggregation_window_seconds: 5,
     event_display_duration_multiplier: 1,
@@ -101,6 +102,7 @@ describe('ObservabilitySummary', () => {
     )
     expect(screen.getByText('Twitch Subs')).toBeInTheDocument()
     expect(screen.getByText('Twitch Bits')).toBeInTheDocument()
+    expect(screen.getByText('TikTok Coin Chests')).toBeInTheDocument()
     expect(screen.getByText('Token Warnings')).toBeInTheDocument()
   })
 

--- a/frontend/src/lib/types/message.ts
+++ b/frontend/src/lib/types/message.ts
@@ -41,7 +41,7 @@ export type EventType =
   // Kick
   | 'kick_subscription' | 'kick_gift_subscription' | 'kick_donation'
   // TikTok
-  | 'gift' | 'follow' | 'like_aggregate' | 'share'
+  | 'gift' | 'follow' | 'like_aggregate' | 'share' | 'treasure_chest'
   // System
   | 'token_expiration_warning'
   | 'source_permission_error'

--- a/frontend/src/lib/types/overlay.ts
+++ b/frontend/src/lib/types/overlay.ts
@@ -122,6 +122,7 @@ export interface EventSettings {
   enable_tiktok_gifts: boolean
   enable_tiktok_follows: boolean
   enable_tiktok_shares: boolean
+  enable_tiktok_treasure_chests: boolean
   // System
   enable_token_warnings: boolean
   // Aggregation

--- a/migrations/084_tiktok_treasure_chest_event_setting.sql
+++ b/migrations/084_tiktok_treasure_chest_event_setting.sql
@@ -1,0 +1,15 @@
+-- Migration: 084_tiktok_treasure_chest_event_setting
+-- Description: Add enable_tiktok_treasure_chests column to overlay_event_settings.
+--   Coin chests (TikTok's treasure boxes) arrive on the ENVELOPE message, which the
+--   listener never subscribed to, so these events were previously never emitted at
+--   all. They fire once per viewer drop, so streamers need a toggle to keep them off
+--   busy overlays: a free one, like the existing TikTok likes/gifts/follows/shares.
+--   Defaults to TRUE: the events never reached an overlay before, so enabling them is
+--   the fix, not a surprise.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS): the migration runner re-applies every
+-- migration on each pod start, so a non-idempotent statement would crash-loop
+-- fresh pods.
+
+ALTER TABLE overlay_event_settings
+    ADD COLUMN IF NOT EXISTS enable_tiktok_treasure_chests BOOLEAN NOT NULL DEFAULT TRUE;

--- a/migrations/084_tiktok_treasure_chest_event_setting_down.sql
+++ b/migrations/084_tiktok_treasure_chest_event_setting_down.sql
@@ -1,0 +1,5 @@
+-- Migration: 084_tiktok_treasure_chest_event_setting (down)
+-- Description: Remove enable_tiktok_treasure_chests column from overlay_event_settings
+
+ALTER TABLE overlay_event_settings
+    DROP COLUMN IF EXISTS enable_tiktok_treasure_chests;

--- a/services/message-processor/classifier/tier.go
+++ b/services/message-processor/classifier/tier.go
@@ -249,6 +249,16 @@ func classifyTikTokEvent(eventType string, value *models.EventValue) (tier strin
 		// Shares are medium value
 		return "medium", 15
 
+	case "treasure_chest":
+		// Coin chests: tier based on coin count, same thresholds as gifts
+		if value != nil && value.Amount >= 1000 {
+			return "high", 35 // 1000+ coins
+		} else if value != nil && value.Amount >= 100 {
+			return "medium", 20 // 100-999 coins
+		} else {
+			return "low", 10 // <100 coins
+		}
+
 	default:
 		return "medium", 15
 	}

--- a/services/message-processor/classifier/tier_test.go
+++ b/services/message-processor/classifier/tier_test.go
@@ -249,6 +249,43 @@ func TestClassifyTikTokLikeAggregate_Few(t *testing.T) {
 	assert.Equal(t, 8, duration)
 }
 
+func TestClassifyTikTokTreasureChest_Large(t *testing.T) {
+	value := &models.EventValue{
+		Amount:   1000,
+		Currency: "coins",
+	}
+	tier, duration := ClassifyEvent("tiktok", "treasure_chest", value)
+	assert.Equal(t, "high", tier)
+	assert.Equal(t, 35, duration)
+}
+
+func TestClassifyTikTokTreasureChest_Medium(t *testing.T) {
+	value := &models.EventValue{
+		Amount:   100,
+		Currency: "coins",
+	}
+	tier, duration := ClassifyEvent("tiktok", "treasure_chest", value)
+	assert.Equal(t, "medium", tier)
+	assert.Equal(t, 20, duration)
+}
+
+func TestClassifyTikTokTreasureChest_Small(t *testing.T) {
+	value := &models.EventValue{
+		Amount:   99,
+		Currency: "coins",
+	}
+	tier, duration := ClassifyEvent("tiktok", "treasure_chest", value)
+	assert.Equal(t, "low", tier)
+	assert.Equal(t, 10, duration)
+}
+
+// A chest with no value must not fall through to the medium/15 default.
+func TestClassifyTikTokTreasureChest_NilValue(t *testing.T) {
+	tier, duration := ClassifyEvent("tiktok", "treasure_chest", nil)
+	assert.Equal(t, "low", tier)
+	assert.Equal(t, 10, duration)
+}
+
 func TestClassifyUnknownPlatform(t *testing.T) {
 	tier, duration := ClassifyEvent("unknown", "event", nil)
 	assert.Equal(t, "medium", tier)

--- a/services/message-processor/filter/event_filter.go
+++ b/services/message-processor/filter/event_filter.go
@@ -182,6 +182,8 @@ func mapEventTypeToColumn(platform, eventType string) string {
 			return "enable_tiktok_follows"
 		case "share":
 			return "enable_tiktok_shares"
+		case "treasure_chest":
+			return "enable_tiktok_treasure_chests"
 		default:
 			return ""
 		}

--- a/services/message-processor/filter/event_filter_test.go
+++ b/services/message-processor/filter/event_filter_test.go
@@ -92,6 +92,7 @@ func TestMapEventTypeToColumn_TikTok(t *testing.T) {
 		{"gift", "enable_tiktok_gifts"},
 		{"follow", "enable_tiktok_follows"},
 		{"share", "enable_tiktok_shares"},
+		{"treasure_chest", "enable_tiktok_treasure_chests"},
 		{"unknown", ""},
 	}
 

--- a/services/message-processor/normalizer/tiktok_event_test.go
+++ b/services/message-processor/normalizer/tiktok_event_test.go
@@ -211,6 +211,99 @@ func TestNormalizeEvent_TikTokShare(t *testing.T) {
 	assert.Equal(t, "Shared stream", unified.Event.Value.DisplayText)
 }
 
+func TestNormalizeEvent_TikTokTreasureChest(t *testing.T) {
+	normalizer := NewTikTokNormalizer()
+
+	raw := &models.RawChatMessage{
+		MessageID: "tt-msg-7",
+		Platform:  "tiktok",
+		ChannelID: "creator",
+		UserID:    "user",
+		Username:  "ChestSender",
+		Text:      "Sent a coin chest",
+		Timestamp: time.Now(),
+		Tags:      map[string]string{},
+		EventType: "treasure_chest",
+		EventData: map[string]interface{}{
+			"coins":    20,
+			"can_open": 1,
+		},
+	}
+
+	unified, err := normalizer.NormalizeEvent(raw, "overlay-tt-7")
+	require.NoError(t, err)
+
+	assert.Equal(t, "treasure_chest", unified.Event.Type)
+	// <100 coins = low tier
+	assert.Equal(t, "low", unified.Event.Tier)
+	assert.Equal(t, 10, unified.Event.Duration)
+	assert.Equal(t, float64(20), unified.Event.Value.Amount)
+	assert.Equal(t, "coins", unified.Event.Value.Currency)
+	assert.Equal(t, "20 coins", unified.Event.Value.DisplayText)
+
+	// can_open is carried through untouched for the frontend
+	assert.Equal(t, 1, unified.Event.Metadata["can_open"])
+}
+
+// Production messages arrive as JSON over Redis Streams, so every number decodes to
+// float64 - the int literals used by the other tests never happen in prod.
+func TestNormalizeEvent_TikTokTreasureChest_JSONFloatCoins(t *testing.T) {
+	normalizer := NewTikTokNormalizer()
+
+	raw := &models.RawChatMessage{
+		MessageID: "tt-msg-8",
+		Platform:  "tiktok",
+		ChannelID: "creator",
+		UserID:    "user",
+		Username:  "ChestSender",
+		Text:      "Sent a coin chest",
+		Timestamp: time.Now(),
+		Tags:      map[string]string{},
+		EventType: "treasure_chest",
+		EventData: map[string]interface{}{
+			"coins":    float64(200),
+			"can_open": float64(2),
+		},
+	}
+
+	unified, err := normalizer.NormalizeEvent(raw, "overlay-tt-8")
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(200), unified.Event.Value.Amount)
+	assert.Equal(t, "200 coins", unified.Event.Value.DisplayText)
+	// 100-999 coins = medium tier
+	assert.Equal(t, "medium", unified.Event.Tier)
+	assert.Equal(t, 20, unified.Event.Duration)
+}
+
+// A chest with no coin payload must still produce a value rather than a nil Event.Value.
+func TestNormalizeEvent_TikTokTreasureChest_MissingCoins(t *testing.T) {
+	normalizer := NewTikTokNormalizer()
+
+	raw := &models.RawChatMessage{
+		MessageID: "tt-msg-9",
+		Platform:  "tiktok",
+		ChannelID: "creator",
+		UserID:    "user",
+		Username:  "ChestSender",
+		Text:      "Sent a coin chest",
+		Timestamp: time.Now(),
+		Tags:      map[string]string{},
+		EventType: "treasure_chest",
+		EventData: map[string]interface{}{},
+	}
+
+	unified, err := normalizer.NormalizeEvent(raw, "overlay-tt-9")
+	require.NoError(t, err)
+
+	require.NotNil(t, unified.Event.Value)
+	assert.Equal(t, float64(0), unified.Event.Value.Amount)
+	assert.Equal(t, "0 coins", unified.Event.Value.DisplayText)
+	// Chests are discrete events, never aggregated like updates
+	assert.Equal(t, "", unified.Event.AggregationID)
+	assert.Equal(t, false, unified.Event.IsUpdate)
+}
+
 func TestPluralize(t *testing.T) {
 	tests := []struct {
 		count    int

--- a/services/message-processor/normalizer/tiktok_normalizer.go
+++ b/services/message-processor/normalizer/tiktok_normalizer.go
@@ -207,6 +207,22 @@ func (n *TikTokNormalizer) NormalizeEvent(raw *models.RawChatMessage, overlayID 
 			Currency:    "share",
 			DisplayText: "Shared stream",
 		}
+
+	case "treasure_chest":
+		coins := 0
+		if c, ok := raw.EventData["coins"].(int); ok {
+			coins = c
+		} else if c, ok := raw.EventData["coins"].(float64); ok {
+			coins = int(c)
+		}
+
+		// can_open (how many viewers may claim the chest) rides along in EventInfo.Metadata,
+		// which is raw.EventData verbatim - no dedicated EventValue field for it.
+		eventValue = &models.EventValue{
+			Amount:      float64(coins),
+			Currency:    "coins",
+			DisplayText: fmt.Sprintf("%d coins", coins),
+		}
 	}
 
 	// Classify event tier and duration

--- a/services/overlay-manager/models/event_settings.go
+++ b/services/overlay-manager/models/event_settings.go
@@ -54,6 +54,9 @@ type EventSettings struct {
 	EnableTikTokGifts   bool `json:"enable_tiktok_gifts" db:"enable_tiktok_gifts"`
 	EnableTikTokFollows bool `json:"enable_tiktok_follows" db:"enable_tiktok_follows"`
 	EnableTikTokShares  bool `json:"enable_tiktok_shares" db:"enable_tiktok_shares"`
+	// Coin chests (TikTok's treasure boxes) arrive on the ENVELOPE message; they fire once
+	// per viewer drop, hence a dedicated toggle alongside likes/gifts/follows/shares.
+	EnableTikTokTreasureChests bool `json:"enable_tiktok_treasure_chests" db:"enable_tiktok_treasure_chests"`
 
 	// System Events
 	EnableTokenWarnings bool `json:"enable_token_warnings" db:"enable_token_warnings"`

--- a/services/overlay-manager/repository/event_settings_repo.go
+++ b/services/overlay-manager/repository/event_settings_repo.go
@@ -62,6 +62,7 @@ func (r *EventSettingsRepository) GetByOverlayID(ctx context.Context, overlayID 
 		       enable_youtube_member_milestones, enable_youtube_member_gifts,
 		       enable_kick_subs, enable_kick_gifts,
 		       enable_tiktok_likes, enable_tiktok_gifts, enable_tiktok_follows, enable_tiktok_shares,
+		       enable_tiktok_treasure_chests,
 		       enable_token_warnings,
 		       tiktok_like_aggregation_window_seconds, event_display_duration_multiplier,
 		       created_at, updated_at
@@ -96,11 +97,12 @@ func (r *EventSettingsRepository) Update(ctx context.Context, settings *models.E
 		    enable_tiktok_gifts = $17,
 		    enable_tiktok_follows = $18,
 		    enable_tiktok_shares = $19,
-		    enable_token_warnings = $20,
-		    tiktok_like_aggregation_window_seconds = $21,
-		    event_display_duration_multiplier = $22,
+		    enable_tiktok_treasure_chests = $20,
+		    enable_token_warnings = $21,
+		    tiktok_like_aggregation_window_seconds = $22,
+		    event_display_duration_multiplier = $23,
 		    updated_at = NOW()
-		WHERE overlay_id = $23
+		WHERE overlay_id = $24
 		RETURNING id, overlay_id,
 		          enable_twitch_subs, enable_twitch_resubs, enable_twitch_gift_subs,
 		          enable_twitch_bits, enable_twitch_raids, enable_twitch_channel_points,
@@ -109,6 +111,7 @@ func (r *EventSettingsRepository) Update(ctx context.Context, settings *models.E
 		          enable_youtube_member_milestones, enable_youtube_member_gifts,
 		          enable_kick_subs, enable_kick_gifts,
 		          enable_tiktok_likes, enable_tiktok_gifts, enable_tiktok_follows, enable_tiktok_shares,
+		          enable_tiktok_treasure_chests,
 		          enable_token_warnings,
 		          tiktok_like_aggregation_window_seconds, event_display_duration_multiplier,
 		          created_at, updated_at
@@ -134,6 +137,7 @@ func (r *EventSettingsRepository) Update(ctx context.Context, settings *models.E
 		settings.EnableTikTokGifts,
 		settings.EnableTikTokFollows,
 		settings.EnableTikTokShares,
+		settings.EnableTikTokTreasureChests,
 		settings.EnableTokenWarnings,
 		settings.TikTokLikeAggregationWindowSeconds,
 		settings.EventDisplayDurationMultiplier,
@@ -175,6 +179,7 @@ func scanEventSettings(row pgx.Row) (*models.EventSettings, error) {
 		&settings.EnableTikTokGifts,
 		&settings.EnableTikTokFollows,
 		&settings.EnableTikTokShares,
+		&settings.EnableTikTokTreasureChests,
 		&settings.EnableTokenWarnings,
 		&settings.TikTokLikeAggregationWindowSeconds,
 		&settings.EventDisplayDurationMultiplier,

--- a/services/overlay-manager/repository/event_settings_repo_test.go
+++ b/services/overlay-manager/repository/event_settings_repo_test.go
@@ -1,0 +1,307 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/overlay-manager/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// treasureChestMigration is the file that adds enable_tiktok_treasure_chests.
+const treasureChestMigration = "084_tiktok_treasure_chest_event_setting.sql"
+
+// TestEventSettingsTreasureChestBackfillsExistingOverlays applies the migration
+// set in two passes with an overlay created in between, so 084 runs against a
+// POPULATED overlay_event_settings table — exactly what a production deploy
+// does. A NOT NULL column added without a default would fail outright there,
+// and a nullable one would make the 27-column Scan blow up on every existing
+// overlay, so this asserts existing rows come out of the migration with coin
+// chests enabled.
+func TestEventSettingsTreasureChestBackfillsExistingOverlays(t *testing.T) {
+	pool, cleanup := setupEventSettingsTestDB(t)
+	defer cleanup()
+
+	before, fromChest := splitAtTreasureChestMigration(t, loadUpMigrations(t))
+	runMigrations(t, pool, before)
+
+	// An overlay that predates the column, i.e. every streamer already on prod.
+	overlayID := seedOverlayWithEventSettings(t, pool, "chest_backfill_canary")
+
+	runMigrations(t, pool, fromChest)
+
+	repo := NewEventSettingsRepositoryFromPool(pool)
+	settings, err := repo.GetByOverlayID(context.Background(), overlayID)
+	require.NoError(t, err)
+	require.NotNil(t, settings)
+
+	assert.True(t, settings.EnableTikTokTreasureChests,
+		"existing overlays must come out of migration 084 with coin chests enabled — the events never reached an overlay before, so enabling them is the fix")
+}
+
+// TestEventSettingsUpdateRoundTripKeepsEveryTogglePositioned is the guard for
+// the placeholder renumbering that inserting enable_tiktok_treasure_chests into
+// the middle of the UPDATE required: a shifted $N binds a value to a
+// NEIGHBOURING column, which silently flips an unrelated event toggle for the
+// streamer. The written pattern alternates on/off so any single-position shift
+// changes the round-tripped value and fails the comparison.
+func TestEventSettingsUpdateRoundTripKeepsEveryTogglePositioned(t *testing.T) {
+	pool, cleanup := setupEventSettingsTestDB(t)
+	defer cleanup()
+
+	runMigrations(t, pool, loadUpMigrations(t))
+	overlayID := seedOverlayWithEventSettings(t, pool, "chest_roundtrip_canary")
+
+	ctx := context.Background()
+	repo := NewEventSettingsRepositoryFromPool(pool)
+
+	settings, err := repo.GetByOverlayID(ctx, overlayID)
+	require.NoError(t, err)
+	require.NotNil(t, settings)
+
+	settings.EnableTwitchSubs = true
+	settings.EnableTwitchResubs = false
+	settings.EnableTwitchGiftSubs = true
+	settings.EnableTwitchBits = false
+	settings.EnableTwitchRaids = true
+	settings.EnableTwitchChannelPoints = false
+	settings.EnableTwitchFollows = true
+	settings.EnableTwitchWatchStreaks = false
+	settings.EnableYouTubeSuperChat = true
+	settings.EnableYouTubeSuperSticker = false
+	settings.EnableYouTubeMembers = true
+	settings.EnableYouTubeMemberMilestones = false
+	settings.EnableYouTubeMemberGifts = true
+	settings.EnableKickSubs = false
+	settings.EnableKickGifts = true
+	settings.EnableTikTokLikes = false
+	settings.EnableTikTokGifts = true
+	settings.EnableTikTokFollows = false
+	settings.EnableTikTokShares = true
+	settings.EnableTikTokTreasureChests = false
+	settings.EnableTokenWarnings = true
+	settings.TikTokLikeAggregationWindowSeconds = 45
+	settings.EventDisplayDurationMultiplier = 2.5
+
+	// Snapshot the INTENDED values first: Update overwrites *settings from the
+	// RETURNING row, so comparing against it afterwards would compare the
+	// database with itself and pass no matter how the columns were bound.
+	want := eventToggles(settings)
+
+	require.NoError(t, repo.Update(ctx, settings))
+	assert.Equal(t, want, eventToggles(settings), "RETURNING row disagrees with the values that were written")
+	assert.Equal(t, 45, settings.TikTokLikeAggregationWindowSeconds)
+	assert.InDelta(t, 2.5, settings.EventDisplayDurationMultiplier, 0.0001)
+
+	reloaded, err := repo.GetByOverlayID(ctx, overlayID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, want, eventToggles(reloaded), "re-read row disagrees with the values that were written")
+	assert.Equal(t, 45, reloaded.TikTokLikeAggregationWindowSeconds)
+	assert.InDelta(t, 2.5, reloaded.EventDisplayDurationMultiplier, 0.0001)
+
+	// The product case: a streamer turns coin chests off on a busy overlay and
+	// nothing else may move with it.
+	for _, enable := range []*bool{
+		&reloaded.EnableTwitchSubs, &reloaded.EnableTwitchResubs, &reloaded.EnableTwitchGiftSubs,
+		&reloaded.EnableTwitchBits, &reloaded.EnableTwitchRaids, &reloaded.EnableTwitchChannelPoints,
+		&reloaded.EnableTwitchFollows, &reloaded.EnableTwitchWatchStreaks,
+		&reloaded.EnableYouTubeSuperChat, &reloaded.EnableYouTubeSuperSticker, &reloaded.EnableYouTubeMembers,
+		&reloaded.EnableYouTubeMemberMilestones, &reloaded.EnableYouTubeMemberGifts,
+		&reloaded.EnableKickSubs, &reloaded.EnableKickGifts,
+		&reloaded.EnableTikTokLikes, &reloaded.EnableTikTokGifts, &reloaded.EnableTikTokFollows,
+		&reloaded.EnableTikTokShares, &reloaded.EnableTikTokTreasureChests, &reloaded.EnableTokenWarnings,
+	} {
+		*enable = true
+	}
+	require.NoError(t, repo.Update(ctx, reloaded))
+
+	reloaded.EnableTikTokTreasureChests = false
+	require.NoError(t, repo.Update(ctx, reloaded))
+
+	final, err := repo.GetByOverlayID(ctx, overlayID)
+	require.NoError(t, err)
+	require.NotNil(t, final)
+
+	for column, enabled := range eventToggles(final) {
+		if column == "enable_tiktok_treasure_chests" {
+			assert.False(t, enabled, "disabling coin chests did not stick")
+			continue
+		}
+		assert.True(t, enabled, "disabling coin chests also turned off %s", column)
+	}
+}
+
+// eventToggles projects every boolean toggle into a DB-column-keyed map, so a
+// failed comparison names the column that drifted instead of printing two
+// 27-field structs.
+func eventToggles(s *models.EventSettings) map[string]bool {
+	return map[string]bool{
+		"enable_twitch_subs":               s.EnableTwitchSubs,
+		"enable_twitch_resubs":             s.EnableTwitchResubs,
+		"enable_twitch_gift_subs":          s.EnableTwitchGiftSubs,
+		"enable_twitch_bits":               s.EnableTwitchBits,
+		"enable_twitch_raids":              s.EnableTwitchRaids,
+		"enable_twitch_channel_points":     s.EnableTwitchChannelPoints,
+		"enable_twitch_follows":            s.EnableTwitchFollows,
+		"enable_twitch_watch_streaks":      s.EnableTwitchWatchStreaks,
+		"enable_youtube_super_chat":        s.EnableYouTubeSuperChat,
+		"enable_youtube_super_sticker":     s.EnableYouTubeSuperSticker,
+		"enable_youtube_members":           s.EnableYouTubeMembers,
+		"enable_youtube_member_milestones": s.EnableYouTubeMemberMilestones,
+		"enable_youtube_member_gifts":      s.EnableYouTubeMemberGifts,
+		"enable_kick_subs":                 s.EnableKickSubs,
+		"enable_kick_gifts":                s.EnableKickGifts,
+		"enable_tiktok_likes":              s.EnableTikTokLikes,
+		"enable_tiktok_gifts":              s.EnableTikTokGifts,
+		"enable_tiktok_follows":            s.EnableTikTokFollows,
+		"enable_tiktok_shares":             s.EnableTikTokShares,
+		"enable_tiktok_treasure_chests":    s.EnableTikTokTreasureChests,
+		"enable_token_warnings":            s.EnableTokenWarnings,
+	}
+}
+
+// seedOverlayWithEventSettings inserts a user + overlay and returns the overlay
+// UUID. The 017 trigger creates the matching overlay_event_settings row, so the
+// repository reads exactly the row production would hand it.
+func seedOverlayWithEventSettings(t *testing.T, pool *pgxpool.Pool, username string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	var overlayID string
+	err := pool.QueryRow(ctx, `
+		WITH new_user AS (
+			INSERT INTO users (twitch_id, username, display_name,
+			                   access_token, refresh_token, token_expires_at)
+			VALUES ($1, $2, $2, 'access-token', 'refresh-token', NOW() + INTERVAL '4 hours')
+			RETURNING id
+		)
+		INSERT INTO overlays (user_id, name)
+		SELECT id, 'event settings overlay' FROM new_user
+		RETURNING id
+	`, uuid.NewString(), username).Scan(&overlayID)
+	require.NoError(t, err)
+
+	return overlayID
+}
+
+// splitAtTreasureChestMigration splits the ordered migration set into the files
+// that precede 084 and 084 plus everything after it.
+func splitAtTreasureChestMigration(t *testing.T, migrations []migrationFile) (before, fromChest []migrationFile) {
+	t.Helper()
+	for _, m := range migrations {
+		if m.name < treasureChestMigration {
+			before = append(before, m)
+			continue
+		}
+		fromChest = append(fromChest, m)
+	}
+	require.NotEmpty(t, before, "no migrations before %s — wrong path?", treasureChestMigration)
+	require.Equal(t, treasureChestMigration, fromChest[0].name, "%s is missing from migrations/", treasureChestMigration)
+	return before, fromChest
+}
+
+type migrationFile struct {
+	name string
+	sql  string
+}
+
+// loadUpMigrations reads migrations/[0-9]*.sql from the repo root in
+// lexicographic order, skipping *_down.sql — the same selection as
+// scripts/run-migrations.sh.
+func loadUpMigrations(t *testing.T) []migrationFile {
+	t.Helper()
+	dir := filepath.Join("..", "..", "..", "migrations")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err, "failed to read migrations dir %s", dir)
+
+	var files []migrationFile
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".sql") || strings.HasSuffix(name, "_down.sql") {
+			continue
+		}
+		if name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err, "failed to read migration %s", name)
+		files = append(files, migrationFile{name: name, sql: string(content)})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+	require.NotEmpty(t, files, "no migration files found — wrong path?")
+	return files
+}
+
+func runMigrations(t *testing.T, pool *pgxpool.Pool, migrations []migrationFile) {
+	t.Helper()
+	ctx := context.Background()
+	for _, m := range migrations {
+		_, err := pool.Exec(ctx, m.sql)
+		require.NoError(t, err, "migration %s failed", m.name)
+	}
+}
+
+// setupEventSettingsTestDB starts a Postgres container with NO pre-created
+// schema, so the real migration set owns the database like a fresh production
+// cluster. The other repositories in this package hand-write a simplified
+// schema, but overlay_event_settings is exactly what migration 084 changes —
+// a hand-written copy would test the copy, not the migration.
+func setupEventSettingsTestDB(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpass"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	require.NoError(t, err)
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		pool.Close()
+		if err := pgContainer.Terminate(ctx); err != nil {
+			t.Logf("Failed to terminate container: %v", err)
+		}
+	}
+
+	return pool, cleanup
+}

--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -58,7 +58,7 @@ import { LeadershipCoordinator } from './coordination/leadership.js';
 
 // Import demand subscriber (Phase 5)
 import { DemandSubscriber, DemandSource } from './demand/subscriber.js';
-import { tiktokAvatarUrl } from './avatar.js';
+import { pickAvatarUrl, tiktokAvatarUrl } from './avatar.js';
 
 // Environment variables
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
@@ -162,7 +162,7 @@ interface RawChatMessage {
   text: string;
   timestamp: string; // ISO 8601
   tags: Record<string, string>;
-  event_type?: string; // "gift", "follow", "like_aggregate", "share", etc.
+  event_type?: string; // "gift", "follow", "like_aggregate", "share", "treasure_chest", etc.
   event_data?: Record<string, unknown>; // Event-specific payload
 }
 
@@ -197,9 +197,17 @@ interface TikTokUserIdentity {
   isModeratorOfAnchor?: boolean;
 }
 
+// Localized display string attached to a message. `key` is a stable template id
+// (e.g. `pm_mt_ttlive_superfanbox_join`) — the connector itself probes it to tell
+// the envelope products apart; see isTikTokCoinChest.
+interface TikTokDisplayText {
+  key?: string;
+}
+
 interface TikTokCommon {
   msgId?: string;
   createTime?: string;
+  displayText?: TikTokDisplayText;
 }
 
 interface TikTokChatData {
@@ -236,9 +244,77 @@ interface TikTokSocialData {
   user?: TikTokUser;
 }
 
+// The chest ("red envelope") a viewer drops into the stream. Note the sender is
+// inlined here as flat `sendUser*` fields rather than a nested `user`, and the
+// avatar is a single image model rather than the thumb/medium/large trio.
+interface TikTokEnvelopeInfo {
+  envelopeId?: string; // stable per-chest id, identical on every frame for that chest
+  businessType?: number; // which envelope product this is; see isTikTokCoinChest
+  diamondCount?: number; // coins in the chest
+  peopleCount?: number; // how many viewers may claim it
+  sendUserId?: string; // numeric sender id
+  sendUserName?: string; // sender display name (this payload carries no @handle)
+  sendUserAvatar?: TikTokImageModel;
+}
+
+interface TikTokEnvelopeData {
+  common?: TikTokCommon;
+  envelopeInfo?: TikTokEnvelopeInfo;
+  display?: number; // `EnvelopeDisplay`: add vs. remove the chest; see isTikTokEnvelopeDrop
+}
+
 // Reads the TikTok @handle, falling back to the numeric id then a placeholder.
 function tiktokUserHandle(user: TikTokUser | undefined): string {
   return user?.displayId || user?.id || 'unknown';
+}
+
+// `EnvelopeBusinessType` values. TikTok multiplexes several products onto the
+// ENVELOPE message and the connector forwards every one of them — its dispatcher
+// emits SUPER_FAN_BOX and then falls through to ENVELOPE for the *same* frame —
+// so the coin chest has to be picked out by business type. Only the two
+// diamond-bearing variants are chests; the rest (portals, merch drops, shells,
+// fan-club boxes, Super Fan Box) must not surface as one.
+const TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN = 0;
+const TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES = new Set<number>([
+  1, // BUSINESS_TYPE_USER_DIAMOND — a viewer drops a chest
+  2 // BUSINESS_TYPE_PLATFORM_DIAMOND — TikTok drops one into the room
+]);
+
+// Tells a coin chest apart from the other envelope products.
+//
+// `businessType` is the authoritative signal, but it decodes to UNKNOWN when
+// TikTok omits it on the wire; treating UNKNOWN as "not a chest" would silently
+// emit nothing for the whole feature, so it falls back to the same display-text
+// probe the connector uses to spot a Super Fan Box.
+function isTikTokCoinChest(data: TikTokEnvelopeData): boolean {
+  if (data.common?.displayText?.key?.toLowerCase().includes('ttlive_superfanbox')) {
+    return false;
+  }
+
+  const businessType = data.envelopeInfo?.businessType ?? TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN;
+  return (
+    businessType === TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN ||
+    TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES.has(businessType)
+  );
+}
+
+// `EnvelopeDisplay` values. The ENVELOPE message doubles as a remove
+// instruction: once a chest expires or has been claimed by everyone it may hold,
+// TikTok re-sends it with display=HIDE so the client takes it off screen. That
+// frame repeats the whole envelopeInfo under a fresh msgId, and it can land long
+// after the dedup TTL has forgotten the drop, so this flag is what keeps one
+// chest from being published twice.
+const TIKTOK_ENVELOPE_DISPLAY_UNKNOWN = 0;
+const TIKTOK_ENVELOPE_DISPLAY_NEW = 1;
+
+// Tells a chest being dropped apart from one being taken off screen.
+//
+// As with businessType, `display` decodes to UNKNOWN when TikTok omits it on the
+// wire; treating UNKNOWN as "not a drop" would silently emit nothing for the
+// whole feature, so only an explicit non-NEW display is dropped.
+function isTikTokEnvelopeDrop(data: TikTokEnvelopeData): boolean {
+  const display = data.display ?? TIKTOK_ENVELOPE_DISPLAY_UNKNOWN;
+  return display === TIKTOK_ENVELOPE_DISPLAY_UNKNOWN || display === TIKTOK_ENVELOPE_DISPLAY_NEW;
 }
 
 // Like aggregation window for tracking likes over 30-second periods
@@ -876,6 +952,10 @@ class TikTokListenerService {
         this.handleShare(username, overlayId, data);
       });
 
+      connection.on(WebcastEvent.ENVELOPE, (data) => {
+        this.handleTreasureBox(username, overlayId, data);
+      });
+
       // Cast to EventEmitter for lifecycle events not in ClientEventMap
       const emitter = connection as unknown as EventEmitter;
 
@@ -1292,6 +1372,92 @@ class TikTokListenerService {
       logger.debug('Published TikTok share event', { username, overlay_id: overlayId });
     } catch (error) {
       logger.error('Failed to handle share event', { username, error });
+    }
+  }
+
+  private async handleTreasureBox(username: string, overlayId: string, data: TikTokEnvelopeData): Promise<void> {
+    try {
+      this.heartbeatMonitor.recordMessage(username);
+
+      // ENVELOPE also carries Super Fan Box (and other) frames; publishing those
+      // would show the streamer a coin chest nobody sent.
+      if (!isTikTokCoinChest(data)) {
+        logger.debug('Skipping non-chest ENVELOPE event', {
+          username,
+          business_type: data.envelopeInfo?.businessType
+        });
+        return;
+      }
+
+      // The same chest comes back as a HIDE frame when it expires or is fully
+      // claimed; republishing that would render the drop twice in the activity
+      // panel and the overlay.
+      if (!isTikTokEnvelopeDrop(data)) {
+        logger.debug('Skipping non-drop ENVELOPE event', {
+          username,
+          display: data.display
+        });
+        return;
+      }
+
+      const envelope = data.envelopeInfo;
+      // The sender may be absent entirely on some frames; a chest without an
+      // identifiable sender must still publish (as Anonymous) rather than throw.
+      const senderId = envelope?.sendUserId || 'unknown';
+      const coins = envelope?.diamondCount || 0;
+      const canOpen = envelope?.peopleCount || 0;
+      const text = 'Sent a coin chest';
+
+      const msgId = data.common?.msgId;
+      const createTime = data.common?.createTime;
+      const timestamp = createTime ? new Date(parseInt(createTime)).toISOString() : new Date().toISOString();
+
+      // Key dedup on the envelope's own id rather than the per-frame msgId, so
+      // every frame TikTok emits for one chest — a replay after a reconnect, or
+      // the same room seen twice across pooled connections — collapses into a
+      // single event. The prefix keeps envelope ids out of the msgId namespace
+      // the other handlers share. Falls back to msgId, as the chat handler does,
+      // when TikTok omits the envelope id.
+      const dedupKey = envelope?.envelopeId ? `envelope:${envelope.envelopeId}` : msgId;
+      if (this.messageDeduplicator.isDuplicate(dedupKey, username, text)) {
+        logger.debug('Skipping duplicate treasure chest event', { msg_id: msgId, username });
+        return;
+      }
+
+      const rawMessage: RawChatMessage = {
+        message_id: msgId || randomUUID(),
+        platform: 'tiktok',
+        channel_id: username,
+        user_id: senderId,
+        username: envelope?.sendUserName || 'Anonymous',
+        text,
+        timestamp: timestamp,
+        tags: {
+          overlay_id: overlayId,
+          user_unique_id: '', // no @handle in the envelope payload; the normalizer falls back to user_id
+          profile_picture_url: pickAvatarUrl(envelope?.sendUserAvatar)
+        },
+        event_type: 'treasure_chest',
+        event_data: {
+          coins,
+          can_open: canOpen
+        }
+      };
+
+      await this.redis.xAdd('chat:raw', '*', { data: JSON.stringify(rawMessage) }, { TRIM: { strategy: 'MAXLEN', strategyModifier: '~', threshold: 100000 } });
+      // Logs the decoded fields, not just the outcome: `tiktok-live-proto/v3` is a
+      // package subpath this tsconfig cannot resolve, so a wire-format rename here
+      // compiles clean and only shows up as zeroed values at runtime.
+      logger.debug('Published TikTok treasure chest event', {
+        username,
+        overlay_id: overlayId,
+        business_type: envelope?.businessType,
+        sender: senderId,
+        coins,
+        can_open: canOpen
+      });
+    } catch (error) {
+      logger.error('Failed to handle treasure chest event', { username, error });
     }
   }
 


### PR DESCRIPTION
## Why

A streamer reported the gap: viewers dropping a **coin chest** during a TikTok live never showed up anywhere live, so they only discovered them afterwards in the TikTok replay.

The cause was upstream of the UI. `tiktok-listener` subscribed to `CHAT`, `GIFT`, `LIKE`, `FOLLOW` and `SOCIAL`, but never to `ENVELOPE`, which is the message TikTok carries treasure boxes on. The event never entered `chat:raw`, so nothing downstream could render it.

The Activity & Events panel itself needed no change: `isAudienceEvent()` is allow-by-default, so the event surfaces there once it flows.

## What

- **Listener** subscribes to `WebcastEvent.ENVELOPE` and publishes `event_type: "treasure_chest"` with `coins` / `can_open`.
- **`ENVELOPE` is multiplexed.** TikTok puts several products on this message (portals, merch drops, shells, fan-club boxes, Super Fan Box) and the connector forwards all of them. Only the diamond-bearing business types (`USER_DIAMOND`, `PLATFORM_DIAMOND`) are treated as chests.
- **`HIDE` frames are skipped.** A chest that expires or is fully claimed is re-sent with `display=HIDE`, repeating the whole payload under a fresh `msgId`, potentially long after the dedup TTL forgot the drop. Without this filter one chest renders twice.
- **Dedup keys on `envelopeId`**, not the per-frame `msgId`, so reconnect replays and pooled connections collapse to a single event.
- **message-processor** normalizes the event, tiers it by coin count (>=1000 high / >=100 medium / else low, mirroring gifts) and maps it to the new toggle.
- **Migration 084** adds `enable_tiktok_treasure_chests`, idempotent, defaulting `TRUE` because these events were previously never emitted at all, so enabling them is the fix rather than a surprise. Not mirrored into `migrations/init/`, following the precedent of 079.
- **Frontend** renders it in both `EventContent` and `CompactEvent`, and exposes an **ungated** toggle beside the other TikTok events.

## Notes for review

- **The sender may be absent.** It arrives as flat `sendUser*` fields on `envelopeInfo` (not a nested `user` like other events, and with no `@handle`), and can be missing entirely on some frames. That degrades to `Anonymous` rather than throwing. Accepted trade-off given the TikTok stack's general instability.
- **Tier thresholds are a guess.** Coins and diamonds are different units, so the gift thresholds were copied as a starting point. Worth retuning once real chests are observed.
- **`peopleCount` -> `can_open`** rides along in `EventInfo.Metadata` rather than getting a dedicated `EventValue` field.

## Verification

Run locally against a nix-provided toolchain (`CGO_ENABLED=0`, no gcc in the environment):

| Check | Result |
|---|---|
| `tiktok-listener` `tsc --noEmit` | pass |
| `tiktok-listener` `vitest run` | 30/30 pass |
| `message-processor` build / vet | pass |
| `message-processor` classifier + normalizer + filter tests | pass |
| `overlay-manager` build / vet | pass |
| `frontend` `tsc --noEmit` | pass |
| `frontend` EventContent / ObservabilitySummary / ActivityPanel / parity tests | 32/32 pass |

**Not verified locally:** the two new `event_settings_repo_test.go` tests are testcontainers-based and need Docker, which is unavailable in the dev environment. They cover the repo SQL column arity and the update round-trip, which is exactly the part no compiler catches, so they need a green CI run before merge.

Field shapes (`envelopeInfo`, `EnvelopeDisplay`, `EnvelopeBusinessType`) were verified against the installed `tiktok-live-proto/v3`, which is what the connector actually imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)