### PR TITLE
feat(metrics): expose DAU/WAU/MAU of actual overlay usage

### DIFF
--- a/deployments/k8s/monitoring/grafana-dashboards/README.md
+++ b/deployments/k8s/monitoring/grafana-dashboards/README.md
@@ -1,0 +1,74 @@
+# All-Chat Grafana Dashboards
+
+Dashboards are **not** stored in this repo. They live in the GitOps repo, as
+ConfigMaps carrying the `grafana_dashboard: "1"` label that Grafana's sidecar
+watches:
+
+    caesar-deployment: apps/platform/allchat-monitoring/
+      allchat-grafana-dashboard-<slug>.yaml   # the dashboard, JSON embedded
+      kustomization.yaml                      # must list the file, or ArgoCD
+                                              # reports Synced and creates nothing
+
+The ArgoCD app `allchat-monitoring` syncs that path automatically with
+`prune: true` and `selfHeal: true`, so a dashboard applied by hand here would
+either drift from git or be reverted. Keeping a second copy in this repo is what
+made the alert ConfigMaps diverge from the cluster in the past.
+
+This file exists to document the metrics the All-Chat dashboards read, since
+those are produced by code in *this* repo.
+
+## User Growth & Actual Usage
+
+Dashboard uid `allchat-user-growth`, "All-Chat: User Growth & Actual Usage".
+Daily / weekly / monthly active streamers, stickiness (DAU/MAU), activation rate,
+and sign-ups for context.
+
+| Metric | Emitted by | Notes |
+|--------|-----------|-------|
+| `allchat_active_users{window="24h"\|"7d"\|"30d"}` | auth-service | DAU/WAU/MAU of real overlay usage, sampled from the database every `USAGE_SAMPLE_INTERVAL_SECONDS` (default 120) |
+| `allchat_total_users_by_platform{platform}` | auth-service | Cumulative sign-ups, seeded from the database at startup |
+| `allchat_user_registrations_total{platform}` | auth-service | Sign-up counter |
+
+Aggregate the gauges with `max(...)` / `max by (platform) (...)`, never `sum(...)`:
+every auth-service replica reports the same fleet-wide value, so summing would
+multiply the numbers by the replica count.
+
+### What "active" means
+
+A distinct, non-banned owner of an overlay whose `overlays.last_connected_at`
+falls inside the window. api-gateway bumps that column on every demand-bearing
+WebSocket attach and on each heartbeat tick (~2 min) while the overlay stays
+attached, so it tracks overlays actually being used in a stream, not logins:
+
+- Viewer "participate" sockets are demand-free and deliberately never bump it.
+- An overlay created but never opened is excluded (its `last_connected_at` still
+  equals its `created_at`) - otherwise the graph would just retell the sign-up
+  story.
+- Logins are not a usable proxy: `users.updated_at` is churned by the daily
+  automated token refresh.
+
+The definition lives in `services/auth-service/repository/usage_repository.go`
+and is shared with the admin dashboard's active-user tiles, so the graph and the
+admin page cannot drift apart.
+
+### Retroactive history
+
+`allchat_active_users` is a Prometheus gauge, so the graph starts filling when
+the metric ships and cannot backfill. For history that predates the rollout,
+`stream_sessions` (written by api-gateway on every session start) holds
+per-overlay session rows:
+
+```sql
+SELECT date_trunc('day', s.started_at) AS day,
+       COUNT(DISTINCT o.user_id)       AS daily_active_users
+FROM stream_sessions s
+JOIN overlays o ON o.id = s.overlay_id
+JOIN users u ON u.id = o.user_id
+WHERE u.is_banned = false
+  AND s.started_at >= NOW() - INTERVAL '180 days'
+GROUP BY 1
+ORDER BY 1;
+```
+
+Graphing that needs a PostgreSQL datasource pointed at the CNPG cluster, which
+does not exist yet.

--- a/docs/OBSERVABILITY_STRATEGY.md
+++ b/docs/OBSERVABILITY_STRATEGY.md
@@ -863,6 +863,32 @@ How long overlays are actively viewed/used.
 
 ---
 
+#### Gauge: `allchat_active_users`
+Distinct streamers who actually used an overlay within a rolling window — the
+DAU/WAU/MAU of real product usage, as opposed to sign-ups.
+
+**Labels**:
+- `window`: `24h`, `7d`, `30d`
+
+**Emitted by**: auth-service, polled from the database by the sampler in
+`services/auth-service/usage/` every `USAGE_SAMPLE_INTERVAL_SECONDS` (default
+120). Every replica reports the same fleet-wide value, so aggregate with
+`max(...)`, never `sum(...)`.
+
+**Calculation**: distinct non-banned owners of an overlay whose
+`overlays.last_connected_at` (bumped by api-gateway on demand-bearing WebSocket
+attach and on each ~2min heartbeat tick) falls inside the window, excluding
+overlays that were created but never opened. Definition lives in
+`services/auth-service/repository/usage_repository.go`, shared with the admin
+dashboard's active-user tiles.
+
+**Graphed by**: *All-Chat: User Growth & Actual Usage* (dashboard uid
+`allchat-user-growth`), provisioned from the GitOps repo at
+`caesar-deployment: apps/platform/allchat-monitoring/`. See
+`deployments/k8s/monitoring/grafana-dashboards/README.md`.
+
+---
+
 ### 9.2 Platform Usage
 
 #### Counter: `allchat_messages_by_platform_total`

