### PR TITLE
fix(youtube-innertube): stop discovery loops leaking on demand flap

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -299,7 +299,13 @@ jobs:
           - twitch-listener
           - twitch-eventsub-listener
           - youtube-listener
+          # The InnerTube listener is the YouTube path that actually runs in
+          # production (the quota-based youtube-listener above is not deployed), so
+          # it must be tested here. It was missing from this matrix while its
+          # undeployed sibling was covered.
+          - youtube-listener-innertube
           - youtube-quota-monitor
+          - kick-listener
           - message-processor
           - share-service
           - source-manager
@@ -308,6 +314,9 @@ jobs:
           - payment-service
           - engagement-service
           - discord-listener
+          # Every Go service under services/ belongs here. tiktok-listener is
+          # deliberately absent: it is a Node service and has no go.mod. Verify with:
+          #   for d in services/*/; do [ -f "$d/go.mod" ] && basename "$d"; done
 
     steps:
       - uses: actions/checkout@v7

--- a/services/youtube-listener-innertube/README.md
+++ b/services/youtube-listener-innertube/README.md
@@ -270,7 +270,7 @@ See "Running Locally" section above for end-to-end validation.
 
 ## Metrics
 
-InnerTube listener exposes Prometheus metrics on `/metrics` endpoint (port 8086).
+InnerTube listener exposes Prometheus metrics on `/metrics` (port 8080, `HTTP_PORT`).
 
 ### Per-Channel Message Rate
 
