### PR TITLE
fix(overlay): make invert_message_order work with a bottom-anchored feed

### DIFF
--- a/docs/CSS_CUSTOMIZATION.md
+++ b/docs/CSS_CUSTOMIZATION.md
@@ -570,19 +570,64 @@ All four combinations are valid. Once the feed is taller than the canvas the
 anchor stops mattering — the overlay scrolls to keep the newest message in view
 in every mode, exactly as it always has.
 
-The overlay wrapper carries the current mode as a stable attribute, so a theme
-can react to it:
+The overlay wrapper carries **both** axes as stable attributes, so a theme can
+react to either without having to guess:
+
+| Attribute | Values | Reflects |
+|-----------|--------|----------|
+| `data-feed-anchor` | `top` / `bottom` | which canvas edge the stack rests on |
+| `data-feed-order` | `newest-last` / `newest-first` | which end of the list is newest (`newest-first` = Invert Message Order is on) |
 
 ```css
 /* Fade the far end of the feed, whichever end that happens to be */
 [data-feed-anchor="top"]    .overlay-live-body > div:last-child  { opacity: 0.6; }
 [data-feed-anchor="bottom"] .overlay-live-body > div:first-child { opacity: 0.6; }
+
+/* Or key off the reading order instead */
+[data-feed-order="newest-first"] .overlay-live-body > div:first-child { font-weight: 600; }
 ```
 
 Bottom anchoring is a flex-column wrapper plus `margin-top: auto` on
 `.overlay-live-body`. Do not override the wrapper's `flex-direction` or the
 list's `margin-top` — that re-pins the feed to the edge the user did not pick.
 Styling the list's children is unaffected.
+
+#### Entry animations follow the order
+
+A new message lands at whichever end of the list is newest, so a vertical entry
+animation has to come in from that side. `data-feed-order` drives two inherited
+custom properties that the built-in `.msg-anim-*` presets read:
+
+| Property | `newest-last` (default) | `newest-first` |
+|----------|------------------------|----------------|
+| `--msg-enter-dir` | `1` (unset; enters from below) | `-1` (enters from above) |
+| `--msg-enter-origin` | `100%` (unset; hinges on its bottom edge) | `0%` (hinges on its top edge) |
+
+Custom keyframes are welcome to read them so they flip too:
+
+```css
+@keyframes my-entry {
+  from { opacity: 0; transform: translateY(calc(40px * var(--msg-enter-dir, 1))); }
+  to   { opacity: 1; transform: none; }
+}
+```
+
+Overriding a `.msg-anim-*` rule outright still works — they are single unlayered
+class selectors, and these properties never raise their specificity.
+
+#### `.scroll-anchor` is not yours to style
+
+The list contains one invisible sentinel, `.scroll-anchor`, next to the newest
+message; the overlay scrolls to it. It must stay a zero-box element. Exclude it
+from any rule that styles overlay rows — the bundled High Contrast theme shows
+the pattern:
+
+```css
+.space-y-3 > div:not(.scroll-anchor) { /* … */ }
+```
+
+A rule that catches it gives the sentinel a real box, which shows up as dead
+space glued to the newest message (very visible on a bottom-anchored feed).
 
 ### Override Display Settings with CSS
 

--- a/docs/overlay-themes/README.md
+++ b/docs/overlay-themes/README.md
@@ -261,10 +261,13 @@ All four combinations are valid. `feed_anchor: bottom` with the order NOT
 inverted is the Twitch-like arrangement: newest at the bottom, older messages
 pushed upward, blank space at the top.
 
-The live overlay wrapper and the editor preview root both carry a stable hook:
+The live overlay wrapper and the editor preview root both carry one stable hook
+per axis:
 
 - `[data-feed-anchor="top"]` — feed glued to the top edge, grows downward
 - `[data-feed-anchor="bottom"]` — feed glued to the bottom edge, grows upward
+- `[data-feed-order="newest-last"]` — normal reading order
+- `[data-feed-order="newest-first"]` — Invert Message Order is on
 
 ```css
 /* Fade the far end of the feed, whichever end that happens to be */
@@ -275,6 +278,35 @@ The live overlay wrapper and the editor preview root both carry a stable hook:
   opacity: 0.6;
 }
 ```
+
+A new message lands at whichever end `data-feed-order` names, so vertical entry
+animations have to enter from that side. The attribute sets two inherited custom
+properties the built-in `.msg-anim-*` presets read — `--msg-enter-dir` (`1`, or
+`-1` when newest-first) and `--msg-enter-origin` (`100%`, or `0%`). Custom
+keyframes can read them and flip for free:
+
+```css
+@keyframes my-entry {
+  from {
+    opacity: 0;
+    transform: translateY(calc(40px * var(--msg-enter-dir, 1)));
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+Overriding a `.msg-anim-*` rule outright still works — they are single unlayered
+class selectors, and these properties do not raise their specificity.
+
+**Exclude `.scroll-anchor`** from any rule that styles overlay rows. It is the
+invisible auto-scroll sentinel rendered next to the newest message and must stay
+a zero-box element; a rule that catches it turns it into dead space glued to the
+newest message, which a bottom-anchored feed shows as a gap on the edge it was
+supposed to rest on. The bundled High Contrast theme shows the pattern:
+`.space-y-3 > div:not(.scroll-anchor)`.
 
 **Do not** set `margin-top`, `justify-content` or `flex-direction` on the
 wrapper or on `.overlay-live-body` itself. Bottom anchoring is implemented as a

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -551,6 +551,12 @@ export default function DocsPage() {
                     targets:
                       'The overlay wrapper, carrying the Feed Anchor setting. Read it to adapt; don’t override the wrapper’s flex-direction or the list’s margin-top, which are what move the feed.',
                   },
+                  {
+                    selector: '[data-feed-order="newest-last|newest-first"]',
+                    kind: 'attribute',
+                    targets:
+                      'The overlay wrapper, carrying the Invert Message Order setting. It also flips --msg-enter-dir and --msg-enter-origin, so entry animations come in from the end the newest message lands on.',
+                  },
                 ]}
               />
               <p>
@@ -562,7 +568,13 @@ export default function DocsPage() {
               </p>
               <Pre lang="css">{`/* Fade the far end of the feed, whichever end that is */
 [data-feed-anchor="top"]    .overlay-live-body > div:last-child  { opacity: 0.6; }
