### PR TITLE
fix(streamdeck): repair device linking, make the property inspector legible, and stop offering TikTok as a send target

### DIFF
--- a/docs/adr/0049-desktop-control-surfaces-via-paired-device-tokens.md
+++ b/docs/adr/0049-desktop-control-surfaces-via-paired-device-tokens.md
@@ -8,6 +8,8 @@
 
 A streamer asked for Stream Deck buttons that drive All-Chat directly: start or close a poll, and send a canned message to every connected chat from the monitor view. The reasoning is the one All-Chat exists for. A multistreamer already has both hands busy, and the dashboard is one more window competing for attention on a second monitor. A physical button that fans a message out to Twitch, YouTube, Kick, TikTok and Discord at once is the shortest path between an intent and five platforms.
 
+> **Correction, 2026-08-31.** The sentence above overstates the send surface, and both plugins copied it into their pickers and READMEs before anyone checked. All-Chat *reads* five platforms but can only *post* to three: `POST /api/v1/auth/chat/send` answers 501 for TikTok (no public API exists for posting into a TikTok live chat) and 400 for Discord (a Discord source is a one-way relay), and `all` fans out to Twitch, YouTube and Kick only. The picker offered TikTok until a streamer asked why the button did nothing. The list is now pinned in `scripts/check-plugin-parity.py` and asserted against both plugins *and* the Elgato HTML picker.
+
 Two questions had to be answered before this is worth planning, and the first is settled:
 
 **Is the Stream Deck platform open, and does it cost us anything?** No cost. Elgato's SDK is free, plugin development is free, and publishing a free plugin to the Elgato Marketplace is free. A plugin is ordinary local software: a Node.js backend for logic plus an optional Chromium-rendered settings panel, talking to the Stream Deck app over a local WebSocket, on Windows 10+ and macOS 10.15+. Nothing about it requires a commercial relationship with Elgato.

--- a/docs/guides/streamdeck.md
+++ b/docs/guides/streamdeck.md
@@ -145,9 +145,15 @@ both outright. A leaked credential is a bad day, not a lost account.
 ## Step 3: The actions
 
 **Send chat message.** Type the message into the key's settings; pressing the key
-fans it out to every chat you have connected — Twitch, YouTube, Kick, TikTok and
-Discord — in one press. This is the action most people buy the hardware for.
-Requires `chat:write`.
+fans it out to every chat you have connected — Twitch, YouTube and Kick — in one
+press. This is the action most people buy the hardware for. Requires
+`chat:write`.
+
+Those three are the platforms All-Chat can *post* to, which is a shorter list
+than the platforms it *reads*. TikTok publishes no API for sending into a live
+chat, and a Discord source is a one-way relay into your overlay, so messages
+still arrive from both but neither can be a target. They are not offered in the
+platform picker and are not included in "all".
 
 **Poll control.** One action with a mode you choose per key. *Start* opens a poll
 from the question and options configured on that key. *Close* ends the poll

--- a/scripts/check-plugin-parity.py
+++ b/scripts/check-plugin-parity.py
@@ -47,6 +47,7 @@ TS_SETTINGS = TS / "src" / "allchat" / "settings.ts"
 PY_SETTINGS = PY / "allchat" / "settings.py"
 TS_LINKING = TS / "src" / "allchat" / "linking.ts"
 PY_LINKING = PY / "allchat" / "linking.py"
+TS_SEND_UI = TS / "com.allchat.streamdeck.sdPlugin" / "ui" / "send-message.html"
 
 # ---------------------------------------------------------------------------
 # 1. The action list. THIS is the contract ADR-0049 asks for: adding a button
@@ -118,6 +119,27 @@ LINKING_TIMEOUTS: tuple[tuple[str, str, float], ...] = (
 #: approve screen; asking for different sets per platform would mean the same button
 #: works on Windows and 403s on Linux.
 LINKING_SCOPES: tuple[str, ...] = ("chat:write", "engagement:write")
+
+# ---------------------------------------------------------------------------
+# 2c. The send surface.
+#
+#     `POST /api/v1/auth/chat/send` posts to Twitch, YouTube and Kick, and `all`
+#     fans out to exactly those (handleStreamerSendToAll in
+#     services/auth-service/handlers/chat_send.go). It is NARROWER than the set of
+#     platforms All-Chat reads chat from, and that gap is the trap: both plugins
+#     shipped `tiktok` in their pickers while auth-service answered 501 to it, so
+#     the button silently did nothing and a streamer had to ask why.
+#
+#     Checked in three places rather than one, because the Elgato picker is a
+#     fourth source of truth written in HTML that no compiler or test reads: the
+#     TS constant, the Python constant, and the <option> list must agree.
+# ---------------------------------------------------------------------------
+SEND_PLATFORMS: tuple[str, ...] = ("all", "twitch", "youtube", "kick")
+
+#: Platforms All-Chat reads but cannot post to. Both plugins must refuse these with
+#: the REASON (see UNSENDABLE_PLATFORMS in either settings module) rather than as an
+#: unknown value, because keys configured before the removal still carry them.
+UNSENDABLE: tuple[str, ...] = ("tiktok", "discord")
 
 # ---------------------------------------------------------------------------
 # 3. Keep-in-sync pointers, e.g.
@@ -243,6 +265,57 @@ def check_constants() -> None:
             )
 
 
+def check_send_platforms() -> None:
+    """The send surface, spelled in four places, must be one list.
+
+    The picker is included deliberately. `tsc` never opens the HTML and no unit test
+    asserts on it, so an <option> the server rejects is invisible until a streamer
+    presses the key.
+    """
+    ts_platforms = _string_list(strip_ts_comments(read(TS_SETTINGS)), "PLATFORMS")
+    py_platforms = _string_list(strip_py_comments(read(PY_SETTINGS)), "PLATFORMS")
+    ui_platforms = tuple(re.findall(r'<option value="([a-z]+)"', read(TS_SEND_UI)))
+
+    for label, found in (
+        (f"{TS_SETTINGS.relative_to(REPO)} PLATFORMS", ts_platforms),
+        (f"{PY_SETTINGS.relative_to(REPO)} PLATFORMS", py_platforms),
+        (f"{TS_SEND_UI.relative_to(REPO)} <option> values", ui_platforms),
+    ):
+        if set(found) != set(SEND_PLATFORMS):
+            fail(
+                f"send-platform drift: {label} is {list(found)}, expected "
+                f"{list(SEND_PLATFORMS)}. The server posts to Twitch/YouTube/Kick only; "
+                f"anything else here is a key that fails on press."
+            )
+
+    # The refusal must name the reason. A platform merely absent from PLATFORMS gets
+    # "not a platform All-Chat sends to", which reads as a typo for a value the plugin
+    # itself offered until recently.
+    for path in (TS_SETTINGS, PY_SETTINGS):
+        # Keys only: `"tiktok": (` in Python, `tiktok:` in TS. The explanation text
+        # itself is prose and deliberately not compared — it is allowed to be worded
+        # for each plugin's UI, as long as both cover the same platforms.
+        keys = set(re.findall(r'^\s*"?([a-z]+)"?:', _unsendable_literal(read(path)), re.MULTILINE))
+        if keys != set(UNSENDABLE):
+            fail(
+                f"{path.relative_to(REPO)} UNSENDABLE_PLATFORMS covers {sorted(keys)}, "
+                f"expected {sorted(UNSENDABLE)}. Each read-only platform needs an "
+                f"explanation, not just an absence."
+            )
+
+
+def _string_list(src: str, name: str) -> tuple[str, ...]:
+    """Values of `NAME = [...]` / `NAME = (...)`, in either language."""
+    match = re.search(rf"^(?:export const )?{name}\s*[:=][^=\[(]*[\[(](.*?)[\])]", src, re.DOTALL | re.MULTILINE)
+    return tuple(re.findall(r'"([a-z]+)"', match.group(1))) if match else ()
+
+
+def _unsendable_literal(src: str) -> str:
+    """The body of the UNSENDABLE_PLATFORMS mapping, in either language."""
+    match = re.search(r"UNSENDABLE_PLATFORMS[^=]*=\s*\{(.*?)\n\}", src, re.DOTALL)
+    return match.group(1) if match else ""
+
+
 def check_sync_pointers() -> None:
     pointers: dict[Path, set[str]] = {}
     for path in PLUGIN_SOURCES:
@@ -335,6 +408,7 @@ def _scope_literal(src: str, name: str) -> str:
 def main() -> int:
     check_action_list()
     check_constants()
+    check_send_platforms()
     check_linking()
     check_sync_pointers()
 
@@ -351,8 +425,9 @@ def main() -> int:
 
     print(
         f"Desktop plugin parity OK: {len(ACTIONS)} actions, "
-        f"{len(SHARED_CONSTANTS)} shared constants, {len(LINKING_TIMEOUTS)} linking "
-        f"timeouts, pointers mutual."
+        f"{len(SHARED_CONSTANTS)} shared constants, {len(SEND_PLATFORMS)} send "
+        f"platforms (picker included), {len(LINKING_TIMEOUTS)} linking timeouts, "
+        f"pointers mutual."
     )
     return 0
 

