### PR TITLE
ci(security): bump Go to 1.25.13 for six stdlib advisories

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -315,7 +315,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: Run tests for ${{ matrix.service }}
         # Skip the actual suite on docs-only PRs. The job still succeeds, so the
@@ -373,7 +373,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: Apply migrations
         env:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
 
       - name: Run full test suite for ${{ matrix.service }}
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25.12'
+          go-version: '1.25.13'
           cache: true
           cache-dependency-path: ${{ matrix.module }}/go.sum
 

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         # under services/ and shared/ declare `go 1.25.6` or newer. The Go
         # service Dockerfiles are less uniform -- they range from
         # golang:1.25-alpine to golang:1.26.5-alpine -- and CI's actions/setup-go
-        # pins 1.25.12. GOTOOLCHAIN below is what keeps that spread honest
+        # pins 1.25.13. GOTOOLCHAIN below is what keeps that spread honest
         # instead of silently downloading a fourth Go.
         pkgs.go_1_26
         pkgs.gopls


### PR DESCRIPTION
`govulncheck` is failing on 23 of 26 modules against `go1.25.12`. All of it is stdlib, none of it is our dependencies:

| Advisory | Package |
| --- | --- |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088) | `encoding/xml` |
| [GO-2026-5972](https://pkg.go.dev/vuln/GO-2026-5972) | `encoding/asn1` |

Every one reports `Fixed in: <pkg>@go1.25.13`, so bumping the four `actions/setup-go` pins clears the gate with no `go.mod` change anywhere.

`flake.nix` does not select the toolchain — it pins `go_1_26` and only *documents* CI's version in a comment. The comment moves with the pins so it does not describe a version the workflows no longer use.

Authored by hand rather than by the agent on BS-1537800044915331092-01: the GitHub App installation lacks the `workflows` permission, so any ref update touching `.github/workflows/**` is rejected at push time regardless of branch or worktree.