-[data-feed-anchor="bottom"] .overlay-live-body > div:first-child { opacity: 0.6; }`}</Pre>
+[data-feed-anchor="bottom"] .overlay-live-body > div:first-child { opacity: 0.6; }
+
+/* Custom entry animation that flips with Invert Message Order */
+@keyframes my-entry {
+  from { opacity: 0; transform: translateY(calc(40px * var(--msg-enter-dir, 1))); }
+  to   { opacity: 1; transform: none; }
+}`}</Pre>
               <p>Example — give each platform its own accent stripe:</p>
               <Pre lang="css">{`.chat-message[data-platform="twitch"]  { border-left: 4px solid #9146FF; }
 .chat-message[data-platform="youtube"] { border-left: 4px solid #FF0000; }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -221,6 +221,28 @@
   overflow-x: clip;
 }
 
+/* DIRECTION OF ENTRY — the stack grows at whichever end the newest message
+   lands on, so a vertical entry animation has to come in from THAT edge. With
+   `invert_message_order` the newest row is the FIRST child, and an unflipped
+   `translateY(110%)` makes it crawl out from underneath its neighbour instead
+   of dropping in from the free space above.
+
+   `data-feed-order` is written on the overlay wrapper from the ORDER axis alone
+   (lib/utils/feedAnchor.ts — the ANCHOR axis moves the whole stack and does not
+   change which end grows). Only the three direction-dependent presets read
+   these; `fly-left`/`fly-right`/`fly-spring`/`swoosh` are horizontal and
+   `soft-focus` is a pure scale, so all five are already order-agnostic.
+
+   Parameterising the keyframes — rather than adding
+   `[data-feed-order='newest-first'] .msg-anim-*` overrides — is deliberate: it
+   keeps every `.msg-anim-*` rule a single unlayered class selector, so the
+   documented "themes and custom CSS can override these" contract still holds at
+   equal specificity. */
+[data-feed-order='newest-first'] {
+  --msg-enter-dir: -1;
+  --msg-enter-origin: 0%;
+}
+
 .msg-anim-fly-left {
   animation: msg-anim-fly-left 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
@@ -246,7 +268,7 @@
 }
 
 .msg-anim-pop {
-  transform-origin: 18% 100%;
+  transform-origin: 18% var(--msg-enter-origin, 100%);
   animation: msg-anim-pop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 @keyframes msg-anim-pop {
@@ -258,19 +280,19 @@
   animation: msg-anim-bounce 600ms linear both;
 }
 @keyframes msg-anim-bounce {
-  0%   { opacity: 0; transform: translateY(110%); }
-  55%  { opacity: 1; transform: translateY(-7%); }
-  75%  { transform: translateY(4%); }
-  90%  { transform: translateY(-2%); }
+  0%   { opacity: 0; transform: translateY(calc(110% * var(--msg-enter-dir, 1))); }
+  55%  { opacity: 1; transform: translateY(calc(-7% * var(--msg-enter-dir, 1))); }
+  75%  { transform: translateY(calc(4% * var(--msg-enter-dir, 1))); }
+  90%  { transform: translateY(calc(-2% * var(--msg-enter-dir, 1))); }
   100% { transform: none; }
 }
 
 .msg-anim-flip {
-  transform-origin: 50% 100%;
+  transform-origin: 50% var(--msg-enter-origin, 100%);
   animation: msg-anim-flip 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 @keyframes msg-anim-flip {
-  from { opacity: 0; transform: perspective(600px) rotateX(-75deg); }
+  from { opacity: 0; transform: perspective(600px) rotateX(calc(-75deg * var(--msg-enter-dir, 1))); }
   to   { opacity: 1; transform: perspective(600px) rotateX(0deg); }
 }
 
@@ -313,7 +335,15 @@
 
 /* Scroll anchor — invisible sentinel div used for auto-scrolling in overlay pages.
    Must never be styled by theme CSS. Use a higher-specificity selector so this
-   overrides broad theme rules like `.space-y-3 > div { ... !important }`. */
+   overrides broad theme rules like `.space-y-3 > div { ... !important }`.
+
+   SCOPE LIMIT: these are UNLAYERED `!important` declarations, which lose to an
+   `!important` declaration inside a cascade layer (CSS Cascade 5 reverses layer
+   order for important declarations, and ranks unlayered last). So this block
+   holds the line against theme/marketplace CSS, but NOT against
+   `@layer visual-customizer` in events.css — that one has to exclude
+   `.scroll-anchor` by selector, and does. Anything new that styles overlay rows
+   from inside a layer must exclude it too, or the sentinel grows a box again. */
 .space-y-3 > div.scroll-anchor,
 .scroll-anchor {
   display: block !important;

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -207,6 +207,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   const ttsFallbackToastShownRef = useRef(false)
 
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  // The full-canvas wrapper. Measured (layout height) by the auto-scroll effect.
+  const feedWrapperRef = useRef<HTMLDivElement>(null)
   // Single source of truth for the two orthogonal feed-layout axes.
   const feedLayout = useMemo(
     () => resolveFeedAnchorLayout(feedAnchor, invertMessageOrder),
@@ -255,17 +257,28 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
     soundPlayerRef.current?.play()
     // Phase 13: speak the message via TTS (D-41, D-42 — independent of sound; both fire on non-filtered)
     ttsPlayerRef.current?.speak(message)
-    setMessages((prev) => [...prev, message].slice(-maxMessagesRef.current))
+    setMessages((prev) =>
+      // Ignore a redelivery of a message already on screen. The render key is
+      // `message.id`, so a duplicate id would be a duplicate React key (and the
+      // deletion path already assumes ids are unique — it removes every row
+      // matching `target_uuid`). A WebSocket reconnect that replays the tail is
+      // the realistic source.
+      prev.some((m) => m.id === message.id)
+        ? prev
+        : [...prev, message].slice(-maxMessagesRef.current)
+    )
   }, [])
 
   const onMessageUpdate = useCallback((updatedMessage: ChatMessage) => {
     setMessages((prev) => {
-      // Find existing message by aggregation_id (TikTok like aggregates)
+      // Find existing message by aggregation_id (TikTok like aggregates), then
+      // by id — an update that carries a live row's id has to REPLACE that row.
+      // Appending it would put the same id on screen twice, and the render key
+      // is the id (see onChat).
       const aggregationId = updatedMessage.event?.aggregation_id
-      if (!aggregationId) {
-        return [...prev, updatedMessage].slice(-maxMessagesRef.current)
-      }
-      const index = prev.findIndex((m) => m.event?.aggregation_id === aggregationId)
+      const index = aggregationId
+        ? prev.findIndex((m) => m.event?.aggregation_id === aggregationId)
+        : prev.findIndex((m) => m.id === updatedMessage.id)
       if (index === -1) {
         // Original message already faded away, treat as new
         return [...prev, updatedMessage].slice(-maxMessagesRef.current)
@@ -522,22 +535,36 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
 
   // Auto-scroll to bottom when new messages arrive.
   //
-  // A bottom-anchored feed that has not yet filled the canvas is already
-  // resting against the edge the newest message is on, so scrolling it is a
-  // no-op at best. Once it overflows, the `mt-auto` has collapsed to 0 and the
-  // feed is a plain scrolling list again — so scroll, exactly as before.
+  // A short bottom-anchored feed has nothing to scroll, so skip the call. Once
+  // it overflows, the `mt-auto` has collapsed to 0 and the feed is a plain
+  // scrolling list again — so scroll, exactly as before.
   useEffect(() => {
     // "Overflows" has to mean "the page scrolls", which is why this measures the
-    // document rather than the list. The wrapper is `min-h-screen p-4`, so the
-    // canvas the list actually gets is the viewport MINUS 32px of padding, and
-    // the wrapper's own box grows with the list once it passes that. Comparing
-    // the list's height against a bare `window.innerHeight` therefore reported
-    // "no overflow" for a band of ~32px in which the page did scroll — and a
+    // wrapper and not the list. The wrapper is `min-h-screen p-4`, so the canvas
+    // the list actually gets is the viewport MINUS 32px of padding, and the
+    // wrapper's own box grows with the list once it passes that. Comparing the
+    // list's height against a bare `window.innerHeight` therefore reported "no
+    // overflow" for a band of ~32px in which the page did scroll — and a
     // bottom-anchored feed then skipped the scroll and let `body`'s
     // `overflow: hidden` clip the newest row until the next message arrived.
-    const overflows = document.documentElement.scrollHeight > window.innerHeight
+    //
+    // `offsetHeight` (LAYOUT height), not `documentElement.scrollHeight`
+    // (SCROLLABLE height): an entry animation translates the new row outside the
+    // list — `msg-anim-bounce` starts at `translateY(110%)`, the default
+    // `slide-in-from-bottom-2` at 8px — and transformed descendants count toward
+    // scrollable overflow. On a bottom-anchored feed, whose list ends flush with
+    // the canvas, that briefly made a feed that fits report an overflow, so this
+    // effect smooth-scrolled the page and let it snap back when the animation
+    // ended: a visible jitter on every single message. Layout height ignores
+    // transforms, which is exactly the question being asked here.
+    const wrapper = feedWrapperRef.current
+    const overflows = wrapper != null && wrapper.offsetHeight > window.innerHeight
     if (!shouldAutoScroll(feedLayout, overflows)) return
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    // `block: 'nearest'` (as on the embed preview) scrolls the minimum needed to
+    // reveal the sentinel instead of always slamming it to the viewport's top
+    // edge, which keeps a transient mid-animation measurement from moving a feed
+    // that is already showing its newest row.
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
   }, [messages, feedLayout])
 
   // Auto-remove old messages based on duration (if fade is enabled)
@@ -677,8 +704,10 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
      * un-anchor the feed.
      */
     <div
+      ref={feedWrapperRef}
       className={clsx('min-h-screen w-full bg-transparent p-4', feedLayout.wrapperClass)}
       data-feed-anchor={feedLayout.dataAnchor}
+      data-feed-order={feedLayout.dataOrder}
     >
       {/* Hide scrollbars and ensure transparent background */}
       <style
@@ -725,8 +754,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       {/* text-shadow inherits to every text node below; the var is injected by
           visualSettingsToCss and gradient usernames force it off locally */}
       {/* `mt-auto` (feedAnchor 'bottom') sits on the list itself, never on its
-          children: `.overlay-live-body > * + *` in events.css and
-          `.scroll-anchor` in globals.css are both `!important` and would win. */}
+          children: `.overlay-live-body > * + *` in events.css is `!important`
+          inside a cascade layer and would beat any child-level rule. */}
       <div
         className={clsx(
           'overlay-live-body space-y-3',
@@ -738,15 +767,22 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
         {feedLayout.sentinelPosition === 'start' && (
           <div ref={messagesEndRef} className="scroll-anchor" />
         )}
-        {orderMessages(messages, invertMessageOrder).map((message, index) => {
+        {orderMessages(messages, invertMessageOrder).map((message) => {
           const isSharedChat = message.metadata?.is_shared_chat === true
           const isEvent = message.event != null
           const eventTierClass = isEvent ? `event-tier-${message.event?.tier}` : ''
           const eventTypeClass = isEvent ? `event-type-${message.event?.type}` : ''
 
           return (
+            /* The key must be POSITION-INDEPENDENT. It used to be
+               `${message.id}-${index}`, and every path that shifts an index —
+               `invert_message_order` (a prepend moves every row), the
+               `max_messages` cap, the fade timer's `slice(1)` — changed every
+               key at once, so React unmounted and remounted the whole feed and
+               every row replayed its entry animation on every new message.
+               `onChat` keeps ids unique, which is what makes the bare id safe. */
             <div
-              key={`${message.id}-${index}`}
+              key={message.id}
               data-message-id={message.id}
               data-platform={message.platform}
               data-event-type={isEvent ? message.event?.type : undefined}
@@ -758,7 +794,7 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                       'chat-message rounded-lg p-3 shadow-lg backdrop-blur-sm',
                       messageAnimation
                         ? MESSAGE_ANIMATION_CLASS[messageAnimation]
-                        : 'animate-in duration-300 slide-in-from-bottom-2',
+                        : feedLayout.defaultEntryAnimationClass,
                       isSharedChat
                         ? 'border-2 border-purple-500/50 bg-purple-900/40'
                         : 'bg-slate-900/90',

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -693,6 +693,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
           useCustomCss && 'overlay-preview'
         )}
         data-feed-anchor={feedLayout.dataAnchor}
+        data-feed-order={feedLayout.dataOrder}
       >
         <div
           ref={feedBodyRef}
@@ -757,7 +758,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                             // editor preview is a faithful pick-and-compare
                             messageAnimation
                               ? MESSAGE_ANIMATION_CLASS[messageAnimation]
-                              : 'animate-in duration-300 slide-in-from-bottom-2'
+                              : feedLayout.defaultEntryAnimationClass
                           )
                     }
                     style={isEvent ? undefined : bubbleStyle}

--- a/frontend/src/lib/utils/__tests__/feedAnchor.test.ts
+++ b/frontend/src/lib/utils/__tests__/feedAnchor.test.ts
@@ -114,8 +114,9 @@ describe('resolveFeedAnchorLayout — all four combinations', () => {
 
   it('puts the auto margin on the list, never on its children', () => {
     // `.overlay-live-body > * + * { margin-top: ... !important }` in events.css
-    // and `.scroll-anchor { margin: 0 !important }` in globals.css would both
-    // beat a child-level rule, so the margin must live on the body element.
+    // beats a child-level rule, so the margin must live on the body element.
+    // (`.scroll-anchor` in globals.css is unlayered, so it does NOT win against
+    // that rule — events.css excludes the sentinel by selector instead.)
     for (const { anchor, invert } of COMBOS) {
       const l = resolveFeedAnchorLayout(anchor, invert)
       expect(l.wrapperClass).not.toContain('mt-auto')
@@ -134,12 +135,46 @@ describe('resolveFeedAnchorLayout — all four combinations', () => {
       // …and the anchor must not perturb the order's output.
       expect(plain.newestAtEnd).toBe(true)
       expect(inverted.newestAtEnd).toBe(false)
+      expect(plain.dataOrder).toBe('newest-last')
+      expect(inverted.dataOrder).toBe('newest-first')
+      expect(plain.defaultEntryAnimationClass).not.toBe(inverted.defaultEntryAnimationClass)
     }
   })
 
   it('always emits a data hook so themes can select on either mode', () => {
     for (const { anchor, invert } of COMBOS) {
       expect(resolveFeedAnchorLayout(anchor, invert).dataAnchor).toBe(anchor)
+    }
+  })
+
+  it('exposes the ORDER axis as its own data hook, independent of the anchor', () => {
+    for (const { anchor, invert } of COMBOS) {
+      const l = resolveFeedAnchorLayout(anchor, invert)
+      expect(l.dataOrder).toBe(invert ? 'newest-first' : 'newest-last')
+      // Same hook for both anchors — direction of entry follows the ORDER only.
+      expect(l.dataOrder).toBe(
+        resolveFeedAnchorLayout(anchor === 'top' ? 'bottom' : 'top', invert).dataOrder
+      )
+    }
+  })
+
+  it('flips the fallback entry animation to match the end the newest row lands on', () => {
+    // The bubble enters at the END of the stack normally and at its START when
+    // the order is inverted; a `slide-in-from-bottom` there slides the new row
+    // out from UNDER its neighbour instead of in from the free edge.
+    for (const anchor of ['top', 'bottom'] as const) {
+      expect(resolveFeedAnchorLayout(anchor, false).defaultEntryAnimationClass).toContain(
+        'slide-in-from-bottom-2'
+      )
+      expect(resolveFeedAnchorLayout(anchor, true).defaultEntryAnimationClass).toContain(
+        'slide-in-from-top-2'
+      )
+      // Duration/engine class is unchanged in both directions.
+      for (const invert of [false, true]) {
+        expect(resolveFeedAnchorLayout(anchor, invert).defaultEntryAnimationClass).toContain(
+          'animate-in duration-300'
+        )
+      }
     }
   })
 

--- a/frontend/src/lib/utils/feedAnchor.ts
+++ b/frontend/src/lib/utils/feedAnchor.ts
@@ -71,9 +71,10 @@ export interface FeedAnchorLayout {
    *
    * `mt-auto` is deliberately on the list, NOT on its children:
    * `.overlay-live-body > * + * { margin-top: ... !important }` in events.css
-   * (`@layer visual-customizer`) would win over any child rule, and the
-   * `:first-child` variant would fight `.scroll-anchor`'s
-   * `margin: 0 !important` in globals.css when the sentinel leads the list.
+   * (`@layer visual-customizer`) would win over any child rule. Note that
+   * `.scroll-anchor`'s own `margin: 0 !important` in globals.css does NOT win
+   * against it — for IMPORTANT declarations a cascade layer outranks unlayered
+   * styles — which is why events.css excludes the sentinel by selector.
    *
    * When the content is taller than the wrapper the auto margin resolves to
    * `0`, so a busy chat behaves exactly as it does today — the mode is a no-op
@@ -102,6 +103,28 @@ export interface FeedAnchorLayout {
    */
   dataAnchor: FeedAnchor
   /**
+   * Stable hook for the ORDER axis: the value for `data-feed-order` on the
+   * wrapper. Sibling of `dataAnchor`, and deliberately a separate attribute —
+   * conflating the two axes is what made #728.
+   *
+   * globals.css keys the direction-dependent entry animations off this: a
+   * message that lands at the START of the stack has to enter from the top
+   * edge, not the bottom. It flips `--msg-enter-dir` / `--msg-enter-origin`,
+   * which the `msg-anim-*` keyframes read, so the `.msg-anim-*` rules stay
+   * single unlayered class selectors that a theme can still override wholesale.
+   */
+  dataOrder: 'newest-first' | 'newest-last'
+  /**
+   * Entry animation used when `visual_settings.messageAnimation` is unset.
+   *
+   * The stock `slide-in-from-bottom-2` assumes the new row appears at the
+   * BOTTOM of the stack. When the order is inverted it appears at the top, and
+   * sliding it up from below makes it emerge from underneath the row beneath
+   * it. The `msg-anim-*` presets solve this in CSS (see `dataOrder`); this
+   * fallback is a pair of utility classes, so it is picked here instead.
+   */
+  defaultEntryAnimationClass: string
+  /**
    * Whether the newest message sits at the END of the rendered list. Follows
    * the order axis only: `true` unless the order is inverted.
    */
@@ -115,9 +138,16 @@ export interface FeedAnchorLayout {
    * Whether the auto-scroll `scrollIntoView` should run at all when the feed
    * is SHORTER than its container (`contentOverflows === false` below).
    *
-   * A bottom-anchored short feed is already resting against the edge the newest
-   * message is on, so scrolling it is a no-op at best and a jitter source at
-   * worst. Top-anchored feeds keep today's unconditional behaviour.
+   * A short bottom-anchored feed has nothing to scroll — the list is sized to
+   * its content and the auto margin has already parked it on the anchored edge
+   * — so the call is a no-op at best and a jitter source at worst. Top-anchored
+   * feeds keep today's unconditional behaviour.
+   *
+   * This follows the ANCHOR only. It is tempting to reason "…because the feed
+   * is already resting against the edge the newest message is on", but that is
+   * false when the order is inverted: the newest row then sits at the far edge
+   * from the anchor. The conclusion survives anyway, because a feed that does
+   * not overflow cannot be scrolled in either direction.
    */
   autoScrollWhenShort: boolean
 }
@@ -140,6 +170,10 @@ export function resolveFeedAnchorLayout(
     bodyClass: bottom ? 'mt-auto' : '',
     scrollBodyClass: bottom ? 'mt-auto max-h-full' : 'h-full',
     dataAnchor: anchor,
+    dataOrder: invertMessageOrder ? 'newest-first' : 'newest-last',
+    defaultEntryAnimationClass: invertMessageOrder
+      ? 'animate-in duration-300 slide-in-from-top-2'
+      : 'animate-in duration-300 slide-in-from-bottom-2',
     newestAtEnd: !invertMessageOrder,
     sentinelPosition: invertMessageOrder ? 'start' : 'end',
     autoScrollWhenShort: !bottom,
@@ -159,8 +193,17 @@ export function resolveFeedAnchorLayout(
  *   taller than the viewport". Those differ by the wrapper's padding, and on the
  *   live overlay (`min-h-screen p-4`) getting it wrong left a ~32px band where
  *   a bottom-anchored feed clipped its newest row instead of scrolling to it.
- *   Measure the document (live overlay) or the scroll container's
- *   `scrollHeight > clientHeight` (embed preview, where the list itself scrolls).
+ *   Measure the wrapper's LAYOUT height against the viewport (live overlay) or
+ *   the scroll container's `scrollHeight > clientHeight` (embed preview, where
+ *   the list itself scrolls).
+ *
+ *   Prefer a layout measurement (`offsetHeight`) over a scrollable one
+ *   (`scrollHeight`) wherever the caller can: entry animations translate the new
+ *   row outside the list, transformed descendants count toward scrollable
+ *   overflow, and a bottom-anchored feed — whose list ends flush with the canvas
+ *   — then reports a phantom overflow for the length of the animation. Pair it
+ *   with `scrollIntoView({ block: 'nearest' })` so even a phantom `true` cannot
+ *   move a feed that is already showing its newest row.
  */
 export function shouldAutoScroll(layout: FeedAnchorLayout, contentOverflows: boolean): boolean {
   return contentOverflows || layout.autoScrollWhenShort

--- a/frontend/src/styles/events.css
+++ b/frontend/src/styles/events.css
@@ -462,9 +462,36 @@
     padding: var(--chat-overlay-padding, 1rem) !important;
     gap: var(--chat-message-gap, 0.75rem) !important;
   }
-  /* space-y-* uses margin-top on siblings — override message gap */
-  .overlay-preview-body > * + * {
+  /* `.scroll-anchor` is excluded everywhere in this block. It is the invisible
+     auto-scroll sentinel the overlay pages render next to the newest message,
+     and globals.css declares it `height/padding/margin: 0 !important` — but
+     that rule is UNLAYERED, and for IMPORTANT declarations a cascade layer
+     outranks unlayered styles, so this block used to win and dress the sentinel
+     as a chat bubble: 12px of padding on a "zero-height" div plus a message
+     gap, i.e. ~36px of dead space glued to the newest message. Invisible while
+     the feed was always top-anchored and scrolled, very visible once
+     `feed_anchor: 'bottom'` parks the stack on an edge (#729) — and it moves to
+     the TOP of the stack when `invert_message_order` puts the sentinel first. */
+
+  /* space-y-* uses margin-top on siblings — override message gap.
+     Both halves skip the sentinel: it must not take a gap of its own, and the
+     message that FOLLOWS it (the newest one, when the order is inverted) must
+     not be treated as a second child and pushed away from the edge. */
+  .overlay-preview-body > *:not(.scroll-anchor) + *:not(.scroll-anchor) {
     margin-top: var(--chat-message-gap, var(--theme-message-gap, 0.75rem)) !important;
+  }
+
+  /* `space-y-*` applies its gap as margin-BOTTOM on every child except the
+     last, and the sentinel is a real child — so whenever it trails the list
+     (i.e. the order is NOT inverted) the newest message keeps a trailing gap
+     and a bottom-anchored feed floats that far off the edge it was told to sit
+     on. The gap BETWEEN rows is already applied as margin-top just above, so
+     dropping this one is pure removal of dead space, including for a theme that
+     styles the gap as margin-bottom itself.
+     `:has()` is already used further down this file; on an engine without it
+     the rule simply does not match and the old trailing gap comes back. */
+  .overlay-preview-body > *:has(+ .scroll-anchor) {
+    margin-bottom: 0 !important;
   }
 
   /* ── Message bubble ─────────────────────────────────────────────────────
@@ -482,7 +509,7 @@
      no-bubble theme asking for `padding: 0` still got 12px on every row. A theme
      states its intent by declaring the `--theme-*` variable; themes that declare
      nothing are unaffected. */
-  .overlay-preview-body > div:not(.event-message) {
+  .overlay-preview-body > div:not(.event-message):not(.scroll-anchor) {
     border-radius: var(
       --chat-bubble-border-radius,
       var(--theme-bubble-border-radius, 0.5rem)
@@ -643,9 +670,34 @@
  * new customizer properties.
  */
 @layer visual-customizer {
-  /* ── Message spacing (space-y-3 → message gap) ─────────────────────── */
-  .overlay-live-body > * + * {
+  /* `.scroll-anchor` is excluded everywhere in this block. It is the invisible
+     auto-scroll sentinel the overlay pages render next to the newest message,
+     and globals.css declares it `height/padding/margin: 0 !important` — but
+     that rule is UNLAYERED, and for IMPORTANT declarations a cascade layer
+     outranks unlayered styles, so this block used to win and dress the sentinel
+     as a chat bubble: 12px of padding on a "zero-height" div plus a message
+     gap, i.e. ~36px of dead space glued to the newest message. Invisible while
+     the feed was always top-anchored and scrolled, very visible once
+     `feed_anchor: 'bottom'` parks the stack on an edge (#729) — and it moves to
+     the TOP of the stack when `invert_message_order` puts the sentinel first. */
+
+  /* ── Message spacing (space-y-3 → message gap) ─────────────────────────
+     Both halves skip the sentinel — see the preview block above. */
+  .overlay-live-body > *:not(.scroll-anchor) + *:not(.scroll-anchor) {
     margin-top: var(--chat-message-gap, var(--theme-message-gap, 0.75rem)) !important;
+  }
+
+  /* `space-y-*` applies its gap as margin-BOTTOM on every child except the
+     last, and the sentinel is a real child — so whenever it trails the list
+     (i.e. the order is NOT inverted) the newest message keeps a trailing gap
+     and a bottom-anchored feed floats that far off the edge it was told to sit
+     on. The gap BETWEEN rows is already applied as margin-top just above, so
+     dropping this one is pure removal of dead space, including for a theme that
+     styles the gap as margin-bottom itself.
+     `:has()` is already used further down this file; on an engine without it
+     the rule simply does not match and the old trailing gap comes back. */
+  .overlay-live-body > *:has(+ .scroll-anchor) {
+    margin-bottom: 0 !important;
   }
 
   /* ── Message bubble ─────────────────────────────────────────────────────
@@ -658,7 +710,7 @@
      no-bubble theme asking for `padding: 0` still got 12px on every row. A theme
      states its intent by declaring the `--theme-*` variable; themes that declare
      nothing are unaffected. */
-  .overlay-live-body > div:not(.event-message) {
+  .overlay-live-body > div:not(.event-message):not(.scroll-anchor) {
     border-radius: var(
       --chat-bubble-border-radius,
       var(--theme-bubble-border-radius, 0.5rem)

--- a/frontend/tests/e2e/overlay-feed-anchor.spec.ts
+++ b/frontend/tests/e2e/overlay-feed-anchor.spec.ts
@@ -15,9 +15,19 @@ import { resolveFeedAnchorLayout, type FeedAnchor } from '../../src/lib/utils/fe
  * The technique under test is deliberately narrow: a flex-column WRAPPER plus
  * `margin-top: auto` on `.overlay-live-body` itself. The margin must not land
  * on the list's children, because `.overlay-live-body > * + *` (events.css,
- * `@layer visual-customizer`) and `.scroll-anchor` (globals.css) are both
- * `!important` and would win. So this drives the REAL events.css and the REAL
- * globals.css read from source rather than restating them.
+ * `@layer visual-customizer`) is `!important` inside a layer and would win. So
+ * this drives the REAL events.css and the REAL globals.css read from source
+ * rather than restating them.
+ *
+ * `.scroll-anchor` (globals.css) does NOT also win there, as this file once
+ * claimed: for IMPORTANT declarations the cascade reverses layer order and ranks
+ * unlayered styles LAST, so the layered rule outranked the sentinel's own guard
+ * and dressed it as a chat bubble. events.css now excludes it by selector; the
+ * sentinel's geometry is asserted in overlay-feed-order.spec.ts, against the
+ * real page.
+ *
+ * Everything here is static geometry. The dynamic half of the feature — what
+ * happens as messages ARRIVE — lives in overlay-feed-order.spec.ts.
  */
 
 const REPO = join(__dirname, '..', '..', '..')
@@ -175,13 +185,12 @@ test.describe('feed anchor — live overlay', () => {
       // The auto margin is on the LIST, so no child rule had to be beaten and
       // the first child still sits flush with the list's own content box. This
       // is the assertion that would fail for the `:first-child { margin-top:
-      // auto }` variant: `.scroll-anchor`'s `margin: 0 !important` (globals.css)
-      // and `.overlay-live-body > * + *` (events.css, layered !important) both
-      // outrank a child-level rule.
+      // auto }` variant: `.overlay-live-body > * + *` (events.css, layered
+      // !important) outranks a child-level rule.
       expect(m.firstChildTop).toBeCloseTo(m.bodyTop, 0)
       if (invert) {
-        // Inverted puts the sentinel first, where globals.css pins it to 0 and
-        // the sibling rule does not reach it.
+        // Inverted puts the sentinel first, and events.css excludes it from the
+        // sibling gap rule, so nothing pushes the stack off the anchored edge.
         expect(m.sentinelMarginTop).toBe('0px')
       }
     })