--- a/services/auth-service/README.md
+++ b/services/auth-service/README.md
@@ -86,6 +86,10 @@ LOG_LEVEL=info  # debug, info, warn, error
 OTEL_ENABLED=false
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317
 
+# Usage metrics: how often the active-user windows behind
+# allchat_active_users{window=...} are re-sampled from the database
+USAGE_SAMPLE_INTERVAL_SECONDS=120
+
 # Application
 APP_VERSION=dev
 ENVIRONMENT=development
@@ -248,6 +252,26 @@ GET /health/ready
 # Prometheus metrics
 GET /metrics
 ```
+
+Besides the HTTP/OAuth metrics, auth-service owns the platform's user-growth
+series:
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `allchat_user_registrations_total{platform}` | counter | New streamer sign-ups |
+| `allchat_viewer_registrations_total{platform}` | counter | New viewer sign-ups |
+| `allchat_total_users_by_platform{platform}` | gauge | Cumulative sign-ups, seeded from the DB at startup |
+| `allchat_active_users{window="24h"\|"7d"\|"30d"}` | gauge | DAU/WAU/MAU of **actual overlay usage** |
+
+`allchat_active_users` is polled from the database by the sampler in `usage/`
+(every `USAGE_SAMPLE_INTERVAL_SECONDS`) rather than incremented in-process:
+"streamers who used an overlay in the last 24h" is a fleet-wide property of a
+window that outlives any pod. The definition of "active" lives in
+`repository/usage_repository.go` and is shared with the admin dashboard's
+active-user tiles. Graphed by the *All-Chat: User Growth & Actual Usage* dashboard
+(provisioned from the GitOps repo, see
+`deployments/k8s/monitoring/grafana-dashboards/README.md`); each replica reports
+the same fleet-wide value, so queries must use `max(...)`, never `sum(...)`.
 
 ---
 

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/caesar/all-chat/services/auth-service/handlers"
 	"github.com/caesar/all-chat/services/auth-service/oauth"
 	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/caesar/all-chat/services/auth-service/usage"
 	sharedAuth "github.com/caesar/all-chat/shared/auth"
 	"github.com/caesar/all-chat/shared/database"
 	"github.com/caesar/all-chat/shared/encryption"
@@ -268,6 +269,17 @@ func main() {
 		businessMetrics.InitTotalUsersByPlatform(counts)
 		log.Info("Seeded allchat_total_users_by_platform from database", zap.Any("counts", counts))
 	}
+
+	// Publish allchat_active_users{window=24h|7d|30d} — the DAU/WAU/MAU of real
+	// overlay usage (sign-up counters say nothing about whether an overlay was
+	// ever opened). Sampled from the database on a ticker; see package usage.
+	usageRepo := repository.NewUsageRepository(db)
+	usageSampler := usage.NewSampler(usageRepo, businessMetrics, log,
+		time.Duration(getEnvAsIntOrDefault("USAGE_SAMPLE_INTERVAL_SECONDS", int(usage.DefaultInterval.Seconds())))*time.Second)
+	usageCtx, stopUsageSampler := context.WithCancel(context.Background())
+	defer stopUsageSampler()
+	go usageSampler.Run(usageCtx)
+
 	healthHandler := handlers.NewHealthHandler(db, redisClient)
 	// audit #20: impersonation tokens are short-lived (default 2h), independent of
 	// the 24h session JWT, so a leaked impersonation token has a small window.

--- a/services/auth-service/handlers/admin.go
+++ b/services/auth-service/handlers/admin.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/caesar/all-chat/services/auth-service/models"
+	"github.com/caesar/all-chat/services/auth-service/repository"
 	"github.com/caesar/all-chat/shared/auth"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -438,11 +439,10 @@ func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
 		ActiveOverlays int            `json:"active_overlays"`
 		TotalSources   map[string]int `json:"total_sources"`
 		// Active users: distinct non-banned owners of an overlay whose WebSocket
-		// connection was seen within the window. overlays.last_connected_at is
-		// heartbeat-refreshed (~2min) while an overlay is live, so it is the
-		// truest signal of real product usage. Logins are not separately tracked
-		// (users.updated_at is polluted by the daily automated token refresh),
-		// which is why overlay connections define activity here.
+		// connection was seen within the window. The definition lives in
+		// repository.UsageRepository, shared with the Prometheus usage sampler
+		// that publishes allchat_active_users{window=...}, so this snapshot and
+		// the Grafana growth graph can never disagree.
 		ActiveUsers24h int `json:"active_users_24h"`
 		ActiveUsers7d  int `json:"active_users_7d"`
 		ActiveUsers30d int `json:"active_users_30d"`
@@ -486,21 +486,14 @@ func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
 		}
 	}
 
-	// Active users (rolling windows): distinct owners of a recently-connected
-	// overlay, excluding banned users. Computed in one round trip via FILTER;
-	// the outer 30d bound keeps the scan to the window that feeds every bucket.
-	err = h.db.QueryRow(c.Request.Context(), `
-		SELECT
-			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '24 hours'),
-			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '7 days'),
-			COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '30 days')
-		FROM overlays o
-		JOIN users u ON u.id = o.user_id
-		WHERE u.is_banned = false
-		  AND o.last_connected_at >= NOW() - INTERVAL '30 days'
-	`).Scan(&stats.ActiveUsers24h, &stats.ActiveUsers7d, &stats.ActiveUsers30d)
+	// Active users (rolling windows), via the shared usage definition.
+	activeUsers, err := repository.NewUsageRepository(h.db).ActiveUserCounts(c.Request.Context())
 	if err != nil {
 		h.logger.Error("Failed to count active users", zap.Error(err))
+	} else {
+		stats.ActiveUsers24h = activeUsers.Day
+		stats.ActiveUsers7d = activeUsers.Week
+		stats.ActiveUsers30d = activeUsers.Month
 	}
 
 	c.JSON(http.StatusOK, stats)

--- a/services/auth-service/handlers/admin_stats_test.go
+++ b/services/auth-service/handlers/admin_stats_test.go
@@ -82,6 +82,7 @@ func setupStatsTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
 			is_active BOOLEAN NOT NULL DEFAULT TRUE,
+			created_at TIMESTAMP DEFAULT NOW(),
 			last_connected_at TIMESTAMP NOT NULL DEFAULT NOW()
 		);
 		CREATE TABLE IF NOT EXISTS overlay_chat_sources (
@@ -113,20 +114,35 @@ func insertUser(t *testing.T, pool *pgxpool.Pool, banned bool) string {
 }
 
 // insertOverlay creates an overlay for userID whose last_connected_at is `ago`
-// before now.
+// before now. created_at is set well before that, since activity requires a
+// last_connected_at that was actually bumped after the row was created.
 func insertOverlay(t *testing.T, pool *pgxpool.Pool, userID string, ago time.Duration) {
 	t.Helper()
 	_, err := pool.Exec(context.Background(),
-		`INSERT INTO overlays (user_id, last_connected_at) VALUES ($1, NOW() - $2::interval)`,
+		`INSERT INTO overlays (user_id, created_at, last_connected_at)
+		 VALUES ($1, NOW() - INTERVAL '90 days', NOW() - $2::interval)`,
 		userID, ago.String())
 	if err != nil {
 		t.Fatalf("insert overlay: %v", err)
 	}
 }
 
+// insertNeverOpenedOverlay creates an overlay the way overlay-manager does, with
+// no timestamps given, so created_at and last_connected_at both land on the
+// statement's NOW() and the overlay reads as "created but never opened".
+func insertNeverOpenedOverlay(t *testing.T, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO overlays (user_id) VALUES ($1)`, userID); err != nil {
+		t.Fatalf("insert never-opened overlay: %v", err)
+	}
+}
+
 // TestGetDashboardStats_ActiveUsers verifies the rolling-window active-user
