### PR TITLE
fix(tiktok): make coin chests observable and stop phantom chest events

### DIFF
--- a/services/tiktok-listener/README.md
+++ b/services/tiktok-listener/README.md
@@ -23,6 +23,7 @@ This service uses the **unofficial** [TikTok-Live-Connector](https://github.com/
 - ✅ **Message deduplication** (prevents replay on reconnect using native TikTok message IDs)
 - ✅ **Native timestamp preservation** (uses TikTok's original message timestamps)
 - ✅ Publishes to Redis Streams (`chat:raw`)
+- ✅ Audience events alongside chat: gifts, follows, shares, aggregated likes, and coin chests
 - ✅ Dynamic stream management (polls database for active channels)
 - ✅ Health check endpoints
 - ✅ Graceful shutdown handling
@@ -236,6 +237,35 @@ Error: Failed to connect to TikTok stream
 3. Service logs for errors
 4. User is actually live on TikTok
 5. Chat is enabled on the stream
+
+### A Coin Chest Did Not Appear
+
+Coin chests ("treasure boxes") ride on TikTok's `ENVELOPE` message, which multiplexes several
+unrelated products, so a chest that never surfaced has more than one possible cause. Every
+`ENVELOPE` frame is logged at `info` (`"Received ENVELOPE frame"`) with its decoded
+`business_type`, `display` and `coins`, and counted by outcome:
+
+```promql
+# Why envelope frames did not become chests
+sum by (outcome) (tiktok_envelope_frames_total)
+```
+
+`outcome` is one of `published`, `super_fan_box` (a Super Fan Box, not a chest), `not_a_drop`
+(the HIDE frame for a chest that expired or was fully claimed), `no_chest_payload` (an envelope
+announcing no chest — these must not render), `duplicate`, or `error`.
+
+**If there is no log line and no counter movement at all, the frame never reached the service.**
+Distinguish "TikTok did not send it" from "the library could not decode it" with:
+
+```promql
+# Every protobuf message TikTok actually sent, by wire name
+sum by (method) (tiktok_wire_messages_total)
+```
+
+`tiktok-live-connector` drops frames whose method is absent from its schema *silently*, so a
+renamed message is otherwise indistinguishable from silence. If `WebcastEnvelopeMessage` is
+missing from that metric while chests are visibly dropping in the stream, the unofficial protocol
+has drifted and `tiktok-live-connector` needs bumping (as in PR #539).
 
 ## Migration Path (Future)
 

--- a/services/tiktok-listener/README.md
+++ b/services/tiktok-listener/README.md
@@ -255,17 +255,29 @@ sum by (outcome) (tiktok_envelope_frames_total)
 announcing no chest — these must not render), `duplicate`, or `error`.
 
 **If there is no log line and no counter movement at all, the frame never reached the service.**
-Distinguish "TikTok did not send it" from "the library could not decode it" with:
+Check what TikTok is actually sending with:
 
 ```promql
-# Every protobuf message TikTok actually sent, by wire name
+# Every protobuf message that decoded, by wire name
 sum by (method) (tiktok_wire_messages_total)
 ```
 
-`tiktok-live-connector` drops frames whose method is absent from its schema *silently*, so a
-renamed message is otherwise indistinguishable from silence. If `WebcastEnvelopeMessage` is
-missing from that metric while chests are visibly dropping in the stream, the unofficial protocol
-has drifted and `tiktok-live-connector` needs bumping (as in PR #539).
+If `WebcastEnvelopeMessage` is missing from that metric while chests are visibly dropping in the
+stream, the envelope is not reaching us in decodable form.
+
+**That narrows it to three causes without separating them**, because this metric counts only frames
+that decoded: TikTok stopped sending the message, TikTok renamed it, or it no longer decodes.
+`tiktok-live-connector` skips a method absent from its schema *silently*, and drops one that throws
+while decoding, so neither leaves a trace. To name an unknown method you need the connector's
+`DEBUG_DESERIALIZE_XD` env var, which `console.log`s the method plus a base64 payload for every
+frame it cannot place. That is noisy and unstructured, so treat it as a deliberate short-lived
+investigation rather than something to leave enabled.
+
+A renamed or undecodable message means the unofficial protocol has drifted and the library needs
+bumping (as in PR #539). Note that as of 2026-08-14 no envelope frame was observed in ~75
+room-minutes across eight live rooms, including one with 61 gifts, so the leading theory is instead
+that TikTok does not push envelopes to **unauthenticated** connections, which is how this service
+connects.
 
 ## Migration Path (Future)
 

--- a/services/tiktok-listener/src/envelope.test.ts
+++ b/services/tiktok-listener/src/envelope.test.ts
@@ -1,0 +1,144 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  hasTikTokChestPayload,
+  isTikTokCoinChest,
+  isTikTokEnvelopeDrop,
+  type TikTokEnvelopeData
+} from './envelope.js';
+
+/** A viewer-dropped chest as it arrives once decoded: USER_DIAMOND, display=NEW, 20 coins. */
+function chestFrame(overrides: Partial<TikTokEnvelopeData> = {}): TikTokEnvelopeData {
+  return {
+    common: { msgId: '7300000000000000001', createTime: '1786600000000' },
+    display: 1,
+    envelopeInfo: {
+      envelopeId: 'env-1',
+      businessType: 1,
+      diamondCount: 20,
+      peopleCount: 1,
+      sendUserId: '6800000000000000002',
+      sendUserName: 'someviewer'
+    },
+    ...overrides
+  };
+}
+
+describe('isTikTokCoinChest', () => {
+  it('accepts a chest dropped by a viewer', () => {
+    expect(isTikTokCoinChest(chestFrame())).toBe(true);
+  });
+
+  it('accepts a chest dropped into the room by the platform', () => {
+    expect(isTikTokCoinChest(chestFrame({ envelopeInfo: { businessType: 2, diamondCount: 100 } }))).toBe(
+      true
+    );
+  });
+
+  // The connector emits SUPER_FAN_BOX and then falls through to ENVELOPE for the same frame, so
+  // without this the streamer would be shown a coin chest for every Super Fan Box join.
+  it('rejects a Super Fan Box by business type', () => {
+    expect(isTikTokCoinChest(chestFrame({ envelopeInfo: { businessType: 19, diamondCount: 20 } }))).toBe(
+      false
+    );
+  });
+
+  it('rejects a Super Fan Box by display-text key even when the business type is absent', () => {
+    const frame = chestFrame({
+      common: { displayText: { key: 'pm_mt_ttlive_superfanbox_join' } },
+      envelopeInfo: { diamondCount: 20 }
+    });
+    expect(isTikTokCoinChest(frame)).toBe(false);
+  });
+
+  it('matches the display-text key case-insensitively', () => {
+    const frame = chestFrame({
+      common: { displayText: { key: 'PM_MT_TTLIVE_SUPERFANBOX_JOIN' } },
+      envelopeInfo: { diamondCount: 20 }
+    });
+    expect(isTikTokCoinChest(frame)).toBe(false);
+  });
+
+  it.each([
+    ['a platform shell', 3],
+    ['a portal', 4],
+    ['a merch drop', 5],
+    ['a fan-club box', 7]
+  ])('rejects %s', (_label, businessType) => {
+    expect(isTikTokCoinChest(chestFrame({ envelopeInfo: { businessType, diamondCount: 20 } }))).toBe(
+      false
+    );
+  });
+
+  // Deliberately permissive: TikTok omits businessType on some frames, and reading that as
+  // "not a chest" would silently disable the whole feature rather than lose one event.
+  it('treats an omitted business type as a possible chest', () => {
+    expect(isTikTokCoinChest(chestFrame({ envelopeInfo: { diamondCount: 20 } }))).toBe(true);
+  });
+});
+
+describe('isTikTokEnvelopeDrop', () => {
+  it('accepts a new drop', () => {
+    expect(isTikTokEnvelopeDrop(chestFrame())).toBe(true);
+  });
+
+  // A chest that expires or is fully claimed comes back with the whole envelopeInfo under a fresh
+  // msgId, which can outlive the dedup TTL — so this flag is what stops one chest rendering twice.
+  it('rejects the HIDE frame that takes a spent chest off screen', () => {
+    expect(isTikTokEnvelopeDrop(chestFrame({ display: 2 }))).toBe(false);
+  });
+
+  it('treats an omitted display as a drop', () => {
+    expect(isTikTokEnvelopeDrop(chestFrame({ display: undefined }))).toBe(true);
+  });
+
+  it('rejects an unrecognised display value', () => {
+    expect(isTikTokEnvelopeDrop(chestFrame({ display: -1 }))).toBe(false);
+  });
+});
+
+describe('hasTikTokChestPayload', () => {
+  it('accepts a frame carrying coins', () => {
+    expect(hasTikTokChestPayload(chestFrame())).toBe(true);
+  });
+
+  // The empty ENVELOPE frame TikTok also sends passes both predicates above, because each treats
+  // its missing field as "probably a chest". Without this guard it published a chest worth 0 coins
+  // from Anonymous.
+  it('rejects a frame with no envelope info at all', () => {
+    expect(hasTikTokChestPayload({ common: { msgId: 'm1' }, display: 1 })).toBe(false);
+  });
+
+  it('rejects a frame whose envelope info carries no coin count', () => {
+    expect(hasTikTokChestPayload(chestFrame({ envelopeInfo: { envelopeId: 'env-2' } }))).toBe(false);
+  });
+
+  it('rejects a frame reporting zero coins', () => {
+    expect(hasTikTokChestPayload(chestFrame({ envelopeInfo: { diamondCount: 0 } }))).toBe(false);
+  });
+
+  it('narrows the coin count so callers need no non-null assertion', () => {
+    const frame = chestFrame();
+    if (!hasTikTokChestPayload(frame)) throw new Error('expected a chest frame');
+    const coins: number = frame.envelopeInfo.diamondCount;
+    expect(coins).toBe(20);
+  });
+});

--- a/services/tiktok-listener/src/envelope.ts
+++ b/services/tiktok-listener/src/envelope.ts
@@ -1,0 +1,131 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Classification of TikTok's ENVELOPE message down to the coin chest (the "treasure box").
+ *
+ * Lives outside index.ts because that module starts the service on import and so cannot be
+ * pulled into a test. These predicates decide whether a streamer sees a chest at all, and every
+ * branch of the handler is a silent return, so they are exactly the logic that needs tests.
+ */
+
+import type { AvatarImageModel } from './avatar.js';
+
+// Localized display string attached to a message. `key` is a stable template id
+// (e.g. `pm_mt_ttlive_superfanbox_join`) — the connector itself probes it to tell
+// the envelope products apart; see isTikTokCoinChest.
+export interface TikTokDisplayText {
+  key?: string;
+}
+
+export interface TikTokEnvelopeCommon {
+  msgId?: string;
+  createTime?: string;
+  displayText?: TikTokDisplayText;
+}
+
+// The chest ("red envelope") a viewer drops into the stream. Note the sender is
+// inlined here as flat `sendUser*` fields rather than a nested `user`, and the
+// avatar is a single image model rather than the thumb/medium/large trio.
+export interface TikTokEnvelopeInfo {
+  envelopeId?: string; // stable per-chest id, identical on every frame for that chest
+  businessType?: number; // which envelope product this is; see isTikTokCoinChest
+  diamondCount?: number; // coins in the chest
+  peopleCount?: number; // how many viewers may claim it
+  sendUserId?: string; // numeric sender id
+  sendUserName?: string; // sender display name (this payload carries no @handle)
+  sendUserAvatar?: AvatarImageModel;
+}
+
+export interface TikTokEnvelopeData {
+  common?: TikTokEnvelopeCommon;
+  envelopeInfo?: TikTokEnvelopeInfo;
+  display?: number; // `EnvelopeDisplay`: add vs. remove the chest; see isTikTokEnvelopeDrop
+}
+
+// `EnvelopeBusinessType` values. TikTok multiplexes several products onto the
+// ENVELOPE message and the connector forwards every one of them — its dispatcher
+// emits SUPER_FAN_BOX and then falls through to ENVELOPE for the *same* frame —
+// so the coin chest has to be picked out by business type. Only the two
+// diamond-bearing variants are chests; the rest (portals, merch drops, shells,
+// fan-club boxes, Super Fan Box) must not surface as one.
+const TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN = 0;
+const TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES = new Set<number>([
+  1, // BUSINESS_TYPE_USER_DIAMOND — a viewer drops a chest
+  2 // BUSINESS_TYPE_PLATFORM_DIAMOND — TikTok drops one into the room
+]);
+
+/**
+ * Tells a coin chest apart from the other envelope products.
+ *
+ * `businessType` is the authoritative signal, but it decodes to UNKNOWN when
+ * TikTok omits it on the wire; treating UNKNOWN as "not a chest" would silently
+ * emit nothing for the whole feature, so it falls back to the same display-text
+ * probe the connector uses to spot a Super Fan Box.
+ */
+export function isTikTokCoinChest(data: TikTokEnvelopeData): boolean {
+  if (data.common?.displayText?.key?.toLowerCase().includes('ttlive_superfanbox')) {
+    return false;
+  }
+
+  const businessType = data.envelopeInfo?.businessType ?? TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN;
+  return (
+    businessType === TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN ||
+    TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES.has(businessType)
+  );
+}
+
+// `EnvelopeDisplay` values. The ENVELOPE message doubles as a remove
+// instruction: once a chest expires or has been claimed by everyone it may hold,
+// TikTok re-sends it with display=HIDE so the client takes it off screen. That
+// frame repeats the whole envelopeInfo under a fresh msgId, and it can land long
+// after the dedup TTL has forgotten the drop, so this flag is what keeps one
+// chest from being published twice.
+const TIKTOK_ENVELOPE_DISPLAY_UNKNOWN = 0;
+const TIKTOK_ENVELOPE_DISPLAY_NEW = 1;
+
+/**
+ * Tells a chest being dropped apart from one being taken off screen.
+ *
+ * As with businessType, `display` decodes to UNKNOWN when TikTok omits it on the
+ * wire; treating UNKNOWN as "not a drop" would silently emit nothing for the
+ * whole feature, so only an explicit non-NEW display is dropped.
+ */
+export function isTikTokEnvelopeDrop(data: TikTokEnvelopeData): boolean {
+  const display = data.display ?? TIKTOK_ENVELOPE_DISPLAY_UNKNOWN;
+  return display === TIKTOK_ENVELOPE_DISPLAY_UNKNOWN || display === TIKTOK_ENVELOPE_DISPLAY_NEW;
+}
+
+/** An envelope frame that carries a real chest: sender fields may still be absent, coins are not. */
+export interface TikTokChestFrame extends TikTokEnvelopeData {
+  envelopeInfo: TikTokEnvelopeInfo & { diamondCount: number };
+}
+
+/**
+ * Whether the frame actually carries a chest, as opposed to announcing one that is not there.
+ *
+ * TikTok also sends ENVELOPE frames with no envelopeInfo at all — upstream issue #27 captured a
+ * treasure-box payload and an empty one side by side. Because the two predicates above
+ * deliberately read a missing businessType/display as "probably a chest" rather than discard a
+ * real drop, an empty frame passes both, and would render a phantom "Sent a coin chest" worth 0
+ * coins from Anonymous. A real chest always carries its coin count, so that is what separates a
+ * drop from an empty announcement.
+ */
+export function hasTikTokChestPayload(data: TikTokEnvelopeData): data is TikTokChestFrame {
+  return !!data.envelopeInfo && (data.envelopeInfo.diamondCount ?? 0) > 0;
+}

--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -897,10 +897,20 @@ class TikTokListenerService {
       // Cast to EventEmitter for lifecycle events not in ClientEventMap
       const emitter = connection as unknown as EventEmitter;
 
-      // Record every frame the connector managed to decode, keyed by its protobuf method name.
-      // This is the only way to tell "TikTok did not send it" apart from "the library could not
-      // decode it": deserializeMessage skips unknown methods without emitting anything, so a
-      // drifted message name is indistinguishable from silence at the handler level.
+      // Record every frame the connector managed to decode, keyed by its protobuf method name,
+      // giving a baseline of what TikTok actually sends on a working connection.
+      //
+      // Note the limit, because it is easy to over-read this metric: `decodedData` fires only for
+      // frames that decoded. deserializeMessage skips a method missing from its schema with a bare
+      // `continue`, and a method that throws while decoding is dropped too (its decodeError is set,
+      // then the caller skips anything without decodedData). So an absent method here means one of
+      // three things — TikTok stopped sending it, TikTok renamed it, or it no longer decodes — and
+      // this metric alone does not separate them. The only hook that does is the connector's
+      // DEBUG_DESERIALIZE_XD env var, which console.logs unknown method names.
+      //
+      // What it does buy: if WebcastEnvelopeMessage never appears while chests are visibly dropped
+      // in the room, the envelope is definitively not reaching us in decodable form, which is the
+      // question that took a prod investigation to answer the first time.
       emitter.on('decodedData', (method: string) => {
         this.metrics.recordWireMessage(method);
       });

--- a/services/tiktok-listener/src/index.ts
+++ b/services/tiktok-listener/src/index.ts
@@ -59,6 +59,12 @@ import { LeadershipCoordinator } from './coordination/leadership.js';
 // Import demand subscriber (Phase 5)
 import { DemandSubscriber, DemandSource } from './demand/subscriber.js';
 import { pickAvatarUrl, tiktokAvatarUrl } from './avatar.js';
+import {
+  hasTikTokChestPayload,
+  isTikTokCoinChest,
+  isTikTokEnvelopeDrop,
+  type TikTokEnvelopeData
+} from './envelope.js';
 
 // Environment variables
 const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
@@ -244,77 +250,9 @@ interface TikTokSocialData {
   user?: TikTokUser;
 }
 
-// The chest ("red envelope") a viewer drops into the stream. Note the sender is
-// inlined here as flat `sendUser*` fields rather than a nested `user`, and the
-// avatar is a single image model rather than the thumb/medium/large trio.
-interface TikTokEnvelopeInfo {
-  envelopeId?: string; // stable per-chest id, identical on every frame for that chest
-  businessType?: number; // which envelope product this is; see isTikTokCoinChest
-  diamondCount?: number; // coins in the chest
-  peopleCount?: number; // how many viewers may claim it
-  sendUserId?: string; // numeric sender id
-  sendUserName?: string; // sender display name (this payload carries no @handle)
-  sendUserAvatar?: TikTokImageModel;
-}
-
-interface TikTokEnvelopeData {
-  common?: TikTokCommon;
-  envelopeInfo?: TikTokEnvelopeInfo;
-  display?: number; // `EnvelopeDisplay`: add vs. remove the chest; see isTikTokEnvelopeDrop
-}
-
 // Reads the TikTok @handle, falling back to the numeric id then a placeholder.
 function tiktokUserHandle(user: TikTokUser | undefined): string {
   return user?.displayId || user?.id || 'unknown';
-}
-
-// `EnvelopeBusinessType` values. TikTok multiplexes several products onto the
-// ENVELOPE message and the connector forwards every one of them — its dispatcher
-// emits SUPER_FAN_BOX and then falls through to ENVELOPE for the *same* frame —
-// so the coin chest has to be picked out by business type. Only the two
-// diamond-bearing variants are chests; the rest (portals, merch drops, shells,
-// fan-club boxes, Super Fan Box) must not surface as one.
-const TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN = 0;
-const TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES = new Set<number>([
-  1, // BUSINESS_TYPE_USER_DIAMOND — a viewer drops a chest
-  2 // BUSINESS_TYPE_PLATFORM_DIAMOND — TikTok drops one into the room
-]);
-
-// Tells a coin chest apart from the other envelope products.
-//
-// `businessType` is the authoritative signal, but it decodes to UNKNOWN when
-// TikTok omits it on the wire; treating UNKNOWN as "not a chest" would silently
-// emit nothing for the whole feature, so it falls back to the same display-text
-// probe the connector uses to spot a Super Fan Box.
-function isTikTokCoinChest(data: TikTokEnvelopeData): boolean {
-  if (data.common?.displayText?.key?.toLowerCase().includes('ttlive_superfanbox')) {
-    return false;
-  }
-
-  const businessType = data.envelopeInfo?.businessType ?? TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN;
-  return (
-    businessType === TIKTOK_ENVELOPE_BUSINESS_TYPE_UNKNOWN ||
-    TIKTOK_ENVELOPE_COIN_BUSINESS_TYPES.has(businessType)
-  );
-}
-
-// `EnvelopeDisplay` values. The ENVELOPE message doubles as a remove
-// instruction: once a chest expires or has been claimed by everyone it may hold,
-// TikTok re-sends it with display=HIDE so the client takes it off screen. That
-// frame repeats the whole envelopeInfo under a fresh msgId, and it can land long
-// after the dedup TTL has forgotten the drop, so this flag is what keeps one
-// chest from being published twice.
-const TIKTOK_ENVELOPE_DISPLAY_UNKNOWN = 0;
-const TIKTOK_ENVELOPE_DISPLAY_NEW = 1;
-
-// Tells a chest being dropped apart from one being taken off screen.
-//
-// As with businessType, `display` decodes to UNKNOWN when TikTok omits it on the
-// wire; treating UNKNOWN as "not a drop" would silently emit nothing for the
-// whole feature, so only an explicit non-NEW display is dropped.
-function isTikTokEnvelopeDrop(data: TikTokEnvelopeData): boolean {
-  const display = data.display ?? TIKTOK_ENVELOPE_DISPLAY_UNKNOWN;
-  return display === TIKTOK_ENVELOPE_DISPLAY_UNKNOWN || display === TIKTOK_ENVELOPE_DISPLAY_NEW;
 }
 
 // Like aggregation window for tracking likes over 30-second periods
@@ -959,6 +897,14 @@ class TikTokListenerService {
       // Cast to EventEmitter for lifecycle events not in ClientEventMap
       const emitter = connection as unknown as EventEmitter;
 
+      // Record every frame the connector managed to decode, keyed by its protobuf method name.
+      // This is the only way to tell "TikTok did not send it" apart from "the library could not
+      // decode it": deserializeMessage skips unknown methods without emitting anything, so a
+      // drifted message name is indistinguishable from silence at the handler level.
+      emitter.on('decodedData', (method: string) => {
+        this.metrics.recordWireMessage(method);
+      });
+
       emitter.on('connected', (state: { roomId?: string }) => {
         logger.info('TikTok stream connected', {
           username,
@@ -1379,9 +1325,23 @@ class TikTokListenerService {
     try {
       this.heartbeatMonitor.recordMessage(username);
 
+      // Logged at info, unlike the other handlers' per-message debug lines. ENVELOPE frames are
+      // rare (a handful per stream at most, against thousands of chats), and a streamer reporting
+      // "my chest never appeared" is otherwise unanswerable: every branch below is a silent
+      // return, so at the INFO level prod runs at, the whole feature leaves no trace either way.
+      logger.info('Received ENVELOPE frame', {
+        username,
+        overlay_id: overlayId,
+        business_type: data.envelopeInfo?.businessType,
+        display: data.display,
+        has_envelope_info: !!data.envelopeInfo,
+        coins: data.envelopeInfo?.diamondCount
+      });
+
       // ENVELOPE also carries Super Fan Box (and other) frames; publishing those
       // would show the streamer a coin chest nobody sent.
       if (!isTikTokCoinChest(data)) {
+        this.metrics.recordEnvelopeFrame('super_fan_box');
         logger.debug('Skipping non-chest ENVELOPE event', {
           username,
           business_type: data.envelopeInfo?.businessType
@@ -1393,6 +1353,7 @@ class TikTokListenerService {
       // claimed; republishing that would render the drop twice in the activity
       // panel and the overlay.
       if (!isTikTokEnvelopeDrop(data)) {
+        this.metrics.recordEnvelopeFrame('not_a_drop');
         logger.debug('Skipping non-drop ENVELOPE event', {
           username,
           display: data.display
@@ -1400,12 +1361,24 @@ class TikTokListenerService {
         return;
       }
 
+      // An ENVELOPE frame can announce no chest at all; publishing that would render a phantom
+      // "Sent a coin chest" worth 0 coins from Anonymous. See hasTikTokChestPayload.
+      if (!hasTikTokChestPayload(data)) {
+        this.metrics.recordEnvelopeFrame('no_chest_payload');
+        logger.debug('Skipping ENVELOPE event with no chest payload', {
+          username,
+          has_envelope_info: !!data.envelopeInfo,
+          coins: data.envelopeInfo?.diamondCount
+        });
+        return;
+      }
+
       const envelope = data.envelopeInfo;
+      const coins = envelope.diamondCount;
       // The sender may be absent entirely on some frames; a chest without an
       // identifiable sender must still publish (as Anonymous) rather than throw.
-      const senderId = envelope?.sendUserId || 'unknown';
-      const coins = envelope?.diamondCount || 0;
-      const canOpen = envelope?.peopleCount || 0;
+      const senderId = envelope.sendUserId || 'unknown';
+      const canOpen = envelope.peopleCount || 0;
       const text = 'Sent a coin chest';
 
       const msgId = data.common?.msgId;
@@ -1418,8 +1391,9 @@ class TikTokListenerService {
       // single event. The prefix keeps envelope ids out of the msgId namespace
       // the other handlers share. Falls back to msgId, as the chat handler does,
       // when TikTok omits the envelope id.
-      const dedupKey = envelope?.envelopeId ? `envelope:${envelope.envelopeId}` : msgId;
+      const dedupKey = envelope.envelopeId ? `envelope:${envelope.envelopeId}` : msgId;
       if (this.messageDeduplicator.isDuplicate(dedupKey, username, text)) {
+        this.metrics.recordEnvelopeFrame('duplicate');
         logger.debug('Skipping duplicate treasure chest event', { msg_id: msgId, username });
         return;
       }
@@ -1429,13 +1403,13 @@ class TikTokListenerService {
         platform: 'tiktok',
         channel_id: username,
         user_id: senderId,
-        username: envelope?.sendUserName || 'Anonymous',
+        username: envelope.sendUserName || 'Anonymous',
         text,
         timestamp: timestamp,
         tags: {
           overlay_id: overlayId,
           user_unique_id: '', // no @handle in the envelope payload; the normalizer falls back to user_id
-          profile_picture_url: pickAvatarUrl(envelope?.sendUserAvatar)
+          profile_picture_url: pickAvatarUrl(envelope.sendUserAvatar)
         },
         event_type: 'treasure_chest',
         event_data: {
@@ -1448,15 +1422,17 @@ class TikTokListenerService {
       // Logs the decoded fields, not just the outcome: `tiktok-live-proto/v3` is a
       // package subpath this tsconfig cannot resolve, so a wire-format rename here
       // compiles clean and only shows up as zeroed values at runtime.
-      logger.debug('Published TikTok treasure chest event', {
+      this.metrics.recordEnvelopeFrame('published');
+      logger.info('Published TikTok treasure chest event', {
         username,
         overlay_id: overlayId,
-        business_type: envelope?.businessType,
+        business_type: envelope.businessType,
         sender: senderId,
         coins,
         can_open: canOpen
       });
     } catch (error) {
+      this.metrics.recordEnvelopeFrame('error');
       logger.error('Failed to handle treasure chest event', { username, error });
     }
   }

--- a/services/tiktok-listener/src/metrics/prometheus.ts
+++ b/services/tiktok-listener/src/metrics/prometheus.ts
@@ -174,12 +174,18 @@ export class PrometheusMetrics {
       registers: [this.registry]
     });
 
-    // Wire-format visibility. TikTok's unofficial protocol drifts without notice and the
-    // connector drops any frame whose method is missing from its schema *silently* (see
-    // `hasProtoName` in tiktok-live-connector), so a renamed message looks exactly like a
-    // message that was never sent. PR #539's empty-comment breakage and the coin chest never
-    // surfacing both had that shape. Counting methods as they arrive turns "TikTok stopped
-    // sending X" and "the library can no longer decode X" into two distinguishable states.
+    // Wire-format visibility. TikTok's unofficial protocol drifts without notice and the connector
+    // drops any frame whose method is missing from its schema *silently* (see `hasProtoName` in
+    // tiktok-live-connector), so a renamed message looks exactly like a message that was never
+    // sent. PR #539's empty-comment breakage and the coin chest never surfacing both had that
+    // shape, and neither was visible from our side at all.
+    //
+    // This counts only what *decoded*, so read it as a baseline of what TikTok sends rather than as
+    // a diagnosis: a method missing from it may have been dropped by TikTok, renamed, or broken in
+    // decode, and those three are not separable here (the connector's DEBUG_DESERIALIZE_XD env var
+    // is the only hook that names an unknown method). Its value is the negative result — proving a
+    // message is not arriving in decodable form, which previously took a prod investigation.
+    //
     // Cardinality is bounded: `method` is a proto type name from a fixed schema, never user input.
     this.wireMessages = new Counter({
       name: 'tiktok_wire_messages_total',

--- a/services/tiktok-listener/src/metrics/prometheus.ts
+++ b/services/tiktok-listener/src/metrics/prometheus.ts
@@ -57,6 +57,10 @@ export class PrometheusMetrics {
   private usernamesAtRisk: Gauge<string>;
   private autoRecoveryTotal: Counter<string>;
 
+  // Wire-format visibility
+  private wireMessages: Counter<string>;
+  private envelopeFrames: Counter<string>;
+
   constructor(logger: Logger) {
     this.logger = logger;
     this.registry = new Registry();
@@ -170,7 +174,40 @@ export class PrometheusMetrics {
       registers: [this.registry]
     });
 
+    // Wire-format visibility. TikTok's unofficial protocol drifts without notice and the
+    // connector drops any frame whose method is missing from its schema *silently* (see
+    // `hasProtoName` in tiktok-live-connector), so a renamed message looks exactly like a
+    // message that was never sent. PR #539's empty-comment breakage and the coin chest never
+    // surfacing both had that shape. Counting methods as they arrive turns "TikTok stopped
+    // sending X" and "the library can no longer decode X" into two distinguishable states.
+    // Cardinality is bounded: `method` is a proto type name from a fixed schema, never user input.
+    this.wireMessages = new Counter({
+      name: 'tiktok_wire_messages_total',
+      help: 'Decoded TikTok wire messages by protobuf method name',
+      labelNames: ['method'],
+      registers: [this.registry]
+    });
+
+    // Envelope frames get their own outcome counter because the ENVELOPE message multiplexes
+    // several products and is filtered down to coin chests, so "no chest appeared" has several
+    // distinct causes that must be told apart without redeploying at debug level.
+    this.envelopeFrames = new Counter({
+      name: 'tiktok_envelope_frames_total',
+      help: 'ENVELOPE frames by outcome (published, or the reason it was not)',
+      labelNames: ['outcome'], // published, super_fan_box, not_a_drop, no_chest_payload, duplicate, error
+      registers: [this.registry]
+    });
+
     this.logger.info('Prometheus metrics initialized');
+  }
+
+  // Wire-format visibility methods
+  recordWireMessage(method: string): void {
+    this.wireMessages.inc({ method });
+  }
+
+  recordEnvelopeFrame(outcome: string): void {
+    this.envelopeFrames.inc({ outcome });
   }
 
   // Heartbeat monitoring methods


### PR DESCRIPTION
## Why

A streamer reported a TikTok coin chest that never reached Activity & Events, with the toggle enabled. Chests shipped two days earlier in #689.

**The pipeline turned out to be correct and deployed.** Verified rather than assumed:

- The listener subscribes to `WebcastEvent.ENVELOPE`, confirmed in the **running pod's** `dist/index.js`, not just in `main`.
- Connector 2.4.0 in the pod maps `WebcastEnvelopeMessage` to the `envelope` event; field names and enum values in `tiktok-live-proto` match what we read.
- Migration 084 is applied, `enable_tiktok_treasure_chests` defaults `true`.
- `event_filter` reads that column straight from Postgres and defaults to enabled.
- The frontend `partitionItems` uses a denylist, so chests land in the activity pane.
- The channel was connected for the whole four-hour window the chest was dropped in.

**The report was still unanswerable**, because every branch of the chest handler logs at `debug` while prod runs at `INFO`. Nothing distinguished "TikTok never sent the frame" from "the frame arrived and we filtered it out".

Both guards are deliberately permissive (a missing `businessType` or `display` reads as "probably a chest"), so any frame that did arrive would have published *something*. Across 12h of `chat:raw`, no chest was published on any channel while gifts, follows and likes flowed normally (4671 likes, 1762 follows, 20 gifts). That points at no ENVELOPE frame arriving at all.

## What

Adds the observability to decide it, and fixes one real defect found on the way.

- **`tiktok_wire_messages_total{method}`** counts every protobuf message that decoded, via the connector's `decodedData` event, giving a baseline of what TikTok actually sends.
- **`tiktok_envelope_frames_total{outcome}`** records why an envelope frame did not become a chest: `super_fan_box`, `not_a_drop`, `no_chest_payload`, `duplicate`, `error`, or `published`.
- The envelope frame is now logged at `info`. Envelopes are rare (a handful per stream against thousands of chats), so this costs nothing.
- **Phantom chests fixed.** TikTok also sends ENVELOPE frames carrying no chest at all (upstream issue #27 captured an empty payload beside a real treasure box). Such a frame passes both permissive guards and rendered "Sent a coin chest" worth 0 coins from Anonymous. `hasTikTokChestPayload` now requires a coin count, which is what actually separates a drop from an announcement.

The guards move to `src/envelope.ts` so they can be tested at all: `index.ts` starts the service on import, which is why it has no tests. Follows the existing `avatar.ts` split, and `hasTikTokChestPayload` is a type predicate so the handler needs no non-null assertions.

## Correction to an earlier claim in this PR

An earlier revision of this branch claimed the wire metric "separates 'TikTok did not send it' from 'the library cannot decode it'". **It does not, and that has been corrected in the comments and the runbook.**

`decodedData` fires only for frames that decoded. `deserializeMessage` skips a method missing from its schema with a bare `continue`, and a method that throws while decoding is dropped too. Both failure modes are invisible to the metric, so an absent method means one of three things: TikTok stopped sending it, TikTok renamed it, or it no longer decodes. The only hook that names an unknown method is the connector's `DEBUG_DESERIALIZE_XD`, which `console.log`s a base64 payload per unplaceable frame and so belongs in a short investigation, not left enabled.

The metric's real value is the negative result: proving a message is not arriving in decodable form, which previously took a prod investigation.

## Verification

- `npx tsc --noEmit` clean, `npm run build` clean.
- `npm test`: **49 passing across 5 files**, up from 30 across 4 (19 new tests over the three predicates, including the empty-frame regression).
- The `decodedData` hook was validated against the real thing: read-only probes connected to live rooms, including the reporting streamer's (returning the same room id prod was on), and recorded the wire methods TikTok sent.

## What this does not do

**It does not prove chests work**, and probing has since made the likely cause look different from proto drift.

No `WebcastEnvelopeMessage` was observed in roughly **75 room-minutes across eight live rooms**, including one with **61 `WebcastGiftMessage`** over 32 minutes of active gifting and LinkMic battles. Not one envelope frame anywhere. That is suggestive rather than conclusive, but it shifts the leading theory to **TikTok not pushing envelopes to unauthenticated connections at all**. This service connects anonymously, and the connector does support authenticated WebSocket sessions (`session` + `authenticateWs`, `WHITELIST_AUTHENTICATED_SESSION_ID_HOST`, `AuthenticatedWebSocketConnectionError`). A chest is a claimable monetary feature, so a logged-in-only push is plausible.

Testing that requires a real TikTok `sessionid` in the listener, which is a credential and account-risk decision, not a bug fix, and would deserve its own ADR.

**Next step after deploy:** read `tiktok_wire_messages_total` when a chest actually drops. If `WebcastEnvelopeMessage` is absent, the envelope is not reaching us in decodable form and the three causes above need separating with `DEBUG_DESERIALIZE_XD`. If it is present, the bug is ours and `tiktok_envelope_frames_total` names which guard dropped it.

## Deliberately not bumped

`tiktok-live-connector` 2.4.3 exists, but `v2.4.0...v2.4.3` contains **no** envelope changes (README, LICENSE, two export fixes, one new message type), so it will not fix this. That diff also relicenses to a modified AGPL whose new §19 withdraws the additional permission for "commercial, closed-source, or hosted SaaS" unless full server-side source is AGPL-3.0, with §21 excepting TikFinity/STV GmbH and Euler Stream by name. All-Chat is AGPL-3.0 so likely fine, but that is a licensing decision, not a routine bump.

## Out of scope, worth a follow-up

`tsconfig.json` has `include: ["src/**/*"]` with no test exclusion, so `*.test.ts` compiles into `dist/` and **test files ship in the production image**. It also makes a local `npm test` double-run after a build (each suite once from `src`, once from `dist`), which is confusing. Not touched here to keep this PR to the reported bug. The clean fix is a `tsconfig.build.json` that excludes tests for emit while `tsc --noEmit` keeps typechecking them.

## Troubleshooting docs

`services/tiktok-listener/README.md` gains a "A Coin Chest Did Not Appear" section with the PromQL for both metrics, how to read them, what they cannot tell you, and the current empirical state.