--- a/frontend/tests/e2e/overlay-feed-order.spec.ts
+++ b/frontend/tests/e2e/overlay-feed-order.spec.ts
@@ -1,0 +1,270 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * The ORDER axis (`display_settings.invert_message_order`) on the REAL live
+ * overlay, driven over a real WebSocket — combined with the ANCHOR axis
+ * (`feed_anchor`, #729), which is where it fell apart.
+ *
+ * `overlay-feed-anchor.spec.ts` covers the static geometry of the four
+ * combinations with hand-built fixtures. It cannot see any of the bugs below,
+ * because all of them only exist once messages ARRIVE ONE AT A TIME:
+ *
+ * 1. The row key was `${message.id}-${index}` — the index into the RENDERED
+ *    list. Inverting the order makes every arrival a prepend, so every index
+ *    (and therefore every key) changed at once and React remounted the entire
+ *    feed, replaying every row's entry animation on every message. The same
+ *    thing happened without inversion once `max_messages` or the fade timer
+ *    started dropping the head.
+ * 2. The `.scroll-anchor` sentinel was not invisible: `@layer visual-customizer`
+ *    in events.css dressed it as a chat bubble (an `!important` inside a layer
+ *    outranks the unlayered `!important` guard in globals.css), so ~36px of
+ *    padded ghost sat between the newest message and the edge it was anchored
+ *    to.
+ * 3. Entry animations are direction-dependent and all of them assumed the new
+ *    row lands at the BOTTOM of the stack. Inverted, it lands at the top and
+ *    slid up out from under its neighbour.
+ * 4. A row animating past the list's bottom edge counts toward the document's
+ *    SCROLLABLE height, so a bottom-anchored feed that fits reported an
+ *    overflow for the length of the animation and auto-scrolled itself.
+ *
+ * These assertions are all "does the feed hold still and stay where it was
+ * told", which is what an OBS scene actually needs.
+ */
+
+const OVERLAY_ID = 'feed-order-overlay'
+const WS_GLOB = '**/ws/overlay/**'
+const VIEWPORT = { width: 600, height: 400 }
+/** `min-h-screen p-4` on the wrapper — the canvas is the viewport minus this. */
+const WRAPPER_PADDING = 16
+
+const connectedFrame = JSON.stringify({ type: 'connected', data: { overlay_id: OVERLAY_ID } })
+
+const chatFrame = (id: string, text: string) =>
+  JSON.stringify({
+    type: 'chat_message',
+    data: {
+      id,
+      overlay_id: OVERLAY_ID,
+      platform: 'kick',
+      channel_id: 'c1',
+      channel_name: 'chan',
+      user: { id: 'u1', username: 'tester', display_name: 'Tester', badges: [] },
+      message: { text, emotes: [] },
+      timestamp: '2026-08-19T12:00:00.000Z',
+      metadata: {},
+    },
+  })
+
+interface Options {
+  invert?: boolean
+  anchor?: 'top' | 'bottom'
+  /** Entry animation preset; omitted means the built-in fallback. */
+  animation?: string
+  /** `display_settings.max_messages`; the default is deliberately generous. */
+  maxMessages?: number
+}
+
+/**
+ * Wait for every running CSS animation to finish. Entry animations translate a
+ * row, and `getBoundingClientRect` includes transforms — measuring geometry
+ * mid-flight reads the animation, not the layout.
+ */
+async function animationsSettled(page: Page) {
+  await page.waitForFunction(
+    () => document.getAnimations().every((a) => a.playState !== 'running'),
+    undefined,
+    { timeout: 5000 }
+  )
+}
+
+/**
+ * Boot the real `/overlay/[id]` with a mocked public config and a socket this
+ * test drives. Returns a `send` that pushes one chat frame.
+ */
+async function boot(page: Page, opts: Options = {}) {
+  const sockets: Array<{ send: (s: string) => void }> = []
+  await page.routeWebSocket(WS_GLOB, (ws) => {
+    sockets.push(ws)
+    ws.send(connectedFrame)
+  })
+  await page.route(`**/api/v1/overlays/public/${OVERLAY_ID}/config`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        display_settings: {
+          invert_message_order: opts.invert === true,
+          feed_anchor: opts.anchor ?? 'top',
+          disable_message_fade: true,
+          max_messages: opts.maxMessages ?? 50,
+        },
+        visual_settings: opts.animation ? { messageAnimation: opts.animation } : {},
+        custom_css: '',
+      }),
+    })
+  )
+  await page.setViewportSize(VIEWPORT)
+  await page.goto(`/overlay/${OVERLAY_ID}`)
+  // The socket and the public config are fetched independently, and the wrapper
+  // renders with the DEFAULT anchor until the config lands — so waiting on the
+  // attribute alone would race a config whose anchor happens to be the default.
+  await expect.poll(() => sockets.length, { timeout: 15_000 }).toBeGreaterThan(0)
+  await expect(page.locator('[data-feed-anchor]')).toHaveAttribute(
+    'data-feed-anchor',
+    opts.anchor ?? 'top'
+  )
+
+  return async (id: string, text: string) => {
+    sockets[sockets.length - 1].send(chatFrame(id, text))
+    await expect(page.locator(`[data-message-id="${id}"]`)).toBeVisible()
+  }
+}
+
+/** Message ids in render order, top of the feed first. */
+async function renderedOrder(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-message-id]')
+    .evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.messageId ?? ''))
+}
+
+/**
+ * Stamp every rendered row so a later check can tell a surviving DOM node from
+ * a remounted one. React never restores an attribute it does not know about, so
+ * a missing stamp is proof the element was destroyed and rebuilt.
+ */
+async function stampRows(page: Page) {
+  await page
+    .locator('[data-message-id]')
+    .evaluateAll((els) => els.forEach((e) => e.setAttribute('data-survived', '1')))
+}
+
+test.describe('Live overlay — invert_message_order with feed_anchor', () => {
+  test('renders newest-first and exposes the order as its own data hook', async ({ page }) => {
+    const send = await boot(page, { invert: true, anchor: 'bottom' })
+    await send('m1', 'first')
+    await send('m2', 'second')
+    await send('m3', 'third')
+
+    expect(await renderedOrder(page)).toEqual(['m3', 'm2', 'm1'])
+    // Two independent axes, two independent hooks — conflating them made #728.
+    const wrapper = page.locator('[data-feed-anchor]')
+    await expect(wrapper).toHaveAttribute('data-feed-anchor', 'bottom')
+    await expect(wrapper).toHaveAttribute('data-feed-order', 'newest-first')
+  })
+
+  test('a new message leaves every existing row mounted', async ({ page }) => {
+    // The regression: an inverted feed prepends, which shifted every index and
+    // therefore every `${id}-${index}` key, so React rebuilt the whole list.
+    const send = await boot(page, { invert: true, anchor: 'bottom' })
+    await send('m1', 'first')
+    await send('m2', 'second')
+    await stampRows(page)
+
+    await send('m3', 'third')
+
+    // The two older rows must be the SAME DOM nodes, and only the new row new.
+    await expect(page.locator('[data-message-id="m1"]')).toHaveAttribute('data-survived', '1')
+    await expect(page.locator('[data-message-id="m2"]')).toHaveAttribute('data-survived', '1')
+    await expect(page.locator('[data-message-id="m3"]')).not.toHaveAttribute('data-survived', '1')
+  })
+
+  test('a dropped head leaves the surviving rows mounted (fade / max_messages path)', async ({
+    page,
+  }) => {
+    // Same defect, reachable with the order NOT inverted: `slice(1)` (fade) and
+    // `slice(-max)` (cap) both shift every index that follows. A 2-message cap
+    // makes the third arrival drop the head.
+    const send = await boot(page, { maxMessages: 2 })
+    await send('m1', 'first')
+    await send('m2', 'second')
+    await stampRows(page)
+
+    await send('m3', 'third')
+
+    expect(await renderedOrder(page)).toEqual(['m2', 'm3'])
+    await expect(page.locator('[data-message-id="m2"]')).toHaveAttribute('data-survived', '1')
+  })
+
+  test('the sentinel adds no box, so the feed rests flush on the anchored edge', async ({
+    page,
+  }) => {
+    // `@layer visual-customizer` used to give `.scroll-anchor` the chat bubble's
+    // 12px padding plus a message gap: ~36px of dead space glued to the newest
+    // message, which a bottom-anchored feed shows as "it will not touch the edge".
+    for (const invert of [false, true]) {
+      const send = await boot(page, { invert, anchor: 'bottom' })
+      await send('m1', 'first')
+      await send('m2', 'second')
+      await animationsSettled(page)
+
+      const box = await page.evaluate(() => {
+        const sentinel = document.querySelector('.scroll-anchor') as HTMLElement
+        const cs = getComputedStyle(sentinel)
+        const rows = [...document.querySelectorAll('[data-message-id]')] as HTMLElement[]
+        const list = document.querySelector('.overlay-live-body') as HTMLElement
+        return {
+          height: sentinel.getBoundingClientRect().height,
+          padding: cs.padding,
+          marginTop: cs.marginTop,
+          marginBottom: cs.marginBottom,
+          listBottom: list.getBoundingClientRect().bottom,
+          lastRowBottom: rows[rows.length - 1].getBoundingClientRect().bottom,
+        }
+      })
+
+      expect(box.height, 'sentinel must occupy no space').toBe(0)
+      expect(box.padding).toBe('0px')
+      expect(box.marginTop).toBe('0px')
+      expect(box.marginBottom).toBe('0px')
+      // Nothing between the last row and the end of the list…
+      expect(box.lastRowBottom).toBeCloseTo(box.listBottom, 0)
+      // …and the list itself sits on the canvas edge it was anchored to.
+      expect(box.listBottom).toBeCloseTo(VIEWPORT.height - WRAPPER_PADDING, 0)
+    }
+  })
+
+  test('entry animations enter from the end the newest row lands on', async ({ page }) => {
+    // `msg-anim-bounce` starts at translateY(110%): correct when the new row is
+    // appended at the bottom, backwards when inversion puts it on top.
+    const firstFrameOffset = async (invert: boolean) => {
+      const send = await boot(page, { invert, anchor: 'bottom', animation: 'bounce' })
+      await send('m1', 'first')
+      await send('m2', 'second')
+      return page.evaluate(() => {
+        const el = document.querySelector('[data-message-id="m2"]') as HTMLElement
+        const anim = el.getAnimations()[0]
+        anim.pause()
+        anim.currentTime = 0
+        // translateY lands in the last cell of the 2D matrix.
+        return new DOMMatrixReadOnly(getComputedStyle(el).transform).m42
+      })
+    }
+
+    expect(await firstFrameOffset(false), 'newest-last enters from below').toBeGreaterThan(0)
+    expect(await firstFrameOffset(true), 'newest-first enters from above').toBeLessThan(0)
+  })
+
+  test('a bottom-anchored feed that fits does not scroll itself while a row animates', async ({
+    page,
+  }) => {
+    // A row translated past the list's bottom edge counts toward the document's
+    // scrollable height. Measuring THAT made a feed that fits look overflowing
+    // mid-animation, so the page smooth-scrolled and snapped back on every
+    // message. The predicate has to use layout height.
+    const send = await boot(page, { invert: false, anchor: 'bottom', animation: 'bounce' })
+    await send('m1', 'first')
+
+    const scrollYs: number[] = []
+    for (let i = 0; i < 6; i++) {
+      scrollYs.push(await page.evaluate(() => window.scrollY))
+      await page.waitForTimeout(60)
+    }
+    await send('m2', 'second')
+    for (let i = 0; i < 8; i++) {
+      scrollYs.push(await page.evaluate(() => window.scrollY))
+      await page.waitForTimeout(60)
+    }
+
+    expect(Math.max(...scrollYs), 'the page must never scroll while the feed fits').toBe(0)
+  })
+})


