### PR TITLE
fix(payment): only count campaign-less members as unattributed

### DIFF
--- a/services/payment-service/README.md
+++ b/services/payment-service/README.md
@@ -121,6 +121,20 @@ Note this affects the identity API only. Webhook payloads carry their member in
 `data` with its relationships intact, so `ParseMemberEvent` needs no such handling —
 which is why a broken identity path can coexist with working webhooks.
 
+A member that declares some *other* campaign is a clean negative: patrons commonly back
+other creators, and the response does contain those memberships (observed in
+production, despite the docs implying that without the `identity.memberships` scope
+only our own campaign comes back — the account in question owns the OAuth client, so
+this may be specific to creator tokens). Such members are not counted as unattributed;
+only campaign-less ones are, or the signal would sit permanently lit.
+
+Residual risk worth knowing: the lone-campaign-less-member fallback assumes such a
+member must be ours. Since foreign memberships demonstrably can appear, that assumption
+rests on `memberships.campaign` being requested — if Patreon ever stops honoring it
+*and* the user backs exactly one other creator, we would grant premium wrongly. Kept
+deliberately, because the error direction is the safer one: wrongly revoking premium
+from a paying patron is what caused the outage this guards against.
+
 ## Configuration
 
 | Env | Required | Default | Notes |
@@ -150,7 +164,7 @@ exports its own correctness signals (`services/payment-service/metrics`):
 | Metric | Type | Meaning |
 |--------|------|---------|
 | `payment_patreon_connections{status}` | gauge | connections per resolved status, as of the last reconcile pass |
-| `payment_patreon_unmatched_members_total` | counter | members received but discarded as unattributable — should be 0 forever |
+| `payment_patreon_unmatched_members_total` | counter | members received that we could not attribute *either way* (they declared no campaign) — should be 0 forever |
 | `payment_patreon_reconcile_last_success_timestamp_seconds` | gauge | last completed pass; detects a dead reconcile goroutine, which a gauge alone cannot |
 
 Three alerts consume them, in `caesar-deployment/apps/platform/allchat-monitoring/`:

