### PR TITLE
fix(device-link): repair device linking end to end and make the property inspector legible

### DIFF
--- a/services/auth-service/repository/device_token_repository.go
+++ b/services/auth-service/repository/device_token_repository.go
@@ -228,11 +228,19 @@ func (r *DeviceTokenRepository) CreateLinkRequest(
 	if redirectURI != "" {
 		redirect = &redirectURI
 	}
+	// The TTL is multiplied into an interval rather than concatenated into one.
+	// `($8 || ' seconds')::INTERVAL` reads fine but types $8 as `text`, because `||`
+	// only has a text overload — and pgx v5 refuses to encode an int64 into a text
+	// parameter ("cannot find encode plan"), so EVERY call failed with a 500 and
+	// device linking could not be started at all. Multiplication takes the numeric
+	// straight through. Do not reintroduce the concatenation: it is not a style
+	// preference, it is the difference between working and a hard failure, and
+	// TestTTLIntervalsAreNotStringConcatenated pins it.
 	row := r.db.QueryRow(ctx, `
 		INSERT INTO device_link_requests
 			(flow, user_code_hash, pkce_challenge, pkce_method, redirect_uri,
 			 device_name, requested_scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + ($8 || ' seconds')::INTERVAL)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + $8 * INTERVAL '1 second')
 		RETURNING `+linkRequestColumns,
 		flow, userCodeHash, pkceChallenge, pkceMethod, redirect,
 		deviceName, requestedScopes, int64(ttl/time.Second))
@@ -351,7 +359,7 @@ func (r *DeviceTokenRepository) ApproveLinkRequest(
 		       device_name = COALESCE(NULLIF($5, ''), device_name),
 		       approved_at = NOW(),
 		       auth_code_hash = $6,
-		       auth_code_expires_at = NOW() + ($7 || ' seconds')::INTERVAL
+		       auth_code_expires_at = NOW() + $7 * INTERVAL '1 second'
 		 WHERE id = $1
 		   AND user_id IS NULL
 		   AND consumed_at IS NULL
@@ -548,7 +556,7 @@ func (r *DeviceTokenRepository) CreateDeviceToken(
 	var id string
 	err = tx.QueryRow(ctx, `
 		INSERT INTO device_tokens (user_id, overlay_id, name, token_hash, scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $5, NOW() + ($6 || ' seconds')::INTERVAL)
+		VALUES ($1, $2, $3, $4, $5, NOW() + $6 * INTERVAL '1 second')
 		RETURNING id::text`,
 		userID, overlayID, name, tokenHash, scopes, int64(lifetime/time.Second)).Scan(&id)
 	if err != nil {

--- a/services/auth-service/repository/device_token_repository_test.go
+++ b/services/auth-service/repository/device_token_repository_test.go
@@ -28,8 +28,15 @@ package repository
 // handlers/device_link_test.go, which drive the whole flow over a fake store.
 
 import (
+	"context"
+	"crypto/sha256"
+	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/shared/middleware"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestConsumeAuthCodeSQL_IsOneAtomicStatementWithEveryGuard(t *testing.T) {
@@ -127,5 +134,157 @@ func TestNoProjectionSelectsADigest(t *testing.T) {
 					"scans into is what the endpoints serialise.", name, secret)
 			}
 		}
+	}
+}
+
+// TestTTLIntervalsAreNotStringConcatenated is the cheap half of the guard against the
+// bug that took device linking down completely: every POST /device/link/start answered
+// 500 with
+//
+//	failed to encode args[7]: unable to encode 600 into text format for text (OID 25):
+//	cannot find encode plan
+//
+// `NOW() + ($8 || ' seconds')::INTERVAL` looks harmless, but `||` has only a text
+// overload, so PostgreSQL infers $8 as text and pgx v5 will not encode an int64 into a
+// text parameter. The working form multiplies instead: `NOW() + $8 * INTERVAL '1 second'`
+// takes the numeric straight through.
+//
+// This runs without a database, which is the point — the DB-backed test below skips when
+// Docker is absent, and this class of break must not depend on Docker being present to
+// be noticed.
+func TestTTLIntervalsAreNotStringConcatenated(t *testing.T) {
+	raw, err := os.ReadFile("device_token_repository.go")
+	if err != nil {
+		t.Fatalf("failed to read the repository source: %v", err)
+	}
+	// Comments are stripped first, because the statements above are commented with the
+	// broken form as a warning — a naive scan would flag the documentation as the bug.
+	var code strings.Builder
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	source := code.String()
+
+	if strings.Contains(source, "|| ' seconds')") {
+		t.Error("a TTL is being concatenated into an INTERVAL again. `($n || ' seconds')::INTERVAL` " +
+			"types the parameter as text, and pgx v5 cannot encode an int64 into text — every call " +
+			"fails with a 500 (\"cannot find encode plan\"). Use `$n * INTERVAL '1 second'`.")
+	}
+	// Three statements take a TTL parameter — CreateLinkRequest, ApproveLinkRequest and
+	// CreateDeviceToken — and all three must use the multiplied form. Counted rather than
+	// matched literally so reindenting a query does not fail the test for no reason.
+	if got := strings.Count(source, "* INTERVAL '1 second'"); got != 3 {
+		t.Errorf("found %d multiplied TTL intervals, want 3 (CreateLinkRequest, "+
+			"ApproveLinkRequest, CreateDeviceToken). If a statement was added or removed, "+
+			"update this count — but every TTL parameter must still be multiplied, not "+
+			"concatenated.", got)
+	}
+}
+
+// TestDeviceLinkTTLsExecuteAgainstRealPostgres is the half that would actually have
+// caught the outage. Everything else in this file, and every test in
+// handlers/device_link_test.go, asserts against strings or a fake store — so all of them
+// stayed green while all three statements were unexecutable. A parameter-type mismatch
+// only exists once PostgreSQL is asked to plan the query, which means the only test that
+// can see it is one that runs it.
+//
+// It drives the real repository against the real migration set: open a link request,
+// approve it, mint the token. Each step asserts the expiry actually landed the configured
+// TTL in the future, because "the statement ran" and "the interval was computed from the
+// argument" are different claims and only the second one is useful.
+func TestDeviceLinkTTLsExecuteAgainstRealPostgres(t *testing.T) {
+	pool, cleanup := setupMigrationTestDB(t)
+	defer cleanup()
+	runMigrations(t, pool, loadUpMigrations(t))
+
+	ctx := context.Background()
+
+	// The two FK targets a device token needs: an owner and an overlay of theirs.
+	var userID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO users (twitch_id, auth_provider, username, display_name,
+		                   access_token, refresh_token, token_expires_at)
+		VALUES ('990001', 'twitch', 'interval_canary', 'Interval Canary',
+		        'access-token', 'refresh-token', NOW() + INTERVAL '4 hours')
+		RETURNING id::text`).Scan(&userID); err != nil {
+		t.Fatalf("failed to insert the owning user: %v", err)
+	}
+	var overlayID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO overlays (user_id, name) VALUES ($1, 'canary overlay')
+		RETURNING id::text`, userID).Scan(&overlayID); err != nil {
+		t.Fatalf("failed to insert the overlay: %v", err)
+	}
+
+	repo := NewDeviceTokenRepository(pool)
+
+	// 1. CreateLinkRequest — the statement behind POST /device/link/start, the one the
+	//    bug report was filed against.
+	req, err := repo.CreateLinkRequest(ctx, FlowLoopback, nil,
+		"a-pkce-challenge", "S256", "http://127.0.0.1:41234/callback",
+		"Stream Deck", []string{"chat:write", "engagement:write"}, LinkRequestTTL)
+	if err != nil {
+		t.Fatalf("CreateLinkRequest failed against a real PostgreSQL: %v\n\n"+
+			"This is the exact failure users saw as a stuck \"Starting…\" and a 500.", err)
+	}
+	assertTTLLanded(t, pool, "CreateLinkRequest", LinkRequestTTL,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_link_requests WHERE id = $1`, req.ID)
+
+	// 2. ApproveLinkRequest — the streamer pressing Approve.
+	authCode := sha256.Sum256([]byte("an-auth-code"))
+	approved, err := repo.ApproveLinkRequest(ctx, req.ID, userID, overlayID,
+		[]string{"chat:write"}, "Stream Deck", authCode[:], AuthCodeTTL)
+	if err != nil {
+		t.Fatalf("ApproveLinkRequest failed against a real PostgreSQL: %v", err)
+	}
+	assertTTLLanded(t, pool, "ApproveLinkRequest", AuthCodeTTL,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((auth_code_expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_link_requests WHERE id = $1`, approved.ID)
+
+	// 3. CreateDeviceToken — minting the credential the plugin ends up holding, with the
+	//    lifetime the production caller passes.
+	tokenHash := sha256.Sum256([]byte("a-device-token"))
+	device, err := repo.CreateDeviceToken(ctx, userID, overlayID, "Stream Deck",
+		tokenHash[:], []string{"chat:write"}, middleware.DeviceTokenLifetime, req.ID)
+	if err != nil {
+		t.Fatalf("CreateDeviceToken failed against a real PostgreSQL: %v", err)
+	}
+	assertTTLLanded(t, pool, "CreateDeviceToken", middleware.DeviceTokenLifetime,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_tokens WHERE id = $1`, device.ID)
+}
+
+// assertTTLLanded checks an expiry landed one TTL in the future rather than merely being
+// set: a statement that silently computed a zero interval would still have "worked".
+//
+// The remaining time is measured BY POSTGRESQL, not by comparing a scanned timestamp
+// against Go's clock. These columns are `timestamp without time zone` while NOW() is a
+// timestamptz, so on a server outside UTC the stored value is local wall-clock and pgx
+// hands it back as though it were UTC. Comparing that against Go's clock reports a
+// whole-hour error while the interval itself is perfectly correct, and a TTL spanning a
+// DST change (the 90-day one does) is off by the DST offset on top. Converting the column
+// back to an absolute instant with `AT TIME ZONE current_setting('TimeZone')` makes the
+// assertion exact on any server timezone rather than only on a UTC one.
+func assertTTLLanded(t *testing.T, pool *pgxpool.Pool, what string, ttl time.Duration, query, id string) {
+	t.Helper()
+	var seconds float64
+	if err := pool.QueryRow(context.Background(), query, id).Scan(&seconds); err != nil {
+		t.Fatalf("%s: failed to read back the expiry: %v", what, err)
+	}
+	got := time.Duration(seconds * float64(time.Second))
+	// Generous slack: the assertion is that the interval was derived from the argument at
+	// all, not that it is accurate to the millisecond.
+	const slack = 2 * time.Minute
+	if got < ttl-slack || got > ttl+slack {
+		t.Errorf("%s: expiry is %v away, want ~%v. The TTL argument is not reaching the "+
+			"interval.", what, got.Round(time.Second), ttl)
 	}
 }

--- a/shared/middleware/devicetoken.go
+++ b/shared/middleware/devicetoken.go
@@ -217,10 +217,18 @@ const resolveDeviceTokenSQL = `
 // polling the active poll every second does not write on every request. The throttle
 // costs nothing in expiry terms: skipping a renewal for up to a minute out of a 90-day
 // window is not observable.
+//
+// The lifetime is MULTIPLIED into an interval, not concatenated into one. `||` has only
+// a text overload, so `($2 || ' seconds')::INTERVAL` types $2 as text and pgx v5 then
+// refuses to encode the int64 lifetime into it. Because this statement is best-effort
+// and its error is only logged at Debug, that failure was SILENT: last_used_at was never
+// recorded and the expiry never slid, so a device token quietly expired 90 days after it
+// was minted no matter how much the deck was used — the opposite of what the comment
+// above promises. Do not reintroduce the concatenation.
 const touchDeviceTokenSQL = `
 	UPDATE device_tokens
 	   SET last_used_at = NOW(),
-	       expires_at   = NOW() + ($2 || ' seconds')::INTERVAL
+	       expires_at   = NOW() + $2 * INTERVAL '1 second'
 	 WHERE id = $1
 	   AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL '1 minute')`
 

--- a/shared/middleware/devicetoken_test.go
+++ b/shared/middleware/devicetoken_test.go
@@ -372,3 +372,25 @@ func TestTokenResolverDispatch_PropagatesRealErrors(t *testing.T) {
 		t.Fatal("dispatcher swallowed a resolver failure")
 	}
 }
+
+func TestTouchDeviceTokenSQL_MultipliesTheLifetimeInsteadOfConcatenatingIt(t *testing.T) {
+	// This statement is best-effort by design and its failure is logged at Debug, which
+	// made it the worst place in the feature for a broken parameter type to hide.
+	//
+	// `expires_at = NOW() + ($2 || ' seconds')::INTERVAL` types $2 as text, because `||`
+	// has only a text overload, and pgx v5 refuses to encode the int64 lifetime into a
+	// text parameter. The UPDATE therefore errored on every authenticated request and
+	// nobody saw it: last_used_at was never written and the expiry never slid, so a
+	// device token expired 90 days after it was minted however heavily the deck was used.
+	// The comment on the constant promises the opposite, so this pins the mechanism that
+	// makes the promise true.
+	if strings.Contains(touchDeviceTokenSQL, "|| ' seconds')") {
+		t.Error("touchDeviceTokenSQL concatenates the lifetime into an INTERVAL again. That " +
+			"types the parameter as text, pgx v5 cannot encode an int64 into text, and because " +
+			"this write is best-effort the failure is invisible — device tokens silently stop " +
+			"being renewed. Use `$2 * INTERVAL '1 second'`.")
+	}
+	if !strings.Contains(touchDeviceTokenSQL, "$2 * INTERVAL '1 second'") {
+		t.Error("touchDeviceTokenSQL no longer derives the expiry from the lifetime parameter")
+	}
+}

--- a/streamcontroller-plugin/actions/base.py
+++ b/streamcontroller-plugin/actions/base.py
@@ -37,7 +37,7 @@ from typing import Any, Mapping
 
 from allchat import errors
 from allchat.api import Connection
-from allchat.errors import AllChatError
+from allchat.errors import AllChatError, link_failure_message
 # Imported as a MODULE, not as names: the two flows are patched wholesale in the
 # tests, and `from ... import link_via_loopback` would bind the original function
 # into this namespace where a patch cannot reach it.
@@ -196,10 +196,11 @@ class AllChatActionBase(ActionBase):
             def work() -> None:
                 try:
                     self.start_linking(on_status)
-                except AllChatError as exc:
-                    on_status("failed", exc.message)
                 except Exception as exc:  # noqa: BLE001
-                    on_status("failed", f"Linking failed: {type(exc).__name__}: {exc}")
+                    # One handler for both cases: link_failure_message decides what a
+                    # streamer should read, including for a non-AllChatError, where the
+                    # old branch showed the exception's class name.
+                    on_status("failed", link_failure_message(exc))
                 finally:
                     button.set_sensitive(True)
 

--- a/streamcontroller-plugin/allchat/errors.py
+++ b/streamcontroller-plugin/allchat/errors.py
@@ -47,6 +47,7 @@ from typing import Any, Mapping
 
 from .settings import (
     ACCOUNT_TOKENS_URL,
+    DEFAULT_BASE_URL,
     SCOPE_CHAT_WRITE,
     SCOPE_ENGAGEMENT_WRITE,
     UPGRADE_URL,
@@ -204,3 +205,59 @@ def forbidden_message(body: Any) -> str:
         f"gate. The usual cause is an overlay ID that belongs to a different account -- "
         f"check the overlay ID in this key's settings."
     )
+
+
+def link_failure_message(exc: BaseException) -> str:
+    """The subtitle shown under the Link button when a link attempt fails.
+
+    The row used to render ``exc.message`` verbatim, and anything that was not an
+    :class:`AllChatError` as ``f"Linking failed: {type(exc).__name__}: {exc}"`` --
+    an exception class name is not something to put in front of a streamer.
+
+    Most of those messages are written for the plugin log: they carry a URL, an
+    errno, an HTTP status or a server-supplied string. This translates the ones
+    that leak detail and deliberately passes the rest through, because several
+    are already good user-facing copy ("The pairing code expired before it was
+    approved. Start linking again.") and replacing those with something generic
+    would be a downgrade. The rule: an authored message with no status attached
+    is copy and survives; anything carrying transport or HTTP detail is replaced.
+
+    Mirrored by ``linkFailureMessage`` in the Stream Deck plugin's ``errors.ts``
+    (this module's header carries the file-level sync pointer). ADR-0049 counts
+    "what the button surfaces on failure" as part of the action contract, so the
+    two plugins must not tell a user two different things about one failure.
+    """
+    if not isinstance(exc, AllChatError):
+        # A TypeError or similar: implementation detail, nothing user-actionable.
+        return (
+            f"Linking did not complete. Press \"Link with All-Chat\" to try again, or "
+            f"paste a personal access token from {ACCOUNT_TOKENS_URL} instead."
+        )
+    if exc.kind == NETWORK:
+        # Unreachable host, DNS, TLS, a timeout, or a loopback port that could not
+        # be bound. All of them carry an errno or a URL in the message.
+        return (
+            "Could not reach All-Chat. Check your internet connection and try again. "
+            "If you self-host, check the Server field in this action's settings."
+        )
+    if exc.kind == FORBIDDEN:
+        return (
+            "The approval could not be verified, so nothing was linked. Press "
+            "\"Link with All-Chat\" and approve the device again."
+        )
+    if exc.kind == UNAUTHORIZED:
+        return unauthorized_message()
+    if exc.status is not None and exc.status >= 500:
+        return (
+            f"All-Chat could not complete the link because the server returned an error "
+            f"(HTTP {exc.status}). That is a fault on the server, not on this machine: "
+            f"try again in a few minutes, and report it if it keeps happening."
+        )
+    if exc.status is not None:
+        return (
+            f"All-Chat refused the link (HTTP {exc.status}). Make sure you are signed in "
+            f"at {DEFAULT_BASE_URL} as the account you want this action to control, then "
+            f"press \"Link with All-Chat\" again."
+        )
+    # No status: an authored message, e.g. the expired pairing code. Show it as written.
+    return exc.message

--- a/streamcontroller-plugin/tests/test_linking.py
+++ b/streamcontroller-plugin/tests/test_linking.py
@@ -437,5 +437,50 @@ class StartLinkingWritesOnlySettingsTest(unittest.TestCase):
         self.assertNotIn("zzz", settings.redact(DEVICE_TOKEN))
 
 
+class LinkFailureMessageTest(unittest.TestCase):
+    """What the Link row says when a link attempt fails.
+
+    The row used to render raw exception text: ``exc.message`` for an
+    :class:`AllChatError` (a URL, an errno, an HTTP status, sometimes a
+    server-supplied string) and ``f"{type(exc).__name__}: {exc}"`` for anything
+    else. Both are log material, not something to show a streamer mid-stream.
+
+    These assertions pin the two halves of the rule: detail-bearing failures are
+    translated, and authored copy is left alone.
+    """
+
+    def test_a_plain_exception_never_shows_its_class_name(self) -> None:
+        message = errors.link_failure_message(TypeError("cannot read property of undefined"))
+        self.assertNotIn("TypeError", message)
+        self.assertNotIn("undefined", message)
+        self.assertIn("Link with All-Chat", message)
+
+    def test_a_transport_failure_does_not_leak_the_url_or_errno(self) -> None:
+        exc = AllChatError(
+            errors.NETWORK,
+            "Could not reach All-Chat at https://allch.at/api/v1/x: ECONNREFUSED",
+        )
+        message = errors.link_failure_message(exc)
+        self.assertNotIn("ECONNREFUSED", message)
+        self.assertNotIn("/api/v1/", message)
+        self.assertIn("internet connection", message)
+
+    def test_a_server_error_is_named_as_the_servers_fault(self) -> None:
+        # The bug this whole change came from: POST /device/link/start answered 500
+        # for every user. "Try again in a few minutes" is the only useful advice, and
+        # blaming the user's connection for it would be wrong.
+        exc = AllChatError(errors.HTTP_ERROR, "All-Chat refused to start linking (HTTP 500)", 500)
+        message = errors.link_failure_message(exc)
+        self.assertIn("500", message)
+        self.assertIn("server", message)
+        self.assertNotIn("internet connection", message)
+
+    def test_authored_copy_with_no_status_survives_verbatim(self) -> None:
+        # This one is already the right thing to show. Replacing it with a generic
+        # "linking failed" would lose the only sentence that tells the user what to do.
+        authored = "The pairing code expired before it was approved. Start linking again."
+        self.assertEqual(authored, errors.link_failure_message(AllChatError(errors.HTTP_ERROR, authored)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-link.js
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-link.js
@@ -1,0 +1,137 @@
+/*
+	The "Link with All-Chat" button, shared by all three property inspectors.
+
+	This script's only job is to ask the plugin to run the device-link flow (ADR-0049)
+	and to render what comes back. It never sees a credential: the plugin writes the
+	device token straight into the key's settings, so there is nothing here to display,
+	copy or leak.
+
+	It lives in one file rather than inline in each page for the reason ADR-0049 gives
+	for the parity gate: three copies of the same logic diverge. It was already three
+	copies, and the button-state handling below would have made it three copies of
+	something worth getting right once.
+
+	Loaded at the end of <body>, after the sdpi-components script in <head>, so the
+	SDPIComponents global is available at parse time.
+*/
+(() => {
+	const button = document.getElementById("allchat-link");
+	const status = document.getElementById("allchat-link-status");
+	if (!button || !status) {
+		return;
+	}
+
+	/*
+		How long to wait for a terminal message before releasing the button.
+
+		The plugin reports "linked" or "failed" on every path it can reach, but if it
+		never reports at all — the flow throws somewhere outside the reporting block, the
+		plugin process dies, the message is dropped because the inspector was
+		re-rendered — the old UI sat on "Starting…" with a dead button and no way back
+		except reopening the key's settings. That is exactly what the bug report
+		described, so the recovery is built in rather than assumed away.
+
+		11 minutes is just past the longest flow: the pairing-code path gives the user
+		600s (CODE_FLOW_TIMEOUT_MS in src/allchat/linking.ts), the loopback path 180s.
+		Anything still silent past that is not slow, it is gone.
+	*/
+	const WATCHDOG_MS = 660_000;
+
+	/** Statuses after which the flow is over and the button is usable again. */
+	const TERMINAL = new Set(["linked", "failed"]);
+
+	let watchdog;
+
+	const clearWatchdog = () => {
+		if (watchdog !== undefined) {
+			clearTimeout(watchdog);
+			watchdog = undefined;
+		}
+	};
+
+	/**
+	 * Renders a state.
+	 *
+	 * `data-state` drives the colour and the ⚠ / ✓ marker from allchat-pi.css. The
+	 * pairing code is appended as an element rather than interpolated into a string so
+	 * it can be given its own line and monospace face, and it is set with textContent
+	 * rather than innerHTML: it comes off the wire, and nothing off the wire is parsed
+	 * as markup here.
+	 */
+	const render = (state, detail, userCode) => {
+		status.dataset.state = state;
+		status.textContent = detail ?? "";
+		if (userCode) {
+			const code = document.createElement("span");
+			code.className = "allchat-code";
+			code.textContent = userCode;
+			status.appendChild(code);
+		}
+	};
+
+	const finish = (state, detail) => {
+		clearWatchdog();
+		button.disabled = false;
+		render(state, detail);
+	};
+
+	button.addEventListener("click", () => {
+		// Guard as well as disable: a queued click on an already-disabled button would
+		// otherwise start a second concurrent flow, and two flows racing to write the
+		// same key's settings means the surviving credential is whichever finished last.
+		if (button.disabled) {
+			return;
+		}
+		button.disabled = true;
+		render("working", "Starting…");
+
+		clearWatchdog();
+		watchdog = setTimeout(() => {
+			finish(
+				"failed",
+				"Linking timed out with no answer from the plugin. Press Link to try again, " +
+					"or paste a personal access token instead.",
+			);
+		}, WATCHDOG_MS);
+
+		SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
+	});
+
+	/*
+		`sendToPropertyInspector` is the observable that carries messages from the plugin.
+
+		The pages used to subscribe to `didReceivePropertyInspectorMessage`, which does not
+		exist on sdpi-components' client — its members are `message`,
+		`didReceiveSettings`, `didReceiveGlobalSettings` and `sendToPropertyInspector`.
+		Reading `.subscribe` off `undefined` threw a TypeError at parse time, and because
+		the click listener was registered on the line ABOVE it, the button still worked
+		while no status update could ever arrive. That is the second half of the reported
+		bug: pressing Link set "Starting…" and nothing was ever able to replace it, so the
+		panel sat there for good even once the server stopped answering 500.
+
+		The observable dispatches the whole Stream Deck message, so the plugin's own
+		payload is one level down in `message.payload`.
+	*/
+	SDPIComponents.streamDeckClient.sendToPropertyInspector.subscribe((message) => {
+		const payload = message?.payload;
+		if (!payload || payload.event !== "link-status") {
+			return;
+		}
+
+		const state = payload.status;
+
+		if (state === "code" && payload.userCode) {
+			// Not terminal: the plugin is still polling for the approval, so the button
+			// stays disabled and the watchdog keeps running.
+			render("code", payload.detail ?? "Enter this code at allch.at/link:", payload.userCode);
+			return;
+		}
+
+		if (TERMINAL.has(state)) {
+			finish(state, payload.detail ?? state);
+			return;
+		}
+
+		render("working", payload.detail ?? state ?? "");
+	});
+})();

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-pi.css
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-pi.css
@@ -1,0 +1,176 @@
+/*
+	Page styling for the All-Chat property inspectors.
+
+	WHY THIS FILE EXISTS
+
+	sdpi-components styles its own custom elements and nothing else. Worse, it declares
+	its palette on `:host` INSIDE each component's shadow root:
+
+		:host { --window-bg-color:#2d2d2d; --font-color:#969696; --input-font-color:#d8d8d8; ... }
+
+	Custom properties inherit downwards, so those variables are visible inside a
+	component and to its light-DOM children, but NOT to the page around them. Nothing
+	sets a page-level colour at all, which left every native element we use (h4, p,
+	span, code, summary, a) on the browser default of black text over the Stream Deck
+	property inspector's dark panel: roughly 1.52:1 against #2d2d2d, where WCAG AA asks
+	for 4.5:1. Rendered, but not readable.
+
+	Two consequences worth spelling out, because both are easy to get wrong:
+
+	  * `body { color: var(--font-color) }` does NOT work. The variable is undefined at
+	    page scope, the declaration is invalid at computed-value time, and `color` then
+	    falls back to inheritance from the root element: black again. Any fix has to
+	    declare its own values rather than borrow the library's.
+	  * The BACKGROUND is set here as well as the foreground. Light text is only safe if
+	    we also own what is behind it, and the panel background is painted by the host
+	    app rather than by anything in this folder.
+
+	The values mirror sdpi-components' own palette so native text sits beside the
+	components without looking pasted in. The library ships no light theme (it contains
+	no prefers-color-scheme rule anywhere), so a single dark palette is the whole story
+	and a media query would be inventing a mode that does not exist.
+
+	Contrast against #2d2d2d, measured, all passing WCAG 2.2 AA for normal text:
+	  --allchat-fg        #d8d8d8   9.66:1
+	  --allchat-fg-muted  #969696   4.66:1
+	  --allchat-error     #ff8a8a   6.07:1
+	  --allchat-success   #81c995   7.03:1
+	  --allchat-link      #8ab4f8   6.53:1
+	  code / pairing code #ffffff  13.77:1
+
+	KEEP IN SYNC: loaded by send-message.html, poll-control.html and
+	prediction-control.html. It is one file precisely because ADR-0049 names drift
+	between duplicated surfaces as the standing risk in this folder.
+*/
+
+:root {
+	--allchat-bg: #2d2d2d;
+	--allchat-fg: #d8d8d8;
+	--allchat-fg-muted: #969696;
+	--allchat-error: #ff8a8a;
+	--allchat-success: #81c995;
+	--allchat-link: #8ab4f8;
+	--allchat-input-bg: #3d3d3d;
+}
+
+body {
+	background-color: var(--allchat-bg);
+	color: var(--allchat-fg);
+}
+
+/* The default UA link colour (#0000ee) is 1.47:1 here, so the help section's links to
+   allch.at were as unreadable as the prose around them. */
+a {
+	color: var(--allchat-link);
+}
+
+h4 {
+	color: var(--allchat-fg);
+}
+
+code {
+	color: #ffffff;
+}
+
+/* `summary` is the only affordance that opens the help section, so it reads as
+   interactive rather than as another line of body text. */
+summary {
+	color: var(--allchat-fg-muted);
+	cursor: pointer;
+}
+
+summary:hover {
+	color: var(--allchat-fg);
+}
+
+/*
+	The Link button. A native <button> does not inherit `color` (the UA stylesheet sets
+	`color: buttontext`), so it needs styling of its own regardless of the rules above,
+	and an unstyled one renders as a light OS-native button on a dark panel.
+
+	Sized and bordered like sdpi-components' own sdpi-button, but on the input
+	background rather than the window background so it reads as a control instead of a
+	rectangle of border.
+*/
+#allchat-link {
+	background-color: var(--allchat-input-bg);
+	color: var(--allchat-fg);
+	border: 1px solid var(--allchat-fg-muted);
+	border-radius: 3px;
+	padding: 6px 12px;
+	font: inherit;
+	cursor: pointer;
+}
+
+#allchat-link:not(:disabled):hover {
+	background-color: #464646;
+}
+
+/*
+	Disabled means "a link attempt is already running". 0.5 is sdpi-components'
+	--opacity-disabled, and the progress cursor says the wait is expected rather than
+	broken. Opacity alone would be a colour-only signal, so the cursor carries it too.
+*/
+#allchat-link:disabled {
+	opacity: 0.5;
+	cursor: progress;
+}
+
+/*
+	Link status.
+
+	Every state used to render as the same unstyled span, so "Linked." and a hard
+	failure were typographically identical and a user who glanced at the panel had no
+	way to tell that one of them needed action. The state is published by
+	allchat-link.js as a data-state attribute and styled here.
+*/
+/* Block, so it stacks under the button inside the same sdpi-item rather than sitting in
+   a separate labelled row. sdpi-item renders its slot into a plain block div, so this is
+   all the stacking needs. It used to be its own `sdpi-item label="Status"`, which read
+   as an independent setting instead of as feedback from the button above it. */
+#allchat-link-status {
+	display: block;
+	margin-top: 6px;
+	line-height: 1.4;
+}
+
+#allchat-link-status[data-state="idle"] {
+	color: var(--allchat-fg-muted);
+}
+
+#allchat-link-status[data-state="working"],
+#allchat-link-status[data-state="code"] {
+	color: var(--allchat-fg);
+}
+
+#allchat-link-status[data-state="linked"] {
+	color: var(--allchat-success);
+}
+
+#allchat-link-status[data-state="failed"] {
+	color: var(--allchat-error);
+}
+
+/* A marker as well as a colour, so the failure state is not signalled by hue alone
+   (WCAG 1.4.1). */
+#allchat-link-status[data-state="failed"]::before {
+	content: "⚠ ";
+}
+
+#allchat-link-status[data-state="linked"]::before {
+	content: "✓ ";
+}
+
+/*
+	The pairing code is the one thing on the page a user has to read off the screen and
+	retype, so it gets a line of its own, a monospace face and letter spacing. White
+	rather than --allchat-fg: it is the payload, not prose.
+*/
+.allchat-code {
+	display: block;
+	margin-top: 4px;
+	font-family: "Consolas", "Menlo", monospace;
+	font-size: 1.4em;
+	letter-spacing: 0.18em;
+	color: #ffffff;
+}

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/poll-control.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/poll-control.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Poll Control</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<!--
@@ -72,12 +79,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -123,36 +133,6 @@
 			</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/prediction-control.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/prediction-control.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Prediction Control</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<!--