### PR DESCRIPTION
Reported as "the combination of invert message order and feed grows from the bottom doesn't work — the inversion is ignored and animations break".

The rendered DOM order was always correct. What broke was everything around it, and reproducing it with a Playwright harness driving the real page turned up **five** distinct defects — three of which also affect feeds that never touched either setting.

## 1. Every message remounted the entire feed

The row key was `` `${message.id}-${index}` `` — the index into the *rendered* list. Inverting makes each arrival a prepend, so every index and therefore every key changed at once. React destroyed and rebuilt all rows, and each replayed its entry animation on every single message. Measured with 5 rows: 5 `animationstart` events per message instead of 1.

The same path fires **without** inversion once `max_messages` or the fade timer starts dropping the head, so this has been live for everyone at steady state.

Key by `message.id` alone. `onChat` now ignores a redelivered id and `onMessageUpdate` replaces by id rather than appending — that is what makes the bare id safe (the deletion path already assumed uniqueness).

## 2. The "invisible" scroll sentinel was a 24px padded box

`@layer visual-customizer` in `events.css` dressed `.scroll-anchor` as a chat bubble. The guard in `globals.css` cannot stop it: for `!important` declarations the cascade **reverses** layer order and ranks unlayered styles *last*, so the layered rule wins.

Result: ~36px of dead space glued to the newest message. Invisible while the feed always scrolled, but `feed_anchor: bottom` parks the stack on an edge — so the feed visibly refused to touch the edge it was told to sit on, and with invert the gap moved to the top of the stack.

