### PR TITLE
fix(tiktok): stop the coin chest toggle promising an undelivered event

### DIFF
--- a/frontend/src/app/overlays/[id]/events/page.tsx
+++ b/frontend/src/app/overlays/[id]/events/page.tsx
@@ -461,9 +461,16 @@ export default function EventSettingsPage({ params }: { params: Promise<{ id: st
                       desc: 'Stream shares to other platforms',
                     },
                     {
+                      // Honest description rather than a promise. TikTok has not been observed
+                      // delivering the ENVELOPE frame a coin chest rides on: no chest reached us
+                      // across ~75 minutes of monitoring eight live rooms, one of them with 61
+                      // gifts, and no undecodable message resembling an envelope appeared either.
+                      // The cause is upstream and still unknown, so the toggle stays (it works the
+                      // moment a frame does arrive) but must not claim a feature we have never once
+                      // delivered. Drop the caveat once a chest is confirmed end to end.
                       key: 'enable_tiktok_treasure_chests',
                       label: 'Coin Chests',
-                      desc: 'Treasure boxes of coins dropped by viewers',
+                      desc: 'Treasure boxes of coins dropped by viewers. Best effort: TikTok does not reliably send these to third-party tools, so they may not appear.',
                     },
                   ].map(({ key, label, desc }) => (
                     <EventToggle

--- a/services/tiktok-listener/README.md
+++ b/services/tiktok-listener/README.md
@@ -274,10 +274,36 @@ frame it cannot place. That is noisy and unstructured, so treat it as a delibera
 investigation rather than something to leave enabled.
 
 A renamed or undecodable message means the unofficial protocol has drifted and the library needs
-bumping (as in PR #539). Note that as of 2026-08-14 no envelope frame was observed in ~75
-room-minutes across eight live rooms, including one with 61 gifts, so the leading theory is instead
-that TikTok does not push envelopes to **unauthenticated** connections, which is how this service
-connects.
+bumping (as in PR #539). **For coin chests specifically, that has been tested and ruled out.** On
+2026-08-14, `DEBUG_DESERIALIZE_XD` on two live rooms showed TikTok does send methods the library
+cannot decode (`WebcastLinkScreenChangeMessage`, `RoomMessage`,
+`WebcastUpdateShareRevenueNoticeMessage`, `WebcastAnchorToolModificationMessage`,
+`WebcastGiftGalleryMessage`, `WebcastPrivilegeAdvanceMessage`), so the check works, and **none of
+them resembles an envelope**. The chest is not arriving under a different name; it is not arriving.
+No envelope frame appeared in ~75 room-minutes across eight live rooms, one with 61 gifts.
+
+### Dead ends, so they are not re-investigated
+
+- **`room_auth` capability flags are not a signal.** `fetchRoomInfo()` is unauthenticated and
+  returns `data.room_auth.GoldenEnvelope` and `data.room_auth.anchor_level_permission.treasure_box`,
+  which look like exactly the per-room switch you want. They are not: for anonymous fetches **all 30
+  `anchor_level_permission` entries read 0**, including `share` for a room that sent us 62 social
+  frames in the same window. The map is uniformly zeroed, so a `0` says nothing about the feature.
+  Do not gate UI or listener behaviour on it.
+- **Polling the gift catalogue is not free.** `fetchAvailableGifts()` returns *"This endpoint
+  requires a Business plan"* from the Euler Stream sign server on our tier.
+- **Bumping `tiktok-live-connector` will not fix it**, per the ruled-out drift above, and 2.4.3
+  relicenses to a modified AGPL restricting hosted SaaS use. See the note in PR #695.
+
+The leading remaining theory is that TikTok pushes envelopes only to **authenticated** sessions
+(this service connects anonymously; the library does support `session` + `authenticateWs`, though it
+forwards the session cookie to the sign server, which is a credential decision, not a config
+change). Chests being region or creator-tier gated, and simply absent from every room sampled, is
+not excluded either.
+
+Probe caveat: cap concurrent probe connections at ~5. Twelve at once exhausts the Euler Stream
+free-tier sign limit, which surfaces as the connector throwing on `Cannot read properties of
+undefined (reading 'retry-after')` rather than a clean 429.
 
 ## Migration Path (Future)
 


### PR DESCRIPTION
Stacked on #695 (branched from `fix/tiktok-chest-observability`), so review that first. Rebase onto `main` once it lands.

## Why

The Coin Chests toggle defaults to enabled and reads *"Treasure boxes of coins dropped by viewers"*. That is a promise we have never once kept: **no chest has ever reached Activity & Events, on any overlay.** A setting that is on by default and silently does nothing is its own bug, separate from whatever is stopping the events upstream.

## What

The description now says it is best effort and that TikTok does not reliably send these to third-party tools.

The toggle stays, and stays on. It works the moment a frame arrives, and disabling it would hide the feature rather than fix it. There is a comment at the site saying to drop the caveat once a chest is confirmed end to end.

## Dead ends recorded in the runbook

The point of this half is that the next person does not repeat two days of investigation.

- **`room_auth` capability flags are not a signal.** `fetchRoomInfo()` is unauthenticated and returns `data.room_auth.GoldenEnvelope` and `data.room_auth.anchor_level_permission.treasure_box`, both reading `0`. That looks exactly like the per-room switch you want, and I briefly took it for the answer. It is not: **all 30** `anchor_level_permission` entries read `0` on an anonymous fetch, including `share` for a room that had just sent us **62** social frames. The map is unpopulated for anonymous callers, so a `0` carries no information. Do not gate UI or listener behaviour on it.
- **Polling the gift catalogue is not free.** `fetchAvailableGifts()` returns *"This endpoint requires a Business plan"* on our Euler Stream tier.
- **Bumping the connector will not fix chests** (drift ruled out in #695) and 2.4.3 relicenses to a modified AGPL restricting hosted-SaaS use.
- **Cap probe concurrency at ~5.** Twelve at once exhausts the free-tier sign limit, surfacing as the connector crashing on `retry-after` rather than a clean 429.

## Deliberately not included

Logging those capability flags per room was the original plan for this PR, and it is dropped. A field that reads `0` for every room and every feature is noise, not observability.

## Related

- #695 — the observability and phantom-chest fix this stacks on.
- zerodytrash/TikTok-Live-Connector#328 — upstream question on whether `ENVELOPE` requires an authenticated session, with the measurements.
- #698 — retiring Euler Stream, prompted by the rate limit and paywalled endpoint found here.