--- a/services/auth-service/repository/device_token_repository.go
+++ b/services/auth-service/repository/device_token_repository.go
@@ -228,11 +228,19 @@ func (r *DeviceTokenRepository) CreateLinkRequest(
 	if redirectURI != "" {
 		redirect = &redirectURI
 	}
+	// The TTL is multiplied into an interval rather than concatenated into one.
+	// `($8 || ' seconds')::INTERVAL` reads fine but types $8 as `text`, because `||`
+	// only has a text overload — and pgx v5 refuses to encode an int64 into a text
+	// parameter ("cannot find encode plan"), so EVERY call failed with a 500 and
+	// device linking could not be started at all. Multiplication takes the numeric
+	// straight through. Do not reintroduce the concatenation: it is not a style
+	// preference, it is the difference between working and a hard failure, and
+	// TestTTLIntervalsAreNotStringConcatenated pins it.
 	row := r.db.QueryRow(ctx, `
 		INSERT INTO device_link_requests
 			(flow, user_code_hash, pkce_challenge, pkce_method, redirect_uri,
 			 device_name, requested_scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + ($8 || ' seconds')::INTERVAL)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, NOW() + $8 * INTERVAL '1 second')
 		RETURNING `+linkRequestColumns,
 		flow, userCodeHash, pkceChallenge, pkceMethod, redirect,
 		deviceName, requestedScopes, int64(ttl/time.Second))
@@ -351,7 +359,7 @@ func (r *DeviceTokenRepository) ApproveLinkRequest(
 		       device_name = COALESCE(NULLIF($5, ''), device_name),
 		       approved_at = NOW(),
 		       auth_code_hash = $6,
-		       auth_code_expires_at = NOW() + ($7 || ' seconds')::INTERVAL
+		       auth_code_expires_at = NOW() + $7 * INTERVAL '1 second'
 		 WHERE id = $1
 		   AND user_id IS NULL
 		   AND consumed_at IS NULL
@@ -548,7 +556,7 @@ func (r *DeviceTokenRepository) CreateDeviceToken(
 	var id string
 	err = tx.QueryRow(ctx, `
 		INSERT INTO device_tokens (user_id, overlay_id, name, token_hash, scopes, expires_at)
-		VALUES ($1, $2, $3, $4, $5, NOW() + ($6 || ' seconds')::INTERVAL)
+		VALUES ($1, $2, $3, $4, $5, NOW() + $6 * INTERVAL '1 second')
 		RETURNING id::text`,
 		userID, overlayID, name, tokenHash, scopes, int64(lifetime/time.Second)).Scan(&id)
 	if err != nil {

--- a/services/auth-service/repository/device_token_repository_test.go
+++ b/services/auth-service/repository/device_token_repository_test.go
@@ -28,8 +28,15 @@ package repository
 // handlers/device_link_test.go, which drive the whole flow over a fake store.
 
 import (
+	"context"
+	"crypto/sha256"
+	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/caesar/all-chat/shared/middleware"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestConsumeAuthCodeSQL_IsOneAtomicStatementWithEveryGuard(t *testing.T) {
@@ -127,5 +134,157 @@ func TestNoProjectionSelectsADigest(t *testing.T) {
 					"scans into is what the endpoints serialise.", name, secret)
 			}
 		}
+	}
+}
+
+// TestTTLIntervalsAreNotStringConcatenated is the cheap half of the guard against the
+// bug that took device linking down completely: every POST /device/link/start answered
+// 500 with
+//
+//	failed to encode args[7]: unable to encode 600 into text format for text (OID 25):
+//	cannot find encode plan
+//
+// `NOW() + ($8 || ' seconds')::INTERVAL` looks harmless, but `||` has only a text
+// overload, so PostgreSQL infers $8 as text and pgx v5 will not encode an int64 into a
+// text parameter. The working form multiplies instead: `NOW() + $8 * INTERVAL '1 second'`
+// takes the numeric straight through.
+//
+// This runs without a database, which is the point — the DB-backed test below skips when
+// Docker is absent, and this class of break must not depend on Docker being present to
+// be noticed.
+func TestTTLIntervalsAreNotStringConcatenated(t *testing.T) {
+	raw, err := os.ReadFile("device_token_repository.go")
+	if err != nil {
+		t.Fatalf("failed to read the repository source: %v", err)
+	}
+	// Comments are stripped first, because the statements above are commented with the
+	// broken form as a warning — a naive scan would flag the documentation as the bug.
+	var code strings.Builder
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		code.WriteString(line)
+		code.WriteString("\n")
+	}
+	source := code.String()
+
+	if strings.Contains(source, "|| ' seconds')") {
+		t.Error("a TTL is being concatenated into an INTERVAL again. `($n || ' seconds')::INTERVAL` " +
+			"types the parameter as text, and pgx v5 cannot encode an int64 into text — every call " +
+			"fails with a 500 (\"cannot find encode plan\"). Use `$n * INTERVAL '1 second'`.")
+	}
+	// Three statements take a TTL parameter — CreateLinkRequest, ApproveLinkRequest and
+	// CreateDeviceToken — and all three must use the multiplied form. Counted rather than
+	// matched literally so reindenting a query does not fail the test for no reason.
+	if got := strings.Count(source, "* INTERVAL '1 second'"); got != 3 {
+		t.Errorf("found %d multiplied TTL intervals, want 3 (CreateLinkRequest, "+
+			"ApproveLinkRequest, CreateDeviceToken). If a statement was added or removed, "+
+			"update this count — but every TTL parameter must still be multiplied, not "+
+			"concatenated.", got)
+	}
+}
+
+// TestDeviceLinkTTLsExecuteAgainstRealPostgres is the half that would actually have
+// caught the outage. Everything else in this file, and every test in
+// handlers/device_link_test.go, asserts against strings or a fake store — so all of them
+// stayed green while all three statements were unexecutable. A parameter-type mismatch
+// only exists once PostgreSQL is asked to plan the query, which means the only test that
+// can see it is one that runs it.
+//
+// It drives the real repository against the real migration set: open a link request,
+// approve it, mint the token. Each step asserts the expiry actually landed the configured
+// TTL in the future, because "the statement ran" and "the interval was computed from the
+// argument" are different claims and only the second one is useful.
+func TestDeviceLinkTTLsExecuteAgainstRealPostgres(t *testing.T) {
+	pool, cleanup := setupMigrationTestDB(t)
+	defer cleanup()
+	runMigrations(t, pool, loadUpMigrations(t))
+
+	ctx := context.Background()
+
+	// The two FK targets a device token needs: an owner and an overlay of theirs.
+	var userID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO users (twitch_id, auth_provider, username, display_name,
+		                   access_token, refresh_token, token_expires_at)
+		VALUES ('990001', 'twitch', 'interval_canary', 'Interval Canary',
+		        'access-token', 'refresh-token', NOW() + INTERVAL '4 hours')
+		RETURNING id::text`).Scan(&userID); err != nil {
+		t.Fatalf("failed to insert the owning user: %v", err)
+	}
+	var overlayID string
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO overlays (user_id, name) VALUES ($1, 'canary overlay')
+		RETURNING id::text`, userID).Scan(&overlayID); err != nil {
+		t.Fatalf("failed to insert the overlay: %v", err)
+	}
+
+	repo := NewDeviceTokenRepository(pool)
+
+	// 1. CreateLinkRequest — the statement behind POST /device/link/start, the one the
+	//    bug report was filed against.
+	req, err := repo.CreateLinkRequest(ctx, FlowLoopback, nil,
+		"a-pkce-challenge", "S256", "http://127.0.0.1:41234/callback",
+		"Stream Deck", []string{"chat:write", "engagement:write"}, LinkRequestTTL)
+	if err != nil {
+		t.Fatalf("CreateLinkRequest failed against a real PostgreSQL: %v\n\n"+
+			"This is the exact failure users saw as a stuck \"Starting…\" and a 500.", err)
+	}
+	assertTTLLanded(t, pool, "CreateLinkRequest", LinkRequestTTL,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_link_requests WHERE id = $1`, req.ID)
+
+	// 2. ApproveLinkRequest — the streamer pressing Approve.
+	authCode := sha256.Sum256([]byte("an-auth-code"))
+	approved, err := repo.ApproveLinkRequest(ctx, req.ID, userID, overlayID,
+		[]string{"chat:write"}, "Stream Deck", authCode[:], AuthCodeTTL)
+	if err != nil {
+		t.Fatalf("ApproveLinkRequest failed against a real PostgreSQL: %v", err)
+	}
+	assertTTLLanded(t, pool, "ApproveLinkRequest", AuthCodeTTL,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((auth_code_expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_link_requests WHERE id = $1`, approved.ID)
+
+	// 3. CreateDeviceToken — minting the credential the plugin ends up holding, with the
+	//    lifetime the production caller passes.
+	tokenHash := sha256.Sum256([]byte("a-device-token"))
+	device, err := repo.CreateDeviceToken(ctx, userID, overlayID, "Stream Deck",
+		tokenHash[:], []string{"chat:write"}, middleware.DeviceTokenLifetime, req.ID)
+	if err != nil {
+		t.Fatalf("CreateDeviceToken failed against a real PostgreSQL: %v", err)
+	}
+	assertTTLLanded(t, pool, "CreateDeviceToken", middleware.DeviceTokenLifetime,
+		`SELECT EXTRACT(EPOCH FROM
+		          ((expires_at AT TIME ZONE current_setting('TimeZone')) - NOW()))
+		   FROM device_tokens WHERE id = $1`, device.ID)
+}
+
+// assertTTLLanded checks an expiry landed one TTL in the future rather than merely being
+// set: a statement that silently computed a zero interval would still have "worked".
+//
+// The remaining time is measured BY POSTGRESQL, not by comparing a scanned timestamp
+// against Go's clock. These columns are `timestamp without time zone` while NOW() is a
+// timestamptz, so on a server outside UTC the stored value is local wall-clock and pgx
+// hands it back as though it were UTC. Comparing that against Go's clock reports a
+// whole-hour error while the interval itself is perfectly correct, and a TTL spanning a
+// DST change (the 90-day one does) is off by the DST offset on top. Converting the column
+// back to an absolute instant with `AT TIME ZONE current_setting('TimeZone')` makes the
+// assertion exact on any server timezone rather than only on a UTC one.
+func assertTTLLanded(t *testing.T, pool *pgxpool.Pool, what string, ttl time.Duration, query, id string) {
+	t.Helper()
+	var seconds float64
+	if err := pool.QueryRow(context.Background(), query, id).Scan(&seconds); err != nil {
+		t.Fatalf("%s: failed to read back the expiry: %v", what, err)
+	}
+	got := time.Duration(seconds * float64(time.Second))
+	// Generous slack: the assertion is that the interval was derived from the argument at
+	// all, not that it is accurate to the millisecond.
+	const slack = 2 * time.Minute
+	if got < ttl-slack || got > ttl+slack {
+		t.Errorf("%s: expiry is %v away, want ~%v. The TTL argument is not reaching the "+
+			"interval.", what, got.Round(time.Second), ttl)
 	}
 }