@@ -81,12 +88,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -135,36 +145,6 @@
 			</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Send Chat Message</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<sdpi-item label="Message">
@@ -43,12 +50,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -96,36 +106,6 @@
 			<p>Sending chat messages is free on every All-Chat account.</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/eslint.config.js
+++ b/streamdeck-plugin/eslint.config.js
@@ -25,4 +25,24 @@ export default tseslint.config(
 			"prefer-const": "error",
 		},
 	},
+	{
+		// Property inspector scripts. These run in the Stream Deck app's embedded
+		// browser, not in the plugin's Node process, so they need browser globals plus
+		// the `SDPIComponents` global that sdpi-components.js installs.
+		//
+		// They are linted at all only because they were moved out of inline <script>
+		// blocks in the three HTML pages, where ESLint never saw them. The global list
+		// is enumerated rather than pulled in wholesale from `globals.browser`: a
+		// property inspector should be touching almost nothing, and a new name showing
+		// up here is worth noticing.
+		files: ["com.allchat.streamdeck.sdPlugin/ui/**/*.js"],
+		languageOptions: {
+			globals: {
+				document: "readonly",
+				setTimeout: "readonly",
+				clearTimeout: "readonly",
+				SDPIComponents: "readonly",
+			},
+		},
+	},
 );