@@ -292,6 +292,37 @@ ignoring(channel_id) (
   rate(youtube_listener_messages_published_total{service="youtube-listener-innertube-canary"}[5m]) > 0
 )
 ```
+
+### Stream Discovery
+
+Discovery polls YouTube for a channel's live stream until it finds one, backing off
+to a 60s cadence and giving up after 1h of fruitless polling. It is **not**
+leader-gated (only poller startup is), so every instance runs its own loop for a
+demanded channel — always reason per pod, never over a fleet-wide `sum()`.
+
+**Concurrent loops per channel (invariant: ≤ 1 per instance):**
+```promql
+max by (channel_id) (youtube_listener_discovery_loops_active{namespace="allchat"})
+```
+Anything above 1 is a leaked loop: it scrapes YouTube on its own cadence and is
+unreachable by demand-loss cancellation (which only cancels the loop holding the
+`m.discovering` reservation), so it survives until the 1h give-up cap. Alerted on as
+`AllChatYouTubeDiscoveryLoopLeak`.
+
+**Discovery poll rate on the busiest instance (healthy: ≈0.017/sec = 1/min):**
+```promql
+max by (channel_id) (rate(youtube_listener_discovery_attempts_total{namespace="allchat"}[5m]))
+```
+Alerted on as `AllChatYouTubeDiscoveryRetryStorm`. A fresh loop briefly reaches
+≈0.027/sec during its 10s/20s/30s aggressive phase; sustained values above that mean
+duplicate loops or something forcing constant rediscovery.
+
+**Channels parked after 1h of fruitless polling:**
+```promql
+sum by (channel_id) (increase(youtube_listener_discovery_gave_up_total{namespace="allchat"}[6h]))
+```
+Repeated give-ups for one channel while its overlay stays connected point at either a
+chronically-offline source or leaked loops aging out.
 
 ### Error Breakdown by Type
 

--- a/services/youtube-listener-innertube/metrics/innertube_metrics.go
+++ b/services/youtube-listener-innertube/metrics/innertube_metrics.go
@@ -49,12 +49,22 @@ type InnerTubeMetrics struct {
 	DeletionBufferOverflows *prometheus.CounterVec // labels: service, channel_id
 
 	// Discovery attempt tracking - for abuse / runaway-loop detection.
-	// A high rate(...) per channel means we are scraping YouTube far more often
-	// than the intended ~1/min cadence (duplicate loops, reset storms, etc.) and
-	// is the signal to alert on. DiscoveryGaveUp counts channels parked after
+	// A high rate(...) means we are scraping YouTube far more often than the
+	// intended ~1/min cadence (duplicate loops, reset storms, etc.). Reason about it
+	// per instance — max by (channel_id), not sum: discovery is not leader-gated, so
+	// a fleet-wide sum scales with replica count and any threshold over it drifts on
+	// every scale-up. DiscoveryGaveUp counts channels parked after
 	// maxDiscoveryDuration so we can see chronically-offline sources.
 	DiscoveryAttempts *prometheus.CounterVec // labels: service, channel_id
 	DiscoveryGaveUp   *prometheus.CounterVec // labels: service, channel_id
+
+	// Concurrent discovery loops per channel. The invariant is at most 1 per
+	// channel per instance — a loop reserves m.discovering[channelID] before it
+	// starts. Anything above 1 is a leaked loop, which multiplies our YouTube
+	// scrape rate and cannot be cancelled through the normal demand path. This is
+	// the direct signal for that; DiscoveryAttempts only shows it indirectly, as a
+	// rate that has to be reasoned about against replica count and backoff phase.
+	DiscoveryLoopsActive *prometheus.GaugeVec // labels: service, channel_id
 }
 
 // NewInnerTubeMetrics creates and registers InnerTube Prometheus metrics
@@ -143,6 +153,13 @@ func NewInnerTubeMetrics() *InnerTubeMetrics {
 			},
 			[]string{"service", "channel_id"},
 		),
+		DiscoveryLoopsActive: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "youtube_listener_discovery_loops_active",
+				Help: "Currently-running stream-discovery loops per channel on this instance. Must never exceed 1; >1 means a leaked loop is double-scraping YouTube.",
+			},
+			[]string{"service", "channel_id"},
+		),
 	}
 }
 
@@ -161,8 +178,8 @@ const (
 
 // ReconnectionReasons define standardized reason labels for reconnection tracking
 const (
-	ReconnectionReasonError    = "error"     // Reconnection after transient error
-	ReconnectionReasonOffline  = "offline"   // Reconnection after stream went offline
-	ReconnectionReasonBackoff  = "backoff"   // Reconnection after backoff period
+	ReconnectionReasonError       = "error"       // Reconnection after transient error
+	ReconnectionReasonOffline     = "offline"     // Reconnection after stream went offline
+	ReconnectionReasonBackoff     = "backoff"     // Reconnection after backoff period
 	ReconnectionReasonRediscovery = "rediscovery" // Reconnection after stream rediscovery
 )

--- a/services/youtube-listener-innertube/streams/manager.go
+++ b/services/youtube-listener-innertube/streams/manager.go
@@ -317,7 +317,7 @@ func (m *Manager) startAsyncDiscovery(channelID, overlayID string, opts Discover
 		} else {
 			// Poller started from cache — release the discovery reservation we
 			// took above and stop, no discovery loop needed.
-			m.cleanupDiscoveryState(channelID)
+			m.cleanupDiscoveryState(state)
 			cancel()
 			return
 		}
@@ -358,6 +358,14 @@ const maxDiscoveryDuration = 1 * time.Hour
 func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 	defer m.wg.Done()
 
+	// Track concurrent loops per channel so a leak is visible directly rather than
+	// having to be inferred from the scrape rate. Every exit path below runs this
+	// defer, so the gauge returns to 0 when the last loop for the channel stops.
+	if m.metrics != nil {
+		m.metrics.DiscoveryLoopsActive.WithLabelValues(metrics.ServiceLabel, state.ChannelID).Inc()
+		defer m.metrics.DiscoveryLoopsActive.WithLabelValues(metrics.ServiceLabel, state.ChannelID).Dec()
+	}
+
 	// Exponential backoff capped at 1 minute. Keep polling indefinitely until a stream is
 	// discovered or the source is deactivated.
 	backoffSequence := []time.Duration{
@@ -375,9 +383,26 @@ func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 				zap.String("channel_id", state.ChannelID),
 				zap.Int("attempts", state.Attempts),
 			)
-			m.cleanupDiscoveryState(state.ChannelID)
+			m.cleanupDiscoveryState(state)
 			return
 		default:
+		}
+
+		// Defence in depth against orphaned loops: if we no longer hold the
+		// reservation, another loop owns this channel and we must stop. An orphan is
+		// invisible to reconcileDemand (which can only cancel states still in
+		// m.discovering), so nothing else would ever stop it before the give-up cap.
+		// Cancelling our own context here is safe: every path that starts a poller
+		// returns from this loop immediately, so no poller is bound to this context
+		// at the top of an iteration — only the cross-platform event subscriber is,
+		// and that must shut down with us.
+		if !m.ownsDiscovery(state) {
+			m.logger.Info("Discovery reservation lost to another loop, exiting",
+				zap.String("channel_id", state.ChannelID),
+				zap.Int("attempts", state.Attempts),
+			)
+			state.CancelFunc()
+			return
 		}
 
 		// Hard wall-clock cap: stop polling YouTube once we've spent
@@ -431,7 +456,7 @@ func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 					}
 				}
 				if started > 0 {
-					m.cleanupDiscoveryState(state.ChannelID)
+					m.cleanupDiscoveryState(state)
 					return
 				}
 				// All pollers failed (leadership held etc.) — fall through to backoff
@@ -466,7 +491,7 @@ func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 							zap.String("channel_id", state.ChannelID),
 							zap.String("video_id", videoID),
 						)
-						m.cleanupDiscoveryState(state.ChannelID)
+						m.cleanupDiscoveryState(state)
 						return
 					}
 					m.logger.Error("Failed to start poller after discovery, will retry",
@@ -477,7 +502,7 @@ func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 					discoveryErr = err
 					// Fall through to backoff and retry the whole discovery+poller process
 				} else {
-					m.cleanupDiscoveryState(state.ChannelID)
+					m.cleanupDiscoveryState(state)
 					return
 				}
 			} else {
@@ -514,7 +539,7 @@ func (m *Manager) discoveryLoop(ctx context.Context, state *DiscoveryState) {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			m.cleanupDiscoveryState(state.ChannelID)
+			m.cleanupDiscoveryState(state)
 			return
 		case <-state.ResetBackoffChan:
 			// Cross-platform trigger: another platform went live, retry immediately.
@@ -567,7 +592,7 @@ func (m *Manager) giveUpDiscovery(state *DiscoveryState) {
 	// Mark gave-up first, then drop the in-progress reservation, so there is no
 	// window in which the channel looks idle to a concurrent periodic sync.
 	m.markDiscoveryGaveUp(state.ChannelID)
-	m.cleanupDiscoveryState(state.ChannelID)
+	m.cleanupDiscoveryState(state)
 
 	// Stop the cross-platform subscription goroutine for this discovery.
 	if state.CancelFunc != nil {
@@ -1150,12 +1175,38 @@ func (m *Manager) handleLeadershipLoss(ctx context.Context, videoID string) {
 	}
 }
 
-// cleanupDiscoveryState removes discovery state after completion or cancellation
-func (m *Manager) cleanupDiscoveryState(channelID string) {
+// cleanupDiscoveryState releases the m.discovering reservation held by state,
+// after completion or cancellation.
+//
+// The identity check is load-bearing. A discovery loop routinely outlives its own
+// reservation: reconcileDemand cancels the context and drops the map entry
+// immediately, but the goroutine only observes ctx.Done() on its next iteration —
+// potentially seconds later, mid-HTTP-request. If demand returns inside that
+// window a fresh loop reserves the slot, and a key-only delete from the dying loop
+// would evict the *new* owner. The channel then looks idle to the 30s periodic
+// sync, which spawns yet another loop while the evicted one is still running.
+// Loops accumulate, and none of them can be stopped by reconcileDemand any more
+// (it only cancels states still present in m.discovering), so each keeps scraping
+// YouTube every 60s until maxDiscoveryDuration. Observed in production as 6 loops
+// started per pod per hour for a single offline channel, tripping
+// AllChatYouTubeDiscoveryRetryStorm.
+func (m *Manager) cleanupDiscoveryState(state *DiscoveryState) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.discovering, channelID)
+	if current, exists := m.discovering[state.ChannelID]; exists && current == state {
+		delete(m.discovering, state.ChannelID)
+	}
+}
+
+// ownsDiscovery reports whether state still holds the m.discovering reservation for
+// its channel. A loop that has lost the reservation must stop: another loop owns
+// the channel now, and continuing would multiply the YouTube poll rate.
+func (m *Manager) ownsDiscovery(state *DiscoveryState) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.discovering[state.ChannelID] == state
 }
 
 // periodicSync periodically syncs active sources (fallback for PostgreSQL LISTEN)

--- a/services/youtube-listener-innertube/streams/manager.go
+++ b/services/youtube-listener-innertube/streams/manager.go
@@ -635,7 +635,15 @@ func (m *Manager) clearGaveUpForDemandChanges(prev, demanded map[string]bool) {
 }
 
 // subscribeToPlatformEvents subscribes to cross-platform events for an overlay
-// and signals backoff reset when other platforms go live
+// and signals backoff reset when other platforms go live.
+//
+// KNOWN LEAK, do not "fix" it by cancelling on success: this goroutine only exits
+// on ctx.Done(), and the paths in discoveryLoop that start a poller deliberately
+// return *without* cancelling, because startPoller passes that same context to
+// poller.Start — cancelling it would kill the live poller and stop message
+// delivery. So a successful discovery leaves one subscriber goroutine and one
+// Redis subscription behind for the process lifetime. Closing it properly means
+// decoupling the poller's context from the discovery context first.
 func (m *Manager) subscribeToPlatformEvents(ctx context.Context, state *DiscoveryState) {
 	defer m.wg.Done()
 

--- a/services/youtube-listener-innertube/streams/manager_test.go
+++ b/services/youtube-listener-innertube/streams/manager_test.go
@@ -361,6 +361,7 @@ func TestManager_OnOverlayDisconnected_StopsPoller(t *testing.T) {
 //   - markDiscoveryGaveUp parks a channel,
 //   - a demand change (newly demanded OR demand lost) clears the marker,
 //   - a channel that stays continuously demanded keeps its marker.
+//
 // Pure in-memory logic — no Redis required.
 func TestManager_DiscoveryGiveUp_RefreshOnDemandChange(t *testing.T) {
 	manager := &Manager{
@@ -393,4 +394,100 @@ func TestManager_DiscoveryGiveUp_RefreshOnDemandChange(t *testing.T) {
 	manager.clearGaveUpForDemandChanges(map[string]bool{}, map[string]bool{parked: true})
 	assert.False(t, manager.hasDiscoveryGivenUp(parked),
 		"re-asserted demand clears the give-up marker so discovery can resume")
+}
+
+// TestManager_CleanupDiscoveryState_KeepsNewerReservation reproduces the loop leak
+// that tripped AllChatYouTubeDiscoveryRetryStorm in production: a discovery loop
+// can outlive its own reservation, and its late cleanup must not evict the loop
+// that replaced it. Pure in-memory logic — no Redis required.
+func TestManager_CleanupDiscoveryState_KeepsNewerReservation(t *testing.T) {
+	manager := &Manager{
+		logger:      zap.NewNop(),
+		discovering: make(map[string]*DiscoveryState),
+	}
+
+	const channelID = "UCleakrepro"
+
+	// A discovery loop is running and holds the reservation.
+	stale := &DiscoveryState{ChannelID: channelID, CancelFunc: func() {}}
+	manager.discovering[channelID] = stale
+
+	// Demand is lost: reconcileDemand cancels the context and drops the reservation
+	// immediately, while the goroutine is still mid-attempt.
+	delete(manager.discovering, channelID)
+
+	// Demand returns before the cancelled goroutine notices, so a fresh loop
+	// reserves the slot and starts polling.
+	fresh := &DiscoveryState{ChannelID: channelID, CancelFunc: func() {}}
+	manager.discovering[channelID] = fresh
+
+	// Only now does the cancelled goroutine reach its cleanup.
+	manager.cleanupDiscoveryState(stale)
+
+	current, exists := manager.discovering[channelID]
+	assert.True(t, exists,
+		"stale cleanup must leave the channel reserved, else periodic sync spawns another loop")
+	assert.Same(t, fresh, current, "stale cleanup must not evict the newer discovery state")
+}
+
+// TestManager_CleanupDiscoveryState_ReleasesOwnReservation verifies the identity
+// check does not break the normal path: the loop that owns the reservation still
+// releases it, so a later sync can rediscover the channel.
+func TestManager_CleanupDiscoveryState_ReleasesOwnReservation(t *testing.T) {
+	manager := &Manager{
+		logger:      zap.NewNop(),
+		discovering: make(map[string]*DiscoveryState),
+	}
+
+	const channelID = "UCowner"
+	owner := &DiscoveryState{ChannelID: channelID, CancelFunc: func() {}}
+	manager.discovering[channelID] = owner
+
+	manager.cleanupDiscoveryState(owner)
+
+	_, exists := manager.discovering[channelID]
+	assert.False(t, exists, "the reservation holder must release its own slot")
+}
+
+// TestManager_DiscoveryLoop_ExitsWhenReservationLost covers the orphan case:
+// a loop that no longer owns its channel is unreachable by reconcileDemand (that
+// only cancels states still in m.discovering), so the loop must notice and stop
+// itself rather than scrape YouTube until the 1h give-up cap.
+func TestManager_DiscoveryLoop_ExitsWhenReservationLost(t *testing.T) {
+	manager := &Manager{
+		logger:      zap.NewNop(),
+		discovering: make(map[string]*DiscoveryState),
+	}
+
+	const channelID = "UCorphan"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orphan := &DiscoveryState{
+		ChannelID:        channelID,
+		StartedAt:        time.Now(),
+		CancelFunc:       cancel,
+		ResetBackoffChan: make(chan struct{}, 1),
+	}
+	owner := &DiscoveryState{ChannelID: channelID, CancelFunc: func() {}}
+	manager.discovering[channelID] = owner
+
+	manager.wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		manager.discoveryLoop(ctx, orphan)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("orphaned discovery loop did not exit; it would keep polling YouTube until the give-up cap")
+	}
+
+	assert.Same(t, owner, manager.discovering[channelID],
+		"the orphan must not touch the current owner's reservation")
+	assert.Error(t, ctx.Err(),
+		"the orphan must cancel its own context so its cross-platform subscriber shuts down")
 }


### PR DESCRIPTION
## Problem

`AllChatYouTubeDiscoveryRetryStorm` fired for channel `UC9XKnYvm82xzzliMqMoB4-A`. It auto-cleared, but the underlying leak was still active: each innertube pod had **6 discovery loops** for that single channel over the previous hour, and Loki shows one pod running two loops simultaneously with unrelated attempt counters (19→22 alongside 60→62). 8 give-ups in 6h for the same channel.

## Cause

`cleanupDiscoveryState` deleted `m.discovering[channelID]` **by key**, without checking the entry belonged to the caller.

A discovery loop routinely outlives its own reservation: `reconcileDemand` cancels the context and drops the map entry immediately, but the goroutine only observes `ctx.Done()` on its next iteration, potentially seconds later and mid-HTTP-request. If demand returns inside that window a fresh loop reserves the slot, and the dying loop's cleanup evicts the **new** owner. The channel then looks idle to the 30s periodic sync, which spawns another loop while the evicted one is still running.

Orphans are unreachable by `reconcileDemand` (it only cancels loops still present in `m.discovering`), so each keeps scraping YouTube every 60s until the 1h give-up cap. Production showed 6 loops started per pod per hour against 6 cancels of which only 1–2 were ever acknowledged.

## Fix

- `cleanupDiscoveryState` takes the state and releases the reservation only if it still holds it.
- `discoveryLoop` exits when it no longer owns the reservation, so any orphan self-terminates rather than polling until the cap. Cancelling its own context there is safe: every path that starts a poller returns from the loop immediately, so no poller is bound to that context at the top of an iteration — only the cross-platform event subscriber, which must shut down with it.
- New `youtube_listener_discovery_loops_active` gauge exposes the invariant (≤1 loop per channel per instance) directly, instead of leaving it to be inferred from the scrape rate.

## Tests

Three new tests, written failing first:

- `TestManager_CleanupDiscoveryState_KeepsNewerReservation` — replays the production sequence; a stale loop's cleanup must not evict its replacement.
- `TestManager_CleanupDiscoveryState_ReleasesOwnReservation` — the identity check must not break the normal release path.
- `TestManager_DiscoveryLoop_ExitsWhenReservationLost` — an orphaned loop terminates itself and cancels its own context.

Full service suite green under `-race`.

## Companion change

caesarakalaeii/caesar-deployment#67 recalibrates the alert and removes a duplicate scrape that made every `sum()`/`rate()` over these pods read 2x.