--- a/shared/middleware/devicetoken.go
+++ b/shared/middleware/devicetoken.go
@@ -217,10 +217,18 @@ const resolveDeviceTokenSQL = `
 // polling the active poll every second does not write on every request. The throttle
 // costs nothing in expiry terms: skipping a renewal for up to a minute out of a 90-day
 // window is not observable.
+//
+// The lifetime is MULTIPLIED into an interval, not concatenated into one. `||` has only
+// a text overload, so `($2 || ' seconds')::INTERVAL` types $2 as text and pgx v5 then
+// refuses to encode the int64 lifetime into it. Because this statement is best-effort
+// and its error is only logged at Debug, that failure was SILENT: last_used_at was never
+// recorded and the expiry never slid, so a device token quietly expired 90 days after it
+// was minted no matter how much the deck was used — the opposite of what the comment
+// above promises. Do not reintroduce the concatenation.
 const touchDeviceTokenSQL = `
 	UPDATE device_tokens
 	   SET last_used_at = NOW(),
-	       expires_at   = NOW() + ($2 || ' seconds')::INTERVAL
+	       expires_at   = NOW() + $2 * INTERVAL '1 second'
 	 WHERE id = $1
 	   AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL '1 minute')`
 

--- a/shared/middleware/devicetoken_test.go
+++ b/shared/middleware/devicetoken_test.go
@@ -372,3 +372,25 @@ func TestTokenResolverDispatch_PropagatesRealErrors(t *testing.T) {
 		t.Fatal("dispatcher swallowed a resolver failure")
 	}
 }
+
+func TestTouchDeviceTokenSQL_MultipliesTheLifetimeInsteadOfConcatenatingIt(t *testing.T) {
+	// This statement is best-effort by design and its failure is logged at Debug, which
+	// made it the worst place in the feature for a broken parameter type to hide.
+	//
+	// `expires_at = NOW() + ($2 || ' seconds')::INTERVAL` types $2 as text, because `||`
+	// has only a text overload, and pgx v5 refuses to encode the int64 lifetime into a
+	// text parameter. The UPDATE therefore errored on every authenticated request and
+	// nobody saw it: last_used_at was never written and the expiry never slid, so a
+	// device token expired 90 days after it was minted however heavily the deck was used.
+	// The comment on the constant promises the opposite, so this pins the mechanism that
+	// makes the promise true.
+	if strings.Contains(touchDeviceTokenSQL, "|| ' seconds')") {
+		t.Error("touchDeviceTokenSQL concatenates the lifetime into an INTERVAL again. That " +
+			"types the parameter as text, pgx v5 cannot encode an int64 into text, and because " +
+			"this write is best-effort the failure is invisible — device tokens silently stop " +
+			"being renewed. Use `$2 * INTERVAL '1 second'`.")
+	}
+	if !strings.Contains(touchDeviceTokenSQL, "$2 * INTERVAL '1 second'") {
+		t.Error("touchDeviceTokenSQL no longer derives the expiry from the lifetime parameter")
+	}
+}

--- a/streamcontroller-plugin/README.md
+++ b/streamcontroller-plugin/README.md
@@ -210,10 +210,16 @@ confirmed as `FRONTEND_URL` in `deployments/k8s/base/configmap.yaml`).
 | Setting    | Meaning                                                         |
 | ---------- | --------------------------------------------------------------- |
 | `message`  | The text to send. Max 500 characters.                           |
-| `platform` | `all` (default), `twitch`, `youtube`, `kick` or `tiktok`.       |
+| `platform` | `all` (default), `twitch`, `youtube` or `kick`.                 |
 
 `all` fans the message out to every connected platform in one press — the reason
 the action exists. Free; needs `chat:write`.
+
+**TikTok and Discord are not send targets.** All-Chat reads their chat onto your
+overlay, but TikTok publishes no API for posting into a live chat and a Discord
+source is a one-way relay, so neither can be posted to and neither is included in
+`all`. A key still set to `tiktok` from an earlier version says so when pressed
+instead of failing silently.
 
 ### Poll control
 

--- a/streamcontroller-plugin/about.json
+++ b/streamcontroller-plugin/about.json
@@ -2,7 +2,7 @@
   "id": "com_allchat_streamcontroller",
   "name": "All-Chat",
   "author": "caesarakalaeii",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": "https://github.com/caesarakalaeii/all-chat",
   "website": "https://allch.at",
   "license": "AGPL-3.0-or-later",

--- a/streamcontroller-plugin/actions/base.py
+++ b/streamcontroller-plugin/actions/base.py
@@ -37,7 +37,7 @@ from typing import Any, Mapping
 
 from allchat import errors
 from allchat.api import Connection
-from allchat.errors import AllChatError
+from allchat.errors import AllChatError, link_failure_message
 # Imported as a MODULE, not as names: the two flows are patched wholesale in the
 # tests, and `from ... import link_via_loopback` would bind the original function
 # into this namespace where a patch cannot reach it.
@@ -196,10 +196,11 @@ class AllChatActionBase(ActionBase):
             def work() -> None:
                 try:
                     self.start_linking(on_status)
-                except AllChatError as exc:
-                    on_status("failed", exc.message)
                 except Exception as exc:  # noqa: BLE001
-                    on_status("failed", f"Linking failed: {type(exc).__name__}: {exc}")
+                    # One handler for both cases: link_failure_message decides what a
+                    # streamer should read, including for a non-AllChatError, where the
+                    # old branch showed the exception's class name.
+                    on_status("failed", link_failure_message(exc))
                 finally:
                     button.set_sensitive(True)
 

--- a/streamcontroller-plugin/actions/send_message.py
+++ b/streamcontroller-plugin/actions/send_message.py
@@ -2,8 +2,12 @@
 
 One key press posts a canned message to one platform, or to every connected
 platform at once with ``platform = "all"``. This is the action ADR-0049 opens
-with: "a physical button that fans a message out to Twitch, YouTube, Kick, TikTok
-and Discord at once is the shortest path between an intent and five platforms."
+with: a physical button that fans a message out to every chat at once is the
+shortest path between an intent and several platforms.
+
+"Every chat" means every chat All-Chat can POST to: Twitch, YouTube and Kick. It
+is deliberately narrower than the platforms All-Chat READS, because TikTok and
+Discord have no send path -- see :data:`allchat.settings.UNSENDABLE_PLATFORMS`.
 
 Free on every account. It needs a PAT carrying ``chat:write``, which the gateway
 checks at the edge and auth-service checks again behind it, so a token minted
@@ -18,7 +22,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from allchat.api import send_chat_message
-from allchat.settings import PLATFORMS
+from allchat.settings import PLATFORMS, UNSENDABLE_PLATFORMS
 
 from .base import AllChatActionBase, ConfigurationError, connection_from, require
 
@@ -48,6 +52,16 @@ class SendMessageAction(AllChatActionBase):
             )
 
         platform = str(settings.get("platform") or DEFAULT_PLATFORM).strip().lower()
+        # A read-only platform is answered before the generic "not a platform" text.
+        # Both are refusals, but only this one is a property of the platform rather
+        # than a typo, and a streamer who picked TikTok deserves the reason instead of
+        # a list it is missing from. Keys configured while TikTok was still offered
+        # land here on their next press.
+        if platform in UNSENDABLE_PLATFORMS:
+            raise ConfigurationError(
+                f"{UNSENDABLE_PLATFORMS[platform]} Point this key at one of: "
+                f"{', '.join(PLATFORMS)}."
+            )
         if platform not in PLATFORMS:
             raise ConfigurationError(
                 f"\"{platform}\" is not a platform All-Chat sends to. Choose one of: "

--- a/streamcontroller-plugin/allchat/api.py
+++ b/streamcontroller-plugin/allchat/api.py
@@ -69,9 +69,13 @@ def _premium(exc: AllChatError, what: str) -> AllChatError:
 def send_chat_message(conn: Connection, message: str, platform: str) -> Any:
     """Sends a chat message as the token's owner.
 
-    ``platform`` is one of ``twitch``, ``youtube``, ``kick``, ``tiktok``, or
-    ``all`` to fan out to every connected platform. Both fields are required by
-    the server. Not premium-gated; needs the ``chat:write`` scope.
+    ``platform`` is one of ``twitch``, ``youtube``, ``kick``, or ``all`` to fan out
+    to every connected one of those three. Both fields are required by the server.
+    Not premium-gated; needs the ``chat:write`` scope.
+
+    TikTok and Discord are NOT valid here even though All-Chat reads their chat:
+    the server answers 501 and 400 respectively. See
+    :data:`allchat.settings.UNSENDABLE_PLATFORMS`.
     """
     return post(
         base_url=conn.base_url,

--- a/streamcontroller-plugin/allchat/errors.py
+++ b/streamcontroller-plugin/allchat/errors.py
@@ -47,6 +47,7 @@ from typing import Any, Mapping
 
 from .settings import (
     ACCOUNT_TOKENS_URL,
+    DEFAULT_BASE_URL,
     SCOPE_CHAT_WRITE,
     SCOPE_ENGAGEMENT_WRITE,
     UPGRADE_URL,
@@ -204,3 +205,59 @@ def forbidden_message(body: Any) -> str:
         f"gate. The usual cause is an overlay ID that belongs to a different account -- "
         f"check the overlay ID in this key's settings."
     )
+
+
+def link_failure_message(exc: BaseException) -> str:
+    """The subtitle shown under the Link button when a link attempt fails.
+
+    The row used to render ``exc.message`` verbatim, and anything that was not an
+    :class:`AllChatError` as ``f"Linking failed: {type(exc).__name__}: {exc}"`` --
+    an exception class name is not something to put in front of a streamer.
+
+    Most of those messages are written for the plugin log: they carry a URL, an
+    errno, an HTTP status or a server-supplied string. This translates the ones
+    that leak detail and deliberately passes the rest through, because several
+    are already good user-facing copy ("The pairing code expired before it was
+    approved. Start linking again.") and replacing those with something generic
+    would be a downgrade. The rule: an authored message with no status attached
+    is copy and survives; anything carrying transport or HTTP detail is replaced.
+
+    Mirrored by ``linkFailureMessage`` in the Stream Deck plugin's ``errors.ts``
+    (this module's header carries the file-level sync pointer). ADR-0049 counts
+    "what the button surfaces on failure" as part of the action contract, so the
+    two plugins must not tell a user two different things about one failure.
+    """
+    if not isinstance(exc, AllChatError):
+        # A TypeError or similar: implementation detail, nothing user-actionable.
+        return (
+            f"Linking did not complete. Press \"Link with All-Chat\" to try again, or "
+            f"paste a personal access token from {ACCOUNT_TOKENS_URL} instead."
+        )
+    if exc.kind == NETWORK:
+        # Unreachable host, DNS, TLS, a timeout, or a loopback port that could not
+        # be bound. All of them carry an errno or a URL in the message.
+        return (
+            "Could not reach All-Chat. Check your internet connection and try again. "
+            "If you self-host, check the Server field in this action's settings."
+        )
+    if exc.kind == FORBIDDEN:
+        return (
+            "The approval could not be verified, so nothing was linked. Press "
+            "\"Link with All-Chat\" and approve the device again."
+        )
+    if exc.kind == UNAUTHORIZED:
+        return unauthorized_message()
+    if exc.status is not None and exc.status >= 500:
+        return (
+            f"All-Chat could not complete the link because the server returned an error "
+            f"(HTTP {exc.status}). That is a fault on the server, not on this machine: "
+            f"try again in a few minutes, and report it if it keeps happening."
+        )
+    if exc.status is not None:
+        return (
+            f"All-Chat refused the link (HTTP {exc.status}). Make sure you are signed in "
+            f"at {DEFAULT_BASE_URL} as the account you want this action to control, then "
+            f"press \"Link with All-Chat\" again."
+        )
+    # No status: an authored message, e.g. the expired pairing code. Show it as written.
+    return exc.message

--- a/streamcontroller-plugin/allchat/settings.py
+++ b/streamcontroller-plugin/allchat/settings.py
@@ -63,8 +63,31 @@ LOOPBACK_PATH = "/allchat/device-callback"
 LOOPBACK_HOST = "127.0.0.1"
 
 #: Platforms accepted by ``POST /api/v1/auth/chat/send``. ``all`` fans the message
-#: out to every connected platform and returns a per-platform result.
-PLATFORMS = ("all", "twitch", "youtube", "kick", "tiktok")
+#: out to every connected platform and returns a per-platform result -- and fans out
+#: to exactly these three, see ``handleStreamerSendToAll`` in
+#: ``services/auth-service/handlers/chat_send.go``.
+#:
+#: This list is the SEND surface, which is narrower than the set of platforms
+#: All-Chat reads chat from. Keep it that way: an entry here that the server cannot
+#: post to is a button that fails on press, which is how ``tiktok`` shipped in both
+#: plugins' pickers while auth-service answered 501 to it.
+PLATFORMS = ("all", "twitch", "youtube", "kick")
+
+#: Platforms All-Chat READS but cannot POST to, with the reason. These are offered
+#: nowhere, but a key configured before they were removed still has one saved, so the
+#: value must be explained rather than reported as a typo.
+#:
+#: KEEP IN SYNC with ``streamdeck-plugin/src/allchat/settings.ts`` (ADR-0049).
+UNSENDABLE_PLATFORMS = {
+    "tiktok": (
+        "TikTok publishes no API for posting into a live chat, so All-Chat can show "
+        "TikTok chat on your overlay but cannot send to it."
+    ),
+    "discord": (
+        "A Discord source is a one-way relay into your overlay. All-Chat has no send "
+        "path back into a Discord channel."
+    ),
+}
 
 #: Scopes a PAT must carry for these actions, mirroring the constants in
 #: ``shared/middleware/apitoken.go``. Shown in error text so a user who minted a

--- a/streamcontroller-plugin/manifest.json
+++ b/streamcontroller-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "com_allchat_streamcontroller",
   "name": "All-Chat",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "app-version": "1.5.0-beta.8",
   "minimum-app-version": "1.5.0-beta.8",
   "github": "https://github.com/caesarakalaeii/all-chat",

--- a/streamcontroller-plugin/tests/test_linking.py
+++ b/streamcontroller-plugin/tests/test_linking.py
@@ -437,5 +437,50 @@ class StartLinkingWritesOnlySettingsTest(unittest.TestCase):
         self.assertNotIn("zzz", settings.redact(DEVICE_TOKEN))
 
 
+class LinkFailureMessageTest(unittest.TestCase):
+    """What the Link row says when a link attempt fails.
+
+    The row used to render raw exception text: ``exc.message`` for an
+    :class:`AllChatError` (a URL, an errno, an HTTP status, sometimes a
+    server-supplied string) and ``f"{type(exc).__name__}: {exc}"`` for anything
+    else. Both are log material, not something to show a streamer mid-stream.
+
+    These assertions pin the two halves of the rule: detail-bearing failures are
+    translated, and authored copy is left alone.
+    """
+
+    def test_a_plain_exception_never_shows_its_class_name(self) -> None:
+        message = errors.link_failure_message(TypeError("cannot read property of undefined"))
+        self.assertNotIn("TypeError", message)
+        self.assertNotIn("undefined", message)
+        self.assertIn("Link with All-Chat", message)
+
+    def test_a_transport_failure_does_not_leak_the_url_or_errno(self) -> None:
+        exc = AllChatError(
+            errors.NETWORK,
+            "Could not reach All-Chat at https://allch.at/api/v1/x: ECONNREFUSED",
+        )
+        message = errors.link_failure_message(exc)
+        self.assertNotIn("ECONNREFUSED", message)
+        self.assertNotIn("/api/v1/", message)
+        self.assertIn("internet connection", message)
+
+    def test_a_server_error_is_named_as_the_servers_fault(self) -> None:
+        # The bug this whole change came from: POST /device/link/start answered 500
+        # for every user. "Try again in a few minutes" is the only useful advice, and
+        # blaming the user's connection for it would be wrong.
+        exc = AllChatError(errors.HTTP_ERROR, "All-Chat refused to start linking (HTTP 500)", 500)
+        message = errors.link_failure_message(exc)
+        self.assertIn("500", message)
+        self.assertIn("server", message)
+        self.assertNotIn("internet connection", message)
+
+    def test_authored_copy_with_no_status_survives_verbatim(self) -> None:
+        # This one is already the right thing to show. Replacing it with a generic
+        # "linking failed" would lose the only sentence that tells the user what to do.
+        authored = "The pairing code expired before it was approved. Start linking again."
+        self.assertEqual(authored, errors.link_failure_message(AllChatError(errors.HTTP_ERROR, authored)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/streamcontroller-plugin/tests/test_routes_and_settings.py
+++ b/streamcontroller-plugin/tests/test_routes_and_settings.py
@@ -169,6 +169,37 @@ class ValidationTest(unittest.TestCase):
             self.assertEqual(base.STATE_ERROR, action.run_action())
         urlopen.assert_not_called()
 
+    def test_send_platforms_are_the_ones_the_server_posts_to(self) -> None:
+        """Narrower than the platforms All-Chat READS, deliberately.
+
+        auth-service posts to Twitch, YouTube and Kick; ``all`` fans out to exactly
+        those (``handleStreamerSendToAll``). TikTok answers 501 and Discord 400, so
+        offering either is a key that fails on press -- which is what shipped, until
+        a streamer asked why TikTok did nothing.
+        """
+        self.assertEqual(("all", "twitch", "youtube", "kick"), settings.PLATFORMS)
+        for platform in ("tiktok", "discord"):
+            self.assertNotIn(platform, settings.PLATFORMS)
+            self.assertIn(platform, settings.UNSENDABLE_PLATFORMS)
+
+    def test_read_only_platform_is_refused_with_the_reason(self) -> None:
+        """A key saved while TikTok was still offered must explain itself.
+
+        The generic "not a platform All-Chat sends to" would read as a typo for a
+        value this plugin's own picker used to contain, so the refusal names the
+        cause instead. Still local: no request is made.
+        """
+        action = make_action(SendMessageAction, message="hi", platform="tiktok")
+        with mock.patch.object(action, "show_state") as show_state:
+            with mock.patch("urllib.request.urlopen") as urlopen:
+                self.assertEqual(base.STATE_ERROR, action.run_action())
+        urlopen.assert_not_called()
+
+        message = show_state.call_args[0][1]
+        self.assertIn("TikTok", message)
+        self.assertIn("no API", message)
+        self.assertNotIn("is not a platform", message)
+
     def test_missing_overlay_id_is_rejected_locally(self) -> None:
         action = make_action(PollControlAction, mode="close")
         with mock.patch("urllib.request.urlopen") as urlopen:

--- a/streamdeck-plugin/README.md
+++ b/streamdeck-plugin/README.md
@@ -207,8 +207,14 @@ no trailing slash.
 ### Send Chat Message
 
 Sends a fixed message to your chat on key-down. Configure the message text and a
-target platform — `twitch`, `youtube`, `kick`, `tiktok`, or `all` to fan out to
-every connected platform. Free on every account.
+target platform — `twitch`, `youtube`, `kick`, or `all` to fan out to every
+connected one of those three. Free on every account.
+
+**TikTok and Discord are not send targets.** All-Chat reads their chat onto your
+overlay, but TikTok publishes no API for posting into a live chat and a Discord
+source is a one-way relay, so neither can be posted to and neither is included in
+`all`. A key still configured for TikTok from an earlier version says so when
+pressed instead of failing silently.
 
 ### Poll Control
 

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/manifest.json
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.elgato.com/streamdeck/plugins/manifest.json",
 	"Name": "All-Chat",
-	"Version": "0.1.0.0",
+	"Version": "0.1.1.0",
 	"Author": "caesarakalaeii",
 	"Description": "Drive your All-Chat account from hardware keys: send chat messages, and start or close polls and predictions. Free plugin; starting polls and predictions needs All-Chat premium.",
 	"Category": "All-Chat",

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-link.js
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-link.js
@@ -1,0 +1,137 @@
+/*
+	The "Link with All-Chat" button, shared by all three property inspectors.
+
+	This script's only job is to ask the plugin to run the device-link flow (ADR-0049)
+	and to render what comes back. It never sees a credential: the plugin writes the
+	device token straight into the key's settings, so there is nothing here to display,
+	copy or leak.
+
+	It lives in one file rather than inline in each page for the reason ADR-0049 gives
+	for the parity gate: three copies of the same logic diverge. It was already three
+	copies, and the button-state handling below would have made it three copies of
+	something worth getting right once.
+
+	Loaded at the end of <body>, after the sdpi-components script in <head>, so the
+	SDPIComponents global is available at parse time.
+*/
+(() => {
+	const button = document.getElementById("allchat-link");
+	const status = document.getElementById("allchat-link-status");
+	if (!button || !status) {
+		return;
+	}
+
+	/*
+		How long to wait for a terminal message before releasing the button.
+
+		The plugin reports "linked" or "failed" on every path it can reach, but if it
+		never reports at all — the flow throws somewhere outside the reporting block, the
+		plugin process dies, the message is dropped because the inspector was
+		re-rendered — the old UI sat on "Starting…" with a dead button and no way back
+		except reopening the key's settings. That is exactly what the bug report
+		described, so the recovery is built in rather than assumed away.
+
+		11 minutes is just past the longest flow: the pairing-code path gives the user
+		600s (CODE_FLOW_TIMEOUT_MS in src/allchat/linking.ts), the loopback path 180s.
+		Anything still silent past that is not slow, it is gone.
+	*/
+	const WATCHDOG_MS = 660_000;
+
+	/** Statuses after which the flow is over and the button is usable again. */
+	const TERMINAL = new Set(["linked", "failed"]);
+
+	let watchdog;
+
+	const clearWatchdog = () => {
+		if (watchdog !== undefined) {
+			clearTimeout(watchdog);
+			watchdog = undefined;
+		}
+	};
+
+	/**
+	 * Renders a state.
+	 *
+	 * `data-state` drives the colour and the ⚠ / ✓ marker from allchat-pi.css. The
+	 * pairing code is appended as an element rather than interpolated into a string so
+	 * it can be given its own line and monospace face, and it is set with textContent
+	 * rather than innerHTML: it comes off the wire, and nothing off the wire is parsed
+	 * as markup here.
+	 */
+	const render = (state, detail, userCode) => {
+		status.dataset.state = state;
+		status.textContent = detail ?? "";
+		if (userCode) {
+			const code = document.createElement("span");
+			code.className = "allchat-code";
+			code.textContent = userCode;
+			status.appendChild(code);
+		}
+	};
+
+	const finish = (state, detail) => {
+		clearWatchdog();
+		button.disabled = false;
+		render(state, detail);
+	};
+
+	button.addEventListener("click", () => {
+		// Guard as well as disable: a queued click on an already-disabled button would
+		// otherwise start a second concurrent flow, and two flows racing to write the
+		// same key's settings means the surviving credential is whichever finished last.
+		if (button.disabled) {
+			return;
+		}
+		button.disabled = true;
+		render("working", "Starting…");
+
+		clearWatchdog();
+		watchdog = setTimeout(() => {
+			finish(
+				"failed",
+				"Linking timed out with no answer from the plugin. Press Link to try again, " +
+					"or paste a personal access token instead.",
+			);
+		}, WATCHDOG_MS);
+
+		SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
+	});
+
+	/*
+		`sendToPropertyInspector` is the observable that carries messages from the plugin.
+
+		The pages used to subscribe to `didReceivePropertyInspectorMessage`, which does not
+		exist on sdpi-components' client — its members are `message`,
+		`didReceiveSettings`, `didReceiveGlobalSettings` and `sendToPropertyInspector`.
+		Reading `.subscribe` off `undefined` threw a TypeError at parse time, and because
+		the click listener was registered on the line ABOVE it, the button still worked
+		while no status update could ever arrive. That is the second half of the reported
+		bug: pressing Link set "Starting…" and nothing was ever able to replace it, so the
+		panel sat there for good even once the server stopped answering 500.
+
+		The observable dispatches the whole Stream Deck message, so the plugin's own
+		payload is one level down in `message.payload`.
+	*/
+	SDPIComponents.streamDeckClient.sendToPropertyInspector.subscribe((message) => {
+		const payload = message?.payload;
+		if (!payload || payload.event !== "link-status") {
+			return;
+		}
+
+		const state = payload.status;
+
+		if (state === "code" && payload.userCode) {
+			// Not terminal: the plugin is still polling for the approval, so the button
+			// stays disabled and the watchdog keeps running.
+			render("code", payload.detail ?? "Enter this code at allch.at/link:", payload.userCode);
+			return;
+		}
+
+		if (TERMINAL.has(state)) {
+			finish(state, payload.detail ?? state);
+			return;
+		}
+
+		render("working", payload.detail ?? state ?? "");
+	});
+})();

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-pi.css
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/allchat-pi.css
@@ -1,0 +1,176 @@
+/*
+	Page styling for the All-Chat property inspectors.
+
+	WHY THIS FILE EXISTS
+
+	sdpi-components styles its own custom elements and nothing else. Worse, it declares
+	its palette on `:host` INSIDE each component's shadow root:
+
+		:host { --window-bg-color:#2d2d2d; --font-color:#969696; --input-font-color:#d8d8d8; ... }
+
+	Custom properties inherit downwards, so those variables are visible inside a
+	component and to its light-DOM children, but NOT to the page around them. Nothing
+	sets a page-level colour at all, which left every native element we use (h4, p,
+	span, code, summary, a) on the browser default of black text over the Stream Deck
+	property inspector's dark panel: roughly 1.52:1 against #2d2d2d, where WCAG AA asks
+	for 4.5:1. Rendered, but not readable.
+
+	Two consequences worth spelling out, because both are easy to get wrong:
+
+	  * `body { color: var(--font-color) }` does NOT work. The variable is undefined at
+	    page scope, the declaration is invalid at computed-value time, and `color` then
+	    falls back to inheritance from the root element: black again. Any fix has to
+	    declare its own values rather than borrow the library's.
+	  * The BACKGROUND is set here as well as the foreground. Light text is only safe if
+	    we also own what is behind it, and the panel background is painted by the host
+	    app rather than by anything in this folder.
+
+	The values mirror sdpi-components' own palette so native text sits beside the
+	components without looking pasted in. The library ships no light theme (it contains
+	no prefers-color-scheme rule anywhere), so a single dark palette is the whole story
+	and a media query would be inventing a mode that does not exist.
+
+	Contrast against #2d2d2d, measured, all passing WCAG 2.2 AA for normal text:
+	  --allchat-fg        #d8d8d8   9.66:1
+	  --allchat-fg-muted  #969696   4.66:1
+	  --allchat-error     #ff8a8a   6.07:1
+	  --allchat-success   #81c995   7.03:1
+	  --allchat-link      #8ab4f8   6.53:1
+	  code / pairing code #ffffff  13.77:1
+
+	KEEP IN SYNC: loaded by send-message.html, poll-control.html and
+	prediction-control.html. It is one file precisely because ADR-0049 names drift
+	between duplicated surfaces as the standing risk in this folder.
+*/
+
+:root {
+	--allchat-bg: #2d2d2d;
+	--allchat-fg: #d8d8d8;
+	--allchat-fg-muted: #969696;
+	--allchat-error: #ff8a8a;
+	--allchat-success: #81c995;
+	--allchat-link: #8ab4f8;
+	--allchat-input-bg: #3d3d3d;
+}
+
+body {
+	background-color: var(--allchat-bg);
+	color: var(--allchat-fg);
+}
+
+/* The default UA link colour (#0000ee) is 1.47:1 here, so the help section's links to
+   allch.at were as unreadable as the prose around them. */
+a {
+	color: var(--allchat-link);
+}
+
+h4 {
+	color: var(--allchat-fg);
+}
+
+code {
+	color: #ffffff;
+}
+
+/* `summary` is the only affordance that opens the help section, so it reads as
+   interactive rather than as another line of body text. */
+summary {
+	color: var(--allchat-fg-muted);
+	cursor: pointer;
+}
+
+summary:hover {
+	color: var(--allchat-fg);
+}
+
+/*
+	The Link button. A native <button> does not inherit `color` (the UA stylesheet sets
+	`color: buttontext`), so it needs styling of its own regardless of the rules above,
+	and an unstyled one renders as a light OS-native button on a dark panel.
+
+	Sized and bordered like sdpi-components' own sdpi-button, but on the input
+	background rather than the window background so it reads as a control instead of a
+	rectangle of border.
+*/
+#allchat-link {
+	background-color: var(--allchat-input-bg);
+	color: var(--allchat-fg);
+	border: 1px solid var(--allchat-fg-muted);
+	border-radius: 3px;
+	padding: 6px 12px;
+	font: inherit;
+	cursor: pointer;
+}
+
+#allchat-link:not(:disabled):hover {
+	background-color: #464646;
+}
+
+/*
+	Disabled means "a link attempt is already running". 0.5 is sdpi-components'
+	--opacity-disabled, and the progress cursor says the wait is expected rather than
+	broken. Opacity alone would be a colour-only signal, so the cursor carries it too.
+*/
+#allchat-link:disabled {
+	opacity: 0.5;
+	cursor: progress;
+}
+
+/*
+	Link status.
+
+	Every state used to render as the same unstyled span, so "Linked." and a hard
+	failure were typographically identical and a user who glanced at the panel had no
+	way to tell that one of them needed action. The state is published by
+	allchat-link.js as a data-state attribute and styled here.
+*/
+/* Block, so it stacks under the button inside the same sdpi-item rather than sitting in
+   a separate labelled row. sdpi-item renders its slot into a plain block div, so this is
+   all the stacking needs. It used to be its own `sdpi-item label="Status"`, which read
+   as an independent setting instead of as feedback from the button above it. */
+#allchat-link-status {
+	display: block;
+	margin-top: 6px;
+	line-height: 1.4;
+}
+
+#allchat-link-status[data-state="idle"] {
+	color: var(--allchat-fg-muted);
+}
+
+#allchat-link-status[data-state="working"],
+#allchat-link-status[data-state="code"] {
+	color: var(--allchat-fg);
+}
+
+#allchat-link-status[data-state="linked"] {
+	color: var(--allchat-success);
+}
+
+#allchat-link-status[data-state="failed"] {
+	color: var(--allchat-error);
+}
+
+/* A marker as well as a colour, so the failure state is not signalled by hue alone
+   (WCAG 1.4.1). */
+#allchat-link-status[data-state="failed"]::before {
+	content: "⚠ ";
+}
+
+#allchat-link-status[data-state="linked"]::before {
+	content: "✓ ";
+}
+
+/*
+	The pairing code is the one thing on the page a user has to read off the screen and
+	retype, so it gets a line of its own, a monospace face and letter spacing. White
+	rather than --allchat-fg: it is the payload, not prose.
+*/
+.allchat-code {
+	display: block;
+	margin-top: 4px;
+	font-family: "Consolas", "Menlo", monospace;
+	font-size: 1.4em;
+	letter-spacing: 0.18em;
+	color: #ffffff;
+}

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/poll-control.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/poll-control.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Poll Control</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<!--
@@ -72,12 +79,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -123,36 +133,6 @@
 			</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/prediction-control.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/prediction-control.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Prediction Control</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<!--
@@ -81,12 +88,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -135,36 +145,6 @@
 			</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>All-Chat — Send Chat Message</title>
 		<script src="https://sdpi-components.dev/releases/v4/sdpi-components.js"></script>
+		<!--
+			sdpi-components styles only its own custom elements, and declares its palette
+			inside their shadow roots, so every native element on this page (h4, p, span,
+			code, summary, a) rendered as black text on the dark property-inspector panel.
+			allchat-pi.css owns the page palette; see the comment at the top of it.
+		-->
+		<link rel="stylesheet" href="allchat-pi.css" />
 	</head>
 	<body>
 		<sdpi-item label="Message">
@@ -43,12 +50,15 @@
 		-->
 		<sdpi-item label="Linking">
 			<button id="allchat-link">Link with All-Chat</button>
-		</sdpi-item>
+			<!--
+				The status sits inside this row, under the button it belongs to, rather
+				than in a separate `label="Status"` row that read as an independent
+				setting instead of as feedback from the button.
 
-		<sdpi-item label="Status">
-			<!-- aria-live so a screen reader announces the pairing code and the
-			     outcome without the user having to hunt for it. -->
-			<span id="allchat-link-status" role="status" aria-live="polite"
+				aria-live so a screen reader announces the pairing code and the outcome
+				without the user having to hunt for it.
+			-->
+			<span id="allchat-link-status" role="status" aria-live="polite" data-state="idle"
 				>Not linked yet.</span
 			>
 		</sdpi-item>
@@ -96,36 +106,6 @@
 			<p>Sending chat messages is free on every All-Chat account.</p>
 		</details>
 
-		<script>
-			/*
-				The Link button's only job is to ask the plugin to run the flow and to
-				render what comes back. It never sees a credential: the plugin writes
-				the device token straight into this key's settings, so there is nothing
-				here to display, copy or leak.
-			*/
-			const linkButton = document.getElementById("allchat-link");
-			const linkStatus = document.getElementById("allchat-link-status");
-
-			linkButton.addEventListener("click", () => {
-				linkStatus.textContent = "Starting…";
-				SDPIComponents.streamDeckClient.send("sendToPlugin", { event: "link" });
-			});
-
-			SDPIComponents.streamDeckClient.didReceivePropertyInspectorMessage.subscribe(
-				(message) => {
-					const payload = message?.payload;
-					if (!payload || payload.event !== "link-status") {
-						return;
-					}
-					if (payload.status === "code" && payload.userCode) {
-						linkStatus.textContent =
-							`Enter this code at allch.at/link: ${payload.userCode}. ` +
-							(payload.detail ?? "");
-						return;
-					}
-					linkStatus.textContent = payload.detail ?? payload.status ?? "";
-				},
-			);
-		</script>
+		<script src="allchat-link.js"></script>
 	</body>
 </html>

--- a/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
+++ b/streamdeck-plugin/com.allchat.streamdeck.sdPlugin/ui/send-message.html
@@ -22,13 +22,21 @@
 			></sdpi-textarea>
 		</sdpi-item>
 
+		<!--
+			These four and no others. The option list is the SEND surface, which is
+			narrower than the platforms All-Chat reads chat from: TikTok publishes no
+			API for posting into a live chat and Discord sources are a one-way relay,
+			so neither can be a target here. TikTok was offered until a streamer asked
+			why the button did nothing — the server had been answering 501 to it all
+			along. KEEP IN SYNC with PLATFORMS in src/allchat/settings.ts; the parity
+			script asserts these match.
+		-->
 		<sdpi-item label="Platform">
 			<sdpi-select setting="platform" default="all">
 				<option value="all">All connected platforms</option>
 				<option value="twitch">Twitch</option>
 				<option value="youtube">YouTube</option>
 				<option value="kick">Kick</option>
-				<option value="tiktok">TikTok</option>
 			</sdpi-select>
 		</sdpi-item>
 

--- a/streamdeck-plugin/eslint.config.js
+++ b/streamdeck-plugin/eslint.config.js
@@ -25,4 +25,24 @@ export default tseslint.config(
 			"prefer-const": "error",
 		},
 	},
+	{
+		// Property inspector scripts. These run in the Stream Deck app's embedded
+		// browser, not in the plugin's Node process, so they need browser globals plus
+		// the `SDPIComponents` global that sdpi-components.js installs.
+		//
+		// They are linted at all only because they were moved out of inline <script>
+		// blocks in the three HTML pages, where ESLint never saw them. The global list
+		// is enumerated rather than pulled in wholesale from `globals.browser`: a
+		// property inspector should be touching almost nothing, and a new name showing
+		// up here is worth noticing.
+		files: ["com.allchat.streamdeck.sdPlugin/ui/**/*.js"],
+		languageOptions: {
+			globals: {
+				document: "readonly",
+				setTimeout: "readonly",
+				clearTimeout: "readonly",
+				SDPIComponents: "readonly",
+			},
+		},
+	},
 );

--- a/streamdeck-plugin/package-lock.json
+++ b/streamdeck-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allchat-streamdeck-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allchat-streamdeck-plugin",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@elgato/streamdeck": "2.1.1",

--- a/streamdeck-plugin/package.json
+++ b/streamdeck-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allchat-streamdeck-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Elgato Stream Deck plugin for All-Chat: send chat messages and drive polls / predictions from hardware keys.",

--- a/streamdeck-plugin/src/actions/base.ts
+++ b/streamdeck-plugin/src/actions/base.ts
@@ -25,6 +25,7 @@ import streamDeck, {
 
 import {
 	AllChatError,
+	linkFailureMessage,
 	malformedTokenMessage,
 	missingTokenMessage,
 	premiumGateMessage,
@@ -171,16 +172,18 @@ export abstract class AllChatAction<
 					report("linked", `Linked. Revoke this device any time at ${ACCOUNT_DEVICES_URL}.`);
 					return;
 				} catch (fallbackError) {
+					// The raw reason goes to the log; the property inspector gets copy a
+					// streamer can act on. See linkFailureMessage.
 					const reason =
 						fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
 					logger.error(`${this.label}: linking failed — ${reason}`);
-					report("failed", reason);
+					report("failed", linkFailureMessage(fallbackError));
 					return;
 				}
 			}
 			const reason = error instanceof Error ? error.message : String(error);
 			logger.error(`${this.label}: linking failed — ${reason}`);
-			report("failed", reason);
+			report("failed", linkFailureMessage(error));
 		}
 	}
 

--- a/streamdeck-plugin/src/actions/send-message.ts
+++ b/streamdeck-plugin/src/actions/send-message.ts
@@ -12,7 +12,7 @@ import { action, type KeyDownEvent } from "@elgato/streamdeck";
 
 import { sendChatMessage } from "../allchat/api.js";
 import { AllChatError } from "../allchat/errors.js";
-import type { SendMessageSettings } from "../allchat/settings.js";
+import { PLATFORMS, UNSENDABLE_PLATFORMS, type SendMessageSettings } from "../allchat/settings.js";
 import { AllChatAction } from "./base.js";
 
 /** Platform used when the key does not name one: fan out everywhere. */
@@ -35,7 +35,27 @@ export class SendMessageAction extends AllChatAction<SendMessageSettings> {
 				);
 			}
 
-			const platform = settings.platform?.trim() || DEFAULT_PLATFORM;
+			const platform = (settings.platform?.trim() || DEFAULT_PLATFORM).toLowerCase();
+
+			// A read-only platform is answered before the generic "not a platform"
+			// text. Both are refusals, but only this one is a property of the
+			// platform rather than a typo, and a streamer who picked TikTok deserves
+			// the reason instead of a list it is missing from. Keys configured while
+			// TikTok was still in the picker land here on their next press.
+			const unsendable = UNSENDABLE_PLATFORMS[platform];
+			if (unsendable) {
+				throw new AllChatError(
+					"not-configured",
+					`${unsendable} Point this key at one of: ${PLATFORMS.join(", ")}.`,
+				);
+			}
+			if (!(PLATFORMS as readonly string[]).includes(platform)) {
+				throw new AllChatError(
+					"not-configured",
+					`"${platform}" is not a platform All-Chat sends to. Choose one of: ${PLATFORMS.join(", ")}.`,
+				);
+			}
+
 			await sendChatMessage(conn, message, platform);
 
 			// Log the length rather than the text: a key can carry anything, and

--- a/streamdeck-plugin/src/allchat/api.ts
+++ b/streamdeck-plugin/src/allchat/api.ts
@@ -59,8 +59,11 @@ export type Prediction = {
 /**
  * Sends a chat message as the token's owner.
  *
- * `platform` is one of `twitch`, `youtube`, `kick`, `tiktok`, or `all` to fan
- * out to every connected platform. Not premium-gated.
+ * `platform` is one of `twitch`, `youtube`, `kick`, or `all` to fan out to every
+ * connected one of those three. Not premium-gated.
+ *
+ * TikTok and Discord are NOT valid here even though All-Chat reads their chat:
+ * the server answers 501 and 400 respectively. See `UNSENDABLE_PLATFORMS`.
  */
 export async function sendChatMessage(
 	conn: Connection,

--- a/streamdeck-plugin/src/allchat/errors.ts
+++ b/streamdeck-plugin/src/allchat/errors.ts
@@ -24,7 +24,7 @@
  * token", the other says "this is premium", and swapping them costs money.
  */
 
-import { UPGRADE_URL, ACCOUNT_TOKENS_URL } from "./settings.js";
+import { UPGRADE_URL, ACCOUNT_TOKENS_URL, DEFAULT_BASE_URL } from "./settings.js";
 
 /** Discriminator for the states a caller may want to react to differently. */
 export type AllChatErrorKind =
@@ -109,6 +109,71 @@ export function missingTokenMessage(): string {
 		`On a second machine or a headless host, paste a personal access token from ` +
 		`${ACCOUNT_TOKENS_URL} instead.`
 	);
+}
+
+/**
+ * The message the property inspector shows when a link attempt fails.
+ *
+ * The Link button used to render `error.message` verbatim. Most of those strings are
+ * built for the plugin log, not for a streamer looking at a settings panel: they carry a
+ * URL, an errno, an HTTP status and sometimes a server-supplied string. The worst case
+ * was a raw JavaScript error message for anything that was not an AllChatError at all.
+ *
+ * This translates only the messages that leak detail, and deliberately passes the others
+ * through — several of them are already good user-facing copy ("The pairing code expired
+ * before it was approved. Start linking again.") and replacing them with something
+ * generic would be a downgrade. The rule is: an authored message with no status attached
+ * is copy and survives; anything carrying transport or HTTP detail gets replaced.
+ *
+ * The raw message is still logged by the caller, so nothing is lost for debugging.
+ *
+ * Mirrored by `link_failure_message` in the StreamController plugin's `errors.py` (this
+ * module's header carries the file-level sync pointer). ADR-0049 counts "what the button
+ * surfaces on failure" as part of the action contract, so the two plugins must not tell a
+ * user two different things about one failure.
+ */
+export function linkFailureMessage(error: unknown): string {
+    if (!(error instanceof AllChatError)) {
+        // A TypeError or similar: implementation detail with no user-actionable content.
+        return (
+            `Linking did not complete. Press "Link with All-Chat" to try again, or paste a ` +
+            `personal access token from ${ACCOUNT_TOKENS_URL} instead.`
+        );
+    }
+    switch (error.kind) {
+        case "network":
+            // Covers an unreachable host, DNS, TLS, a timeout and a loopback port that
+            // could not be bound. All of them carry an errno or a URL in the message.
+            return (
+                `Could not reach All-Chat. Check your internet connection and try again. If you ` +
+                `self-host, check the Server field in this key's settings.`
+            );
+        case "forbidden":
+            return (
+                `The approval could not be verified, so nothing was linked. Press "Link with ` +
+                `All-Chat" and approve the device again.`
+            );
+        case "unauthorized":
+            return unauthorizedMessage();
+        default:
+            break;
+    }
+    if (error.status !== undefined && error.status >= 500) {
+        return (
+            `All-Chat could not complete the link because the server returned an error (HTTP ` +
+            `${error.status}). That is a fault on the server, not on this machine: try again in ` +
+            `a few minutes, and report it if it keeps happening.`
+        );
+    }
+    if (error.status !== undefined) {
+        return (
+            `All-Chat refused the link (HTTP ${error.status}). Make sure you are signed in at ` +
+            `${DEFAULT_BASE_URL} as the account you want this key to control, then press "Link ` +
+            `with All-Chat" again.`
+        );
+    }
+    // No status: an authored message, e.g. the expired pairing code. Show it as written.
+    return error.message;
 }
 
 /** The message shown/logged when the configured string is not an All-Chat credential. */