--- a/streamdeck-plugin/src/actions/base.ts
+++ b/streamdeck-plugin/src/actions/base.ts
@@ -25,6 +25,7 @@ import streamDeck, {
 
 import {
 	AllChatError,
+	linkFailureMessage,
 	malformedTokenMessage,
 	missingTokenMessage,
 	premiumGateMessage,
@@ -171,16 +172,18 @@ export abstract class AllChatAction<
 					report("linked", `Linked. Revoke this device any time at ${ACCOUNT_DEVICES_URL}.`);
 					return;
 				} catch (fallbackError) {
+					// The raw reason goes to the log; the property inspector gets copy a
+					// streamer can act on. See linkFailureMessage.
 					const reason =
 						fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
 					logger.error(`${this.label}: linking failed — ${reason}`);
-					report("failed", reason);
+					report("failed", linkFailureMessage(fallbackError));
 					return;
 				}
 			}
 			const reason = error instanceof Error ? error.message : String(error);
 			logger.error(`${this.label}: linking failed — ${reason}`);
-			report("failed", reason);
+			report("failed", linkFailureMessage(error));
 		}
 	}
 

--- a/streamdeck-plugin/src/allchat/errors.ts
+++ b/streamdeck-plugin/src/allchat/errors.ts
@@ -24,7 +24,7 @@
  * token", the other says "this is premium", and swapping them costs money.
  */
 
