### PR TITLE
fix(payment): request memberships.campaign so patrons resolve to active

### DIFF
--- a/services/payment-service/README.md
+++ b/services/payment-service/README.md
@@ -106,6 +106,21 @@ keep no separate grace timer.
 | `former_patron` | `former` | no |
 | no membership to our campaign | `none` | no |
 
+### Reading a membership from the identity API
+
+Patreon serializes a relationship on an `included` resource **only when that
+relationship path is itself requested** via `include`. `parseIdentity` attributes a
+member to us by its `campaign` relationship, so `include` must carry
+`memberships.campaign` — without it every member arrives campaign-less, matches
+nothing, and a paying patron reads as `none`. Because `none` is also the honest answer
+for a non-patron, that failure is invisible: it silently revokes premium on the next
+reconcile pass. `MembershipSnapshot.UnmatchedMembers` exists to tell the two apart and
+is logged as a warning by `entitlement.Apply` whenever members had to be discarded.
+
+Note this affects the identity API only. Webhook payloads carry their member in
+`data` with its relationships intact, so `ParseMemberEvent` needs no such handling —
+which is why a broken identity path can coexist with working webhooks.
+
 ## Configuration
 
 | Env | Required | Default | Notes |
@@ -124,6 +139,25 @@ keep no separate grace timer.
 | `JWT_SECRET_V1` | yes | – | validates user JWTs |
 | `TOKEN_ENCRYPTION_KEY_V1` | yes | – | encrypts stored Patreon tokens |
 | `DATABASE_*`, `REDIS_*`, `FRONTEND_URL` | – | localhost | standard |
+
+## Metrics and alerting
+
+Entitlement is derived from a third party's response shape, so "the process is healthy"
+and "the answers are right" are independent properties. `up`, HTTP status and error
+rate all stay clean while every patron silently resolves to `none`, so this service
+exports its own correctness signals (`services/payment-service/metrics`):
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `payment_patreon_connections{status}` | gauge | connections per resolved status, as of the last reconcile pass |
+| `payment_patreon_unmatched_members_total` | counter | members received but discarded as unattributable — should be 0 forever |
+| `payment_patreon_reconcile_last_success_timestamp_seconds` | gauge | last completed pass; detects a dead reconcile goroutine, which a gauge alone cannot |
+
+Three alerts consume them, in `caesar-deployment/apps/platform/allchat-monitoring/`:
+`PatreonEntitlementsAllUnresolved` (critical — connections exist and none are active),
+`PatreonUnmatchedMembersDiscarded` and `PatreonReconcileStalled` (both warning). The
+alerts reference the metric names as strings, so `metrics_test.go` pins them; renaming
+a metric without updating the alert would leave it unfirable.
 
 ## Deployment
 