--- a/streamdeck-plugin/src/allchat/settings.ts
+++ b/streamdeck-plugin/src/allchat/settings.ts
@@ -74,6 +74,38 @@ export const LOOPBACK_PATH = "/allchat/device-callback";
  */
 export const LOOPBACK_HOST = "127.0.0.1";
 
+/**
+ * Platforms accepted by `POST /api/v1/auth/chat/send`. `all` fans the message out
+ * to every connected platform and returns a per-platform result — and fans out to
+ * exactly these three, see `handleStreamerSendToAll` in
+ * `services/auth-service/handlers/chat_send.go`.
+ *
+ * This list is the SEND surface, which is narrower than the set of platforms
+ * All-Chat reads chat from. Keep it that way: an entry here that the server cannot
+ * post to is a button that fails on press, which is how `tiktok` shipped in both
+ * plugins' pickers while auth-service answered 501 to it.
+ *
+ * The picker in `ui/send-message.html` offers these and nothing else; the parity
+ * script asserts that, because the picker is where the drift actually happened.
+ */
+export const PLATFORMS = ["all", "twitch", "youtube", "kick"] as const;
+
+/**
+ * Platforms All-Chat READS but cannot POST to, with the reason. These are offered
+ * nowhere, but a key configured before they were removed still has one saved, so the
+ * value must be explained rather than reported as a typo.
+ *
+ * KEEP IN SYNC with `streamcontroller-plugin/allchat/settings.py` (ADR-0049).
+ */
+export const UNSENDABLE_PLATFORMS: Readonly<Record<string, string>> = {
+	tiktok:
+		"TikTok publishes no API for posting into a live chat, so All-Chat can show " +
+		"TikTok chat on your overlay but cannot send to it.",
+	discord:
+		"A Discord source is a one-way relay into your overlay. All-Chat has no send " +
+		"path back into a Discord channel.",
+};
+
 /** Settings shared by all three action types. */
 export type ConnectionSettings = {
 	/**
@@ -93,7 +125,7 @@ export type ConnectionSettings = {
 export type SendMessageSettings = ConnectionSettings & {
 	/** Message text sent on key-down. */
 	message?: string;
-	/** Target platform: `twitch` | `youtube` | `kick` | `tiktok` | `all`. */
+	/** Target platform: one of {@link PLATFORMS}. */
 	platform?: string;
 };
 