--- a/services/payment-service/patreon/oauth.go
+++ b/services/payment-service/patreon/oauth.go
@@ -144,9 +144,12 @@ func (o *OAuth) GetIdentityWithMembership(ctx context.Context, accessToken, camp
 // campaign owning the OAuth client, so there is nothing else it could be. Two or
 // more campaign-less members are ambiguous and are never guessed at.
 //
-// When nothing matches, the returned snapshot reports how many members it had to
-// discard via UnmatchedMembers, so a parse failure is distinguishable from a genuine
-// non-patron instead of both reading as StatusNone.
+// When nothing matches, UnmatchedMembers reports how many members we could not
+// attribute EITHER WAY, so a parse failure is distinguishable from a genuine
+// non-patron instead of both reading as StatusNone. A member that explicitly declares
+// some other campaign is not counted: that is a clean negative (the patron backs a
+// different creator, which is common and expected), and counting it would make the
+// signal fire constantly on healthy traffic.
 func parseIdentity(body []byte, campaignID string) (*MembershipSnapshot, error) {
 	var doc apiDocument
 	if err := json.Unmarshal(body, &doc); err != nil {
@@ -181,6 +184,6 @@ func parseIdentity(body []byte, campaignID string) (*MembershipSnapshot, error) 
 		return snap, nil
 	}
 
-	snap.UnmatchedMembers = len(members)
+	snap.UnmatchedMembers = len(campaignless)
 	return snap, nil
 }

--- a/services/payment-service/patreon/patreon_test.go
+++ b/services/payment-service/patreon/patreon_test.go
@@ -165,9 +165,12 @@ func TestParseIdentity_MembershipToDifferentCampaign(t *testing.T) {
 	assert.Equal(t, "patreon-user-9", snap.PatreonUserID)
 	assert.Equal(t, "", snap.PatronStatus)
 	assert.Equal(t, StatusNone, SubscriptionStatusFor(*snap, 500))
-	// The member was attributable and genuinely wasn't ours, so this StatusNone is
-	// trustworthy — nothing was discarded.
-	assert.Equal(t, 1, snap.UnmatchedMembers)
+	// The member declared a campaign and it wasn't ours: an explicit, unambiguous
+	// negative, so nothing was discarded and this StatusNone is trustworthy.
+	// Counting it would light the PatreonUnmatchedMembersDiscarded alert permanently,
+	// since backing other creators is common — observed in production the day this
+	// shipped, on an account that backs another campaign.
+	assert.Zero(t, snap.UnmatchedMembers)
 }
 
 func TestParseIdentity_CampaignlessMemberIsTakenAsOurs(t *testing.T) {
@@ -236,6 +239,36 @@ func TestParseIdentity_AmbiguousCampaignlessMembersAreNotGuessed(t *testing.T) {
 	assert.Equal(t, "", snap.PatronStatus)
 	assert.Equal(t, StatusNone, SubscriptionStatusFor(*snap, 500))
 	assert.Equal(t, 2, snap.UnmatchedMembers)
+}
+
+func TestParseIdentity_OtherCampaignAlongsideOursStillMatches(t *testing.T) {
+	// Production showed the identity API CAN return a membership to a campaign that
+	// is not ours, so the presence of foreign members must not disturb matching ours
+	// or inflate the discard counter.
+	body := []byte(`{
+		"data": { "type": "user", "id": "patreon-user-9", "attributes": { "email": "fan@example.com" } },
+		"included": [
+			{
+				"type": "member",
+				"id": "member-other",
+				"attributes": { "patron_status": "active_patron", "currently_entitled_amount_cents": 1000 },
+				"relationships": { "campaign": { "data": { "type": "campaign", "id": "some-other-campaign" } } }
+			},
+			{
+				"type": "member",
+				"id": "member-ours",
+				"attributes": { "patron_status": "active_patron", "currently_entitled_amount_cents": 500 },
+				"relationships": { "campaign": { "data": { "type": "campaign", "id": "16269405" } } }
+			}
+		]
+	}`)
+
+	snap, err := parseIdentity(body, "16269405")
+	require.NoError(t, err)
+	assert.Equal(t, patronActive, snap.PatronStatus)
+	assert.Equal(t, 500, snap.EntitledCents)
+	assert.Equal(t, StatusActive, SubscriptionStatusFor(*snap, 500))
+	assert.Zero(t, snap.UnmatchedMembers)
 }
 
 func TestParseIdentity_NonPatronReportsNothingDiscarded(t *testing.T) {

--- a/services/payment-service/patreon/types.go
+++ b/services/payment-service/patreon/types.go
@@ -53,11 +53,16 @@ type MembershipSnapshot struct {
 	TierID           string
 
 	// UnmatchedMembers is how many member resources the identity response carried
-	// that could not be attributed to our campaign. It is 0 both on a successful
-	// match and for a genuine non-patron (who has no members at all); a non-zero
-	// value alongside an empty PatronStatus means we discarded real membership data
-	// and the resulting StatusNone is not trustworthy. Always 0 for webhook payloads,
-	// which carry their member directly.
+	// that could not be attributed EITHER WAY — i.e. they declared no campaign at
+	// all. A non-zero value alongside an empty PatronStatus means we discarded
+	// membership data we could not rule in or out, so the resulting StatusNone is not
+	// trustworthy.
+	//
+	// It stays 0 for a successful match, for a genuine non-patron (no members at
+	// all), and for a patron who backs some OTHER creator — that last case is an
+	// explicit, unambiguous negative and is both common and expected, so counting it
+	// would keep the signal permanently lit on healthy traffic. Always 0 for webhook
+	// payloads, which carry their member directly.
 	UnmatchedMembers int
 }
 


### PR DESCRIPTION
Follow-up to #781, caught by the metric it fixes within minutes of that PR reaching production.

## What happened

The startup reconcile after #781 deployed resolved KingOfLightning correctly:

```
user_id=24050dcd-…  patreon_user_id=83716  status=active  is_premium=true
```

But it also logged:

```
WARN  Patreon identity returned membership(s) we could not attribute to our campaign
      patreon_user_id=67342835  unmatched_members=1
payment_patreon_unmatched_members_total 1
```

That account backs a **different creator**. `parseIdentity` handled it correctly — the member declared a foreign campaign, so it resolved to `none`, which is right. The bug is that `UnmatchedMembers` counted it.

## Why it needed fixing immediately

`PatreonUnmatchedMembersDiscarded` is `increase(payment_patreon_unmatched_members_total[7h]) > 0`. With the counter already at 1 it would have fired within minutes and stayed lit for 7 hours, re-tripping on every reconcile pass, for any user who backs another creator on Patreon.

A permanently-firing warning is worse than no warning: it trains you to ignore the one signal that detects a silent entitlement break. That defeats the entire point of #781's observability.

## The fix

Count only members that could not be attributed **either way** — those declaring no campaign at all, which is exactly the shape the original bug produced. A member that explicitly names some other campaign is a clean, unambiguous negative.

| Case | Before | After |
|---|---|---|
| membership to our campaign | 0 | 0 |
| no members at all (non-patron) | 0 | 0 |
| membership to another campaign | **1** ⚠️ | 0 |
| campaign-less member (the original bug) | 1 | 1 |

`TestParseIdentity_MembershipToDifferentCampaign` now asserts 0, and a new `TestParseIdentity_OtherCampaignAlongsideOursStillMatches` covers a foreign membership sitting alongside ours — proving foreign members neither block matching nor inflate the counter.

## A documented residual

Production disproved the docs' implication that without the `identity.memberships` scope only our own campaign comes back — we demonstrably received a foreign membership. (The account owns the OAuth client, so this may be specific to creator tokens, but the assumption is no longer safe to state as fact.)

The lone-campaign-less-member fallback from #781 therefore rests on `memberships.campaign` being honored, not on that guarantee. Kept deliberately and documented in the README: its error direction is the safer one, since wrongly *revoking* premium from a paying patron is the outage it guards against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