-// counts: an active user is a distinct non-banned owner of an overlay whose
-// last_connected_at falls inside the 24h / 7d / 30d window.
+// counts: an active user is a distinct non-banned owner of an overlay that was
+// genuinely connected inside the 24h / 7d / 30d window. Creating an overlay is
+// not usage, so an overlay whose last_connected_at was never bumped past its
+// created_at does not count.
 func TestGetDashboardStats_ActiveUsers(t *testing.T) {
 	pool, cleanup := setupStatsTestDB(t)
 	defer cleanup()
@@ -156,6 +172,10 @@ func TestGetDashboardStats_ActiveUsers(t *testing.T) {
 	insertOverlay(t, pool, u6, 2*time.Hour)
 	insertOverlay(t, pool, u6, 5*time.Hour)
 
+	// u7: signed up and created an overlay but never opened it -> not usage
+	u7 := insertUser(t, pool, false)
+	insertNeverOpenedOverlay(t, pool, u7)
+
 	handler := &AdminHandler{db: pool, logger: zap.NewNop()}
 
 	gin.SetMode(gin.TestMode)
@@ -180,8 +200,8 @@ func TestGetDashboardStats_ActiveUsers(t *testing.T) {
 		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
 	}
 
-	if stats.TotalUsers != 6 {
-		t.Errorf("total_users = %d, want 6", stats.TotalUsers)
+	if stats.TotalUsers != 7 {
+		t.Errorf("total_users = %d, want 7", stats.TotalUsers)
 	}
 	if stats.BannedUsers != 1 {
 		t.Errorf("banned_users = %d, want 1", stats.BannedUsers)

--- a/services/auth-service/repository/usage_repository.go
+++ b/services/auth-service/repository/usage_repository.go
@@ -1,0 +1,96 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// rowQuerier is the slice of pgx used by UsageRepository. Narrowing it to
+// QueryRow keeps the repository usable with a *pgxpool.Pool, a transaction, or
+// a stub in tests.
+type rowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// ActiveUserCounts holds the rolling-window active-user counts that define
+// "actual product usage": distinct streamers whose overlay was genuinely
+// connected within the window (DAU / WAU / MAU).
+type ActiveUserCounts struct {
+	Day   int `json:"day"`
+	Week  int `json:"week"`
+	Month int `json:"month"`
+}
+
+// UsageRepository answers product-usage questions over the operational tables.
+// It is the single home of the "active user" definition so the admin dashboard
+// and the Prometheus usage sampler can never drift apart.
+type UsageRepository struct {
+	db rowQuerier
+}
+
+// NewUsageRepository creates a usage repository over the given querier.
+func NewUsageRepository(db rowQuerier) *UsageRepository {
+	return &UsageRepository{db: db}
+}
+
+// activeUserCountsQuery counts distinct owners of a recently-connected overlay
+// per rolling window in one round trip.
+//
+// Why overlays.last_connected_at defines activity:
+//   - api-gateway bumps it on every demand-bearing WebSocket attach AND on each
+//     heartbeat tick (~2min) while the overlay stays attached, so it tracks real
+//     overlay usage rather than a login. Viewer "participate" sockets are
+//     demand-free and deliberately do NOT bump it (see websocket.Manager).
+//   - logins are not a usable proxy: users.updated_at is polluted by the daily
+//     automated token refresh.
+//
+// Two exclusions keep the number honest:
+//   - banned users never count as active.
+//   - `last_connected_at > created_at` filters overlays that were created but
+//     never opened. Migration 052 gave the column DEFAULT NOW(), so a fresh
+//     overlay row starts with last_connected_at exactly equal to created_at
+//     (same statement, same NOW()); any real attach bumps it strictly later.
+//     Without this, merely creating an overlay would count as 30 days of usage
+//     and the metric would just re-tell the sign-up story.
+//
+// The outer 30d bound keeps the scan to the window that feeds every bucket and
+// lets idx_overlays_last_connected_at do the work.
+const activeUserCountsQuery = `
+	SELECT
+		COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '24 hours'),
+		COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '7 days'),
+		COUNT(DISTINCT o.user_id) FILTER (WHERE o.last_connected_at >= NOW() - INTERVAL '30 days')
+	FROM overlays o
+	JOIN users u ON u.id = o.user_id
+	WHERE u.is_banned = false
+	  AND o.last_connected_at > o.created_at
+	  AND o.last_connected_at >= NOW() - INTERVAL '30 days'
+`
+
+// ActiveUserCounts returns the number of distinct streamers who actually used an
+// overlay in the last 24 hours, 7 days and 30 days.
+func (r *UsageRepository) ActiveUserCounts(ctx context.Context) (ActiveUserCounts, error) {
+	var counts ActiveUserCounts
+	if err := r.db.QueryRow(ctx, activeUserCountsQuery).Scan(&counts.Day, &counts.Week, &counts.Month); err != nil {
+		return ActiveUserCounts{}, fmt.Errorf("failed to count active users: %w", err)
+	}
+	return counts, nil
+}

--- a/services/auth-service/repository/usage_repository_test.go
+++ b/services/auth-service/repository/usage_repository_test.go
@@ -1,0 +1,157 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// usageSchema mirrors the production shape the active-user query depends on:
+// users.is_banned, and overlays.created_at / last_connected_at both defaulting to
+// NOW() (migration 001 + 052). The shared defaults are the whole point — a
+// never-opened overlay must come out with the two timestamps equal.
+const usageSchema = `
+	CREATE TABLE users (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		username VARCHAR(50) UNIQUE NOT NULL,
+		is_banned BOOLEAN NOT NULL DEFAULT FALSE,
+		created_at TIMESTAMP DEFAULT NOW()
+	);
+
+	CREATE TABLE overlays (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+		name VARCHAR(100) NOT NULL,
+		created_at TIMESTAMP DEFAULT NOW(),
+		updated_at TIMESTAMP DEFAULT NOW(),
+		last_connected_at TIMESTAMP NOT NULL DEFAULT NOW()
+	);
+`
+
+func seedUser(t *testing.T, pool *pgxpool.Pool, username string, banned bool) string {
+	t.Helper()
+	var id string
+	err := pool.QueryRow(context.Background(),
+		`INSERT INTO users (username, is_banned) VALUES ($1, $2) RETURNING id`,
+		username, banned).Scan(&id)
+	if err != nil {
+		t.Fatalf("failed to seed user %s: %v", username, err)
+	}
+	return id
+}
+
+// seedOverlay inserts an overlay that was created 60 days ago and last connected
+// `connectedAgo` ago (a Postgres interval literal such as '3 days').
+func seedOverlay(t *testing.T, pool *pgxpool.Pool, userID, name, connectedAgo string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO overlays (user_id, name, created_at, updated_at, last_connected_at)
+		VALUES ($1, $2, NOW() - INTERVAL '60 days', NOW() - INTERVAL '60 days', NOW() - $3::interval)`,
+		userID, name, connectedAgo)
+	if err != nil {
+		t.Fatalf("failed to seed overlay %s: %v", name, err)
+	}
+}
+
+// seedNeverOpenedOverlay inserts an overlay the way overlay-manager does — no
+// timestamp columns given — so created_at and last_connected_at both fall to the
+// statement's NOW() and are exactly equal.
+func seedNeverOpenedOverlay(t *testing.T, pool *pgxpool.Pool, userID, name string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO overlays (user_id, name) VALUES ($1, $2)`, userID, name); err != nil {
+		t.Fatalf("failed to seed never-opened overlay %s: %v", name, err)
+	}
+}
+
+func TestActiveUserCountsRollingWindows(t *testing.T) {
+	pool, cleanup := setupMigrationTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, usageSchema); err != nil {
+		t.Fatalf("failed to create usage schema: %v", err)
+	}
+
+	// Counts in every window: connected an hour ago.
+	today := seedUser(t, pool, "today_streamer", false)
+	seedOverlay(t, pool, today, "today overlay", "1 hour")
+
+	// Counts in 7d and 30d only.
+	thisWeek := seedUser(t, pool, "week_streamer", false)
+	seedOverlay(t, pool, thisWeek, "week overlay", "3 days")
+
+	// Counts in 30d only.
+	thisMonth := seedUser(t, pool, "month_streamer", false)
+	seedOverlay(t, pool, thisMonth, "month overlay", "20 days")
+
+	// Churned: outside every window.
+	churned := seedUser(t, pool, "churned_streamer", false)
+	seedOverlay(t, pool, churned, "churned overlay", "45 days")
+
+	// Signed up, created an overlay, never opened it: not a usage event.
+	neverOpened := seedUser(t, pool, "never_opened_streamer", false)
+	seedNeverOpenedOverlay(t, pool, neverOpened, "untouched overlay")
+
+	// Banned users never count, however recently they connected.
+	banned := seedUser(t, pool, "banned_streamer", true)
+	seedOverlay(t, pool, banned, "banned overlay", "1 hour")
+
+	// Multiple overlays from one streamer must collapse to a single active user.
+	multi := seedUser(t, pool, "multi_overlay_streamer", false)
+	seedOverlay(t, pool, multi, "multi overlay a", "2 hours")
+	seedOverlay(t, pool, multi, "multi overlay b", "5 hours")
+
+	counts, err := NewUsageRepository(pool).ActiveUserCounts(ctx)
+	if err != nil {
+		t.Fatalf("ActiveUserCounts() returned error: %v", err)
+	}
+
+	// today + multi
+	if counts.Day != 2 {
+		t.Errorf("24h window: expected 2 active users, got %d", counts.Day)
+	}
+	// today + multi + thisWeek
+	if counts.Week != 3 {
+		t.Errorf("7d window: expected 3 active users, got %d", counts.Week)
+	}
+	// today + multi + thisWeek + thisMonth
+	if counts.Month != 4 {
+		t.Errorf("30d window: expected 4 active users, got %d", counts.Month)
+	}
+}
+
+func TestActiveUserCountsEmptyDatabase(t *testing.T) {
+	pool, cleanup := setupMigrationTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, usageSchema); err != nil {
+		t.Fatalf("failed to create usage schema: %v", err)
+	}
+
+	counts, err := NewUsageRepository(pool).ActiveUserCounts(ctx)
+	if err != nil {
+		t.Fatalf("ActiveUserCounts() on an empty database returned error: %v", err)
+	}
+	if counts != (ActiveUserCounts{}) {
+		t.Errorf("expected all-zero counts on an empty database, got %+v", counts)
+	}
+}

--- a/services/auth-service/usage/sampler.go
+++ b/services/auth-service/usage/sampler.go
@@ -1,0 +1,114 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package usage samples product-usage aggregates from the database into
+// Prometheus gauges.
+//
+// Sign-ups are event-shaped and counted in-process where they happen
+// (allchat_user_registrations_total). Usage is not: "how many streamers used an
+// overlay in the last 24h" is a property of the whole fleet over a window that
+// outlives any single pod, so it is polled from the database on a ticker instead
+// of derived from in-process events. Same reasoning as the total-users gauge
+// seeded at auth-service startup.
+package usage
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/caesar/all-chat/shared/metrics"
+	"go.uber.org/zap"
+)
+
+// DefaultInterval is how often the active-user windows are re-sampled. The query
+// is a single indexed aggregate over a 30-day slice of the overlays table, so a
+// minute-scale cadence is cheap; it also comfortably out-resolves the rolling
+// windows themselves.
+const DefaultInterval = 2 * time.Minute
+
+// activeUserCounter reads rolling-window active-user counts (implemented by
+// repository.UsageRepository).
+type activeUserCounter interface {
+	ActiveUserCounts(ctx context.Context) (repository.ActiveUserCounts, error)
+}
+
+// activeUserGauges receives the sampled counts (implemented by
+// metrics.BusinessMetrics).
+type activeUserGauges interface {
+	SetActiveUsers(window string, count int)
+}
+
+// Sampler periodically publishes allchat_active_users{window=...}.
+type Sampler struct {
+	repo     activeUserCounter
+	metrics  activeUserGauges
+	logger   *zap.Logger
+	interval time.Duration
+}
+
+// NewSampler creates a usage sampler. A non-positive interval falls back to
+// DefaultInterval.
+func NewSampler(repo activeUserCounter, m activeUserGauges, logger *zap.Logger, interval time.Duration) *Sampler {
+	if interval <= 0 {
+		interval = DefaultInterval
+	}
+	return &Sampler{repo: repo, metrics: m, logger: logger, interval: interval}
+}
+
+// Sample runs one query and updates the gauges. Errors are returned for the
+// caller to log; the gauges keep their previous values so a transient database
+// blip shows as a flat line rather than a drop to zero.
+func (s *Sampler) Sample(ctx context.Context) error {
+	counts, err := s.repo.ActiveUserCounts(ctx)
+	if err != nil {
+		return err
+	}
+
+	s.metrics.SetActiveUsers(metrics.ActiveUserWindowDay, counts.Day)
+	s.metrics.SetActiveUsers(metrics.ActiveUserWindowWeek, counts.Week)
+	s.metrics.SetActiveUsers(metrics.ActiveUserWindowMonth, counts.Month)
+	return nil
+}
+
+// Run samples immediately (so the gauges are populated before the first scrape,
+// not one interval later) and then on every tick until ctx is cancelled.
+func (s *Sampler) Run(ctx context.Context) {
+	s.sampleAndLog(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("Usage sampler stopped")
+			return
+		case <-ticker.C:
+			s.sampleAndLog(ctx)
+		}
+	}
+}
+
+func (s *Sampler) sampleAndLog(ctx context.Context) {
+	if err := s.Sample(ctx); err != nil {
+		if ctx.Err() != nil {
+			// Shutdown cancelled the query mid-flight; not a fault worth alarming on.
+			return
+		}
+		s.logger.Warn("Failed to sample active-user metrics (non-fatal, gauges keep last value)", zap.Error(err))
+	}
+}