### PR DESCRIPTION
Two Stream Deck fixes. Both were reported by streamers who had a button that did nothing and no way to tell why.

Closes #793. Closes #794.

## 1. Device linking was broken end to end (`7e0111c8`)

Two independent faults, both required for the flow to work at all:

- **Every `POST /device/link/start` returned 500.** `NOW() + ($n || ' seconds')::INTERVAL` types the parameter as text (`||` has only a text overload) and pgx v5 will not encode an int64 into a text parameter. Fixed at all **four** sites; #793 listed three and missed `touchDeviceTokenSQL` in `shared/middleware`. That fourth one is best-effort and logs at Debug, so it failed silently: `last_used_at` was never written and the expiry never slid, meaning device tokens expired 90 days after minting however heavily the deck was used, the opposite of what the code promises.
- **The status never updated**, which is why the panel sat on "Starting…" forever. The pages subscribed to `streamDeckClient.didReceivePropertyInspectorMessage`, which does not exist in sdpi-components v4. Reading `.subscribe` off `undefined` threw at parse time, and the click listener was registered on the line above, so the button worked while no reply could ever render. Fixing the SQL alone would still have left the panel stuck.

#794's premise was right and its fix was not: `--sdpi-color` does not exist, and sdpi-components declares its palette on `:host` inside each component's shadow root, so no library variable is reachable from `body`. The library injects `body,html{background-color:#2d2d2d}` and never sets a colour, leaving native elements at the UA default: black on dark grey, **1.52:1**. `allchat-pi.css` declares its own palette. Measured in Chromium against the real bundle, all ≥ 4.5:1: prose 9.66, code 13.77, links 6.53 (the UA link blue was 1.47:1, which #794 did not mention), button 7.62.

