### PR TITLE
feat(overlay): differently-coloured chat bubbles, per platform and by palette

### DIFF
--- a/docs/overlay-themes/README.md
+++ b/docs/overlay-themes/README.md
@@ -387,6 +387,17 @@ Sticky Notes is the worked example. Neo-Brutalist and Trading Card keep their
 per-row variety on the shadow and the foil border respectively, which are
 colour-independent and need none of this.
 
+Separately, the streamer can set **differently-coloured bubbles** (Appearance →
+Bubble colors): a fill per platform, and/or a palette cycled down the feed. Those
+are enforced like the table above, as `!important` rules on
+`[data-platform='<p>']` and `[data-bubble-slot='<n>']` rows, so they replace your
+bubble fill when configured and emit nothing when not. Events are never painted.
+
+Do not key any theme rule off `data-bubble-slot`. It is assigned from **arrival
+order**, not position, so that a row keeps its colour as the feed scrolls — a
+theme reading it would be styling "the 3rd message ever seen". Use `nth-child`
+for positional rhythm; a unit test enforces this.
+
 #### Message Container
 - `.space-y-3 > div` - Individual message wrapper
 - `.bg-gray-900/90` - Default dark background

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -47,7 +47,17 @@ import { renderMessageContent } from '@/lib/renderMessage'
 import PlatformStatusIndicators from '@/components/PlatformStatusIndicators'
 import { useOverlayStream } from '@/hooks/useOverlayStream'
 import { buildGradientCSS } from '@/lib/utils/gradient'
-import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import {
+  BUBBLE_SLOT_ATTR,
+  resolveBubblePalette,
+  visualSettingsToCss,
+} from '@/lib/utils/visual-settings-to-css'
+import {
+  admitBubbleSlot,
+  bubbleSlot,
+  EMPTY_BUBBLE_SLOTS,
+  type BubbleSlotState,
+} from '@/lib/utils/bubbleSlot'
 import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
 import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
@@ -206,6 +216,11 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   })
   const ttsFallbackToastShownRef = useRef(false)
 
+  // Bubble palette: 2+ fills cycled down the feed, and the per-row slot that
+  // decides which one a row gets. Empty palette ⇒ no slot attribute is written.
+  const [bubblePalette, setBubblePalette] = useState<string[]>([])
+  const [bubbleSlots, setBubbleSlots] = useState<BubbleSlotState>(EMPTY_BUBBLE_SLOTS)
+
   const messagesEndRef = useRef<HTMLDivElement>(null)
   // The full-canvas wrapper. Measured (layout height) by the auto-scroll effect.
   const feedWrapperRef = useRef<HTMLDivElement>(null)
@@ -222,6 +237,7 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   useEffect(() => {
     filterSettingsRef.current = filterSettings
   }, [filterSettings])
+
 
   // Phase 12: Destroy sound player on unmount
   useEffect(() => {
@@ -257,6 +273,9 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
     soundPlayerRef.current?.play()
     // Phase 13: speak the message via TTS (D-41, D-42 — independent of sound; both fire on non-filtered)
     ttsPlayerRef.current?.speak(message)
+    // Arrival order for the bubble palette (idempotent per id, so a
+    // double-invoked updater cannot burn a number).
+    setBubbleSlots((prev) => admitBubbleSlot(prev, message.id, maxMessagesRef.current * 2))
     setMessages((prev) =>
       // Ignore a redelivery of a message already on screen. The render key is
       // `message.id`, so a duplicate id would be a duplicate React key (and the
@@ -270,6 +289,7 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   }, [])
 
   const onMessageUpdate = useCallback((updatedMessage: ChatMessage) => {
+    setBubbleSlots((prev) => admitBubbleSlot(prev, updatedMessage.id, maxMessagesRef.current * 2))
     setMessages((prev) => {
       // Find existing message by aggregation_id (TikTok like aggregates), then
       // by id — an update that carries a live row's id has to REPLACE that row.
@@ -392,6 +412,8 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       // Background fills / shadow / max-width (see state decl).
       setContainerStyle(overlayContainerStyle(vs))
       setBubbleStyle(chatBubbleStyle(vs))
+      // Unconditional: clearing the palette has to drop the slot attributes too.
+      setBubblePalette(resolveBubblePalette(vs))
       for (const key of ['fontFamily', 'usernameFontFamily', 'timestampFontFamily'] as const) {
         if (typeof vs[key] === 'string') ensureGoogleFontLoaded(vs[key]!)
       }
@@ -794,6 +816,14 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
               data-platform={message.platform}
               data-event-type={isEvent ? message.event?.type : undefined}
               data-username={message.user?.username}
+              {...{
+                // Which palette fill this row takes. Keyed on arrival order, not
+                // position, so a row keeps its colour as the feed scrolls (see
+                // BubbleSlotTracker). Events keep their own themed chrome.
+                [BUBBLE_SLOT_ATTR]: isEvent
+                  ? undefined
+                  : bubbleSlot(bubbleSlots, message.id, bubblePalette.length),
+              }}
               className={clsx(
                 isEvent
                   ? ['event-message', eventTierClass, eventTypeClass]

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -1804,6 +1804,10 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
 
   // --- Visual appearance settings state ---
   const [visualSettings, setVisualSettings] = useState<Partial<VisualSettings>>({})
+  // Server-resolved `bubble_colors` gate (ADR-0008). Ships open, so this stays
+  // false unless the gate is flipped to premium in the admin UI — at which point
+  // the controls lock without a deploy.
+  const [bubbleColorsLocked, setBubbleColorsLocked] = useState(false)
   const [iframeVisibilityDefaults, setIframeVisibilityDefaults] = useState<Partial<VisualSettings>>(
     {}
   )
@@ -2275,6 +2279,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           }
 
           const savedCss = config.custom_css || ''
+          setBubbleColorsLocked(config.bubble_colors_locked === true)
+
           const tid = typeof config.theme_id === 'string' ? config.theme_id : ''
           setThemeId(tid)
           // Resolve the bundled theme CSS for this overlay: preloaded into the
@@ -3187,7 +3193,7 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                     <BubbleColorsGroup
                       visualSettings={visualSettings}
                       onChange={handleVisualSettingsChange}
-                      isPremium={user?.is_premium ?? false}
+                      locked={bubbleColorsLocked}
                     />
                   )}
                   {activeSection === 'visibility' && (

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -98,6 +98,7 @@ import { StatusBadge } from '@/app/dashboard/shares/components/StatusBadge'
 import { RevocationConfirmModal } from '@/app/dashboard/shares/components/RevocationConfirmModal'
 import { cn } from '@/lib/utils'
 import { TypographyGroup } from '@/components/appearance/TypographyGroup'
+import { BubbleColorsGroup } from '@/components/appearance/BubbleColorsGroup'
 import { ColorsGroup } from '@/components/appearance/ColorsGroup'
 import { BackgroundGroup } from '@/components/appearance/BackgroundGroup'
 import { VisibilityGroup } from '@/components/appearance/VisibilityGroup'
@@ -1930,6 +1931,9 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           showPlatformBadge: settings.showPlatformBadge,
           showPlatformIndicators: settings.showPlatformIndicators,
           messageAnimation: settings.messageAnimation,
+          // The palette's CSS rules key on a per-row attribute the preview has
+          // to render itself, so it needs the list, not just the CSS.
+          bubblePalette: settings.bubblePalette,
         },
       },
       '*'
@@ -3177,6 +3181,13 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
                     <BackgroundGroup
                       visualSettings={visualSettings}
                       onChange={handleVisualSettingsChange}
+                    />
+                  )}
+                  {activeSection === 'bubble-colors' && (
+                    <BubbleColorsGroup
+                      visualSettings={visualSettings}
+                      onChange={handleVisualSettingsChange}
+                      isPremium={user?.is_premium ?? false}
                     />
                   )}
                   {activeSection === 'visibility' && (

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -42,7 +42,17 @@ import { buildGradientCSS } from '@/lib/utils/gradient'
 import { renderMessageContent } from '@/lib/renderMessage'
 import { resolveTwitchBadgeIcons } from '@/lib/twitchBadges'
 import { sortMessageBadges } from '@/lib/badgeOrder'
-import { visualSettingsToCss } from '@/lib/utils/visual-settings-to-css'
+import {
+  BUBBLE_SLOT_ATTR,
+  resolveBubblePalette,
+  visualSettingsToCss,
+} from '@/lib/utils/visual-settings-to-css'
+import {
+  admitBubbleSlot,
+  bubbleSlot,
+  EMPTY_BUBBLE_SLOTS,
+  type BubbleSlotState,
+} from '@/lib/utils/bubbleSlot'
 import {
   isMessageAnimation,
   MESSAGE_ANIMATION_CLASS,
@@ -190,6 +200,11 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
   // visual-inline-styles); keeps this preview in sync with the live overlay.
   const [containerStyle, setContainerStyle] = useState<React.CSSProperties>({})
   const [bubbleStyle, setBubbleStyle] = useState<React.CSSProperties>({})
+  // Bubble palette: 2+ fills cycled down the feed. Arrives on load from
+  // visual_settings and live via VISUAL_SETTINGS_UPDATE (the CSS alone is not
+  // enough — the per-row slot attribute has to be written in React).
+  const [bubblePalette, setBubblePalette] = useState<string[]>([])
+  const [bubbleSlots, setBubbleSlots] = useState<BubbleSlotState>(EMPTY_BUBBLE_SLOTS)
   const [platformBadgePosition, setPlatformBadgePosition] = useState<'before' | 'after'>('before')
   const [platformBadgeStyle, setPlatformBadgeStyle] = useState<'text' | 'icon'>('text')
   const [showPlatformBadge, setShowPlatformBadge] = useState(true)
@@ -319,6 +334,8 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         }
         // Unconditional so switching back to the default clears the class live
         setMessageAnimation(isMessageAnimation(s.messageAnimation) ? s.messageAnimation : null)
+        // Same reason: emptying the palette has to drop the slot attributes too
+        setBubblePalette(resolveBubblePalette({ bubblePalette: s.bubblePalette }))
         return
       }
       // Live custom/theme CSS from the editor (theme apply, or typing in the
@@ -451,6 +468,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         setVisualSettingsCss(vcCss)
         setContainerStyle(overlayContainerStyle(vs))
         setBubbleStyle(chatBubbleStyle(vs))
+        setBubblePalette(resolveBubblePalette(vs))
         // Apply non-CSS visual settings
         if (vs.showPlatformBadge !== undefined) {
           setShowPlatformBadge(vs.showPlatformBadge !== 'none')
@@ -614,6 +632,8 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
       // Phase 13: speak the message via TTS (D-41, D-42 — independent of sound; both fire on non-filtered)
       ttsPlayerRef.current?.speak(message)
 
+      // Arrival order for the bubble palette (idempotent per id)
+      setBubbleSlots((prev) => admitBubbleSlot(prev, message.id, maxMessages * 2))
       setMessages((prev) => [...prev, message].slice(-maxMessages))
     })
 
@@ -633,6 +653,7 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMessages((prev) => (prev.length > maxMessages ? prev.slice(-maxMessages) : prev))
   }, [maxMessages])
