### PR TITLE
fix(overlay): measure feed overflow against the canvas, not the viewport

### DIFF
--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -207,9 +207,6 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   const ttsFallbackToastShownRef = useRef(false)
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
-  // The message list element, so the auto-scroll effect can tell whether the
-  // feed actually overflows its canvas before deciding to scroll it.
-  const feedBodyRef = useRef<HTMLDivElement>(null)
   // Single source of truth for the two orthogonal feed-layout axes.
   const feedLayout = useMemo(
     () => resolveFeedAnchorLayout(feedAnchor, invertMessageOrder),
@@ -530,8 +527,15 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   // no-op at best. Once it overflows, the `mt-auto` has collapsed to 0 and the
   // feed is a plain scrolling list again — so scroll, exactly as before.
   useEffect(() => {
-    const body = feedBodyRef.current
-    const overflows = body != null && body.getBoundingClientRect().height > window.innerHeight
+    // "Overflows" has to mean "the page scrolls", which is why this measures the
+    // document rather than the list. The wrapper is `min-h-screen p-4`, so the
+    // canvas the list actually gets is the viewport MINUS 32px of padding, and
+    // the wrapper's own box grows with the list once it passes that. Comparing
+    // the list's height against a bare `window.innerHeight` therefore reported
+    // "no overflow" for a band of ~32px in which the page did scroll — and a
+    // bottom-anchored feed then skipped the scroll and let `body`'s
+    // `overflow: hidden` clip the newest row until the next message arrived.
+    const overflows = document.documentElement.scrollHeight > window.innerHeight
     if (!shouldAutoScroll(feedLayout, overflows)) return
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, feedLayout])
@@ -724,7 +728,6 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
           children: `.overlay-live-body > * + *` in events.css and
           `.scroll-anchor` in globals.css are both `!important` and would win. */}
       <div
-        ref={feedBodyRef}
         className={clsx(
           'overlay-live-body space-y-3',
           feedLayout.bodyClass,

--- a/frontend/src/lib/utils/feedAnchor.ts
+++ b/frontend/src/lib/utils/feedAnchor.ts
@@ -153,6 +153,14 @@ export function resolveFeedAnchorLayout(
  * and stay testable. When the content overflows, every mode scrolls: the
  * bottom-anchored auto margin has collapsed to `0` and the feed is once again a
  * plain scrolling list whose newest row must be brought into view.
+ *
+ * @param contentOverflows must mean "the feed no longer fits the canvas it is
+ *   anchored in", i.e. the SCROLL CONTAINER overflows — not merely "the list is
+ *   taller than the viewport". Those differ by the wrapper's padding, and on the
+ *   live overlay (`min-h-screen p-4`) getting it wrong left a ~32px band where
+ *   a bottom-anchored feed clipped its newest row instead of scrolling to it.
+ *   Measure the document (live overlay) or the scroll container's
+ *   `scrollHeight > clientHeight` (embed preview, where the list itself scrolls).
  */
 export function shouldAutoScroll(layout: FeedAnchorLayout, contentOverflows: boolean): boolean {
   return contentOverflows || layout.autoScrollWhenShort


### PR DESCRIPTION
Follow-up to #729 (`display_settings.feed_anchor`).

## The bug

The auto-scroll predicate compared the message list's height against a bare
`window.innerHeight`:

```ts
const overflows = body != null && body.getBoundingClientRect().height > window.innerHeight
```

The wrapper is `min-h-screen w-full bg-transparent p-4`, so the canvas the list
actually gets is the viewport **minus 32px** of padding. The page therefore
starts scrolling once the list passes `100vh - 32px`, not `100vh`.

That leaves a band of roughly 32px where the page genuinely scrolls while the
predicate reports no overflow. It only bites in the new opt-in mode:

* With `feed_anchor: 'top'`, `autoScrollWhenShort` is `true`, so the scroll
  happens regardless and the band is invisible.
* With `feed_anchor: 'bottom'`, `autoScrollWhenShort` is `false`. Inside the
  band the `mt-auto` has already collapsed to `0`, so the feed is a plain
  scrolling list, but the scroll was skipped and the injected
  `body { overflow: hidden !important }` clipped up to 32px off the newest row.

It self-corrected as soon as one more message pushed the feed past `100vh`, so
the visible symptom was a briefly half-cut newest row, not a stuck feed.

## The fix

Measure the document instead:

```ts
const overflows = document.documentElement.scrollHeight > window.innerHeight
```

That is the condition actually wanted ("the page scrolls"), and it accounts for
the wrapper's padding without hardcoding 32px anywhere. It also makes the list
ref redundant, so that is removed.

The embed preview needed no change: its list **is** the scroll container
(`overflow-y-auto` + `max-h-full`), so its existing
`scrollHeight > clientHeight` is already the right measure. The two surfaces
legitimately measure differently, which is what caused the mix-up, so
`shouldAutoScroll`'s doc comment now spells out what `contentOverflows` must
mean on each.

## Verification

Run locally against this branch:

* `tsc --noEmit`: exit 0
* `vitest --project unit --run` full suite: 94 files, 993 passed, 3 todo
* `feedAnchor.test.ts`: 19/19 (pure module unchanged in behaviour, so its
  contract tests still hold)
* the required `a11y-static` eslint gate: 0 errors (29 warnings, all
  pre-existing `noInlineConfig` notices in untouched files)
* `prettier --check` on both touched files: clean

No behaviour change for `feed_anchor: 'top'`, which is the default and what
every pre-#729 overlay resolves to.