--- a/services/auth-service/usage/sampler_test.go
+++ b/services/auth-service/usage/sampler_test.go
@@ -1,0 +1,194 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package usage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/services/auth-service/repository"
+	"github.com/caesar/all-chat/shared/metrics"
+	"go.uber.org/zap"
+)
+
+// The production types must keep satisfying the sampler's narrow interfaces —
+// these assertions fail the build if either signature drifts.
+var (
+	_ activeUserCounter = (*repository.UsageRepository)(nil)
+	_ activeUserGauges  = (*metrics.BusinessMetrics)(nil)
+)
+
+type fakeRepo struct {
+	mu     sync.Mutex
+	counts repository.ActiveUserCounts
+	err    error
+	calls  int
+}
+
+func (f *fakeRepo) ActiveUserCounts(context.Context) (repository.ActiveUserCounts, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return repository.ActiveUserCounts{}, f.err
+	}
+	return f.counts, nil
+}
+
+func (f *fakeRepo) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+type fakeGauges struct {
+	mu     sync.Mutex
+	values map[string]int
+}
+
+func newFakeGauges() *fakeGauges {
+	return &fakeGauges{values: make(map[string]int)}
+}
+
+func (f *fakeGauges) SetActiveUsers(window string, count int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[window] = count
+}
+
+func (f *fakeGauges) snapshot() map[string]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]int, len(f.values))
+	for k, v := range f.values {
+		out[k] = v
+	}
+	return out
+}
+
+func TestSampleSetsOneGaugePerWindow(t *testing.T) {
+	repo := &fakeRepo{counts: repository.ActiveUserCounts{Day: 7, Week: 23, Month: 61}}
+	gauges := newFakeGauges()
+	sampler := NewSampler(repo, gauges, zap.NewNop(), time.Minute)
+
+	if err := sampler.Sample(context.Background()); err != nil {
+		t.Fatalf("Sample() returned error: %v", err)
+	}
+
+	want := map[string]int{
+		metrics.ActiveUserWindowDay:   7,
+		metrics.ActiveUserWindowWeek:  23,
+		metrics.ActiveUserWindowMonth: 61,
+	}
+	got := gauges.snapshot()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d windows set, got %d (%v)", len(want), len(got), got)
+	}
+	for window, count := range want {
+		if got[window] != count {
+			t.Errorf("window %q: expected %d, got %d", window, count, got[window])
+		}
+	}
+}
+
+// A failed query must leave the gauges alone: Prometheus then shows a flat line
+// across the blip instead of a cliff to zero that would read as "nobody is using
+// the product".
+func TestSampleLeavesGaugesUntouchedOnError(t *testing.T) {
+	repo := &fakeRepo{counts: repository.ActiveUserCounts{Day: 5, Week: 5, Month: 5}}
+	gauges := newFakeGauges()
+	sampler := NewSampler(repo, gauges, zap.NewNop(), time.Minute)
+
+	if err := sampler.Sample(context.Background()); err != nil {
+		t.Fatalf("first Sample() returned error: %v", err)
+	}
+
+	repo.err = errors.New("connection refused")
+	if err := sampler.Sample(context.Background()); err == nil {
+		t.Fatal("expected Sample() to return the query error")
+	}
+
+	if got := gauges.snapshot()[metrics.ActiveUserWindowDay]; got != 5 {
+		t.Errorf("expected the previous value 5 to survive the failed sample, got %d", got)
+	}
+}
+
+// Run must publish before the first scrape rather than one interval later, so the
+// gauges are never scraped as a pre-initialised zero.
+func TestRunSamplesImmediatelyAndStopsOnCancel(t *testing.T) {
+	repo := &fakeRepo{counts: repository.ActiveUserCounts{Day: 1, Week: 2, Month: 3}}
+	gauges := newFakeGauges()
+	sampler := NewSampler(repo, gauges, zap.NewNop(), time.Hour) // ticker must not fire
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sampler.Run(ctx)
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for repo.callCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("Run() did not sample before the first tick")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	if got := gauges.snapshot()[metrics.ActiveUserWindowMonth]; got != 3 {
+		t.Errorf("expected the immediate sample to publish 3 for the 30d window, got %d", got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not return after context cancellation")
+	}
+}
+
+func TestRunResamplesOnEveryTick(t *testing.T) {
+	repo := &fakeRepo{counts: repository.ActiveUserCounts{Day: 1, Week: 1, Month: 1}}
+	sampler := NewSampler(repo, newFakeGauges(), zap.NewNop(), 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sampler.Run(ctx)
+
+	deadline := time.After(2 * time.Second)
+	for repo.callCount() < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected repeated samples, got %d", repo.callCount())
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+}
+
+func TestNewSamplerFallsBackToDefaultInterval(t *testing.T) {
+	for _, interval := range []time.Duration{0, -time.Second} {
+		if got := NewSampler(&fakeRepo{}, newFakeGauges(), zap.NewNop(), interval).interval; got != DefaultInterval {
+			t.Errorf("interval %v: expected fallback to %v, got %v", interval, DefaultInterval, got)
+		}
+	}
+}

--- a/shared/metrics/business.go
+++ b/shared/metrics/business.go
@@ -29,6 +29,21 @@ import (
 // user signed up since the last pod restart.
 var knownPlatforms = []string{"twitch", "youtube", "kick"}
 
+// Rolling windows exported as the `window` label of allchat_active_users —
+// the DAU / WAU / MAU of real overlay usage. Windows are rolling (last 24h,
+// last 7d, last 30d), not calendar buckets, so the series is meaningful at
+// every scrape instead of only at day boundaries.
+const (
+	ActiveUserWindowDay   = "24h"
+	ActiveUserWindowWeek  = "7d"
+	ActiveUserWindowMonth = "30d"
+)
+
+// activeUserWindows lists the label values allchat_active_users is pre-initialised
+// with, so the three series exist in /metrics from the first scrape rather than
+// appearing only once the first sample lands.
+var activeUserWindows = []string{ActiveUserWindowDay, ActiveUserWindowWeek, ActiveUserWindowMonth}
+
 // BusinessMetrics provides business-level metrics for the platform
 type BusinessMetrics struct {
 	// User Growth
@@ -44,7 +59,11 @@ type BusinessMetrics struct {
 	OverlaySessionDuration *prometheus.HistogramVec
 
 	// Platform Usage
-	MessagesByPlatform        *prometheus.CounterVec
+	MessagesByPlatform *prometheus.CounterVec
+	// ActiveUsers is the DAU/WAU/MAU of actual overlay usage, labelled by rolling
+	// window. Sampled from the database (see the auth-service usage sampler)
+	// rather than incremented in-process, because activity is a property of the
+	// fleet over time, not of a single pod's lifetime.
 	ActiveUsers               *prometheus.GaugeVec
 	ConnectedPlatformsPerUser *prometheus.GaugeVec
 
@@ -84,6 +103,13 @@ func newBusinessMetricsWithRegistry(reg prometheus.Registerer) *BusinessMetrics 
 		},
 		[]string{"platform"},
 	)
+	activeUsers := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "allchat_active_users",
+			Help: "Distinct streamers who actually used an overlay within the rolling window (window=24h/7d/30d, i.e. DAU/WAU/MAU), sampled from the database",
+		},
+		[]string{"window"},
+	)
 
 	// Pre-initialise known label combinations so the metrics are always
 	// present in /metrics, even before any sign-up happens in the current
@@ -92,6 +118,9 @@ func newBusinessMetricsWithRegistry(reg prometheus.Registerer) *BusinessMetrics 
 		userRegs.WithLabelValues(p)
 		viewerRegs.WithLabelValues(p)
 		totalUsers.WithLabelValues(p)
+	}
+	for _, w := range activeUserWindows {
+		activeUsers.WithLabelValues(w)
 	}
 
 	return &BusinessMetrics{
@@ -127,13 +156,7 @@ func newBusinessMetricsWithRegistry(reg prometheus.Registerer) *BusinessMetrics 
 			},
 			[]string{"platform"},
 		),