--- a/services/payment-service/entitlement/service.go
+++ b/services/payment-service/entitlement/service.go
@@ -24,6 +24,7 @@ package entitlement
 import (
 	"context"
 
+	"github.com/caesar/all-chat/services/payment-service/metrics"
 	"github.com/caesar/all-chat/services/payment-service/patreon"
 	"github.com/caesar/all-chat/services/payment-service/repository"
 	"github.com/caesar/all-chat/shared/premium"
@@ -64,6 +65,16 @@ func (s *Service) Apply(ctx context.Context, snap *patreon.MembershipSnapshot, u
 	}
 
 	status = patreon.SubscriptionStatusFor(*snap, threshold)
+
+	// A StatusNone we arrived at by discarding members is a read failure wearing the
+	// same clothes as a non-patron. Say so loudly: revoking premium is the one thing
+	// this path does that a user notices, and it must never happen quietly again.
+	if status == patreon.StatusNone && snap.UnmatchedMembers > 0 {
+		metrics.UnmatchedMembers.Add(float64(snap.UnmatchedMembers))
+		s.logger.Warn("Patreon identity returned membership(s) we could not attribute to our campaign; treating as no membership",
+			zap.String("patreon_user_id", snap.PatreonUserID),
+			zap.Int("unmatched_members", snap.UnmatchedMembers))
+	}
 
 	if err = s.subs.Upsert(ctx, repository.Subscription{
 		UserID:           userID,

--- a/services/payment-service/go.mod
+++ b/services/payment-service/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/services/payment-service/metrics/metrics.go
+++ b/services/payment-service/metrics/metrics.go
@@ -1,0 +1,98 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package metrics holds payment-service's Prometheus instrumentation for Patreon
+// entitlement resolution.
+//
+// These exist because of a failure mode that `up`-style liveness cannot see: the
+// service was Ready, scraped fine, and answered every request, while silently
+// resolving every paying patron to "no membership" and revoking their premium on the
+// next reconcile pass. Entitlement is derived from a third party's response shape, so
+// "the process is healthy" and "the answers are right" are independent properties and
+// need independent signals.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// trackedStatuses are the subscription status label values ConnectionsByStatus is
+// pre-initialised with. Pre-seeding matters more here than for a dashboard metric:
+// an alert comparing `active == 0` must be able to observe a *present* series at
+// zero. Absent series make the comparison vacuous and the alert silently unfirable,
+// which is the same class of invisible failure these metrics exist to catch.
+var trackedStatuses = []string{"active", "none", "declined", "former", "expired"}
+
+var (
+	// UnmatchedMembers counts Patreon member resources we received but could not
+	// attribute to our campaign, and therefore discarded. The identity API only
+	// serializes a member's campaign relationship when `include` requests it, so a
+	// regression there turns every patron into an apparent non-patron. Any sustained
+	// increase means we are throwing away real membership data.
+	UnmatchedMembers = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "payment_patreon_unmatched_members_total",
+		Help: "Patreon member resources discarded because they could not be attributed to our campaign",
+	})
+
+	// ConnectionsByStatus is how many Patreon connections resolved to each
+	// subscription status on the last completed reconcile pass. Reported as a gauge
+	// of the whole population rather than a counter of transitions, because the
+	// question worth alerting on is a statement about the current fleet: "we have
+	// connections, and none of them are active."
+	ConnectionsByStatus = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "payment_patreon_connections",
+		Help: "Patreon connections by resolved subscription status as of the last reconcile pass",
+	}, []string{"status"})
+
+	// ReconcileLastSuccess is the Unix timestamp of the last reconcile pass that
+	// completed. Without it the gauges above are indistinguishable from fresh when
+	// the loop dies: Prometheus keeps serving the last value it saw, so a stalled
+	// reconciler looks exactly like a healthy steady state.
+	ReconcileLastSuccess = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "payment_patreon_reconcile_last_success_timestamp_seconds",
+		Help: "Unix timestamp of the last completed Patreon reconcile pass",
+	})
+)
+
+func init() {
+	for _, s := range trackedStatuses {
+		ConnectionsByStatus.WithLabelValues(s)
+	}
+}
+
+// ObserveReconcileStatuses publishes the status tally of a completed reconcile pass.
+// Statuses absent from counts are reset to 0 rather than left untouched, so a status
+// that stops occurring falls to zero instead of holding its last value forever.
+func ObserveReconcileStatuses(counts map[string]int) {
+	for _, s := range trackedStatuses {
+		ConnectionsByStatus.WithLabelValues(s).Set(float64(counts[s]))
+	}
+	for s, n := range counts {
+		if !tracked(s) {
+			ConnectionsByStatus.WithLabelValues(s).Set(float64(n))
+		}
+	}
+}
+
+func tracked(status string) bool {
+	for _, s := range trackedStatuses {
+		if s == status {
+			return true
+		}
+	}
+	return false
+}