-import { UPGRADE_URL, ACCOUNT_TOKENS_URL } from "./settings.js";
+import { UPGRADE_URL, ACCOUNT_TOKENS_URL, DEFAULT_BASE_URL } from "./settings.js";
 
 /** Discriminator for the states a caller may want to react to differently. */
 export type AllChatErrorKind =
@@ -109,6 +109,71 @@ export function missingTokenMessage(): string {
 		`On a second machine or a headless host, paste a personal access token from ` +
 		`${ACCOUNT_TOKENS_URL} instead.`
 	);
+}
+
+/**
+ * The message the property inspector shows when a link attempt fails.
+ *
+ * The Link button used to render `error.message` verbatim. Most of those strings are
+ * built for the plugin log, not for a streamer looking at a settings panel: they carry a
+ * URL, an errno, an HTTP status and sometimes a server-supplied string. The worst case
+ * was a raw JavaScript error message for anything that was not an AllChatError at all.
+ *
+ * This translates only the messages that leak detail, and deliberately passes the others
+ * through — several of them are already good user-facing copy ("The pairing code expired
+ * before it was approved. Start linking again.") and replacing them with something
+ * generic would be a downgrade. The rule is: an authored message with no status attached
+ * is copy and survives; anything carrying transport or HTTP detail gets replaced.
+ *
+ * The raw message is still logged by the caller, so nothing is lost for debugging.
+ *
+ * Mirrored by `link_failure_message` in the StreamController plugin's `errors.py` (this
+ * module's header carries the file-level sync pointer). ADR-0049 counts "what the button
+ * surfaces on failure" as part of the action contract, so the two plugins must not tell a
+ * user two different things about one failure.
+ */
+export function linkFailureMessage(error: unknown): string {
+    if (!(error instanceof AllChatError)) {
+        // A TypeError or similar: implementation detail with no user-actionable content.
+        return (
+            `Linking did not complete. Press "Link with All-Chat" to try again, or paste a ` +
+            `personal access token from ${ACCOUNT_TOKENS_URL} instead.`
+        );
+    }
+    switch (error.kind) {
+        case "network":
+            // Covers an unreachable host, DNS, TLS, a timeout and a loopback port that
+            // could not be bound. All of them carry an errno or a URL in the message.
+            return (
+                `Could not reach All-Chat. Check your internet connection and try again. If you ` +
+                `self-host, check the Server field in this key's settings.`
+            );
+        case "forbidden":
+            return (
+                `The approval could not be verified, so nothing was linked. Press "Link with ` +
+                `All-Chat" and approve the device again.`
+            );
+        case "unauthorized":
+            return unauthorizedMessage();
+        default:
+            break;
+    }
+    if (error.status !== undefined && error.status >= 500) {
+        return (
+            `All-Chat could not complete the link because the server returned an error (HTTP ` +
+            `${error.status}). That is a fault on the server, not on this machine: try again in ` +
+            `a few minutes, and report it if it keeps happening.`
+        );
+    }
+    if (error.status !== undefined) {
+        return (
+            `All-Chat refused the link (HTTP ${error.status}). Make sure you are signed in at ` +
+            `${DEFAULT_BASE_URL} as the account you want this key to control, then press "Link ` +
+            `with All-Chat" again.`
+        );
+    }
+    // No status: an authored message, e.g. the expired pairing code. Show it as written.
+    return error.message;
 }
 
 /** The message shown/logged when the configured string is not an All-Chat credential. */