-		ActiveUsers: factory.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "allchat_active_users_total",
-				Help: "Number of users with active sessions",
-			},
-			[]string{},
-		),
+		ActiveUsers: activeUsers,
 		ConnectedPlatformsPerUser: factory.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "allchat_connected_platforms_per_user",
@@ -191,9 +214,10 @@ func (m *BusinessMetrics) RecordMessageByPlatform(platform string) {
 	m.MessagesByPlatform.WithLabelValues(platform).Inc()
 }
 
-// SetActiveUsers sets the number of active users
-func (m *BusinessMetrics) SetActiveUsers(count int) {
-	m.ActiveUsers.WithLabelValues().Set(float64(count))
+// SetActiveUsers sets the number of distinct streamers who used an overlay within
+// the given rolling window (one of the ActiveUserWindow* constants).
+func (m *BusinessMetrics) SetActiveUsers(window string, count int) {
+	m.ActiveUsers.WithLabelValues(window).Set(float64(count))
 }
 
 // SetActiveSourcesTotal sets the total active sources for a platform


### PR DESCRIPTION
## Why

We could see sign-ups and nothing else. There was no metric answering *"do registered streamers actually put an overlay on screen?"* — `allchat_active_users_total` existed in `shared/metrics/business.go` but nothing ever called `SetActiveUsers`, so it was a permanently-zero series.

## What

`allchat_active_users{window="24h"|"7d"|"30d"}` — the DAU/WAU/MAU of real overlay usage, sampled from the database by auth-service every `USAGE_SAMPLE_INTERVAL_SECONDS` (default 120).

Usage is a fleet-wide property of a window that outlives any pod, so it is polled rather than incremented in-process — the same reasoning behind the total-users gauge seeded at startup. The sampler publishes once before the first scrape, and keeps the previous value if a query fails so a database blip reads as a flat line rather than a cliff to zero.

**Active** = a distinct, non-banned owner of an overlay whose `overlays.last_connected_at` falls in the window. api-gateway bumps that column on demand-bearing WebSocket attach and on each ~2min heartbeat, so it tracks overlays in use during a stream, not logins (`users.updated_at` is churned by the daily token refresh, and viewer participate sockets are demand-free and never bump it).

The definition moved into `repository.UsageRepository`, shared with the admin dashboard tiles that previously carried their own copy of the query. It gained one exclusion: an overlay whose `last_connected_at` was never bumped past its `created_at` was created but never opened. Migration 052 gave the column `DEFAULT NOW()`, so both timestamps come from the same INSERT statement and stay exactly equal until a real attach bumps one — without this, creating an overlay would count as 30 days of usage and the graph would just retell the sign-up story.

## Dashboard

Already live: **All-Chat: User Growth & Actual Usage** (uid `allchat-user-growth`), provisioned from the caesar-deployment GitOps repo (`caesarakalaeii/caesar-deployment@fbf7408`). Its active-user panels read "No data" until this ships; the sign-up panels already render. Every query aggregates with `max(...)`, never `sum(...)` — each replica reports the same fleet-wide value.

## Testing

- Unit tests for the sampler: one gauge per window, gauges untouched on query error, immediate publish before the first tick, re-sample on tick, interval fallback. Compile-time assertions keep `UsageRepository`/`BusinessMetrics` satisfying the sampler interfaces.
- Integration tests (testcontainers) for the query: rolling-window boundaries, banned owners, DISTINCT across multiple overlays, and the never-opened exclusion.
- `handlers/admin_stats_test.go` extended with a never-opened overlay; its fixture schema needed `created_at`, which the new query reads.
- Docker was unavailable in my environment, so the two testcontainers suites could not run locally — I replayed both fixture sets against a real PostgreSQL 16 instead and they produce the asserted numbers (2/3/4, `total_users` 7). CI covers the real runs.
- `go build` / `go vet` clean; `shared/metrics` and the sampler suite pass.