`events.css` now excludes the sentinel from the bubble chrome and from both halves of the gap rule, and drops the trailing `space-y` margin it creates.

## 3. Entry animations pointed the wrong way

`bounce` (`translateY(110%)`), `pop` and `flip` (both hinged on `100%`) all assume the new row lands at the *bottom* of the stack. Inverted it lands on top, so the row crawled out from under its neighbour.

New `data-feed-order` hook on the wrapper — sibling of `data-feed-anchor`, following the ORDER axis only — drives `--msg-enter-dir` / `--msg-enter-origin`, and the fallback utility flips to `slide-in-from-top-2`. Parameterising the keyframes rather than adding `[data-feed-order] .msg-anim-*` overrides is deliberate: it keeps every preset a single unlayered class selector, so the documented "themes can override these" contract still holds at equal specificity.

## 4. The animation triggered a phantom scroll

A row translated past the list's bottom edge counts toward the document's *scrollable* height. On a bottom-anchored feed that fits, the predicate read 414 > 400, smooth-scrolled the page 14px, then snapped back when the animation ended — a jitter on every message.

The predicate now measures the wrapper's `offsetHeight` (layout, transform-immune) instead of `documentElement.scrollHeight`, and `scrollIntoView` uses `block: 'nearest'` as the embed preview already did.