### PR DESCRIPTION
Closes #793. Closes #794.

Device linking was broken by **two independent faults**, both of which had to be fixed for the flow to work at all. #793 found one of them.

## 1. Every `POST /device/link/start` returned 500

`NOW() + ($n || ' seconds')::INTERVAL` types the parameter as `text` (`||` has only a text overload), and pgx v5 refuses to encode an `int64` into a text parameter. Replaced with `$n * INTERVAL '1 second'`.

#793 listed three sites. There is a **fourth**: `touchDeviceTokenSQL` in `shared/middleware/devicetoken.go`. That one is best-effort and logs its error at Debug, so it was failing **silently** on every authenticated request: `last_used_at` was never written and the expiry never slid forward. Device tokens therefore expired 90 days after minting however heavily the deck was used, which is the opposite of what the code and `docs/guides/streamdeck.md` promise.

## 2. The status never updated, which is why the panel sat on "Starting…" forever

The pages subscribed to `streamDeckClient.didReceivePropertyInspectorMessage`. That does not exist in sdpi-components v4 — the client's members are `message`, `didReceiveSettings`, `didReceiveGlobalSettings` and `sendToPropertyInspector`. Reading `.subscribe` off `undefined` threw a `TypeError` at parse time, and because the click listener was registered on the line *above* it, the button kept working while no reply could ever be rendered.

