### PR TITLE
ci(plugins): build, test, parity-check and package both desktop plugins

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,0 +1,228 @@
+name: Desktop Plugins
+
+# Build, test, parity-check and PACKAGE the two desktop control surfaces from
+# ADR-0049: `streamdeck-plugin/` (TypeScript, Elgato SDK, Windows + macOS) and
+# `streamcontroller-plugin/` (Python, StreamController, Linux).
+#
+# Why this workflow exists at all, given both plugins are thin HTTP clients:
+#
+#   1. NOTHING ELSE COMPILES THEM. build-and-push.yml builds service images and
+#      the frontend; neither plugin is a service, has a Dockerfile or appears in
+#      any other workflow, so until now a TypeScript error or a broken Python
+#      import could land on main unnoticed. The Python plugin already ships 46
+#      unit tests that nothing was running.
+#   2. PACKAGING IS THE DELIVERABLE. A plugin is not useful as source. Every run
+#      uploads the two installable artifacts — a signed-shape `.streamDeckPlugin`
+#      for the Elgato app and a zip of the StreamController plugin folder — so a
+#      PR can be installed and tested on real hardware from the run page,
+#      without a local Node toolchain.
+#   3. DRIFT IS THE STATED RISK. ADR-0049: "the button set now exists twice and
+#      will diverge unless it is defined once." The parity job runs the pinned
+#      action list in scripts/check-plugin-parity.py against both plugins.
+#
+# Structure follows frontend-a11y.yml deliberately: an intra-workflow "skip
+# shim" (a `changes` job plus per-job `if:`) rather than a top-level `paths:`
+# filter, because a workflow skipped by `paths:` never reports its contexts and
+# a required check would leave PRs permanently "Expected"/blocked (ADR-0033).
+# These jobs are NOT required checks today, but they are shaped so they can be
+# made required without that trap.
+#
+# EVERY job sets timeout-minutes. Without it a job inherits GitHub's 6-hour
+# default, and on 2026-08-19 two hung installs sat for ~4 hours on PR #729 (see
+# PR #731). A hang is worse than a failure: there is no signal to act on.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Observed ~15-30s. A checkout plus a paths-filter.
+    timeout-minutes: 10
+    outputs:
+      streamdeck: ${{ steps.filter.outputs.streamdeck }}
+      streamcontroller: ${{ steps.filter.outputs.streamcontroller }}
+      parity: ${{ steps.filter.outputs.parity }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            streamdeck:
+              - 'streamdeck-plugin/**'
+              - '.github/workflows/plugins.yml'
+            streamcontroller:
+              - 'streamcontroller-plugin/**'
+              - '.github/workflows/plugins.yml'
+            parity:
+              - 'streamdeck-plugin/**'
+              - 'streamcontroller-plugin/**'
+              - 'scripts/check-plugin-parity.py'
+              - '.github/workflows/plugins.yml'
+
+  streamdeck:
+    name: Elgato plugin (lint, build, package)
+    needs: changes
+    if: needs.changes.outputs.streamdeck == 'true'
+    runs-on: ubuntu-latest
+    # Observed ~1min end to end locally (npm ci ~5s, build ~3s, pack ~15s).
+    # The headroom is for a slow npm mirror; past this it is stuck, not slow.
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: streamdeck-plugin
+    steps:
+      - uses: actions/checkout@v7
+
+      # Node 22 matches the flake dev shell (pkgs.nodejs_22) and the frontend
+      # workflows. It is NOT the runtime: the Stream Deck app supplies its own
+      # Node (manifest.json pins Nodejs.Version "20"), so this is build-only and
+      # package.json's `engines` floor of 20.5.1 is what actually constrains us.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: streamdeck-plugin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ESLint plus `tsc --noEmit`. The plugin has no unit tests of its own; the
+      # equivalent assertions live in the Python plugin's suite, and the parity
+      # job below is what stops the two from meaning different things.
+      - name: Lint and type-check
+        run: npm run lint
+
+      - name: Build (tsc -> com.allchat.streamdeck.sdPlugin/bin)
+        run: npm run build
+
+      # The .sdPlugin folder IS the plugin, so an empty bin/ is a silent
+      # non-build: tsc can succeed having emitted nothing if the config drifts.
+      - name: Assert the compiled entrypoint exists
+        run: test -s com.allchat.streamdeck.sdPlugin/bin/plugin.js
+
+      # Elgato's own manifest validator. Pinned to an exact version rather than
+      # @latest: this is a network fetch on every run and an unpinned tool that
+      # tightens a rule would turn every unrelated PR red. `pack` validates too,
+      # but running it separately makes a manifest failure legible as such.
+      - name: Validate manifest (Elgato CLI)
+        run: npx --yes @elgato/cli@1.9.0 validate com.allchat.streamdeck.sdPlugin
+
+      - name: Package (.streamDeckPlugin)
+        run: npx --yes @elgato/cli@1.9.0 pack com.allchat.streamdeck.sdPlugin --output dist
+
+      # Downloadable from the run page: unzip, double-click, and the Stream Deck
+      # app installs it. This is how a reviewer tests a PR on real hardware.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: allchat-streamdeck-plugin
+          path: streamdeck-plugin/dist/*.streamDeckPlugin
+          if-no-files-found: error
+
+  streamcontroller:
+    name: StreamController plugin (tests, package)
+    needs: changes
+    if: needs.changes.outputs.streamcontroller == 'true'
+    runs-on: ubuntu-latest
+    # Observed <10s. The suite is 46 stdlib-only unit tests with a stubbed
+    # urlopen; nothing here touches the network.
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: streamcontroller-plugin
+    steps:
+      - uses: actions/checkout@v7
+
+      # 3.11 is the FLOOR (requirements.txt: "Minimum interpreter: Python 3.11,
+      # matching what StreamController ships against"), and the floor is what
+      # needs testing — a newer interpreter would hide a 3.11 syntax break in a
+      # plugin that runs inside somebody else's process.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      # No `pip install`: requirements.txt is deliberately empty of packages, and
+      # keeping the CI environment bare is what proves that claim stays true.
+      - name: Syntax gate (compileall)
+        run: python3 -m compileall -q .
+
+      - name: Unit tests
+        run: python3 -m unittest discover -s tests -t .
+
+      # The three JSON files are the plugin's whole contract with the
+      # StreamController store. A trailing comma in one of them is invisible in
+      # review and fatal at load time, and the two versions drifting apart is
+      # the store's most common submission rejection.
+      - name: Validate plugin metadata
+        run: |
+          python3 - <<'PY'
+          import json, pathlib, sys
+
+          manifest = json.loads(pathlib.Path("manifest.json").read_text())
+          about = json.loads(pathlib.Path("about.json").read_text())
+          json.loads(pathlib.Path("attribution.json").read_text())
+
+          problems = []
+          if manifest["version"] != about["version"]:
+              problems.append(
+                  f'manifest.json version {manifest["version"]!r} != about.json version {about["version"]!r}'
+              )
+          if manifest["id"] != about["id"]:
+              problems.append(f'manifest.json id {manifest["id"]!r} != about.json id {about["id"]!r}')
+          if about.get("license") != "AGPL-3.0-or-later":
+              problems.append(
+                  "about.json must declare AGPL-3.0-or-later: ADR-0049 makes the licence question a "
+                  "release gate, because this plugin is loaded into StreamController's GPL-3.0 process"
+              )
+          if problems:
+              print("\n".join(f"  - {p}" for p in problems), file=sys.stderr)
+              sys.exit(1)
+          print(f'StreamController metadata OK (version {manifest["version"]})')
+          PY
+
+      # Staged copy rather than a zip-with-exclusions, so what ships is an
+      # explicit allowlist. tests/ is left out on purpose: it is 46 files of
+      # mock plumbing that a user's StreamController would import-scan for no
+      # reason. Everything listed here is something the host actually loads.
+      - name: Package (zip)
+        run: |
+          version=$(python3 -c "import json;print(json.load(open('manifest.json'))['version'])")
+          staged="dist/com_allchat_streamcontroller"
+          mkdir -p "$staged"
+          cp -r main.py manifest.json about.json attribution.json requirements.txt README.md actions allchat "$staged/"
+          find "$staged" -name '__pycache__' -type d -prune -exec rm -rf {} +
+          (cd dist && zip -qr "allchat-streamcontroller-plugin-${version}.zip" com_allchat_streamcontroller)
+          ls -la dist
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: allchat-streamcontroller-plugin
+          path: streamcontroller-plugin/dist/*.zip
+          if-no-files-found: error
+
+  parity:
+    name: Plugin parity (ADR-0049 action list)
+    needs: changes
+    if: needs.changes.outputs.parity == 'true'
+    runs-on: ubuntu-latest
+    # Observed <1s. Pure text analysis of six source files.
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      # Fails when a button, a user-visible constant or a keep-in-sync pointer
+      # exists on one plugin and not the other. See the script's docstring for
+      # what is pinned and why each check is there.
+      - name: Action list, shared constants and sync pointers
+        run: python3 scripts/check-plugin-parity.py

--- a/scripts/check-plugin-parity.py
+++ b/scripts/check-plugin-parity.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Parity gate for the two desktop plugins (ADR-0049).
+
+Two plugins ship the same buttons in two languages: `streamdeck-plugin/`
+(TypeScript, Elgato SDK, Windows + macOS) and `streamcontroller-plugin/`
+(Python, StreamController, Linux). ADR-0049 names the resulting risk exactly:
+
+    The real cost of two plugins is drift, not effort. [...] the *button set*
+    now exists twice and will diverge unless it is defined once. Treat the
+    action list (name, endpoint, payload, and what the button surfaces on
+    failure) as the single source both implementations follow.
+
+This script is that single source, made executable. It is deliberately not a
+string-diff of the two files: they are different languages and are *supposed*
+to read differently. It pins the three things that must not diverge:
+
+1.  **The action list.** Every entry below must exist in both API modules, and
+    neither module may carry a route-bearing public function the other lacks —
+    that is precisely "a button that exists on Linux but not Windows".
+2.  **The shared constants.** Host, token prefix and the two URLs a user is
+    sent to. These are user-visible, and a mismatch here is invisible in review
+    (it already happened: UPGRADE_URL pointed at the homepage on one side and
+    at /upgrade on the other).
+3.  **The keep-in-sync pointers are mutual.** The convention CLAUDE.md uses for
+    OnboardingChecklist.tsx / upgrade only works when both ends point at each
+    other; a one-way pointer rots the moment someone edits the unmarked file.
+
+Standard library only, so it runs in the flake dev shell, in CI, and in the
+Caterpillar sandbox without an install step:
+
+    python3 scripts/check-plugin-parity.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TS = REPO / "streamdeck-plugin"
+PY = REPO / "streamcontroller-plugin"
+
+TS_API = TS / "src" / "allchat" / "api.ts"
+PY_API = PY / "allchat" / "api.py"
+TS_SETTINGS = TS / "src" / "allchat" / "settings.ts"
+PY_SETTINGS = PY / "allchat" / "settings.py"
+
+# ---------------------------------------------------------------------------
+# 1. The action list. THIS is the contract ADR-0049 asks for: adding a button
+#    means adding a row here and implementing it on both sides, in one change.
+#    The route column is documentation for the reader, not something this script
+#    can verify against a running server.
+# ---------------------------------------------------------------------------
+ACTIONS: tuple[tuple[str, str, str], ...] = (
+    ("sendChatMessage", "send_chat_message", "POST /api/v1/auth/chat/send"),
+    ("startPoll", "start_poll", "POST /api/v1/engagement/overlays/:id/polls  (premium)"),
+    ("closePoll", "close_poll", "POST /api/v1/engagement/overlays/:id/polls/:pollId/close"),
+    ("activePoll", "active_poll", "GET  /api/v1/engagement/overlays/:id/active-poll"),
+    ("startPrediction", "start_prediction", "POST /api/v1/engagement/overlays/:id/predictions  (premium)"),
+    ("lockPrediction", "lock_prediction", "POST /api/v1/engagement/overlays/:id/predictions/:pid/lock"),
+    ("resolvePrediction", "resolve_prediction", "POST /api/v1/engagement/overlays/:id/predictions/:pid/resolve"),
+    ("cancelPrediction", "cancel_prediction", "POST /api/v1/engagement/overlays/:id/predictions/:pid/cancel"),
+    ("activePrediction", "active_prediction", "GET  /api/v1/engagement/overlays/:id/active-prediction"),
+)
+
+# Public helpers that legitimately exist on one side only. Every entry needs a
+# reason, because "add it to the allowlist" is the easy way to defeat this gate.
+TS_ONLY_ALLOWED: dict[str, str] = {}
+PY_ONLY_ALLOWED: dict[str, str] = {
+    # The TS actions read `poll.id` off the typed response directly; Python has
+    # no such type, so it needs a runtime shape-sniffer. It drives no route.
+    "extract_id": "response-shape helper with no TypeScript counterpart (TS has typed responses)",
+}
+
+# ---------------------------------------------------------------------------
+# 2. Constants that are user-visible and must be identical in both plugins.
+# ---------------------------------------------------------------------------
+SHARED_CONSTANTS: tuple[tuple[Path, Path, str], ...] = (
+    (TS_API, PY_API, "CHAT_SEND_PATH"),
+    (TS_SETTINGS, PY_SETTINGS, "DEFAULT_BASE_URL"),
+    (TS_SETTINGS, PY_SETTINGS, "ACCOUNT_TOKENS_URL"),
+    (TS_SETTINGS, PY_SETTINGS, "UPGRADE_URL"),
+    (TS_SETTINGS, PY_SETTINGS, "PAT_PREFIX"),
+)
+
+# ---------------------------------------------------------------------------
+# 3. Keep-in-sync pointers, e.g.
+#       KEEP IN SYNC with ``streamdeck-plugin/src/allchat/api.ts`` (ADR-0049).
+#    Matched in either language's comment syntax; the quoting around the path is
+#    whatever the surrounding docstring/JSDoc uses, so it is skipped over.
+# ---------------------------------------------------------------------------
+POINTER = re.compile(r"KEEP IN SYNC with[`'\"\s]+([A-Za-z0-9_./-]+\.(?:ts|py))")
+
+PLUGIN_SOURCES = sorted(
+    [p for p in (TS / "src").rglob("*.ts")] + [p for p in PY.rglob("*.py") if "tests" not in p.parts]
+)
+
+
+def read(path: Path) -> str:
+    if not path.is_file():
+        fail(f"expected file is missing: {path.relative_to(REPO)}")
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+errors: list[str] = []
+
+
+def fail(message: str) -> None:
+    errors.append(message)
+
+
+def strip_ts_comments(src: str) -> str:
+    """Remove // and /* */ comments so documentation prose is never mistaken for code.
+
+    The TS api module documents routes in its header block, so a naive scan
+    would 'find' functions and paths that are only being described.
+    """
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    return re.sub(r"^\s*//.*$", "", src, flags=re.MULTILINE)
+
+
+def strip_py_comments(src: str) -> str:
+    """Same idea for Python: drop docstrings and # comments."""
+    src = re.sub(r'"""(?:.|\n)*?"""', "", src)
+    src = re.sub(r"'''(?:.|\n)*?'''", "", src)
+    return re.sub(r"^\s*#.*$", "", src, flags=re.MULTILINE)
+
+
+def ts_exported_functions(src: str) -> set[str]:
+    return set(re.findall(r"^export\s+(?:async\s+)?function\s+(\w+)", strip_ts_comments(src), re.MULTILINE))
+
+
+def py_public_functions(src: str) -> set[str]:
+    """Top-level, non-underscore defs. Indented defs are methods, not API."""
+    return set(re.findall(r"^def\s+([a-z][A-Za-z0-9_]*)\s*\(", strip_py_comments(src), re.MULTILINE))
+
+
+def ts_constant(src: str, name: str) -> str | None:
+    """Value of `export const NAME = "..."` or a backtick template of one.
+
+    `${DEFAULT_BASE_URL}` is resolved so a composed URL can be compared against
+    the Python f-string that composes it the same way.
+    """
+    match = re.search(rf"^export const {name}\s*=\s*([`\"'])(.*?)\1\s*;", strip_ts_comments(src), re.MULTILINE)
+    if not match:
+        return None
+    return resolve_base_url_placeholder(src, match.group(2), ts=True)
+
+
+def py_constant(src: str, name: str) -> str | None:
+    """Value of `NAME = "..."` or `NAME = f"..."`, with the same placeholder resolution."""
+    match = re.search(rf"^{name}\s*=\s*f?([\"'])(.*?)\1\s*$", strip_py_comments(src), re.MULTILINE)
+    if not match:
+        return None
+    return resolve_base_url_placeholder(src, match.group(2), ts=False)
+
+
+def resolve_base_url_placeholder(src: str, value: str, *, ts: bool) -> str:
+    """Substitute the one interpolation both plugins use: the base URL."""
+    if "DEFAULT_BASE_URL" not in value:
+        return value
+    pattern = r"^export const DEFAULT_BASE_URL\s*=\s*\"(.*?)\"" if ts else r"^DEFAULT_BASE_URL\s*=\s*\"(.*?)\""
+    base = re.search(pattern, src, re.MULTILINE)
+    if not base:
+        return value
+    return value.replace("${DEFAULT_BASE_URL}" if ts else "{DEFAULT_BASE_URL}", base.group(1))
+
+
+def check_action_list() -> None:
+    ts_funcs = ts_exported_functions(read(TS_API))
+    py_funcs = py_public_functions(read(PY_API))
+
+    for ts_name, py_name, route in ACTIONS:
+        if ts_name not in ts_funcs:
+            fail(f"{TS_API.relative_to(REPO)} does not export `{ts_name}` ({route})")
+        if py_name not in py_funcs:
+            fail(f"{PY_API.relative_to(REPO)} does not define `{py_name}` ({route})")
+
+    known_ts = {a[0] for a in ACTIONS} | set(TS_ONLY_ALLOWED)
+    known_py = {a[1] for a in ACTIONS} | set(PY_ONLY_ALLOWED)
+
+    for extra in sorted(ts_funcs - known_ts):
+        fail(
+            f"{TS_API.relative_to(REPO)} exports `{extra}`, which is not in the ADR-0049 action list. "
+            f"Add it to ACTIONS here and implement it in {PY_API.relative_to(REPO)}, or allowlist it with a reason."
+        )
+    for extra in sorted(py_funcs - known_py):
+        fail(
+            f"{PY_API.relative_to(REPO)} defines `{extra}`, which is not in the ADR-0049 action list. "
+            f"Add it to ACTIONS here and implement it in {TS_API.relative_to(REPO)}, or allowlist it with a reason."
+        )
+
+
+def check_constants() -> None:
+    for ts_path, py_path, name in SHARED_CONSTANTS:
+        ts_value = ts_constant(read(ts_path), name)
+        py_value = py_constant(read(py_path), name)
+        if ts_value is None:
+            fail(f"{ts_path.relative_to(REPO)} does not export a string constant `{name}`")
+        if py_value is None:
+            fail(f"{py_path.relative_to(REPO)} does not define a string constant `{name}`")
+        if ts_value is not None and py_value is not None and ts_value != py_value:
+            fail(
+                f"`{name}` differs between the plugins: "
+                f"{ts_path.relative_to(REPO)} has {ts_value!r}, {py_path.relative_to(REPO)} has {py_value!r}"
+            )
+
+
+def check_sync_pointers() -> None:
+    pointers: dict[Path, set[str]] = {}
+    for path in PLUGIN_SOURCES:
+        targets = set(POINTER.findall(path.read_text(encoding="utf-8")))
+        if targets:
+            pointers[path] = targets
+
+    if not pointers:
+        fail("no KEEP IN SYNC pointers found at all; the drift convention has been deleted")
+
+    for path, targets in pointers.items():
+        source_rel = path.relative_to(REPO).as_posix()
+        for target_rel in sorted(targets):
+            target = REPO / target_rel
+            if not target.is_file():
+                fail(f"{source_rel} points at {target_rel}, which does not exist")
+                continue
+            back = POINTER.findall(target.read_text(encoding="utf-8"))
+            if source_rel not in back:
+                fail(
+                    f"one-way KEEP IN SYNC pointer: {source_rel} -> {target_rel}, but {target_rel} "
+                    f"does not point back. Add `KEEP IN SYNC with {source_rel} (ADR-0049).` to it."
+                )
+
+
+def main() -> int:
+    check_action_list()
+    check_constants()
+    check_sync_pointers()
+
+    if errors:
+        print("Desktop plugin parity check FAILED (ADR-0049):\n", file=sys.stderr)
+        for message in errors:
+            print(f"  - {message}", file=sys.stderr)
+        print(
+            "\nBoth plugins implement one action list. If a button changed on one side, "
+            "change it on the other in the same PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Desktop plugin parity OK: {len(ACTIONS)} actions, "
+        f"{len(SHARED_CONSTANTS)} shared constants, pointers mutual."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/streamcontroller-plugin/.gitignore
+++ b/streamcontroller-plugin/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 *.py[cod]
+# Packaging output (the staged plugin folder and its zip), produced by
+# .github/workflows/plugins.yml and reproducible locally with the same steps.
+dist/

--- a/streamcontroller-plugin/README.md
+++ b/streamcontroller-plugin/README.md
@@ -229,6 +229,23 @@ a future refactor cannot quietly turn the feature's only advertisement into a
 generic error, nor start telling mis-scoped users to buy something that will not
 help them.
 
+### Packaging
+
+`.github/workflows/plugins.yml` runs the two commands above on every PR that
+touches this directory, validates `manifest.json` / `about.json` /
+`attribution.json` (including that the two versions and ids agree, and that the
+licence is still `AGPL-3.0-or-later`), and uploads an installable zip as a run
+artifact. Unzip it into the plugins directory named under
+[Install](#install) to test a branch.
+
+The zip is a staged **allowlist**, not the whole directory: `main.py`, the three
+JSON files, `requirements.txt`, `README.md`, `actions/` and `allchat/`. `tests/`
+is deliberately left out — it is mock plumbing that a user's StreamController
+would import-scan for nothing.
+
+Not submitted to the StreamController plugin store yet; see
+[Before submitting to StreamController's plugin store](#before-submitting-to-streamcontrollers-plugin-store).
+
 ### Layout
 
 ```

--- a/streamdeck-plugin/.gitignore
+++ b/streamdeck-plugin/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 com.allchat.streamdeck.sdPlugin/bin/
 *.streamDeckPlugin
+# Packaging output (`npm ci && npm run build && npx @elgato/cli pack … --output dist`),
+# produced locally and by .github/workflows/plugins.yml.
+dist/

--- a/streamdeck-plugin/README.md
+++ b/streamdeck-plugin/README.md
@@ -33,7 +33,7 @@ the server working correctly, not the plugin failing. The plugin treats that 403
 as its own distinct state: the key shows Stream Deck's alert and the plugin log
 carries a specific message explaining that starting polls and predictions is a
 premium feature, that the close/lock/resolve/cancel keys still work, and that you
-can upgrade at <https://allch.at>. It is never reported as a generic
+can upgrade at <https://allch.at/upgrade>. It is never reported as a generic
 "request failed".
 
 The asymmetry is intentional in the product: if you started a round while
@@ -86,6 +86,30 @@ instead use `streamdeck link com.allchat.streamdeck.sdPlugin`, then
 > rather than `devDependencies` on purpose: this package is private and never
 > published, and CI runs with `NODE_ENV=production`, where `npm ci` drops dev
 > dependencies and the build would fail with `tsc: not found`.
+
+### Packaging
+
+`.github/workflows/plugins.yml` lints, builds, validates the manifest and packs
+this plugin on every PR that touches it, and uploads the resulting
+`com.allchat.streamdeck.streamDeckPlugin` as a run artifact. That artifact is
+how a reviewer installs a branch on real hardware without a local toolchain:
+download it from the run page, unzip, double-click.
+
+The same two commands work locally, with the Elgato CLI pinned to the version CI
+uses:
+
+```bash
+npx --yes @elgato/cli@1.9.0 validate com.allchat.streamdeck.sdPlugin
+npx --yes @elgato/cli@1.9.0 pack com.allchat.streamdeck.sdPlugin --output dist
+```
+
+> **Gotcha:** the Elgato CLI **rewrites `manifest.json` in place**, reformatting
+> it and stripping the trailing newline. That is invisible in CI (the checkout is
+> thrown away) but shows up as an unrelated diff locally, so
+> `git checkout com.allchat.streamdeck.sdPlugin/manifest.json` after packing.
+
+The plugin is not published to the Elgato Marketplace yet; the artifact is the
+only distribution today.
 
 ---
 

--- a/streamdeck-plugin/src/actions/poll-control.ts
+++ b/streamdeck-plugin/src/actions/poll-control.ts
@@ -12,6 +12,8 @@
  * - `close` → `POST /api/v1/engagement/overlays/:id/polls/:pollId/close`.
  *   Deliberately free, so a streamer who started a poll while premium (or via
  *   the web app) can always end it.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/actions/poll_control.py` (ADR-0049).
  */
 
 import { action, type KeyDownEvent } from "@elgato/streamdeck";

--- a/streamdeck-plugin/src/actions/prediction-control.ts
+++ b/streamdeck-plugin/src/actions/prediction-control.ts
@@ -13,6 +13,9 @@
  * A typical premium streamer binds four keys to this action, one per mode. A
  * free account binds three: the start key will keep telling them, informatively,
  * what it would unlock.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/actions/prediction_control.py`
+ * (ADR-0049).
  */
 
 import { action, type KeyDownEvent } from "@elgato/streamdeck";

--- a/streamdeck-plugin/src/actions/send-message.ts
+++ b/streamdeck-plugin/src/actions/send-message.ts
@@ -4,6 +4,8 @@
  * Route: `POST /api/v1/auth/chat/send`, authenticated with the key's personal
  * access token. This action is **not** premium-gated; it works on every account
  * that has a connected platform.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/actions/send_message.py` (ADR-0049).
  */
 
 import { action, type KeyDownEvent } from "@elgato/streamdeck";

--- a/streamdeck-plugin/src/allchat/api.ts
+++ b/streamdeck-plugin/src/allchat/api.ts
@@ -17,6 +17,11 @@
  * round it already started, it just cannot open a new one. Keeping the flag next
  * to the path is what stops the plugin from ever reporting a premium 403 as a
  * generic failure.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/allchat/api.py` (ADR-0049). The
+ * action list both plugins implement is pinned in
+ * `scripts/check-plugin-parity.py`; a new route belongs in all three places in
+ * one change, or it becomes a button that exists on Linux but not Windows.
  */
 
 import { get, post } from "./client.js";

--- a/streamdeck-plugin/src/allchat/errors.ts
+++ b/streamdeck-plugin/src/allchat/errors.ts
@@ -18,6 +18,10 @@
  *   not to look like a broken button.
  *
  * Neither path ever puts the token in a message or a log line.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/allchat/errors.py` (ADR-0049). The
+ * 401-vs-403 split is the part that must not drift: one says "re-paste your
+ * token", the other says "this is premium", and swapping them costs money.
  */
 
 import { UPGRADE_URL, ACCOUNT_TOKENS_URL } from "./settings.js";

--- a/streamdeck-plugin/src/allchat/settings.ts
+++ b/streamdeck-plugin/src/allchat/settings.ts
@@ -4,6 +4,10 @@
  *
  * The property inspector writes these verbatim into Stream Deck's per-action
  * settings store, so every field is optional: a freshly dropped key has `{}`.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/allchat/settings.py` (ADR-0049).
+ * The constants below are user-visible on both plugins and are compared by
+ * `scripts/check-plugin-parity.py`.
  */
 
 /**
@@ -16,8 +20,13 @@ export const DEFAULT_BASE_URL = "https://allch.at";
 /** Where a user mints a personal access token, and where they upgrade. */
 export const ACCOUNT_TOKENS_URL = `${DEFAULT_BASE_URL}/settings/api-tokens`;
 
-/** Page advertised when the server reports the premium engagement gate. */
-export const UPGRADE_URL = `${DEFAULT_BASE_URL}`;
+/**
+ * Page advertised when the server reports the premium engagement gate. This is
+ * `/upgrade`, not the homepage: a user who just pressed a key and was told they
+ * need premium should land on the page that explains it, and the
+ * StreamController plugin has always pointed there.
+ */
+export const UPGRADE_URL = `${DEFAULT_BASE_URL}/upgrade`;
 
 /**
  * Every All-Chat personal access token carries this prefix; the server routes a


### PR DESCRIPTION
## What and why

Neither desktop plugin was built, tested or packaged by any workflow. Both landed on main in #707 / #708 as ordinary source directories, and `build-and-push.yml` builds service images and the frontend — a plugin is neither. So a TypeScript error or a broken Python import could reach main unnoticed, and the StreamController plugin's 46 unit tests were running nowhere.

## `.github/workflows/plugins.yml`

Four jobs behind the same intra-workflow skip shim `frontend-a11y.yml` uses (a `changes` paths-filter job plus per-job `if:`, never a top-level `paths:` filter, so these can be made required checks without the permanently-"Expected" trap from ADR-0033). Every job sets `timeout-minutes`, per the #731 lesson.

| Job | What it does |
| --- | --- |
| `streamdeck` | `npm ci`, `npm run lint` (eslint + `tsc --noEmit`), `npm run build`, assert `bin/plugin.js` is non-empty, `@elgato/cli@1.9.0 validate`, then `pack` → uploads `com.allchat.streamdeck.streamDeckPlugin` |
| `streamcontroller` | `compileall` + the unit suite on **Python 3.11** (the documented floor is the version worth testing), metadata validation, staged-allowlist zip → uploads it |
| `parity` | `scripts/check-plugin-parity.py` |

The artifacts matter as much as the gates. A plugin is not useful as source and neither is published to a store yet, so a run artifact is currently the only way to install a branch on real hardware: download, unzip, double-click.

Verified locally end to end in the flake dev shell — `npm ci && npm run lint && npm run build`, `validate`, `pack` (produces a 32 KB `.streamDeckPlugin`), `compileall`, 46 tests green, the metadata check, the staged zip, and `actionlint` (which also shellchecks the `run:` blocks and pyflakes the heredoc) clean.

## `scripts/check-plugin-parity.py`

ADR-0049 names the risk and the remedy: *"the button set now exists twice and will diverge unless it is defined once. Treat the action list as the single source both implementations follow."* This script is that source, made executable. It pins the nine-action list, fails when a route-bearing public function exists on only one side, compares the five user-visible constants, and requires every `KEEP IN SYNC` pointer to be mutual. Standard library only, so it runs in the dev shell, in CI and in a Caterpillar sandbox with no install step.

It found two real divergences on main, both fixed here:

- **`UPGRADE_URL` differed.** `https://allch.at` in the Elgato plugin, `https://allch.at/upgrade` in the StreamController one — so a premium 403 sent Windows and macOS users to the homepage instead of the page that explains the gate. The Linux value wins; `streamdeck-plugin/README.md` updated to match.
- **All six `KEEP IN SYNC` pointers were one-way** (Python → TypeScript). A one-way pointer rots the moment someone edits the unmarked file, so the reciprocals are added.

## Notes

- `dist/` added to both plugin `.gitignore`s.
- The Elgato CLI **rewrites `manifest.json` in place** when it validates or packs (reformats arrays, drops the trailing newline). Harmless in CI, confusing locally, so it is documented as a gotcha in the plugin README.
- Not addressed here, and deliberately: the ADR-0049 pairing flow (tracked separately), Marketplace / plugin-store submission, and the GPL-3.0 licence sign-off that ADR-0049 makes a release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)