## 5. Stale reasoning

Comments in `feedAnchor.ts` and `overlay-feed-anchor.spec.ts` asserted that `.scroll-anchor` "would win" against the layered rule. That is what let #2 through. Corrected, with the cascade rule spelled out so the next person does not rely on it either.

## Verification

`frontend/tests/e2e/overlay-feed-order.spec.ts` drives the real `/overlay/[id]` over a mocked WebSocket. All six tests **fail on the pre-fix tree and pass after**:

- newest-first order plus both data hooks
- a new message leaves every existing row mounted
- a dropped head leaves the survivors mounted (fade / `max_messages` path)
- the sentinel adds no box, and the feed rests flush on the anchored edge
- entry animations enter from the end the newest row lands on
- a bottom-anchored feed that fits never scrolls itself mid-animation

The existing `overlay-feed-anchor.spec.ts` covers static geometry only and could not see any of this; it is now scoped explicitly against the new spec.

Also green: `tsc --noEmit`, 34 relevant unit tests, 37 e2e (feed-order, feed-anchor, editor, custom-css, a11y).

Pre-existing red on `main`, unrelated and unchanged by this branch: the api-tokens unit file (7), and `dashboard` / `landing` / `overlay-view` / `theme-contrast` e2e (20). Confirmed failing on a clean tree.

## Docs

`docs/CSS_CUSTOMIZATION.md`, `docs/overlay-themes/README.md` and the in-app docs page gain `data-feed-order`, the two entry-direction custom properties, and a warning to exclude `.scroll-anchor` from any rule that styles overlay rows.

Frontend only, no migration, no new setting — `feed_anchor` and `invert_message_order` are unchanged in shape.