**Fixing the SQL alone would still have left the panel stuck on "Starting…".** This is the other half of the reported symptom.

## How this was verified

Not by reading. The bug report is bot-proposed, so every claim was checked against the source and then against something running.

- All four statements were executed against a **real PostgreSQL 16** with the full migration set applied. The reported error reproduced verbatim before the change:
  ```
  unable to encode 600 into text format for text (OID 25): cannot find encode plan
  ```
  and all four pass after it.
- The observable name and every contrast figure below were **measured in Chromium against the real sdpi-components bundle**, confirming `sendToPropertyInspector.subscribe` is a function and `didReceivePropertyInspectorMessage` is `undefined`.

## Tests

Nothing that existed could see either fault: the repository tests are DB-free shape assertions and the handler tests drive a fake store, so every one of them stayed green while all three statements were unexecutable.

- A **DB-backed test** driving the real repository through open → approve → mint, asserting each TTL actually landed rather than merely that the statement ran. The remaining time is measured by PostgreSQL, not by comparing a scanned timestamp against Go's clock: these columns are `timestamp without time zone` while `NOW()` is a `timestamptz`, so on a non-UTC server the naive comparison is off by the UTC offset (and by the DST offset again for the 90-day TTL) while the interval is perfectly correct. Verified on a Europe/Berlin server, where the naive version reports 2h10m for a 10m TTL.
- Source guards forbidding the concatenated form in both files.
- Four cases for the new failure-message mapping in the Python suite.