## 2. TikTok was offered as a chat send target (`15be7c66`)

> "Why did you add TikTok to the supported platforms if it's not possible to send messages in the TikTok chat through All-Chat?"

The streamer is right and it was our bug. Both plugins listed TikTok in the send-message platform picker, but `auth-service` has always answered `501` to it (`chat_send.go:520`): TikTok publishes no public API for posting into a live chat. The key did nothing on press, with no explanation.

The claim traces to ADR-0049's opening paragraph ("fans a message out to Twitch, YouTube, Kick, TikTok and Discord"), which describes the **read** surface. The **send** surface is Twitch, YouTube and Kick, and `all` fans out to exactly those three (`handleStreamerSendToAll`). `ChatSendBar.tsx` and `/docs` already had this right; only the two plugins drifted.

- Dropped TikTok from the Elgato picker and the Python `PLATFORMS` tuple.
- Added `UNSENDABLE_PLATFORMS` to both plugins, so a key still saved as `tiktok` refuses **with the reason**. The generic "not a platform All-Chat sends to" reads as a typo for a value our own picker offered until this PR.
- Pinned the send surface in `check-plugin-parity.py` across the TS constant, the Python constant **and the HTML picker**. The picker is a fourth source of truth that `tsc` never opens and no test read, which is exactly why this survived review. Verified by re-adding the option: the check fails with the drift named.

## Verification

- All four SQL statements run against a real PostgreSQL 16 with the full migration set, reproducing the reported error verbatim before the change and passing after.
- New DB-backed repository test asserting each TTL actually landed, measured by PostgreSQL rather than Go's clock so it holds on a non-UTC server. Nothing that existed could see either fault: the repository tests are DB-free shape assertions and the handler tests drive a fake store, so all of them stayed green while the statements were unexecutable.
- Source guards forbidding the concatenated SQL form in both files.
- StreamController plugin: 71 tests pass, including two new ones covering the send surface and the reasoned refusal.
- Stream Deck plugin: `npm run lint` (eslint + `tsc --noEmit`) and `npm run build` clean.
- `scripts/check-plugin-parity.py` passes; the new `check_send_platforms()` verified to fail on a reintroduced TikTok option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