--- a/services/payment-service/metrics/metrics_test.go
+++ b/services/payment-service/metrics/metrics_test.go
@@ -1,0 +1,74 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrackedStatusesArePreSeeded(t *testing.T) {
+	// The alert for the "healthy but every patron reads as none" failure compares
+	// active against 0. That comparison needs the series to EXIST at zero before the
+	// first reconcile pass, or the alert can never fire — the same silent-failure
+	// shape these metrics exist to catch.
+	for _, s := range trackedStatuses {
+		assert.NotNil(t, ConnectionsByStatus.WithLabelValues(s), "status %q not pre-seeded", s)
+	}
+	assert.Zero(t, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("active")))
+}
+
+func TestObserveReconcileStatusesResetsAbsentStatuses(t *testing.T) {
+	ObserveReconcileStatuses(map[string]int{"active": 3, "none": 1})
+	assert.Equal(t, 3.0, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("active")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("none")))
+
+	// A status that stops occurring must fall to zero. Leaving the previous value in
+	// place would let a fleet that has lost every active patron keep reporting the
+	// old healthy number indefinitely.
+	ObserveReconcileStatuses(map[string]int{"none": 4})
+	assert.Zero(t, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("active")))
+	assert.Equal(t, 4.0, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("none")))
+}
+
+func TestExportedMetricNames(t *testing.T) {
+	// These names are referenced as strings by the PatreonEntitlementsAllUnresolved,
+	// PatreonUnmatchedMembersDiscarded and PatreonReconcileStalled alerts in
+	// caesar-deployment (apps/platform/allchat-monitoring/allchat-*-alerts.yaml).
+	// A rename here would leave those alerts silently unfirable — the same invisible
+	// failure they were written to catch — so pin the names and make the coupling
+	// break loudly instead.
+	// CollectAndCount counts series carrying the given name, so a wrong name yields 0.
+	// The exact series count is deliberately not asserted: it tracks the number of
+	// status labels seen so far, which depends on test order.
+	ObserveReconcileStatuses(map[string]int{"active": 1})
+	assert.Positive(t, testutil.CollectAndCount(ConnectionsByStatus, "payment_patreon_connections"))
+	assert.Equal(t, 1, testutil.CollectAndCount(UnmatchedMembers, "payment_patreon_unmatched_members_total"))
+	assert.Equal(t, 1, testutil.CollectAndCount(ReconcileLastSuccess, "payment_patreon_reconcile_last_success_timestamp_seconds"))
+}
+
+func TestObserveReconcileStatusesAcceptsUntrackedStatus(t *testing.T) {
+	// An unrecognised status must still be published rather than dropped: a status we
+	// forgot to track silently vanishing is how you end up with a fleet whose numbers
+	// do not add up to the connection count.
+	ObserveReconcileStatuses(map[string]int{"active": 1, "some_new_status": 2})
+	assert.Equal(t, 2.0, testutil.ToFloat64(ConnectionsByStatus.WithLabelValues("some_new_status")))
+
+	ObserveReconcileStatuses(map[string]int{})
+}