+
 
   // Phase 12: Destroy sound player on unmount
   useEffect(() => {
@@ -754,6 +775,12 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                     key={message.id}
                     data-platform={message.platform}
                     data-event-type={isEvent ? message.event?.type : undefined}
+                    {...{
+                      // See the live overlay: keyed on arrival order, not position.
+                      [BUBBLE_SLOT_ATTR]: isEvent
+                        ? undefined
+                        : bubbleSlot(bubbleSlots, message.id, bubblePalette.length),
+                    }}
                     className={
                       isEvent
                         ? clsx('event-message', eventTierClass, eventTypeClass)

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -16,7 +16,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Check, MessagesSquare, Radio, ShieldCheck, Sparkles, Users, Volume2 } from 'lucide-react'
+import {
+  Check,
+  MessagesSquare,
+  Palette,
+  Radio,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  Volume2,
+} from 'lucide-react'
 import Link from 'next/link'
 import { AppNav } from '@/components/AppNav'
 import { Card } from '@/components/ui/card'
@@ -26,7 +35,7 @@ import { PATREON_JOIN_URL } from '@/lib/constants'
 export const metadata = {
   title: 'Upgrade to Premium | All-Chat',
   description:
-    'Back All-Chat on Patreon to unlock premium features: moderate from your overlay, ElevenLabs TTS, YouTube stream selection, shared chat, and viewer flairs.',
+    'Back All-Chat on Patreon to unlock premium features: moderate from your overlay, ElevenLabs TTS, YouTube stream selection, shared chat, differently-coloured bubbles, and viewer flairs.',
   alternates: { canonical: '/upgrade' },
 }
 
@@ -68,6 +77,12 @@ const features: PremiumFeature[] = [
     icon: MessagesSquare,
     title: 'Shared chat',
     description: 'Combine several channels into one shared conversation across your overlays.',
+  },
+  {
+    icon: Palette,
+    title: 'Differently-coloured bubbles',
+    description:
+      'Give each platform its own bubble colour so you can tell sources apart at a glance, or cycle a palette of up to six colours down the feed.',
   },
   {
     icon: Sparkles,

--- a/frontend/src/app/upgrade/page.tsx
+++ b/frontend/src/app/upgrade/page.tsx
@@ -16,16 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {
-  Check,
-  MessagesSquare,
-  Palette,
-  Radio,
-  ShieldCheck,
-  Sparkles,
-  Users,
-  Volume2,
-} from 'lucide-react'
+import { Check, MessagesSquare, Radio, ShieldCheck, Sparkles, Users, Volume2 } from 'lucide-react'
 import Link from 'next/link'
 import { AppNav } from '@/components/AppNav'
 import { Card } from '@/components/ui/card'
@@ -35,7 +26,7 @@ import { PATREON_JOIN_URL } from '@/lib/constants'
 export const metadata = {
   title: 'Upgrade to Premium | All-Chat',
   description:
-    'Back All-Chat on Patreon to unlock premium features: moderate from your overlay, ElevenLabs TTS, YouTube stream selection, shared chat, differently-coloured bubbles, and viewer flairs.',
+    'Back All-Chat on Patreon to unlock premium features: moderate from your overlay, ElevenLabs TTS, YouTube stream selection, shared chat, and viewer flairs.',
   alternates: { canonical: '/upgrade' },
 }
 
@@ -77,12 +68,6 @@ const features: PremiumFeature[] = [
     icon: MessagesSquare,
     title: 'Shared chat',
     description: 'Combine several channels into one shared conversation across your overlays.',
-  },
-  {
-    icon: Palette,
-    title: 'Differently-coloured bubbles',
-    description:
-      'Give each platform its own bubble colour so you can tell sources apart at a glance, or cycle a palette of up to six colours down the feed.',
   },
   {
     icon: Sparkles,

--- a/frontend/src/components/appearance/BubbleColorsGroup.tsx
+++ b/frontend/src/components/appearance/BubbleColorsGroup.tsx
@@ -19,7 +19,7 @@
  */
 
 /**
- * Differently-coloured chat bubbles (premium), on two independent axes:
+ * Differently-coloured chat bubbles, on two independent axes:
  *
  * - Per platform — Twitch rows one fill, YouTube another. Useful for
  *   multistreamers who want to tell sources apart at a glance.
@@ -27,6 +27,11 @@
  *
  * A platform fill wins over the palette on that platform's rows; the emitted CSS
  * encodes that by source order (see bubbleFillRules).
+ *
+ * Free to use. `locked` comes from the server-resolved `bubble_colors_locked`
+ * flag on the overlay config rather than from `user.is_premium`, so flipping the
+ * `bubble_colors` gate to premium in the admin UI locks these controls with no
+ * deploy — and until someone does, nothing here mentions Premium.
  */
 
 import React from 'react'
@@ -51,13 +56,14 @@ const PLATFORMS: ReadonlyArray<{ field: keyof VisualSettings; label: string; sam
 export interface BubbleColorsGroupProps {
   visualSettings: Partial<VisualSettings>
   onChange: (patch: Partial<VisualSettings>) => void
-  isPremium: boolean
+  /** Server-resolved `bubble_colors_locked`; the gate ships open, so normally false. */
+  locked?: boolean
 }
 
 export function BubbleColorsGroup({
   visualSettings,
   onChange,
-  isPremium,
+  locked = false,
 }: BubbleColorsGroupProps): React.ReactElement {
   const palette = visualSettings.bubblePalette ?? []
 
@@ -69,7 +75,7 @@ export function BubbleColorsGroup({
 
   return (
     <div className="space-y-5">
-      {!isPremium && (
+      {locked && (
         <div className="flex items-start gap-2 rounded-lg border border-border bg-surface p-3">
           <PremiumBadge />
           <p className="text-sm text-text-sub">
@@ -79,7 +85,7 @@ export function BubbleColorsGroup({
         </div>
       )}
 
-      <fieldset disabled={!isPremium} className="space-y-5 disabled:opacity-50">
+      <fieldset disabled={locked} className="space-y-5 disabled:opacity-50">
         <div className="space-y-3">
           <div>
             <h3 className="text-sm font-medium text-text">Per platform</h3>
@@ -99,7 +105,7 @@ export function BubbleColorsGroup({
                 <button
                   type="button"
                   aria-label={`Reset ${platform.label} bubble colour`}
-                  disabled={!isPremium}
+                  disabled={locked}
                   onClick={() => onChange({ [platform.field]: undefined })}
                   className="rounded p-1 text-text-dim transition-colors hover:text-text disabled:cursor-not-allowed"
                 >
@@ -131,7 +137,7 @@ export function BubbleColorsGroup({
               <button
                 type="button"
                 aria-label={`Remove colour ${index + 1}`}
-                disabled={!isPremium}
+                disabled={locked}
                 onClick={() => writePalette(palette.filter((_, i) => i !== index))}
                 className="rounded p-1 text-text-dim transition-colors hover:text-text disabled:cursor-not-allowed"
               >
@@ -143,7 +149,7 @@ export function BubbleColorsGroup({
           {palette.length < MAX_BUBBLE_PALETTE && (
             <button
               type="button"
-              disabled={!isPremium}
+              disabled={locked}
               onClick={() => writePalette([...palette, NEW_SWATCH])}
               className="hover:bg-surface-alt flex items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors disabled:cursor-not-allowed"
             >

--- a/frontend/src/components/appearance/BubbleColorsGroup.tsx
+++ b/frontend/src/components/appearance/BubbleColorsGroup.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Differently-coloured chat bubbles (premium), on two independent axes:
+ *
+ * - Per platform — Twitch rows one fill, YouTube another. Useful for
+ *   multistreamers who want to tell sources apart at a glance.
+ * - Palette — 2 to MAX_BUBBLE_PALETTE fills cycled down the feed, for rhythm.
+ *
+ * A platform fill wins over the palette on that platform's rows; the emitted CSS
+ * encodes that by source order (see bubbleFillRules).
+ */
+
+import React from 'react'
+import { Plus, RotateCcw, X } from 'lucide-react'
+import { PremiumBadge } from '@/components/PremiumBadge'
+import { PremiumUpsellLink } from '@/components/PremiumUpsellLink'
+import type { VisualSettings } from '@/lib/types/visual-settings'
+import { MAX_BUBBLE_PALETTE } from '@/lib/utils/visual-settings-to-css'
+import { ColorPickerControl } from './ColorPickerControl'
+
+/** Starting colour for a newly added palette entry — a neutral dark bubble. */
+const NEW_SWATCH = '#1e293b'
+
+const PLATFORMS: ReadonlyArray<{ field: keyof VisualSettings; label: string; sample: string }> = [
+  { field: 'twitchBubbleBg', label: 'Twitch', sample: '#2a1b3d' },
+  { field: 'youtubeBubbleBg', label: 'YouTube', sample: '#3d1b1b' },
+  { field: 'kickBubbleBg', label: 'Kick', sample: '#1b3d22' },
+  { field: 'tiktokBubbleBg', label: 'TikTok', sample: '#1b333d' },
+  { field: 'discordBubbleBg', label: 'Discord', sample: '#22253d' },
+]
+
+export interface BubbleColorsGroupProps {
+  visualSettings: Partial<VisualSettings>
+  onChange: (patch: Partial<VisualSettings>) => void
+  isPremium: boolean
+}
+
+export function BubbleColorsGroup({
+  visualSettings,
+  onChange,
+  isPremium,
+}: BubbleColorsGroupProps): React.ReactElement {
+  const palette = visualSettings.bubblePalette ?? []
+
+  // Always write the whole list back: the setting is one array, and an entry's
+  // index is what decides which rows get it.
+  const writePalette = (next: string[]): void => {
+    onChange({ bubblePalette: next.length > 0 ? next : undefined })
+  }
+
+  return (
+    <div className="space-y-5">
+      {!isPremium && (
+        <div className="flex items-start gap-2 rounded-lg border border-border bg-surface p-3">
+          <PremiumBadge />
+          <p className="text-sm text-text-sub">
+            Different bubble colours per platform, or a palette cycled down the feed, are a{' '}
+            <PremiumUpsellLink>Premium</PremiumUpsellLink> feature.
+          </p>
+        </div>
+      )}
+
+      <fieldset disabled={!isPremium} className="space-y-5 disabled:opacity-50">
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-text">Per platform</h3>
+            <p className="text-xs text-text-dim">
+              Tell sources apart at a glance. Unset platforms keep the normal bubble background.
+            </p>
+          </div>
+          {PLATFORMS.map((platform) => {
+            const current = visualSettings[platform.field]
+            return (
+              <div key={String(platform.field)} className="flex items-center gap-1">
+                <ColorPickerControl
+                  label={platform.label}
+                  value={typeof current === 'string' ? current : platform.sample}
+                  onChange={(hex) => onChange({ [platform.field]: hex })}
+                />
+                <button
+                  type="button"
+                  aria-label={`Reset ${platform.label} bubble colour`}
+                  disabled={!isPremium}
+                  onClick={() => onChange({ [platform.field]: undefined })}
+                  className="rounded p-1 text-text-dim transition-colors hover:text-text disabled:cursor-not-allowed"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                </button>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-text">Palette</h3>
+            <p className="text-xs text-text-dim">
+              Two or more colours, cycled down the feed. A row keeps its colour while it is on
+              screen. Needs at least two to take effect.
+            </p>
+          </div>
+
+          {palette.map((color, index) => (
+            <div key={index} className="flex items-center gap-1">
+              <ColorPickerControl
+                label={`Colour ${index + 1}`}
+                value={color}
+                onChange={(hex) =>
+                  writePalette(palette.map((entry, i) => (i === index ? hex : entry)))
+                }
+              />
+              <button
+                type="button"
+                aria-label={`Remove colour ${index + 1}`}
+                disabled={!isPremium}
+                onClick={() => writePalette(palette.filter((_, i) => i !== index))}
+                className="rounded p-1 text-text-dim transition-colors hover:text-text disabled:cursor-not-allowed"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+
+          {palette.length < MAX_BUBBLE_PALETTE && (
+            <button
+              type="button"
+              disabled={!isPremium}
+              onClick={() => writePalette([...palette, NEW_SWATCH])}
+              className="hover:bg-surface-alt flex items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-1.5 text-sm text-text transition-colors disabled:cursor-not-allowed"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add colour
+            </button>
+          )}
+
+          {palette.length === 1 && (
+            <p className="text-xs text-text-dim">
+              One colour behaves the same as Bubble background. Add a second to start cycling.
+            </p>
+          )}
+        </div>
+      </fieldset>
+    </div>
+  )
+}

--- a/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
+++ b/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import React from 'react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import type { VisualSettings } from '@/lib/types/visual-settings'
+import { MAX_BUBBLE_PALETTE } from '@/lib/utils/visual-settings-to-css'
+import { BubbleColorsGroup } from '../BubbleColorsGroup'
+
+afterEach(() => {
+  cleanup()
+})
+
+const renderGroup = (
+  visualSettings: Partial<VisualSettings>,
+  isPremium = true
+): { onChange: ReturnType<typeof vi.fn> } => {
+  const onChange = vi.fn()
+  render(
+    <BubbleColorsGroup visualSettings={visualSettings} onChange={onChange} isPremium={isPremium} />
+  )
+  return { onChange }
+}
+
+describe('BubbleColorsGroup', () => {
+  it('renders a colour control per platform', () => {
+    renderGroup({})
+    for (const platform of ['Twitch', 'YouTube', 'Kick', 'TikTok', 'Discord']) {
+      expect(screen.getByText(platform)).toBeDefined()
+    }
+  })
+
+  it('reports a patch when a platform bubble colour is reset', () => {
+    const { onChange } = renderGroup({ twitchBubbleBg: '#2a1b3d' })
+    fireEvent.click(screen.getByLabelText(/reset twitch bubble colour/i))
+    expect(onChange).toHaveBeenCalledWith({ twitchBubbleBg: undefined })
+  })
+
+  it('appends a palette entry, keeping the existing ones', () => {
+    const { onChange } = renderGroup({ bubblePalette: ['#111111', '#222222'] })
+    fireEvent.click(screen.getByText(/add colour/i))
+
+    const patch = onChange.mock.calls[0][0] as Partial<VisualSettings>
+    expect(patch.bubblePalette).toHaveLength(3)
+    expect(patch.bubblePalette?.slice(0, 2)).toEqual(['#111111', '#222222'])
+  })
+
+  it('removes a palette entry by index', () => {
+    const { onChange } = renderGroup({ bubblePalette: ['#111111', '#222222', '#333333'] })
+    fireEvent.click(screen.getByLabelText(/remove colour 2/i))
+    expect(onChange).toHaveBeenCalledWith({ bubblePalette: ['#111111', '#333333'] })
+  })
+
+  /** An empty list must clear the setting, not persist `[]`. */
+  it('unsets the palette when the last entry is removed', () => {
+    const { onChange } = renderGroup({ bubblePalette: ['#111111'] })
+    fireEvent.click(screen.getByLabelText(/remove colour 1/i))
+    expect(onChange).toHaveBeenCalledWith({ bubblePalette: undefined })
+  })
+
+  it('stops offering more entries at the maximum', () => {
+    renderGroup({
+      bubblePalette: Array.from({ length: MAX_BUBBLE_PALETTE }, (_, i) => `#00000${i}`),
+    })
+    expect(screen.queryByText(/add colour/i)).toBeNull()
+  })
+
+  it('says a single colour does nothing yet', () => {
+    renderGroup({ bubblePalette: ['#111111'] })
+    expect(screen.getByText(/add a second to start cycling/i)).toBeDefined()
+  })
+
+  it('locks every control behind premium and says so', () => {
+    renderGroup({ bubblePalette: ['#111111', '#222222'] }, false)
+
+    // The notice interleaves an upsell link, so match the paragraph's full text.
+    expect(screen.getByText(/different bubble colours per platform/i)).toBeDefined()
+    expect(screen.getByLabelText(/remove colour 1/i)).toHaveProperty('disabled', true)
+    expect(screen.getByText(/add colour/i)).toHaveProperty('disabled', true)
+  })
+})

--- a/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
+++ b/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
@@ -30,12 +30,10 @@ afterEach(() => {
 
 const renderGroup = (
   visualSettings: Partial<VisualSettings>,
-  isPremium = true
+  locked = false
 ): { onChange: ReturnType<typeof vi.fn> } => {
   const onChange = vi.fn()
-  render(
-    <BubbleColorsGroup visualSettings={visualSettings} onChange={onChange} isPremium={isPremium} />
-  )
+  render(<BubbleColorsGroup visualSettings={visualSettings} onChange={onChange} locked={locked} />)
   return { onChange }
 }
 
@@ -87,8 +85,22 @@ describe('BubbleColorsGroup', () => {
     expect(screen.getByText(/add a second to start cycling/i)).toBeDefined()
   })
 
-  it('locks every control behind premium and says so', () => {
-    renderGroup({ bubblePalette: ['#111111', '#222222'] }, false)
+  /** The gate ships open, so nothing should mention Premium by default. */
+  it('is free by default, with no upsell', () => {
+    renderGroup({ bubblePalette: ['#111111', '#222222'] })
+
+    expect(screen.queryByText(/premium/i)).toBeNull()
+    expect(screen.getByLabelText(/remove colour 1/i)).toHaveProperty('disabled', false)
+    expect(screen.getByText(/add colour/i)).toHaveProperty('disabled', false)
+  })
+
+  /**
+   * `locked` comes from the server-resolved `bubble_colors_locked` flag, so
+   * flipping the gate to premium in the admin UI locks the controls with no
+   * deploy — and the controls must actually go dead, not just look it.
+   */
+  it('locks every control and shows the upsell when the gate is closed', () => {
+    renderGroup({ bubblePalette: ['#111111', '#222222'] }, true)
 
     // The notice interleaves an upsell link, so match the paragraph's full text.
     expect(screen.getByText(/different bubble colours per platform/i)).toBeDefined()

--- a/frontend/src/components/editor/sectionRegistry.ts
+++ b/frontend/src/components/editor/sectionRegistry.ts
@@ -40,6 +40,7 @@ export type EditorSectionId =
   | 'typography'
   | 'colors'
   | 'background'
+  | 'bubble-colors'
   | 'visibility'
   | 'sizing'
   | 'platform-colors'
@@ -212,6 +213,22 @@ export const EDITOR_SECTIONS: EditorSection[] = [
       { label: 'Padding', keywords: 'spacing inside' },
       { label: 'Message gap', keywords: 'spacing between distance' },
       { label: 'Backdrop blur', keywords: 'glass frosted' },
+    ],
+  },
+  {
+    id: 'bubble-colors',
+    group: 'appearance',
+    title: 'Bubble Colors',
+    navLabel: 'Bubble colors',
+    description: 'A different bubble fill per platform, or a palette cycled down the feed.',
+    keywords: 'premium multicolour multicolor alternating rotate cycle rainbow per platform',
+    entries: [
+      { label: 'Twitch bubble', keywords: 'platform fill purple' },
+      { label: 'YouTube bubble', keywords: 'platform fill red' },
+      { label: 'Kick bubble', keywords: 'platform fill green' },
+      { label: 'TikTok bubble', keywords: 'platform fill cyan' },
+      { label: 'Discord bubble', keywords: 'platform fill blurple' },
+      { label: 'Palette', keywords: 'cycle alternate rotate colours colors' },
     ],
   },
   {

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -380,7 +380,7 @@ export function OnboardingChecklist({
                   <span className="font-medium text-text">Differently-coloured bubbles</span>
                   <p className="text-xs text-text-sub">
                     Give each platform its own bubble colour, or cycle a palette down the feed,
-                    under Bubble colors in Appearance. (Premium)
+                    under Bubble colors in Appearance. Free.
                   </p>
                 </li>
                 <li>

--- a/frontend/src/components/onboarding/OnboardingChecklist.tsx
+++ b/frontend/src/components/onboarding/OnboardingChecklist.tsx
@@ -377,6 +377,13 @@ export function OnboardingChecklist({
                   </p>
                 </li>
                 <li>
+                  <span className="font-medium text-text">Differently-coloured bubbles</span>
+                  <p className="text-xs text-text-sub">
+                    Give each platform its own bubble colour, or cycle a palette down the feed,
+                    under Bubble colors in Appearance. (Premium)
+                  </p>
+                </li>
+                <li>
                   <span className="font-medium text-text">Viewer flairs</span>
                   <p className="text-xs text-text-sub">
                     Premium cosmetics for chatters, like animated name gradients, under Flairs in

--- a/frontend/src/lib/types/overlay.ts
+++ b/frontend/src/lib/types/overlay.ts
@@ -55,6 +55,15 @@ export interface OverlayConfig {
    * propagate on deploy; custom_css is only the user's raw overrides.
    */
   theme_id?: string
+  /**
+   * Resolved per request by overlay-manager, never persisted: true when the
+   * `bubble_colors` feature gate (ADR-0008) is closed for this user, so the
+   * editor locks those controls instead of offering a setting the save path
+   * would drop. Ships false — the gate exists to make the feature flippable
+   * from the admin UI without a deploy, not because it is an upsell today.
+   * Absent on the unauthenticated public overlay-config route.
+   */
+  bubble_colors_locked?: boolean
   created_at: string
   updated_at: string
 }
@@ -220,12 +229,7 @@ export interface ChatSource {
 }
 
 export type StreamSelectionStrategy =
-  | 'first_found'
-  | 'most_viewers'
-  | 'fewest_viewers'
-  | 'title_match'
-  | 'title_match_all'
-  | 'all'
+  'first_found' | 'most_viewers' | 'fewest_viewers' | 'title_match' | 'title_match_all' | 'all'
 
 export interface YouTubeSourceConfig {
   stream_select?: StreamSelectionStrategy

--- a/frontend/src/lib/types/visual-settings.ts
+++ b/frontend/src/lib/types/visual-settings.ts
@@ -111,6 +111,27 @@ export interface VisualSettings {
   backdropBlur?: string         // --chat-backdrop-blur
   maxWidth?: string             // --chat-max-width
 
+  /**
+   * Differently-coloured bubbles (premium). Two independent axes:
+   *
+   * - `bubblePalette` — 2 to MAX_BUBBLE_PALETTE fills cycled down the feed,
+   *   keyed on the `data-bubble-slot` the overlay surfaces write per row.
+   * - `<platform>BubbleBg` — pins one platform's rows to a fill, and wins over
+   *   the palette on those rows.
+   *
+   * Neither is in PROPERTY_MAP. A palette is a list, not a single custom
+   * property, and keeping both out of the map also keeps theme-css-parser from
+   * back-filling them out of a theme — so a set value here is always the
+   * streamer's own choice and is safe to enforce over theme CSS. See
+   * bubbleFillRules in visual-settings-to-css.
+   */
+  bubblePalette?: string[]
+  twitchBubbleBg?: string
+  youtubeBubbleBg?: string
+  kickBubbleBg?: string
+  tiktokBubbleBg?: string
+  discordBubbleBg?: string
+
   // Visibility toggles ('inline' | 'none' for inline elements; 'block' | 'none' for block)
   showAvatars?: 'inline' | 'none'        // --chat-show-avatars
   showBadges?: 'inline' | 'none'         // --chat-show-badges

--- a/frontend/src/lib/utils/__tests__/bubbleSlot.test.ts
+++ b/frontend/src/lib/utils/__tests__/bubbleSlot.test.ts
@@ -1,0 +1,99 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  admitBubbleSlot,
+  bubbleSlot,
+  EMPTY_BUBBLE_SLOTS,
+  type BubbleSlotState,
+} from '../bubbleSlot'
+
+const admitAll = (ids: string[], keep = 100): BubbleSlotState =>
+  ids.reduce((state, id) => admitBubbleSlot(state, id, keep), EMPTY_BUBBLE_SLOTS)
+
+describe('bubble palette slots', () => {
+  it('cycles through the palette in arrival order', () => {
+    const state = admitAll(['a', 'b', 'c', 'd'])
+    expect(['a', 'b', 'c', 'd'].map((id) => bubbleSlot(state, id, 3))).toEqual([0, 1, 2, 0])
+  })
+
+  /**
+   * The whole reason this module exists. The feed keeps the newest N with
+   * `slice(-max)`, so cycling on list position would re-colour every row on
+   * screen each time a message arrives.
+   */
+  it('keeps a row on its colour as older rows are pruned', () => {
+    let state = admitAll(['a', 'b', 'c'])
+    const before = bubbleSlot(state, 'c', 3)
+
+    // 'd' arrives — 'c' has moved from index 2 to index 1 in the rendered list
+    state = admitBubbleSlot(state, 'd', 100)
+
+    expect(bubbleSlot(state, 'c', 3)).toBe(before)
+    expect(bubbleSlot(state, 'd', 3)).toBe(0)
+  })
+
+  it('recolours consistently when the palette length changes', () => {
+    const state = admitAll(['a', 'b', 'c', 'd'])
+    expect(['a', 'b', 'c', 'd'].map((id) => bubbleSlot(state, id, 2))).toEqual([0, 1, 0, 1])
+    expect(['a', 'b', 'c', 'd'].map((id) => bubbleSlot(state, id, 4))).toEqual([0, 1, 2, 3])
+  })
+
+  /** Safe inside a React state updater, which may run twice. */
+  it('is idempotent per id and returns the same object', () => {
+    const first = admitAll(['a', 'b'])
+    const again = admitBubbleSlot(first, 'a', 100)
+
+    expect(again).toBe(first)
+    expect(bubbleSlot(again, 'a', 3)).toBe(0)
+    expect(bubbleSlot(again, 'b', 3)).toBe(1)
+  })
+
+  it('never mutates the state it was given', () => {
+    const first = admitAll(['a'])
+    admitBubbleSlot(first, 'b', 100)
+    expect(first.byId.size).toBe(1)
+    expect(first.next).toBe(1)
+  })
+
+  it('has no slot without a palette to cycle, or for an unknown id', () => {
+    const state = admitAll(['a'])
+    expect(bubbleSlot(state, 'a', 0)).toBeUndefined()
+    expect(bubbleSlot(state, 'a', 1)).toBeUndefined()
+    expect(bubbleSlot(state, 'never-seen', 3)).toBeUndefined()
+  })
+
+  it('evicts the oldest arrivals instead of growing without bound', () => {
+    let state: BubbleSlotState = EMPTY_BUBBLE_SLOTS
+    for (let i = 0; i < 5000; i++) {
+      state = admitBubbleSlot(state, `m${i}`, 100)
+    }
+
+    expect(state.byId.size).toBe(100)
+    // Arrival numbers keep counting, so the cycle does not restart on eviction
+    expect(bubbleSlot(state, 'm4999', 3)).toBe(4999 % 3)
+    expect(bubbleSlot(state, 'm0', 3)).toBeUndefined()
+  })
+
+  it('keeps at least one entry even with a nonsensical limit', () => {
+    const state = admitBubbleSlot(admitAll(['a'], 0), 'b', 0)
+    expect(state.byId.size).toBe(1)
+    expect(bubbleSlot(state, 'b', 2)).toBe(1 % 2)
+  })
+})

--- a/frontend/src/lib/utils/__tests__/customizer-coverage.test.ts
+++ b/frontend/src/lib/utils/__tests__/customizer-coverage.test.ts
@@ -194,6 +194,40 @@ describe('visual customizer property coverage', () => {
     expect('--customizer-bubble-bg-set').not.toMatch(/^--(chat|platform)-/)
   })
 
+  /**
+   * The bubble-fill settings are emitted as rules only, never as `:root`
+   * variables. Adding them to PROPERTY_MAP would put them in theme-css-parser's
+   * reverse map, and a theme's `var()` fallback would then be read back as a
+   * streamer choice — the same trap that keeps "Bubble background" cooperative.
+   * A palette is also a list, which has no single-custom-property form.
+   */
+  it('keeps the bubble-fill settings out of the parsed variable namespace', () => {
+    const mapped = new Set(PROPERTY_MAP.map(([field]) => field))
+    for (const field of [
+      'bubblePalette',
+      'twitchBubbleBg',
+      'youtubeBubbleBg',
+      'kickBubbleBg',
+      'tiktokBubbleBg',
+      'discordBubbleBg',
+    ] as const) {
+      expect(mapped.has(field), `${field} must not be in PROPERTY_MAP`).toBe(false)
+    }
+  })
+
+  /**
+   * `data-bubble-slot` is assigned from arrival order by BubbleSlotTracker, so a
+   * theme keying off it would be styling "the 3rd message ever seen", not a
+   * position. Per-row rhythm belongs on `nth-child` (see the Sticky Notes note in
+   * the theme README).
+   */
+  it('keeps the palette slot attribute out of theme CSS', () => {
+    const users = BUNDLED_THEMES.filter((theme) => theme.css.includes('data-bubble-slot')).map(
+      (theme) => theme.id
+    )
+    expect(users).toEqual([])
+  })
+
   it('forces the three settings that had no consumer', () => {
     for (const field of [
       'textShadow',

--- a/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
+++ b/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
@@ -17,7 +17,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { visualSettingsToCss } from '../visual-settings-to-css'
+import {
+  MAX_BUBBLE_PALETTE,
+  resolveBubblePalette,
+  visualSettingsToCss,
+} from '../visual-settings-to-css'
 import type { VisualSettings } from '@/lib/types/visual-settings'
 
 describe('visualSettingsToCss', () => {
@@ -68,6 +72,14 @@ describe('visualSettingsToCss', () => {
       bubbleBorderColor: '#333333',
       bubblePadding: '12px',
       bubbleShadow: 'none',
+      // Differently-coloured bubbles: emitted as rules, never as --chat-* vars,
+      // so they must not move the custom-property count asserted below.
+      bubblePalette: ['#111111', '#222222'],
+      twitchBubbleBg: '#2a1b3d',
+      youtubeBubbleBg: '#3d1b1b',
+      kickBubbleBg: '#1b3d22',
+      tiktokBubbleBg: '#1b333d',
+      discordBubbleBg: '#22253d',
       messageGap: '8px',
       backdropBlur: '0px',
       maxWidth: '100%',
@@ -214,5 +226,86 @@ describe('visualSettingsToCss forced overrides', () => {
     })
     expect(result).not.toContain('text-shadow')
     expect(result).toContain('--chat-message-color: #ffffff;')
+  })
+})
+
+/**
+ * Differently-coloured bubbles. A palette is a list rather than a single value,
+ * so it can only ever be delivered as rules — keyed on the per-row
+ * `data-bubble-slot` the overlay surfaces write, because :nth-child shifts as
+ * the feed prunes.
+ */
+describe('visualSettingsToCss bubble fills', () => {
+  it('emits one rule per palette entry, on both surfaces', () => {
+    const result = visualSettingsToCss({ bubblePalette: ['#111111', '#222222', '#333333'] })
+
+    for (const scope of ['.overlay-live-body', '.overlay-preview-body']) {
+      for (const slot of [0, 1, 2]) {
+        expect(result).toContain(`${scope} > div[data-bubble-slot='${slot}']:not(.event-message)`)
+      }
+    }
+    expect(result).toContain('background-color: #333333 !important;')
+    expect(result).not.toContain("data-bubble-slot='3'")
+  })
+
+  it('ignores a palette that cannot cycle', () => {
+    // One colour is just "Bubble background" — cycling needs at least two.
+    expect(visualSettingsToCss({ bubblePalette: ['#111111'] })).toBe('')
+    expect(visualSettingsToCss({ bubblePalette: [] })).toBe('')
+    expect(resolveBubblePalette({ bubblePalette: ['#111111'] })).toEqual([])
+  })
+
+  it('clamps the palette to MAX_BUBBLE_PALETTE', () => {
+    const tooMany = Array.from({ length: MAX_BUBBLE_PALETTE + 3 }, (_, i) => `#00000${i}`)
+    expect(resolveBubblePalette({ bubblePalette: tooMany })).toHaveLength(MAX_BUBBLE_PALETTE)
+    expect(visualSettingsToCss({ bubblePalette: tooMany })).not.toContain(
+      `data-bubble-slot='${MAX_BUBBLE_PALETTE}'`
+    )
+  })
+
+  it('drops unusable palette entries rather than emitting broken CSS', () => {
+    expect(
+      resolveBubblePalette({ bubblePalette: ['#111111', 'rgba(0, 0, 0, 0.5', '#222222'] })
+    ).toEqual(['#111111', '#222222'])
+  })
+
+  it('fills a platform bubble on both surfaces', () => {
+    const result = visualSettingsToCss({ twitchBubbleBg: '#2a1b3d' })
+
+    expect(result).toContain(".overlay-live-body > div[data-platform='twitch']:not(.event-message)")
+    expect(result).toContain(
+      ".overlay-preview-body > div[data-platform='twitch']:not(.event-message)"
+    )
+    expect(result).toContain('background-color: #2a1b3d !important;')
+    expect(result).not.toContain("data-platform='youtube'")
+  })
+
+  /**
+   * The precedence rule. Both selectors are one class + one attribute, so
+   * specificity ties and source order decides — the platform rule has to come
+   * after every palette rule.
+   */
+  it('puts platform fills after the palette so they win on those rows', () => {
+    const result = visualSettingsToCss({
+      bubblePalette: ['#111111', '#222222'],
+      twitchBubbleBg: '#2a1b3d',
+    })
+
+    const lastSlot = result.lastIndexOf('data-bubble-slot')
+    const firstPlatform = result.indexOf("data-platform='twitch'")
+    expect(lastSlot).toBeGreaterThan(-1)
+    expect(firstPlatform).toBeGreaterThan(lastSlot)
+  })
+
+  it('never paints an event card', () => {
+    const result = visualSettingsToCss({
+      bubblePalette: ['#111111', '#222222'],
+      discordBubbleBg: '#22253d',
+    })
+    const rules = result.split('\n').filter((line) => line.includes('> div['))
+    expect(rules.length).toBeGreaterThan(0)
+    for (const rule of rules) {
+      expect(rule).toContain(':not(.event-message)')
+    }
   })
 })

--- a/frontend/src/lib/utils/bubbleSlot.ts
+++ b/frontend/src/lib/utils/bubbleSlot.ts
@@ -1,0 +1,90 @@
+/**
+ * This file is part of All-Chat.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Stable palette slot per message, for the "differently-coloured bubbles"
+ * setting (`bubblePalette`).
+ *
+ * Why not `:nth-child` or the render index: the feed keeps the newest N with
+ * `slice(-max)`, so once the buffer is full every surviving row's position
+ * shifts by one on each new message. Cycling colours on position therefore
+ * re-colours the WHOLE feed on every message — a visible shimmer, and the reason
+ * the bundled `nth-child(even)` themes flicker on a busy stream today.
+ *
+ * Arrival order does not shift. Each message gets a monotonic number the first
+ * time it is seen, and its slot is `number % paletteLength` — so a row keeps its
+ * colour for as long as it is on screen, and changing the palette length
+ * recolours everything consistently instead of leaving old rows behind.
+ *
+ * This is a plain immutable value rather than a mutable tracker in a ref: the
+ * overlay pages read it while rendering, and a ref read during render can return
+ * something the committed tree never saw. Every function here is pure, and
+ * `admitBubbleSlot` is idempotent, so it is safe inside a React state updater
+ * (which may run twice).
+ */
+
+export interface BubbleSlotState {
+  /** Arrival number the next unseen message will take. */
+  readonly next: number
+  /** message id → arrival number, in ascending arrival order. */
+  readonly byId: ReadonlyMap<string, number>
+}
+
+export const EMPTY_BUBBLE_SLOTS: BubbleSlotState = { next: 0, byId: new Map() }
+
+/**
+ * Records arrival order for a message, keeping at most `keep` entries.
+ *
+ * Re-admitting a known id returns the state unchanged, so an edited or
+ * re-delivered message never jumps colour and a double-invoked state updater
+ * cannot burn a number.
+ *
+ * Eviction drops the oldest arrivals: a stream running for hours would otherwise
+ * accumulate one entry per message forever. `Map` preserves insertion order and
+ * insertions only ever happen in ascending arrival order, so the oldest entry is
+ * simply the first key. Pass roughly twice the on-screen buffer so nothing
+ * visible can be evicted.
+ */
+export function admitBubbleSlot(state: BubbleSlotState, id: string, keep: number): BubbleSlotState {
+  if (state.byId.has(id)) return state
+
+  const byId = new Map(state.byId)
+  byId.set(id, state.next)
+  const limit = Math.max(keep, 1)
+  while (byId.size > limit) {
+    const oldest = byId.keys().next()
+    if (oldest.done) break
+    byId.delete(oldest.value)
+  }
+  return { next: state.next + 1, byId }
+}
+
+/**
+ * Slot for a rendered row, or undefined when there is no palette to cycle (the
+ * caller then omits the attribute entirely). An id that was never admitted also
+ * yields undefined rather than a wrong-but-plausible 0.
+ */
+export function bubbleSlot(
+  state: BubbleSlotState,
+  id: string,
+  paletteLength: number
+): number | undefined {
+  if (paletteLength < 2) return undefined
+  const arrival = state.byId.get(id)
+  return arrival === undefined ? undefined : arrival % paletteLength
+}

--- a/frontend/src/lib/utils/visual-settings-to-css.ts
+++ b/frontend/src/lib/utils/visual-settings-to-css.ts
@@ -207,13 +207,87 @@ export const OVERRIDDEN_FIELDS: ReadonlySet<keyof VisualSettings> = new Set(
   OVERRIDE_RULES.map((rule) => rule.field)
 )
 
+/**
+ * Longest bubble palette the editor offers and the emitter renders. Bounded
+ * because each entry costs a rule per surface, and because a rhythm the eye can
+ * follow needs a short cycle — beyond half a dozen it just reads as noise.
+ */
+export const MAX_BUBBLE_PALETTE = 6
+
+/** Per-row attribute the overlay surfaces write for the palette to key on. */
+export const BUBBLE_SLOT_ATTR = 'data-bubble-slot'
+
+/** VisualSettings field → the `data-platform` value whose bubble it fills. */
+const BUBBLE_TINT_PLATFORMS: ReadonlyArray<[keyof VisualSettings, string]> = [
+  ['twitchBubbleBg', 'twitch'],
+  ['youtubeBubbleBg', 'youtube'],
+  ['kickBubbleBg', 'kick'],
+  ['tiktokBubbleBg', 'tiktok'],
+  ['discordBubbleBg', 'discord'],
+]
+
+/**
+ * The palette actually in effect: entries that are usable CSS colours, clamped
+ * to MAX_BUBBLE_PALETTE, and only if at least two survive (one colour is the
+ * plain "Bubble background" setting, not a cycle).
+ *
+ * Exported because the overlay surfaces need the same length to compute
+ * `data-bubble-slot`; deriving it twice would drift.
+ */
+export function resolveBubblePalette(settings: Partial<VisualSettings>): string[] {
+  const palette = (settings.bubblePalette ?? [])
+    .filter((color) => typeof color === 'string' && color !== '' && hasBalancedParens(color))
+    .slice(0, MAX_BUBBLE_PALETTE)
+  return palette.length >= 2 ? palette : []
+}
+
+/**
+ * Differently-coloured bubbles: a palette cycled down the feed, plus per-platform
+ * fills that win over it.
+ *
+ * Emitted as `!important` rules inside the cascade layer for the same reason as
+ * OVERRIDE_RULES — a theme's own `background: … !important` on the row would
+ * otherwise beat them — and, like those, only when configured, so an unset
+ * control leaves the theme's fill alone.
+ *
+ * Order matters and is the precedence rule: palette first, platform second. Both
+ * selectors are one class plus one attribute, so specificity ties and the later
+ * rule wins. That is what makes "a platform tint overrides the palette on that
+ * platform's rows" true without any `:not()` gymnastics.
+ */
+function bubbleFillRules(settings: Partial<VisualSettings>): string[] {
+  const blocks: string[] = []
+
+  const rule = (predicate: string, color: string): string =>
+    [
+      FEED_SCOPES.map((scope) => `  ${scope} > div${predicate}:not(.event-message)`).join(',\n') +
+        ' {',
+      `    background-color: ${color} !important;`,
+      '  }',
+    ].join('\n')
+
+  // `.scroll-anchor` needs no exclusion here: the sentinel carries neither a
+  // slot attribute nor a platform, so no predicate below can match it.
+  resolveBubblePalette(settings).forEach((color, slot) => {
+    blocks.push(rule(`[${BUBBLE_SLOT_ATTR}='${slot}']`, color))
+  })
+
+  for (const [field, platform] of BUBBLE_TINT_PLATFORMS) {
+    const color = settings[field]
+    if (typeof color !== 'string' || color === '' || !hasBalancedParens(color)) continue
+    blocks.push(rule(`[data-platform='${platform}']`, color))
+  }
+
+  return blocks
+}
+
 /** Renders the set OVERRIDE_RULES as CSS rule blocks; empty when none apply. */
 function overrideRules(settings: Partial<VisualSettings>): string[] {
   const blocks: string[] = []
 
   for (const { field, targets, properties } of OVERRIDE_RULES) {
     const value = settings[field]
-    if (value === undefined || value === '') continue
+    if (typeof value !== 'string' || value === '') continue
     if (!hasBalancedParens(value)) continue
 
     const selectors = FEED_SCOPES.flatMap((scope) =>
@@ -244,7 +318,7 @@ export function visualSettingsToCss(settings: Partial<VisualSettings>): string {
 
   for (const [field, cssVar] of PROPERTY_MAP) {
     const value = settings[field]
-    if (value === undefined) continue
+    if (typeof value !== 'string') continue
     if (!hasBalancedParens(value)) continue
     declarations.push(`    ${cssVar}: ${value};`)
   }
@@ -259,7 +333,7 @@ export function visualSettingsToCss(settings: Partial<VisualSettings>): string {
   if (declarations.length > 0) {
     blocks.push(['  :root {', ...declarations, '  }'].join('\n'))
   }
-  blocks.push(...overrideRules(settings))
+  blocks.push(...overrideRules(settings), ...bubbleFillRules(settings))
 
   if (blocks.length === 0) {
     return ''

--- a/migrations/088_bubble_colors_feature_gate.sql
+++ b/migrations/088_bubble_colors_feature_gate.sql
@@ -1,0 +1,39 @@
+-- All-Chat Migration 088: Bubble colors feature gate
+-- Migration: 088
+--
+-- Registers the 'bubble_colors' feature gate (ADR-0008) for differently-coloured
+-- chat bubbles: a fill per platform, and/or a palette cycled down the feed.
+--
+-- Seeded is_premium=FALSE — this ships OPEN, unlike every other gate in this
+-- table. Each of those sits on a real marginal cost or risk (tts = audio delivery
+-- bandwidth, moderation = YouTube quota and platform write access, engagement =
+-- send quota, sharing = abuse prevention). Bubble colours are pure client-side
+-- CSS: nothing is served, metered or written on anyone's behalf, and telling
+-- Twitch from YouTube at a glance serves the multistream promise the product
+-- exists for. The gate is registered anyway so it can be turned into an upsell
+-- from the feature-gate admin endpoint without a redeploy, which is what
+-- CLAUDE.md "Shipping a Feature" asks for.
+--
+-- overlay-manager resolves this key on GET /overlays/:id/config (as
+-- `bubble_colors_locked`) so the editor locks the controls the moment it is
+-- flipped, and re-checks it on PUT, carrying over the stored values instead of
+-- accepting new ones. Settings saved while the gate was open keep rendering: the
+-- public overlay-config read path is deliberately not gated, so a flip stops new
+-- configuration rather than retroactively restyling live overlays.
+--
+-- IDEMPOTENCY: every service runs the full migration set on each pod restart (the
+-- runner does not track applied migrations), so this script must be safe to
+-- re-execute — hence ON CONFLICT DO NOTHING (the row's is_premium is owned by the
+-- admin toggle thereafter and must not be reset by a re-run).
+
+BEGIN;
+
+INSERT INTO feature_gates (feature_key, is_premium, description)
+VALUES (
+    'bubble_colors',
+    FALSE,
+    'Differently-coloured chat bubbles — a fill per platform and/or a palette cycled down the feed'
+)
+ON CONFLICT (feature_key) DO NOTHING;
+
+COMMIT;

--- a/migrations/088_bubble_colors_feature_gate_down.sql
+++ b/migrations/088_bubble_colors_feature_gate_down.sql
@@ -1,0 +1,12 @@
+-- All-Chat Migration 088 (down): remove the bubble colors feature gate
+--
+-- Reverses 088_bubble_colors_feature_gate.sql. Safe to run if the row is absent.
+--
+-- With the row gone the gate cache reports the key as not-premium, so the feature
+-- stays open — the same state it ships in. Nothing to migrate back.
+
+BEGIN;
+
+DELETE FROM feature_gates WHERE feature_key = 'bubble_colors';
+
+COMMIT;

--- a/services/overlay-manager/cmd/main.go
+++ b/services/overlay-manager/cmd/main.go
@@ -41,6 +41,7 @@ import (
 	sharedRedis "github.com/caesar/all-chat/shared/redis"
 	"github.com/caesar/all-chat/shared/tracing"
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -213,7 +214,7 @@ func main() {
 	mpClient := clients.NewMessageProcessorClient(config.MessageProcessorURL, config.MessageProcessorAPIKey, tracingEnabled, log)
 	overlayHandler := handlers.NewOverlayHandler(overlayRepo, sourceRepo, configRepo)
 	seventvResolver := clients.NewSevenTVResolver(log)
-	configHandler := handlers.NewConfigHandler(configRepo, overlayRepo, sourceRepo, seventvResolver)
+	configHandler := handlers.NewConfigHandler(configRepo, overlayRepo, sourceRepo, seventvResolver, bubbleColorsGate{gates: gateCache, db: dbPool})
 	sourcesHandler := handlers.NewSourcesHandler(sourceRepo, overlayRepo, dbPool, log, redisClient, bm, tokenCipher)
 
 	// Discord source guard (ADR-0048): a Discord source is acted on by the SHARED bot, so
@@ -408,6 +409,27 @@ func main() {
 }
 
 // Config holds application configuration
+// bubbleColorsGate combines the feature-gate cache with the per-user premium
+// lookup for the `bubble_colors` key (ADR-0008), mirroring moderation-service's
+// moderationGate so the read flag on GET /overlays/:id/config and the field
+// filter on PUT agree on cohort membership.
+//
+// The key ships is_premium=false, so this short-circuits to true without touching
+// the database; it only costs a query once the gate is flipped to premium.
+type bubbleColorsGate struct {
+	gates *featuregates.FeatureGateCache
+	db    *pgxpool.Pool
+}
+
+func (g bubbleColorsGate) BubbleColorsEnabled(ctx context.Context, userID string) (bool, error) {
+	if g.gates == nil || !g.gates.IsPremium(featuregates.GateBubbleColors) {
+		return true, nil
+	}
+	var isPremium bool
+	err := g.db.QueryRow(ctx, "SELECT is_premium FROM users WHERE id = $1", userID).Scan(&isPremium)
+	return isPremium, err
+}
+
 type Config struct {
 	Port                   string
 	GinMode                string

--- a/services/overlay-manager/handlers/config.go
+++ b/services/overlay-manager/handlers/config.go
@@ -37,17 +37,60 @@ type SevenTVResolver interface {
 	Resolve(ctx context.Context, input string) (clients.ResolvedSet, error)
 }
 
+// BubbleColorsGate answers whether differently-coloured chat bubbles are open for
+// a user (ADR-0008, gate key `bubble_colors`). Mirrors moderation-service's
+// moderationGate: when the gate row is not premium everyone is in, otherwise only
+// premium users are.
+//
+// It cannot be shared/middleware.RequirePremium: that aborts the whole request,
+// and this route saves the entire overlay config (theme, filters, fonts, …). Only
+// a handful of visual_settings keys are gated, so the check has to be per-field.
+type BubbleColorsGate interface {
+	BubbleColorsEnabled(ctx context.Context, userID string) (bool, error)
+}
+
+// bubbleColorSettings are the visual_settings keys the `bubble_colors` gate owns.
+// Names match the frontend's VisualSettings fields (lib/types/visual-settings.ts);
+// the emitted CSS lives in lib/utils/visual-settings-to-css.ts.
+var bubbleColorSettings = []string{
+	"bubblePalette",
+	"twitchBubbleBg",
+	"youtubeBubbleBg",
+	"kickBubbleBg",
+	"tiktokBubbleBg",
+	"discordBubbleBg",
+}
+
 // ConfigHandler manages overlay configuration routes.
 type ConfigHandler struct {
 	repo            OverlayConfigRepository
 	overlays        OverlayRepository
 	sources         SourceRepository
 	seventvResolver SevenTVResolver
+	// bubbleColors may be nil, which means open — the same fail-open default
+	// moderation-service's OpenGate provides, so a service wired without a gate
+	// cache (or a test) behaves as the gate's seeded state does.
+	bubbleColors BubbleColorsGate
 }
 
 // NewConfigHandler returns a ConfigHandler.
-func NewConfigHandler(repo OverlayConfigRepository, overlays OverlayRepository, sources SourceRepository, seventvResolver SevenTVResolver) *ConfigHandler {
-	return &ConfigHandler{repo: repo, overlays: overlays, sources: sources, seventvResolver: seventvResolver}
+func NewConfigHandler(repo OverlayConfigRepository, overlays OverlayRepository, sources SourceRepository, seventvResolver SevenTVResolver, bubbleColors BubbleColorsGate) *ConfigHandler {
+	return &ConfigHandler{repo: repo, overlays: overlays, sources: sources, seventvResolver: seventvResolver, bubbleColors: bubbleColors}
+}
+
+// bubbleColorsLocked reports whether the requester may NOT configure bubble
+// colours. A gate-lookup error locks the controls: showing an editable control
+// whose value the save path will drop is the failure mode this whole feature was
+// built to avoid.
+func (h *ConfigHandler) bubbleColorsLocked(ctx context.Context, userID string) bool {
+	if h.bubbleColors == nil {
+		return false
+	}
+	enabled, err := h.bubbleColors.BubbleColorsEnabled(ctx, userID)
+	if err != nil {
+		return true
+	}
+	return !enabled
 }
 
 // HandleGetConfig returns the configuration for an overlay owned by the requester.
@@ -75,7 +118,16 @@ func (h *ConfigHandler) HandleGetConfig(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, config)
+	// Embedded pointer flattens into the same JSON object, so the response shape
+	// is unchanged apart from one added field. Resolved per request and never
+	// persisted; the unauthenticated HandleGetPublicConfig does not carry it.
+	c.JSON(http.StatusOK, struct {
+		*models.OverlayConfig
+		BubbleColorsLocked bool `json:"bubble_colors_locked"`
+	}{
+		OverlayConfig:      config,
+		BubbleColorsLocked: h.bubbleColorsLocked(c.Request.Context(), userID.(string)),
+	})
 }
 
 // HandleUpdateConfig updates the overlay configuration for the owner.
@@ -139,6 +191,19 @@ func (h *ConfigHandler) HandleUpdateConfig(c *gin.Context) {
 		config.CustomCSS = *req.CustomCSS
 	}
 	if req.VisualSettings != nil {
+		// Gated keys are carried over from the stored config rather than rejected:
+		// this route saves everything, so failing the request would block unrelated
+		// edits, and overwriting with the incoming values would let a locked user
+		// set them. Carrying over also means an unrelated save never silently wipes
+		// colours configured while the gate was open.
+		if h.bubbleColorsLocked(c.Request.Context(), userID.(string)) {
+			for _, key := range bubbleColorSettings {
+				delete(req.VisualSettings, key)
+				if stored, ok := config.VisualSettings[key]; ok {
+					req.VisualSettings[key] = stored
+				}
+			}
+		}
 		config.VisualSettings = req.VisualSettings
 	}
 	if req.ThemeID != nil {

--- a/services/overlay-manager/handlers/config_bubble_colors_test.go
+++ b/services/overlay-manager/handlers/config_bubble_colors_test.go
@@ -1,0 +1,198 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/caesar/all-chat/services/overlay-manager/models"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capturingConfigRepo records what Update was asked to persist, which is the only
+// way to tell "the gated keys were carried over" from "they were accepted".
+type capturingConfigRepo struct {
+	cfg   *models.OverlayConfig
+	saved *models.OverlayConfig
+}
+
+func (r *capturingConfigRepo) GetByOverlayID(context.Context, string) (*models.OverlayConfig, error) {
+	if r.cfg == nil {
+		return nil, errors.New("not found")
+	}
+	return r.cfg, nil
+}
+
+func (r *capturingConfigRepo) Update(_ context.Context, cfg *models.OverlayConfig) error {
+	r.saved = cfg
+	return nil
+}
+
+type stubBubbleGate struct {
+	enabled bool
+	err     error
+}
+
+func (g stubBubbleGate) BubbleColorsEnabled(context.Context, string) (bool, error) {
+	return g.enabled, g.err
+}
+
+func bubbleRouter(repo OverlayConfigRepository, gate BubbleColorsGate) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewConfigHandler(repo, &stubOverlayRepo{owned: true}, &stubSourceRepo{}, nil, gate)
+	r := gin.New()
+	r.Use(func(c *gin.Context) { c.Set("user_id", "u1") })
+	r.GET("/:id/config", h.HandleGetConfig)
+	r.PUT("/:id/config", h.HandleUpdateConfig)
+	return r
+}
+
+func storedConfig(visual map[string]any) *models.OverlayConfig {
+	return &models.OverlayConfig{
+		ID:             "c1",
+		OverlayID:      "o1",
+		VisualSettings: visual,
+	}
+}
+
+func putConfig(t *testing.T, r *gin.Engine, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPut, "/o1/config", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestBubbleColorsGateReportedOnRead(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		gate       BubbleColorsGate
+		wantLocked bool
+	}{
+		// The seeded state: gate row is not premium, so the feature is open.
+		{name: "gate open", gate: stubBubbleGate{enabled: true}, wantLocked: false},
+		{name: "gate closed", gate: stubBubbleGate{enabled: false}, wantLocked: true},
+		// Fail closed. Handing back an editable control whose value the save path
+		// will drop is the exact failure this feature was built to remove.
+		{name: "gate lookup error", gate: stubBubbleGate{err: errors.New("db down")}, wantLocked: true},
+		// A service wired without a gate behaves as the seeded state does.
+		{name: "no gate wired", gate: nil, wantLocked: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := bubbleRouter(&capturingConfigRepo{cfg: storedConfig(nil)}, tc.gate)
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/o1/config", nil))
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+			assert.Equal(t, tc.wantLocked, got["bubble_colors_locked"])
+			// The flag rides alongside the config, it does not replace it.
+			assert.Equal(t, "o1", got["overlay_id"])
+		})
+	}
+}
+
+func TestBubbleColorsAcceptedWhenGateOpen(t *testing.T) {
+	repo := &capturingConfigRepo{cfg: storedConfig(nil)}
+	r := bubbleRouter(repo, stubBubbleGate{enabled: true})
+
+	w := putConfig(t, r, map[string]any{
+		"visual_settings": map[string]any{
+			"bubblePalette":  []string{"#111111", "#222222"},
+			"twitchBubbleBg": "#2a1b3d",
+			"fontFamily":     "Inter",
+		},
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, repo.saved)
+	assert.Equal(t, "#2a1b3d", repo.saved.VisualSettings["twitchBubbleBg"])
+	assert.Len(t, repo.saved.VisualSettings["bubblePalette"], 2)
+}
+
+// The save must not fail: this route persists the whole config, so rejecting it
+// would block unrelated edits (theme, fonts, filters) over a cosmetic setting.
+func TestBubbleColorsDroppedButRestOfConfigSavedWhenLocked(t *testing.T) {
+	repo := &capturingConfigRepo{cfg: storedConfig(nil)}
+	r := bubbleRouter(repo, stubBubbleGate{enabled: false})
+
+	w := putConfig(t, r, map[string]any{
+		"visual_settings": map[string]any{
+			"bubblePalette":   []string{"#111111", "#222222"},
+			"twitchBubbleBg":  "#2a1b3d",
+			"discordBubbleBg": "#22253d",
+			"fontFamily":      "Inter",
+		},
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, repo.saved)
+	for _, key := range bubbleColorSettings {
+		assert.NotContains(t, repo.saved.VisualSettings, key, key+" must not be settable while locked")
+	}
+	assert.Equal(t, "Inter", repo.saved.VisualSettings["fontFamily"])
+}
+
+// Carrying over rather than deleting matters for a lapsed subscriber: an
+// unrelated save must not silently wipe colours configured while the gate was
+// open, and must not let them be changed either.
+func TestBubbleColorsCarriedOverWhenLocked(t *testing.T) {
+	repo := &capturingConfigRepo{cfg: storedConfig(map[string]any{
+		"twitchBubbleBg": "#OLD",
+		"bubblePalette":  []any{"#aaaaaa", "#bbbbbb"},
+	})}
+	r := bubbleRouter(repo, stubBubbleGate{enabled: false})
+
+	w := putConfig(t, r, map[string]any{
+		"visual_settings": map[string]any{
+			"twitchBubbleBg": "#NEW",
+			"fontFamily":     "Inter",
+		},
+	})
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, repo.saved)
+	assert.Equal(t, "#OLD", repo.saved.VisualSettings["twitchBubbleBg"])
+	assert.Len(t, repo.saved.VisualSettings["bubblePalette"], 2)
+	assert.Equal(t, "Inter", repo.saved.VisualSettings["fontFamily"])
+}
+
+// Every key the frontend can send has to be covered, or the gate leaks. Names
+// mirror VisualSettings in frontend/src/lib/types/visual-settings.ts.
+func TestBubbleColorSettingsCoversEveryGatedField(t *testing.T) {
+	assert.ElementsMatch(t, []string{
+		"bubblePalette",
+		"twitchBubbleBg",
+		"youtubeBubbleBg",
+		"kickBubbleBg",
+		"tiktokBubbleBg",
+		"discordBubbleBg",
+	}, bubbleColorSettings)
+}

--- a/services/overlay-manager/handlers/tts_test.go
+++ b/services/overlay-manager/handlers/tts_test.go
@@ -1110,7 +1110,7 @@ func TestPublicConfigHidesTTSKey(t *testing.T) {
 	cfgRepo := &stubConfigRepo{cfg: cfg}
 	overlays := &stubOverlayRepo{owned: true}
 	sources := &stubSourceRepo{}
-	ch := NewConfigHandler(cfgRepo, overlays, sources, nil)
+	ch := NewConfigHandler(cfgRepo, overlays, sources, nil, nil)
 
 	r := gin.New()
 	r.GET("/public/:id/config", ch.HandleGetPublicConfig)

--- a/shared/featuregates/cache.go
+++ b/shared/featuregates/cache.go
@@ -67,6 +67,17 @@ const (
 	// paid capability. Flip to is_premium=false to graduate to all users. Viewer
 	// participation and points earning are NOT gated by this.
 	GateEngagement = "engagement"
+
+	// GateBubbleColors is the feature key for differently-coloured chat bubbles:
+	// a fill per platform, and/or a palette cycled down the feed.
+	//
+	// Seeded is_premium=FALSE — unlike every other key here, this one ships OPEN.
+	// It is pure client-side CSS: no bandwidth, no platform quota, no send path,
+	// no abuse surface, and telling Twitch from YouTube at a glance serves the
+	// multistream promise that is the product's reason to exist. The gate exists
+	// so it can be turned into an upsell from the admin UI without a deploy
+	// (CLAUDE.md "Shipping a Feature"), not because it is one today.
+	GateBubbleColors = "bubble_colors"
 )
 
 // FeatureGate represents a single row from the feature_gates table.


### PR DESCRIPTION
Follow-up to #738, which is also this PR's base — it adds the emitter mechanism this builds on. **Merge #738 first**, then this retargets to `main` automatically.

Adds an Appearance → **Bubble colors** section (premium) with two independent axes.

## Per platform

Twitch rows one fill, YouTube another, and so on. Keyed on the `data-platform` attribute every row already carries on all overlay surfaces, so it is stable by construction — a row's colour never changes as the feed scrolls. This is the useful half for multistreamers: you can tell sources apart at a glance.

## Palette

Two to six fills cycled down the feed, keyed on a per-row `data-bubble-slot`.

A platform fill **wins over** the palette on that platform's rows. The precedence is carried by source order rather than `:not()` gymnastics: both selectors are one class plus one attribute, so specificity ties and the platform block is emitted last.

## Why not `:nth-child`

Cycling on `:nth-child` or the render index would have been wrong. The feed keeps the newest N with `slice(-max)`, so once the buffer is full every surviving row shifts by one on each new message and the whole feed re-colours. That is a visible shimmer — and it is why the bundled `nth-child(even)` themes (Sticky Notes, Trading Card, Neo-Brutalist) flicker on a busy stream today.

Arrival order does not shift. `lib/utils/bubbleSlot.ts` gives each message a monotonic number when it first arrives; the slot is `number % paletteLength`. So:

- a row keeps its colour for as long as it is on screen
- changing the palette length recolours everything consistently instead of leaving old rows behind
- the map evicts oldest-first, so a stream running for hours does not leak one entry per message

It is an immutable value threaded through a state updater rather than a mutable tracker in a ref: the overlay pages read it while rendering, and a ref read during render can return something the committed tree never saw (`react-hooks/refs` flags exactly this). `admitBubbleSlot` is idempotent per id, so a double-invoked updater cannot burn a number.

## Cascade behaviour

Same contract as the forced rules in #738: `!important` inside `@layer visual-customizer`, because a theme's own `background: … !important` on the row would otherwise beat them — and **nothing is emitted when unconfigured**, so an unset control leaves the theme's fill untouched. Event cards are never painted.

The fields stay out of `PROPERTY_MAP` on purpose. A palette has no single-custom-property form, and keeping them out also keeps `theme-css-parser` from back-filling them out of a theme, so a set value is always the streamer's own choice and is safe to enforce. A test asserts both.

## Verified in Chromium

Against Neon Glass and Sticky Notes, with rows `twitch/slot0`, `youtube/slot1`, `kick/slot2`, `twitch/slot0`:

```
row0 twitch/slot0 : rgb(16, 16, 16)   palette
row1 youtube/slot1: rgb(255, 0, 0)    platform fill overrides the palette
row2 kick/slot2   : rgb(48, 48, 48)   palette
row3 twitch/slot0 : rgb(16, 16, 16)   palette
event card        : theme's own fill  never painted
scroll sentinel   : 0px               never grows a box
unset customizer == no customizer at all: true
```

## Release checklist (CLAUDE.md)

- [x] Premium toggle — gated in the UI, following the SoundGroup/TTSGroup pattern (`isPremium` prop, `PremiumBadge` + `PremiumUpsellLink`, disabled fieldset)
- [x] Onboarding extras tour — added to the "Optional: go further" list and the `/upgrade` premium features list (the two are kept in sync per the comment at both sites)
- [ ] Patreon post — to write once this is deployed

## Testing

- 1045 frontend unit tests pass (13 new for the emitter, 8 for the slot logic, 8 for the UI group); `tsc --noEmit` clean
- no new eslint errors: the 6 remaining `react-hooks` errors in the touched files are present on `main` too (verified by linting `main`'s copies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)