## #794: right premise, wrong fix

The diagnosis was correct and the one-liner would not have worked:

- `--sdpi-color` **does not exist**. The real names are `--font-color`, `--window-bg-color`, `--input-font-color`.
- Even the right name would not resolve. sdpi-components declares its palette on `:host` **inside each component's shadow root**, so it is visible within a component and to its light-DOM children, never to `body` above them. `body { color: var(--font-color) }` is invalid at computed-value time and `color` falls back to inheritance: black again.

The library injects `body,html{background-color:#2d2d2d}` and never sets a colour, which is exactly why native elements sat at the UA default of black on dark grey: **1.52:1**, against AA's 4.5:1. `allchat-pi.css` declares its own palette, and sets the background as well as the foreground so light text does not depend on the host painting the panel.

Measured in Chromium, all ≥ 4.5:1:

| element | before | after |
|---|---|---|
| `h4`, `p` | 1.52:1 | **9.66:1** |
| `code` | 1.52:1 | **13.77:1** |
| `a` (help links) | **1.47:1** | **6.53:1** |
| `summary` | 1.52:1 | 4.66:1 |
| button | n/a | 7.62:1 |

The links are a case #794 did not mention: the UA link blue `#0000ee` on `#2d2d2d` was the worst contrast on the page. No `prefers-color-scheme` branch, because the library ships no light theme (zero occurrences in the bundle), so a media query would be inventing a mode that does not exist.