--- a/services/payment-service/patreon/oauth.go
+++ b/services/payment-service/patreon/oauth.go
@@ -99,7 +99,11 @@ func (o *OAuth) RefreshToken(ctx context.Context, refreshToken string) (*oauth2.
 // PatronStatus (which maps to StatusNone).
 func (o *OAuth) GetIdentityWithMembership(ctx context.Context, accessToken, campaignID string) (*MembershipSnapshot, error) {
 	q := url.Values{}
-	q.Set("include", "memberships.currently_entitled_tiers")
+	// memberships.campaign is load-bearing: Patreon serializes a relationship on an
+	// included resource only when that relationship path is itself requested, and
+	// parseIdentity attributes a member to us via exactly that relationship. Omitting
+	// it makes every member arrive campaign-less, which read as "not a patron".
+	q.Set("include", "memberships.currently_entitled_tiers,memberships.campaign")
 	q.Set("fields[member]", "patron_status,currently_entitled_amount_cents,last_charge_status,next_charge_date")
 	q.Set("fields[user]", "email,full_name")
 
@@ -132,6 +136,17 @@ func (o *OAuth) GetIdentityWithMembership(ctx context.Context, accessToken, camp
 
 // parseIdentity extracts the patron identity and their membership to campaignID
 // from an identity API document. data is the "user"; the member(s) are in included.
+//
+// A member that declares a campaign is matched against campaignID. If the document
+// carries exactly one member and it declares NO campaign, that member is taken as
+// ours: we request neither the identity.memberships scope (see identityScopes) nor
+// any other campaign, and Patreon then returns only the caller's membership to the
+// campaign owning the OAuth client, so there is nothing else it could be. Two or
+// more campaign-less members are ambiguous and are never guessed at.
+//
+// When nothing matches, the returned snapshot reports how many members it had to
+// discard via UnmatchedMembers, so a parse failure is distinguishable from a genuine
+// non-patron instead of both reading as StatusNone.
 func parseIdentity(body []byte, campaignID string) (*MembershipSnapshot, error) {
 	var doc apiDocument
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -143,19 +158,29 @@ func parseIdentity(body []byte, campaignID string) (*MembershipSnapshot, error) 
 		Email:         doc.Data.Attributes.Email,
 	}
 
+	var members, campaignless []apiResource
 	for _, inc := range doc.Included {
 		if inc.Type != "member" {
 			continue
 		}
-		if inc.Relationships.Campaign == nil || inc.Relationships.Campaign.Data == nil {
+		members = append(members, inc)
+
+		rel := inc.Relationships.Campaign
+		if rel == nil || rel.Data == nil {
+			campaignless = append(campaignless, inc)
 			continue
 		}
-		if inc.Relationships.Campaign.Data.ID != campaignID {
-			continue
+		if rel.Data.ID == campaignID {
+			memberToSnapshot(inc, snap)
+			return snap, nil
 		}
-		memberToSnapshot(inc, snap)
-		break
 	}
 
+	if len(members) == 1 && len(campaignless) == 1 {
+		memberToSnapshot(campaignless[0], snap)
+		return snap, nil
+	}
+
+	snap.UnmatchedMembers = len(members)
 	return snap, nil
 }

--- a/services/payment-service/patreon/patreon_test.go
+++ b/services/payment-service/patreon/patreon_test.go
@@ -165,4 +165,89 @@ func TestParseIdentity_MembershipToDifferentCampaign(t *testing.T) {
 	assert.Equal(t, "patreon-user-9", snap.PatreonUserID)
 	assert.Equal(t, "", snap.PatronStatus)
 	assert.Equal(t, StatusNone, SubscriptionStatusFor(*snap, 500))
+	// The member was attributable and genuinely wasn't ours, so this StatusNone is
+	// trustworthy — nothing was discarded.
+	assert.Equal(t, 1, snap.UnmatchedMembers)
+}
+
+func TestParseIdentity_CampaignlessMemberIsTakenAsOurs(t *testing.T) {
+	// The shape Patreon actually returns when the include param does not request
+	// memberships.campaign: the member is present and active, but carries no campaign
+	// relationship to match on. This regressed every connected patron to StatusNone
+	// and, via the 6h reconcile, revoked their premium.
+	body := []byte(`{
+		"data": {
+			"type": "user",
+			"id": "205145299",
+			"attributes": { "email": "fan@example.com", "full_name": "A Fan" },
+			"relationships": {
+				"memberships": { "data": [ { "type": "member", "id": "member-1" } ] }
+			}
+		},
+		"included": [
+			{
+				"type": "member",
+				"id": "member-1",
+				"attributes": {
+					"patron_status": "active_patron",
+					"currently_entitled_amount_cents": 500
+				},
+				"relationships": {
+					"currently_entitled_tiers": { "data": [ { "type": "tier", "id": "28904026" } ] }
+				}
+			}
+		]
+	}`)
+
+	snap, err := parseIdentity(body, "16269405")
+	require.NoError(t, err)
+	assert.Equal(t, "205145299", snap.PatreonUserID)
+	assert.Equal(t, patronActive, snap.PatronStatus)
+	assert.Equal(t, 500, snap.EntitledCents)
+	assert.Equal(t, "28904026", snap.TierID)
+	assert.Equal(t, StatusActive, SubscriptionStatusFor(*snap, 500))
+	assert.Zero(t, snap.UnmatchedMembers)
+}
+
+func TestParseIdentity_AmbiguousCampaignlessMembersAreNotGuessed(t *testing.T) {
+	// Two campaign-less members (only reachable with the identity.memberships scope,
+	// which we don't request) can't be told apart, so we must not hand premium to
+	// someone for backing an unrelated creator.
+	body := []byte(`{
+		"data": { "type": "user", "id": "patreon-user-9", "attributes": { "email": "fan@example.com" } },
+		"included": [
+			{
+				"type": "member",
+				"id": "member-1",
+				"attributes": { "patron_status": "active_patron", "currently_entitled_amount_cents": 1000 },
+				"relationships": {}
+			},
+			{
+				"type": "member",
+				"id": "member-2",
+				"attributes": { "patron_status": "active_patron", "currently_entitled_amount_cents": 2000 },
+				"relationships": {}
+			}
+		]
+	}`)
+
+	snap, err := parseIdentity(body, "16269405")
+	require.NoError(t, err)
+	assert.Equal(t, "", snap.PatronStatus)
+	assert.Equal(t, StatusNone, SubscriptionStatusFor(*snap, 500))
+	assert.Equal(t, 2, snap.UnmatchedMembers)
+}
+
+func TestParseIdentity_NonPatronReportsNothingDiscarded(t *testing.T) {
+	// A genuine non-patron has no members at all. StatusNone here is correct, and
+	// UnmatchedMembers must stay 0 so it is distinguishable from a parse failure.
+	body := []byte(`{
+		"data": { "type": "user", "id": "patreon-user-9", "attributes": { "email": "fan@example.com" } },
+		"included": []
+	}`)
+
+	snap, err := parseIdentity(body, "16269405")
+	require.NoError(t, err)
+	assert.Equal(t, StatusNone, SubscriptionStatusFor(*snap, 500))
+	assert.Zero(t, snap.UnmatchedMembers)
 }

--- a/services/payment-service/patreon/types.go
+++ b/services/payment-service/patreon/types.go
@@ -51,6 +51,14 @@ type MembershipSnapshot struct {
 	LastChargeStatus string
 	NextChargeDate   *time.Time
 	TierID           string
+
+	// UnmatchedMembers is how many member resources the identity response carried
+	// that could not be attributed to our campaign. It is 0 both on a successful
+	// match and for a genuine non-patron (who has no members at all); a non-zero
+	// value alongside an empty PatronStatus means we discarded real membership data
+	// and the resulting StatusNone is not trustworthy. Always 0 for webhook payloads,
+	// which carry their member directly.
+	UnmatchedMembers int
 }
 
 // SubscriptionStatusFor maps a membership snapshot to our subscription status.

--- a/services/payment-service/reconcile/manager.go
+++ b/services/payment-service/reconcile/manager.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/caesar/all-chat/services/payment-service/entitlement"
+	"github.com/caesar/all-chat/services/payment-service/metrics"
 	"github.com/caesar/all-chat/services/payment-service/patreon"
 	"github.com/caesar/all-chat/services/payment-service/repository"
 	"go.uber.org/zap"
@@ -110,6 +111,7 @@ func (m *Manager) ProcessBatch(ctx context.Context) error {
 	}
 
 	var reconciled, failed int
+	statuses := make(map[string]int, len(tokens))
 	for _, t := range tokens {
 		accessToken := t.AccessToken
 
@@ -137,19 +139,29 @@ func (m *Manager) ProcessBatch(ctx context.Context) error {
 			continue
 		}
 
-		if _, _, applyErr := m.entitlement.Apply(ctx, snap, t.UserID, t.ViewerID, nil); applyErr != nil {
+		status, _, applyErr := m.entitlement.Apply(ctx, snap, t.UserID, t.ViewerID, nil)
+		if applyErr != nil {
 			m.logger.Error("Failed to apply reconciled membership",
 				subjectLabel(t), zap.Error(applyErr))
 			failed++
 			continue
 		}
+		statuses[status]++
 		reconciled++
 	}
+
+	// Publish the population tally, not just the pass's success count: a pass where
+	// every connection resolved cleanly to "not a patron" is indistinguishable from a
+	// healthy one in reconciled/failed terms, and that is exactly the shape a broken
+	// membership read takes.
+	metrics.ObserveReconcileStatuses(statuses)
+	metrics.ReconcileLastSuccess.SetToCurrentTime()
 
 	m.logger.Info("Reconcile batch complete",
 		zap.Int("reconciled", reconciled),
 		zap.Int("failed", failed),
-		zap.Int("total", len(tokens)))
+		zap.Int("total", len(tokens)),
+		zap.Int("active", statuses[patreon.StatusActive]))
 	return nil
 }
 


### PR DESCRIPTION
## The bug

Reported by a streamer: Patreon shows connected on allch.at, premium reads inactive, and reconnecting does nothing. It affected **100% of connected patrons**, not a subset.

Patreon's identity API serializes a relationship on an `included` resource **only when that relationship path is itself requested** via `include`. Our call asked for `memberships.currently_entitled_tiers` and never `memberships.campaign`, so every member arrived with no `campaign` relationship. `parseIdentity` attributed members by exactly that relationship, discarded all of them, and left `PatronStatus` empty — which maps to `StatusNone`.

Two things turned that into an outage rather than a bug:

1. **`StatusNone` is also the honest answer for a non-patron**, so a total read failure and "not a patron" were indistinguishable in logs and in the DB.
2. **`reconcile` actively revokes.** It re-queries every 6h and applies the result, so even correctly-granted premium was wiped within 6 hours. The OAuth callback shares the same read path, which is why reconnecting could never recover.

## Evidence

The two code paths that read a membership disagreed in production:

```
"status":"active"  →   2   (webhook path — reads its member from `data`)
"status":"none"    → 117   (identity path — every single call)
```

`ParseMemberEvent` never filters by campaign, which is why webhooks kept working throughout and masked the severity.

I ruled out the competing hypothesis (wrong `PATREON_CAMPAIGN_ID`, which produces identical symptoms) against the real campaign id in a stored webhook body — it matches the configmap exactly.

## The fix

- Request `memberships.campaign`.
- Accept a lone campaign-less member as ours. Safe because we deliberately don't request the `identity.memberships` scope, and Patreon then returns only the OAuth client's own campaign membership. Two or more campaign-less members stay ambiguous and are never guessed at, so nobody gets premium for backing an unrelated creator.
- `MembershipSnapshot.UnmatchedMembers` + a `WARN` in `entitlement.Apply`, so a discard-driven `none` can never be silent again.

## Correctness metrics

This had no signal at all — the service was Ready, `up==1`, HTTP 200 and error-free the whole time, so liveness alerting structurally could not see it. New `payment-service/metrics`:

| Metric | Catches |
|---|---|
| `payment_patreon_connections{status}` | "we have connections and none are active" |
| `payment_patreon_unmatched_members_total` | members arriving and being discarded |
| `payment_patreon_reconcile_last_success_timestamp_seconds` | a dead reconcile goroutine, which the gauges alone cannot show |

Consumed by `PatreonEntitlementsAllUnresolved` (critical), `PatreonUnmatchedMembersDiscarded` and `PatreonReconcileStalled` in caesar-deployment `feat/patreon-entitlement-alerts`. The alerts reference these names as strings, so `metrics_test.go` pins them.

## Verification

- `go build`, `go vet`, `gofmt`, full unit suite green.
- The regression tests were confirmed **non-vacuous**: stashing `oauth.go` and re-running them against the old parser fails with `expected: active, actual: none`.
- Pre-seeding of status labels is load-bearing, not cosmetic — an `== 0` alert against an *absent* series can never fire, the same invisible failure this PR is about. `TestTrackedStatusesArePreSeeded` guards it.

## Deploy / recovery

A rollout restart is sufficient: `reconcile.Manager.Start` runs `ProcessBatch` immediately on startup, so all connections are re-queried at once instead of waiting up to 6h. Watch for `"status":"active"` replacing the run of `none`.

Patrons who pledged but never ran the connect flow sit as orphaned rows (`user_id` NULL) and self-link on connect via `user_id = COALESCE(EXCLUDED.user_id, ...)`.

Note: `golangci-lint` flags a pre-existing errcheck on `patreon/oauth.go:120` (`defer resp.Body.Close()`) — untouched by this PR, left out to keep the payment hotfix reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