## The remaining #793 UI points

1. **Button disabled during the flow**, re-enabled on a terminal outcome. Guarded as well as disabled, so a queued click cannot start a second concurrent flow racing to write the same key's settings.
2. **States are distinguished** by colour *and* a marker (`⚠` / `✓`), so the signal is not colour alone. The pairing code gets its own line and a monospace face.
3. **Raw exception text replaced** by kind-aware copy. Deliberately narrower than the issue proposed: a blanket "check your internet connection" would be wrong for a 500 and would have thrown away messages that are already good user-facing copy, so an authored message with no status attached survives verbatim (an expired pairing code still says so) and only the ones carrying a URL, errno or HTTP status are replaced. The raw reason is still logged.
4. **Status moved under the button** inside the same `sdpi-item`, instead of a separate `label="Status"` row that read as an independent setting.

Plus a watchdog that releases the button if no terminal message ever arrives, so "stuck forever with a dead button" becomes recoverable rather than permanent.

## Parity

The same raw-exception surfacing existed in the StreamController plugin, which showed the exception's *class name* (`f"Linking failed: {type(exc).__name__}: {exc}"`). ADR-0049 counts "what the button surfaces on failure" as part of the action contract, so both plugins now share the mapping. The Python side already disabled its button correctly.

## Housekeeping

The property inspector script moved out of three inline copies into one file, which is what ADR-0049 asks for in this folder and means it is **linted for the first time** (inline `<script>` in HTML was invisible to ESLint). Its globals are enumerated rather than pulled in wholesale, so a new one is worth noticing.

## Gates run locally

`eslint` + `tsc --noEmit`, `npm run build`, Elgato `validate`, `check-plugin-parity.py` (9 actions, 11 constants, pointers mutual), `compileall`, 69 Python tests, `gofmt`, `go vet`, and the auth-service + shared middleware Go suites. All green.

Not covered: no test drives the property inspector pages in CI (there is no harness for them), so items 1–4 and the contrast figures were verified with a scripted Chromium pass locally rather than pinned by a check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
