### PR TITLE
fix(support-bot): stop leaking the Grafana token, report timeouts, file every requested issue

### DIFF
--- a/services/support-bot/src/__tests__/agent.test.ts
+++ b/services/support-bot/src/__tests__/agent.test.ts
@@ -5,6 +5,7 @@ vi.mock('execa', () => ({
   execa: vi.fn(),
 }));
 
+import { access, readFile } from 'node:fs/promises';
 import { execa } from 'execa';
 import { queryCodebase } from '../claude/agent.js';
 
@@ -31,7 +32,7 @@ describe('queryCodebase', () => {
     const result = await queryCodebase('how does twitch work?', ['/repos/all-chat']);
 
     expect(result.answer).toBe('Twitch IRC is used for chat messages.');
-    expect(result.issueProposal).toBeNull();
+    expect(result.issueProposals).toEqual([]);
     expect(result.infraVerdict).toBeNull();
   });
 
@@ -78,18 +79,38 @@ describe('queryCodebase', () => {
     expect(allowedToolsValue).not.toContain('Edit');
   });
 
-  it('includes --mcp-config with grafana-caesar server when Grafana env vars are set', async () => {
-    mockExeca.mockResolvedValueOnce({
-      stdout: JSON.stringify({ result: 'Some answer' }),
-    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+  /**
+   * Reads whatever --mcp-config points at DURING the subprocess call, because the file is
+   * removed as soon as execa settles. Returns the path too, so a test can assert it is gone.
+   */
+  async function runCapturingMcpConfig(): Promise<{ path: string; contents: string }> {
+    let captured = { path: '', contents: '' };
+    mockExeca.mockImplementationOnce((async (_file: unknown, args: unknown) => {
+      const list = args as string[];
+      const path = list[list.indexOf('--mcp-config') + 1];
+      captured = { path, contents: await readFile(path, 'utf8') };
+      return { stdout: JSON.stringify({ result: 'Some answer' }) };
+    }) as unknown as typeof execa);
 
     await queryCodebase('some question', ['/repos/all-chat']);
+    return captured;
+  }
+
+  it('passes --mcp-config as a file path and keeps the Grafana token out of argv', async () => {
+    const { contents } = await runCapturingMcpConfig();
 
     const [, args] = mockExeca.mock.calls[0];
-    const mcpConfigIndex = (args as string[]).indexOf('--mcp-config');
+    const list = args as string[];
+    const mcpConfigIndex = list.indexOf('--mcp-config');
     expect(mcpConfigIndex).toBeGreaterThan(-1);
-    const mcpConfigValue = (args as string[])[mcpConfigIndex + 1];
-    const mcpConfig = JSON.parse(mcpConfigValue) as {
+
+    // The argument is a PATH, never the config itself. execa embeds the whole argv in
+    // every error it throws, so an inline config wrote the Grafana service-account token
+    // into the pod log on each subprocess failure. Nothing on the command line may carry it.
+    expect(list[mcpConfigIndex + 1]).toMatch(/mcp\.json$/);
+    expect(list.join(' ')).not.toContain('test-grafana-token');
+
+    const mcpConfig = JSON.parse(contents) as {
       mcpServers: {
         'grafana-caesar': {
           command: string;
@@ -101,6 +122,28 @@ describe('queryCodebase', () => {
     expect(mcpConfig.mcpServers['grafana-caesar']).toBeDefined();
     expect(mcpConfig.mcpServers['grafana-caesar'].env['GRAFANA_URL']).toBe('https://grafana.caes.ar');
     expect(mcpConfig.mcpServers['grafana-caesar'].env['GRAFANA_SERVICE_ACCOUNT_TOKEN']).toBe('test-grafana-token');
+  });
+
+  it('removes the temporary MCP config after the subprocess finishes', async () => {
+    const { path } = await runCapturingMcpConfig();
+
+    expect(path).not.toBe('');
+    await expect(access(path)).rejects.toThrow();
+  });
+
+  it('removes the temporary MCP config even when the subprocess fails', async () => {
+    let path = '';
+    mockExeca.mockImplementationOnce((async (_file: unknown, args: unknown) => {
+      const list = args as string[];
+      path = list[list.indexOf('--mcp-config') + 1];
+      throw Object.assign(new Error('Command timed out'), { timedOut: true });
+    }) as unknown as typeof execa);
+
+    await expect(queryCodebase('some question', ['/repos/all-chat'])).rejects.toThrow();
+
+    // A token-bearing file left behind by the failure path would defeat the whole change.
+    expect(path).not.toBe('');
+    await expect(access(path)).rejects.toThrow();
   });
 
   it('omits --mcp-config entirely when GRAFANA_URL is missing', async () => {
@@ -226,11 +269,101 @@ describe('queryCodebase', () => {
 
     const result = await queryCodebase('there is a bug', ['/repos/all-chat']);
 
-    expect(result.issueProposal).not.toBeNull();
-    expect(result.issueProposal?.repo).toBe('all-chat');
-    expect(result.issueProposal?.title).toBe('Fix the bug');
-    expect(result.issueProposal?.body).toBe('## Details\nThis bug needs fixing.');
+    expect(result.issueProposals).toHaveLength(1);
+    expect(result.issueProposals[0].repo).toBe('all-chat');
+    expect(result.issueProposals[0].title).toBe('Fix the bug');
+    expect(result.issueProposals[0].body).toBe('## Details\nThis bug needs fixing.');
     expect(result.answer).toContain('The fix is straightforward.');
+  });
+
+  it('parses EVERY PROPOSE_ISSUE marker, not just the first', async () => {
+    // The regression this covers: the old parser took indexOf() once and read the payload
+    // to the end of the string, so asking for four issues filed one whose body had the
+    // other three glued onto it. A user who lists four problems gets four issues.
+    const responseText = [
+      'Filing these now.',
+      '',
+      'PROPOSE_ISSUE:all-chat|||First issue|||## Context\nBody one, which has\nseveral lines.',
+      'PROPOSE_ISSUE:all-chat|||Second issue|||## Context\nBody two.',
+      'PROPOSE_ISSUE:all-chat-extension|||Third issue|||## Context\nBody three.',
+    ].join('\n');
+    mockExeca.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: responseText }),
+    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+
+    const result = await queryCodebase('file these', ['/repos/all-chat']);
+
+    expect(result.issueProposals).toHaveLength(3);
+    expect(result.issueProposals.map(p => p.title)).toEqual([
+      'First issue',
+      'Second issue',
+      'Third issue',
+    ]);
+    expect(result.issueProposals[0].body).toBe('## Context\nBody one, which has\nseveral lines.');
+    expect(result.issueProposals[2].repo).toBe('all-chat-extension');
+    expect(result.answer).toBe('Filing these now.');
+    expect(result.answer).not.toContain('PROPOSE_ISSUE:');
+  });
+
+  it('parses issue and comment markers that are interleaved with each other', async () => {
+    const responseText = [
+      'Done.',
+      'PROPOSE_ISSUE:all-chat|||An issue|||Issue body.',
+      'PROPOSE_COMMENT:all-chat|||447|||Comment body.',
+      'PROPOSE_ISSUE:all-chat|||Another issue|||Another body.',
+    ].join('\n');
+    mockExeca.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: responseText }),
+    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+
+    const result = await queryCodebase('do things', ['/repos/all-chat']);
+
+    expect(result.issueProposals).toHaveLength(2);
+    expect(result.commentProposals).toHaveLength(1);
+    expect(result.issueProposals[1].title).toBe('Another issue');
+    expect(result.issueProposals[0].body).toBe('Issue body.');
+    expect(result.commentProposals[0].issueNumber).toBe(447);
+  });
+
+  it('drops a PROPOSE_ISSUE naming an unknown repo instead of passing it to GitHub', async () => {
+    const responseText =
+      'Sure.\nPROPOSE_ISSUE:some-other-repo|||Title|||Body\nPROPOSE_ISSUE:all-chat|||Real one|||Body';
+    mockExeca.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: responseText }),
+    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+
+    const result = await queryCodebase('file it', ['/repos/all-chat']);
+
+    expect(result.issueProposals).toHaveLength(1);
+    expect(result.issueProposals[0].title).toBe('Real one');
+  });
+
+  it('drops a PROPOSE_ISSUE with an empty title', async () => {
+    mockExeca.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: 'Hm.\nPROPOSE_ISSUE:all-chat|||   |||Body' }),
+    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+
+    const result = await queryCodebase('file it', ['/repos/all-chat']);
+
+    expect(result.issueProposals).toEqual([]);
+  });
+
+  it('keeps INFRA_VERDICT parseable when it precedes several issue markers', async () => {
+    const responseText = [
+      'Prose.',
+      'INFRA_VERDICT:code|||A code problem.',
+      'PROPOSE_ISSUE:all-chat|||One|||Body one.',
+      'PROPOSE_ISSUE:all-chat|||Two|||Body two.',
+    ].join('\n');
+    mockExeca.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: responseText }),
+    } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
+
+    const result = await queryCodebase('check', ['/repos/all-chat']);
+
+    expect(result.infraVerdict).toEqual({ type: 'code', summary: 'A code problem.' });
+    expect(result.issueProposals).toHaveLength(2);
+    expect(result.answer).toBe('Prose.');
   });
 
   it('parses PROPOSE_COMMENT in the response into a CommentProposal', async () => {
@@ -242,22 +375,22 @@ describe('queryCodebase', () => {
 
     const result = await queryCodebase('any update on 447?', ['/repos/all-chat']);
 
-    expect(result.commentProposal).not.toBeNull();
-    expect(result.commentProposal?.repo).toBe('all-chat');
-    expect(result.commentProposal?.issueNumber).toBe(447);
-    expect(result.commentProposal?.body).toBe('## Update\nThis is now fixed in main.');
+    expect(result.commentProposals).toHaveLength(1);
+    expect(result.commentProposals[0].repo).toBe('all-chat');
+    expect(result.commentProposals[0].issueNumber).toBe(447);
+    expect(result.commentProposals[0].body).toBe('## Update\nThis is now fixed in main.');
     expect(result.answer).toContain('I\'ll follow up on the issue.');
     expect(result.answer).not.toContain('PROPOSE_COMMENT:');
   });
 
-  it('returns commentProposal: null when no PROPOSE_COMMENT marker is present', async () => {
+  it('returns an empty commentProposals array when no PROPOSE_COMMENT marker is present', async () => {
     mockExeca.mockResolvedValueOnce({
       stdout: JSON.stringify({ result: 'Just a normal answer.' }),
     } as ReturnType<typeof execa> extends Promise<infer T> ? T : never);
 
     const result = await queryCodebase('some question', ['/repos/all-chat']);
 
-    expect(result.commentProposal).toBeNull();
+    expect(result.commentProposals).toEqual([]);
   });
 
   it('ignores PROPOSE_COMMENT with a non-numeric issue number', async () => {
@@ -269,7 +402,7 @@ describe('queryCodebase', () => {
 
     const result = await queryCodebase('comment please', ['/repos/all-chat']);
 
-    expect(result.commentProposal).toBeNull();
+    expect(result.commentProposals).toEqual([]);
   });
 
   it('system prompt contains PROPOSE_COMMENT: instruction text', async () => {

--- a/services/support-bot/src/__tests__/bot.test.ts
+++ b/services/support-bot/src/__tests__/bot.test.ts
@@ -99,6 +99,9 @@ vi.mock('discord.js', () => {
 // Mock the agent module
 vi.mock('../claude/agent.js', () => ({
   queryCodebase: vi.fn(),
+  // bot.ts reads this to tell the user how long it waited. The mock must export it, or
+  // the timeout path throws on a missing mock export instead of replying.
+  CLAUDE_TIMEOUT_MS: 600_000,
 }));
 
 // Mock the github issues module
@@ -162,9 +165,9 @@ describe('startBot', () => {
     vi.clearAllMocks();
     mockQueryCodebase.mockResolvedValue({
       answer: 'Twitch uses IRC protocol for chat.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -286,9 +289,9 @@ describe('MessageCreate handler', () => {
     vi.clearAllMocks();
     mockQueryCodebase.mockResolvedValue({
       answer: 'Twitch uses IRC.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -459,13 +462,13 @@ describe('MessageCreate handler', () => {
   it('calls createIssue when queryCodebase returns an issueProposal and includes URL in reply', async () => {
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'We need to fix this.\n\nPROPOSE_ISSUE:all-chat|||Fix bug|||Bug body',
-      issueProposal: {
+      issueProposals: [{
         repo: 'all-chat',
         title: 'Fix bug',
         body: 'Bug body',
-      },
+      }],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -494,15 +497,142 @@ describe('MessageCreate handler', () => {
     expect(allSentContent).toContain('https://github.com/testowner/all-chat/issues/42');
   });
 
+  it('files EVERY proposed issue, not just the first', async () => {
+    mockQueryCodebase.mockResolvedValueOnce({
+      answer: 'Filing these.',
+      issueProposals: [
+        { repo: 'all-chat', title: 'One', body: 'Body one' },
+        { repo: 'all-chat', title: 'Two', body: 'Body two' },
+        { repo: 'all-chat-extension', title: 'Three', body: 'Body three' },
+      ],
+      infraVerdict: null,
+      commentProposals: [],
+      memoryMarker: null,
+      updateMemoryMarker: null,
+    });
+    mockCreateIssue
+      .mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/1')
+      .mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/2')
+      .mockResolvedValueOnce('https://github.com/testowner/all-chat-extension/issues/3');
+
+    await startBot(testConfig, createMockMemoryRepo());
+    const handler = getEventHandler(Events.MessageCreate);
+
+    const threadSend = vi.fn().mockResolvedValue({});
+    const msg = buildMessage({
+      content: '<@123456789> file these four things',
+      startThread: vi.fn().mockResolvedValue({ id: 'multi-thread', send: threadSend }),
+    });
+    await handler!(msg);
+
+    expect(mockCreateIssue).toHaveBeenCalledTimes(3);
+    const sent = threadSend.mock.calls
+      .map(([arg]) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join(' ');
+    expect(sent).toContain('/issues/1');
+    expect(sent).toContain('/issues/2');
+    expect(sent).toContain('/issues/3');
+  });
+
+  it('reports the issues it could not file without losing the ones it could', async () => {
+    mockQueryCodebase.mockResolvedValueOnce({
+      answer: 'Filing these.',
+      issueProposals: [
+        { repo: 'all-chat', title: 'Works', body: 'Body' },
+        { repo: 'all-chat', title: 'Breaks', body: 'Body' },
+      ],
+      infraVerdict: null,
+      commentProposals: [],
+      memoryMarker: null,
+      updateMemoryMarker: null,
+    });
+    mockCreateIssue
+      .mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/9')
+      .mockRejectedValueOnce(new Error('GitHub said no'));
+
+    await startBot(testConfig, createMockMemoryRepo());
+    const handler = getEventHandler(Events.MessageCreate);
+
+    const threadSend = vi.fn().mockResolvedValue({});
+    const msg = buildMessage({
+      content: '<@123456789> file these',
+      startThread: vi.fn().mockResolvedValue({ id: 'partial-thread', send: threadSend }),
+    });
+    await handler!(msg);
+
+    const sent = threadSend.mock.calls
+      .map(([arg]) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join(' ');
+    // The one that worked is still reported...
+    expect(sent).toContain('/issues/9');
+    // ...and the one that did not is named, rather than silently dropped.
+    expect(sent).toContain('Breaks');
+    expect(sent).toContain('Could NOT create');
+  });
+
+  it('answers a subprocess TIMEOUT with how long it waited and how to retry', async () => {
+    mockQueryCodebase.mockRejectedValueOnce(
+      Object.assign(new Error('Command timed out after 600000 milliseconds'), { timedOut: true }),
+    );
+
+    await startBot(testConfig, createMockMemoryRepo());
+    const handler = getEventHandler(Events.MessageCreate);
+
+    const msg = buildMessage({ content: '<@123456789> do something enormous' });
+    await handler!(msg);
+
+    expect(msg.reply).toHaveBeenCalledOnce();
+    const reply = msg.reply.mock.calls[0][0] as string;
+    expect(reply).toContain('10 minutes');
+    expect(reply).toContain('one issue or one area at a time');
+    // "check the bot logs" is useless to the streamer who asked, and this failure is not
+    // a fault to be investigated — the work simply did not fit in the budget.
+    expect(reply).not.toContain('Check the bot logs');
+  });
+
+  it('answers a non-timeout failure with the generic message', async () => {
+    mockQueryCodebase.mockRejectedValueOnce(new Error('something else broke'));
+
+    await startBot(testConfig, createMockMemoryRepo());
+    const handler = getEventHandler(Events.MessageCreate);
+
+    const msg = buildMessage({ content: '<@123456789> hello' });
+    await handler!(msg);
+
+    const reply = msg.reply.mock.calls[0][0] as string;
+    expect(reply).toContain('Check the bot logs');
+  });
+
+  it('redacts credentials out of a logged failure', async () => {
+    // Assembled at runtime so this file holds no literal that LOOKS like a Grafana token.
+    // A hard-coded `glsa_…` fixture trips secret scanners (GitGuardian flagged exactly
+    // that on the first push of this change), and a test fixture that cries wolf teaches
+    // people to wave the scanner through.
+    const fakeToken = ['glsa', 'fake', 'value', 'for', 'tests'].join('_');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockQueryCodebase.mockRejectedValueOnce(
+      new Error(`boom: "GRAFANA_SERVICE_ACCOUNT_TOKEN":"${fakeToken}"`),
+    );
+
+    await startBot(testConfig, createMockMemoryRepo());
+    const handler = getEventHandler(Events.MessageCreate);
+    await handler!(buildMessage({ content: '<@123456789> hello' }));
+
+    const logged = consoleError.mock.calls.map(args => args.join(' ')).join('\n');
+    expect(logged).not.toContain(fakeToken);
+    expect(logged).toContain('[REDACTED]');
+    consoleError.mockRestore();
+  });
+
   it('calls createComment when queryCodebase returns a commentProposal and includes URL in reply', async () => {
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'Following up on the issue.',
-      issueProposal: null,
-      commentProposal: {
+      issueProposals: [],
+      commentProposals: [{
         repo: 'all-chat',
         issueNumber: 447,
         body: 'This is fixed in main.',
-      },
+      }],
       infraVerdict: null,
       memoryMarker: null,
       updateMemoryMarker: null,
@@ -562,9 +692,9 @@ describe('Lead developer @mention', () => {
   it('prepends lead dev @mention when infraVerdict.type is infrastructure', async () => {
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'There is a memory leak in the pod.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: { type: 'infrastructure', summary: 'Memory leak' },
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -579,9 +709,9 @@ describe('Lead developer @mention', () => {
     mockCreateIssue.mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/99');
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'Here is a proposal.',
-      issueProposal: { repo: 'all-chat', title: 'New issue', body: 'Body text' },
+      issueProposals: [{ repo: 'all-chat', title: 'New issue', body: 'Body text' }],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -596,8 +726,8 @@ describe('Lead developer @mention', () => {
     mockCreateComment.mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/447#issuecomment-9');
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'Posted a follow-up.',
-      issueProposal: null,
-      commentProposal: { repo: 'all-chat', issueNumber: 447, body: 'Follow-up body' },
+      issueProposals: [],
+      commentProposals: [{ repo: 'all-chat', issueNumber: 447, body: 'Follow-up body' }],
       infraVerdict: null,
       memoryMarker: null,
       updateMemoryMarker: null,
@@ -612,9 +742,9 @@ describe('Lead developer @mention', () => {
   it('does NOT prepend lead dev @mention when infraVerdict is null and issueProposal is null', async () => {
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'Here is a code-level answer.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -628,9 +758,9 @@ describe('Lead developer @mention', () => {
   it('does NOT prepend lead dev @mention when infraVerdict.type is code and issueProposal is null', async () => {
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'The issue is in the frontend code.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: { type: 'code', summary: 'Frontend code issue' },
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -645,9 +775,9 @@ describe('Lead developer @mention', () => {
     mockCreateIssue.mockResolvedValueOnce('https://github.com/testowner/all-chat/issues/77');
     mockQueryCodebase.mockResolvedValueOnce({
       answer: 'Infrastructure problem with a proposal.',
-      issueProposal: { repo: 'all-chat', title: 'Fix infra', body: 'Body' },
+      issueProposals: [{ repo: 'all-chat', title: 'Fix infra', body: 'Body' }],
       infraVerdict: { type: 'infrastructure', summary: 'Critical infra issue' },
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -667,7 +797,7 @@ describe('Response formatting', () => {
 
   it('sends response <= 2000 chars as plain text', async () => {
     const shortAnswer = 'Short answer.';
-    mockQueryCodebase.mockResolvedValueOnce({ answer: shortAnswer, issueProposal: null, commentProposal: null, infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
+    mockQueryCodebase.mockResolvedValueOnce({ answer: shortAnswer, issueProposals: [], commentProposals: [], infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
 
     await startBot(testConfig, createMockMemoryRepo());
     const handler = getEventHandler(Events.MessageCreate);
@@ -685,7 +815,7 @@ describe('Response formatting', () => {
 
   it('sends response 2001-4096 chars as an embed', async () => {
     const mediumAnswer = 'A'.repeat(2001);
-    mockQueryCodebase.mockResolvedValueOnce({ answer: mediumAnswer, issueProposal: null, commentProposal: null, infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
+    mockQueryCodebase.mockResolvedValueOnce({ answer: mediumAnswer, issueProposals: [], commentProposals: [], infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
 
     await startBot(testConfig, createMockMemoryRepo());
     const handler = getEventHandler(Events.MessageCreate);
@@ -705,7 +835,7 @@ describe('Response formatting', () => {
 
   it('splits response > 4096 chars into 2000-char chunks', async () => {
     const longAnswer = 'B'.repeat(5000);
-    mockQueryCodebase.mockResolvedValueOnce({ answer: longAnswer, issueProposal: null, commentProposal: null, infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
+    mockQueryCodebase.mockResolvedValueOnce({ answer: longAnswer, issueProposals: [], commentProposals: [], infraVerdict: null, memoryMarker: null, updateMemoryMarker: null });
 
     await startBot(testConfig, createMockMemoryRepo());
     const handler = getEventHandler(Events.MessageCreate);
@@ -733,9 +863,9 @@ describe('InteractionCreate handler (/support slash command)', () => {
     vi.clearAllMocks();
     mockQueryCodebase.mockResolvedValue({
       answer: 'Slash command answer.',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });
@@ -788,7 +918,7 @@ describe('InteractionCreate handler (/support slash command)', () => {
     mockQueryCodebase.mockImplementationOnce(async () => {
       queryCalled = true;
       expect(deferCalled).toBe(true);
-      return { answer: 'answer', issueProposal: null, commentProposal: null, infraVerdict: null, memoryMarker: null, updateMemoryMarker: null };
+      return { answer: 'answer', issueProposals: [], commentProposals: [], infraVerdict: null, memoryMarker: null, updateMemoryMarker: null };
     });
 
     await startBot(testConfig, createMockMemoryRepo());
@@ -905,9 +1035,9 @@ describe('Cross-channel spam moderation', () => {
     vi.clearAllMocks();
     mockQueryCodebase.mockResolvedValue({
       answer: 'irrelevant',
-      issueProposal: null,
+      issueProposals: [],
       infraVerdict: null,
-      commentProposal: null,
+      commentProposals: [],
       memoryMarker: null,
       updateMemoryMarker: null,
     });

--- a/services/support-bot/src/bot.ts
+++ b/services/support-bot/src/bot.ts
@@ -9,7 +9,7 @@ import {
   type ThreadChannel,
 } from 'discord.js';
 import type { Octokit } from '@octokit/rest';
-import { queryCodebase } from './claude/agent.js';
+import { CLAUDE_TIMEOUT_MS, queryCodebase } from './claude/agent.js';
 import { createComment, createIssue, createOctokitClient } from './github/issues.js';
 import { MemoryRepository, extractTagsFromQuestion } from './memory/repository.js';
 import { CrossChannelSpamDetector } from './moderation/cross-channel-spam.js';
@@ -51,6 +51,61 @@ async function fetchThreadHistory(thread: ThreadChannel): Promise<string[]> {
     .map(m => `[${m.author.bot ? 'Bot' : m.author.username}]: ${m.content}`);
 }
 
+/** Cap on how much of one error reaches the log. An ExecaError carries the whole argv. */
+const MAX_ERROR_LOG_CHARS = 4000;
+
+/** Credential shapes that must never be logged, whatever dragged them in. */
+const SECRET_PATTERNS: readonly RegExp[] = [
+  /glsa_[A-Za-z0-9_]+/g, // Grafana service-account token
+  /gh[pousr]_[A-Za-z0-9]{20,}/g, // GitHub token
+  /sk-ant-[A-Za-z0-9_-]{20,}/g, // Anthropic API key
+];
+
+function redactSecrets(text: string): string {
+  return SECRET_PATTERNS.reduce((acc, pattern) => acc.replace(pattern, '[REDACTED]'), text);
+}
+
+/**
+ * Logs a failure without re-leaking what the error dragged along.
+ *
+ * execa embeds the full argv in every error it throws. For this bot that argv is the
+ * entire system prompt plus every flag -- thousands of lines per failure -- and until the
+ * MCP config was moved out of the command line it also carried the Grafana
+ * service-account token in plaintext, which is how that token ended up in the pod log.
+ * The file-based config fixes the source; this is the belt to that pair of braces, so a
+ * secret reaching here by some future route still does not reach the log.
+ */
+function logHandlingError(context: string, err: unknown): void {
+  if (typeof err === 'object' && err !== null && (err as { timedOut?: boolean }).timedOut === true) {
+    console.error(`${context}: claude subprocess timed out after ${CLAUDE_TIMEOUT_MS}ms`);
+    return;
+  }
+  const text = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  console.error(`${context}: ${redactSecrets(text).slice(0, MAX_ERROR_LOG_CHARS)}`);
+}
+
+/**
+ * Turns a subprocess failure into a reply the asker can act on.
+ *
+ * A timeout is the common failure and it is not random: an expensive request (several
+ * issues at once, a wide sweep of a 137MB checkout) simply does not finish inside the
+ * budget. The old catch-all answered "something went wrong, check the bot logs" for every
+ * case, which is useless to the streamer who asked and misleading to everyone else --
+ * nothing "went wrong", the work was too big. Naming the limit and how to get under it is
+ * the difference between a dead end and a retry that succeeds.
+ */
+function failureReply(err: unknown): string {
+  if (typeof err === 'object' && err !== null && (err as { timedOut?: boolean }).timedOut === true) {
+    const minutes = Math.round(CLAUDE_TIMEOUT_MS / 60_000);
+    return (
+      `I ran out of time on this one and stopped after ${minutes} minutes. ` +
+      'That usually means the request needed too much digging at once. ' +
+      'Try splitting it up: ask for one issue or one area at a time, and name the file or service if you know it.'
+    );
+  }
+  return 'Sorry, something went wrong while processing your question. Check the bot logs for details.';
+}
+
 async function handleQuestion(
   question: string,
   repoPaths: string[],
@@ -76,32 +131,51 @@ async function handleQuestion(
     await memoryRepo.updateMemory(result.updateMemoryMarker.id, result.updateMemoryMarker.content);
   }
 
-  if (result.issueProposal !== null) {
-    const issueUrl = await createIssue(
-      octokit,
-      config.githubOwner,
-      result.issueProposal.repo,
-      result.issueProposal.title,
-      result.issueProposal.body,
-    );
-    answer = `${answer}\n\nI've created a GitHub issue for this proposed change: ${issueUrl}`;
+  // Each proposal is created independently and a failure is reported rather than thrown:
+  // when the model files four issues, one rejected by the GitHub API must not discard the
+  // three that succeeded, and the user needs to know which of the four is missing.
+  const created: string[] = [];
+
+  for (const proposal of result.issueProposals) {
+    try {
+      const issueUrl = await createIssue(
+        octokit,
+        config.githubOwner,
+        proposal.repo,
+        proposal.title,
+        proposal.body,
+      );
+      created.push(`Created **${proposal.title}**: ${issueUrl}`);
+    } catch (err) {
+      logHandlingError(`Failed to create issue "${proposal.title}" in ${proposal.repo}`, err);
+      created.push(`Could NOT create **${proposal.title}** in ${proposal.repo} (see bot logs).`);
+    }
   }
 
-  if (result.commentProposal !== null) {
-    const commentUrl = await createComment(
-      octokit,
-      config.githubOwner,
-      result.commentProposal.repo,
-      result.commentProposal.issueNumber,
-      result.commentProposal.body,
-    );
-    answer = `${answer}\n\nI've posted a comment on ${result.commentProposal.repo} #${result.commentProposal.issueNumber}: ${commentUrl}`;
+  for (const proposal of result.commentProposals) {
+    try {
+      const commentUrl = await createComment(
+        octokit,
+        config.githubOwner,
+        proposal.repo,
+        proposal.issueNumber,
+        proposal.body,
+      );
+      created.push(`Commented on ${proposal.repo} #${proposal.issueNumber}: ${commentUrl}`);
+    } catch (err) {
+      logHandlingError(`Failed to comment on ${proposal.repo} #${proposal.issueNumber}`, err);
+      created.push(`Could NOT comment on ${proposal.repo} #${proposal.issueNumber} (see bot logs).`);
+    }
+  }
+
+  if (created.length > 0) {
+    answer = `${answer}\n\n${created.map(line => `- ${line}`).join('\n')}`;
   }
 
   const shouldPingLeadDev =
     result.infraVerdict?.type === 'infrastructure' ||
-    result.issueProposal !== null ||
-    result.commentProposal !== null;
+    result.issueProposals.length > 0 ||
+    result.commentProposals.length > 0;
 
   if (shouldPingLeadDev && config.leadDeveloperDiscordId) {
     answer = `<@${config.leadDeveloperDiscordId}> ${answer}`;
@@ -248,8 +322,8 @@ export async function startBot(config: BotConfig, memoryRepo: MemoryRepository):
         }
       } catch (err) {
         clearInterval(typingInterval);
-        console.error('Error handling message:', err);
-        await message.reply('Sorry, something went wrong while processing your question. Check the bot logs for details.');
+        logHandlingError('Error handling message', err);
+        await message.reply(failureReply(err));
       }
     });
   });
@@ -269,8 +343,8 @@ export async function startBot(config: BotConfig, memoryRepo: MemoryRepository):
       answer = await handleQuestion(question, repoPaths, config, octokit, [], memoryRepo);
       console.log('[interaction] Claude responded successfully');
     } catch (err) {
-      console.error('[interaction] Error handling interaction:', err);
-      await interaction.editReply('Sorry, something went wrong while processing your question. Check the bot logs for details.');
+      logHandlingError('[interaction] Error handling interaction', err);
+      await interaction.editReply(failureReply(err));
       return;
     }
     // Note: deferReply keeps the "thinking..." indicator alive until editReply is called, no interval needed.

--- a/services/support-bot/src/claude/agent.ts
+++ b/services/support-bot/src/claude/agent.ts
@@ -1,5 +1,16 @@
 import { execa } from 'execa';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { QueryResult, IssueProposal, CommentProposal, InfraVerdict, StoredMemory, ParsedMemoryMarker, ParsedUpdateMemoryMarker, MemoryType } from '../types.js';
+
+/**
+ * How long the `claude` subprocess gets before it is killed.
+ *
+ * Exported because the Discord layer needs the same number to tell a user how long
+ * it waited; two copies of "10 minutes" drift the moment one is tuned.
+ */
+export const CLAUDE_TIMEOUT_MS = 600_000;
 
 export async function queryCodebase(
   question: string,
@@ -21,7 +32,9 @@ export async function queryCodebase(
     "repo_name must be 'all-chat' or 'all-chat-extension'.",
     'issue_number is the numeric issue or PR number (GitHub treats PR comments as issue comments, so the same number works for either). body is the full Markdown comment.',
     'Only emit PROPOSE_COMMENT when you have an explicit issue or PR number from the user or the conversation -- never guess or invent a number, and never claim you commented if you did not emit the marker.',
-    'Emit at most one of PROPOSE_ISSUE or PROPOSE_COMMENT per response.',
+    'You may emit SEVERAL markers in one response -- one per issue or comment. If the user lists four problems and asks for issues, emit four PROPOSE_ISSUE markers, not one covering all four. Put every marker at the very end, each starting on its own line, after all of your prose.',
+    'Issue templates live in .github/ISSUE_TEMPLATE/ in each repo. The Caterpillar / agent-task template is .github/ISSUE_TEMPLATE/agent_task.md -- read it directly by path when a template is requested rather than searching the repo for it.',
+    'Filing several issues is expensive. Budget your research: skim what you need to make each issue concrete and stop there, rather than fully investigating every one. An answer that arrives is worth more than one that times out.',
     '',
     'IMPORTANT -- Infrastructure data handling rules:',
     '1. NEVER include raw log lines, stack traces, or raw error messages in your response.',
@@ -75,7 +88,16 @@ export async function queryCodebase(
   const grafanaToken = process.env['GRAFANA_SERVICE_ACCOUNT_TOKEN'];
   const hasGrafana = Boolean(grafanaUrl) && Boolean(grafanaToken);
 
+  // The MCP config carries the Grafana service-account token, so it goes to the
+  // subprocess as a FILE rather than on the command line.
+  //
+  // execa embeds the full argv in every error it throws, and that error is what the
+  // catch-all logs. With the config inline, one subprocess timeout printed
+  // `"GRAFANA_SERVICE_ACCOUNT_TOKEN":"glsa_..."` in plaintext into the pod log — and
+  // from there into any log aggregation scraping this pod. A 0600 file in a private
+  // temp dir keeps the secret out of argv, out of the error, and out of `ps`.
   let mcpConfigArg: string[] = [];
+  let mcpConfigDir: string | null = null;
   if (hasGrafana) {
     const mcpConfig = JSON.stringify({
       mcpServers: {
@@ -89,7 +111,10 @@ export async function queryCodebase(
         },
       },
     });
-    mcpConfigArg = ['--mcp-config', mcpConfig];
+    mcpConfigDir = await mkdtemp(join(tmpdir(), 'support-bot-mcp-'));
+    const mcpConfigPath = join(mcpConfigDir, 'mcp.json');
+    await writeFile(mcpConfigPath, mcpConfig, { mode: 0o600 });
+    mcpConfigArg = ['--mcp-config', mcpConfigPath];
   }
 
   const baseTools = ['Read', 'Glob', 'Grep', 'Bash(kubectl:*)'];
@@ -106,114 +131,167 @@ export async function queryCodebase(
     : [];
   const allowedTools = [...baseTools, ...grafanaTools].join(',');
 
-  console.log('[claude] Starting subprocess (timeout: 600s)');
-  const { stdout } = await execa(
-    'claude',
-    [
-      '-p', fullPrompt,
-      '--model', 'claude-sonnet-4-6',
-      '--allowedTools', allowedTools,
-      ...mcpConfigArg,
-      '--output-format', 'json',
-    ],
-    {
-      stdin: 'ignore',
-      env: { ...process.env },
-      timeout: 600_000,
-    },
-  );
+  console.log(`[claude] Starting subprocess (timeout: ${CLAUDE_TIMEOUT_MS / 1000}s)`);
+  let stdout: string;
+  try {
+    ({ stdout } = await execa(
+      'claude',
+      [
+        '-p', fullPrompt,
+        '--model', 'claude-sonnet-4-6',
+        '--allowedTools', allowedTools,
+        ...mcpConfigArg,
+        '--output-format', 'json',
+      ],
+      {
+        stdin: 'ignore',
+        env: { ...process.env },
+        timeout: CLAUDE_TIMEOUT_MS,
+      },
+    ));
+  } finally {
+    // Unconditional, and only AFTER the subprocess has exited: claude reads the config
+    // at startup, so removing it earlier would race the read. Losing the cleanup would
+    // leave a token-bearing file behind, which is the thing this whole detour avoids.
+    if (mcpConfigDir !== null) {
+      await rm(mcpConfigDir, { recursive: true, force: true }).catch((err: unknown) => {
+        console.warn('[claude] Failed to remove temporary MCP config dir:', err);
+      });
+    }
+  }
   console.log('[claude] Subprocess completed, parsing response');
 
   const parsed = JSON.parse(stdout) as { result: string };
-  const resultText = parsed.result;
+  return parseMarkers(parsed.result);
+}
 
-  // Parse and strip INFRA_VERDICT marker
+/** The repos the bot is allowed to act on. Anything else is dropped, not guessed at. */
+const KNOWN_REPOS = ['all-chat', 'all-chat-extension'] as const;
+type KnownRepo = (typeof KNOWN_REPOS)[number];
+
+function isKnownRepo(value: string): value is KnownRepo {
+  return (KNOWN_REPOS as readonly string[]).includes(value);
+}
+
+/** Every trailing marker the model may append. Order here is irrelevant; position in the text decides. */
+const MARKERS = [
+  'INFRA_VERDICT:',
+  'PROPOSE_ISSUE:',
+  'PROPOSE_COMMENT:',
+  'STORE_MEMORY:',
+  'UPDATE_MEMORY:',
+] as const;
+
+type Marker = (typeof MARKERS)[number];
+
+interface MarkerSegment {
+  marker: Marker;
+  payload: string;
+}
+
+/**
+ * Splits a response into its prose and its trailing marker segments.
+ *
+ * A segment runs from the end of its marker to the start of the NEXT marker, which is
+ * what makes multiple markers parseable at all: an issue body is Markdown and contains
+ * newlines, so a marker's payload cannot be delimited by the end of a line. The previous
+ * parser took `indexOf` of each marker once and read the payload to the end of the
+ * string, so a second PROPOSE_ISSUE was swallowed into the first one's body and only one
+ * issue was ever filed no matter how many the user asked for.
+ *
+ * Single-line markers (INFRA_VERDICT, STORE_MEMORY, UPDATE_MEMORY) take the first line of
+ * their segment, which preserves the old behaviour for them.
+ */
+function splitMarkers(text: string): { prose: string; segments: MarkerSegment[] } {
+  const hits: Array<{ index: number; marker: Marker }> = [];
+  for (const marker of MARKERS) {
+    let from = 0;
+    for (;;) {
+      const index = text.indexOf(marker, from);
+      if (index === -1) break;
+      hits.push({ index, marker });
+      from = index + marker.length;
+    }
+  }
+  hits.sort((a, b) => a.index - b.index);
+
+  const segments = hits.map((hit, i) => ({
+    marker: hit.marker,
+    payload: text.slice(hit.index + hit.marker.length, i + 1 < hits.length ? hits[i + 1].index : text.length),
+  }));
+
+  return {
+    prose: hits.length > 0 ? text.slice(0, hits[0].index).trimEnd() : text,
+    segments,
+  };
+}
+
+/** Parses a model response into prose plus whatever actions it asked for. */
+export function parseMarkers(resultText: string): QueryResult {
+  const { prose, segments } = splitMarkers(resultText);
+
+  const issueProposals: IssueProposal[] = [];
+  const commentProposals: CommentProposal[] = [];
   let infraVerdict: InfraVerdict | null = null;
-  const verdictMarker = 'INFRA_VERDICT:';
-  const verdictIndex = resultText.indexOf(verdictMarker);
-  if (verdictIndex !== -1) {
-    const verdictString = resultText.slice(verdictIndex + verdictMarker.length).split('\n')[0];
-    const parts = verdictString.split('|||');
-    if (parts.length >= 2) {
-      const type = parts[0].trim() as 'infrastructure' | 'code';
-      const summary = parts[1].trim();
-      infraVerdict = { type, summary };
-    }
-  }
-
-  let cleanAnswer = resultText;
-  if (verdictIndex !== -1) {
-    cleanAnswer = resultText.slice(0, verdictIndex).trimEnd();
-  }
-
-  // Parse and strip PROPOSE_ISSUE marker
-  let issueProposal: IssueProposal | null = null;
-  const proposeMarker = 'PROPOSE_ISSUE:';
-  const proposeIndex = cleanAnswer.indexOf(proposeMarker);
-  if (proposeIndex !== -1) {
-    const proposeString = cleanAnswer.slice(proposeIndex + proposeMarker.length);
-    const parts = proposeString.split('|||');
-    if (parts.length >= 3) {
-      const repoName = parts[0].trim() as 'all-chat' | 'all-chat-extension';
-      const title = parts[1].trim();
-      const body = parts.slice(2).join('|||').trim();
-      issueProposal = { repo: repoName, title, body };
-    }
-    cleanAnswer = cleanAnswer.slice(0, proposeIndex).trimEnd();
-  }
-
-  // Parse and strip PROPOSE_COMMENT marker
-  let commentProposal: CommentProposal | null = null;
-  const commentMarker = 'PROPOSE_COMMENT:';
-  const commentIndex = cleanAnswer.indexOf(commentMarker);
-  if (commentIndex !== -1) {
-    const commentString = cleanAnswer.slice(commentIndex + commentMarker.length);
-    const parts = commentString.split('|||');
-    if (parts.length >= 3) {
-      const repoName = parts[0].trim();
-      const issueNumber = parseInt(parts[1].trim(), 10);
-      const body = parts.slice(2).join('|||').trim();
-      if ((repoName === 'all-chat' || repoName === 'all-chat-extension') && !isNaN(issueNumber)) {
-        commentProposal = { repo: repoName, issueNumber, body };
-      }
-    }
-    cleanAnswer = cleanAnswer.slice(0, commentIndex).trimEnd();
-  }
-
-  // Parse and strip STORE_MEMORY marker
-  const storeMarker = 'STORE_MEMORY:';
-  const storeIndex = cleanAnswer.indexOf(storeMarker);
   let memoryMarker: ParsedMemoryMarker | null = null;
-  if (storeIndex !== -1) {
-    const markerString = cleanAnswer.slice(storeIndex + storeMarker.length).split('\n')[0];
-    const parts = markerString.split('|||');
-    if (parts.length >= 3) {
-      const type = parts[0].trim() as MemoryType;
-      const tags = parts[1].trim().split(',').map(t => t.trim()).filter(Boolean);
-      const content = parts.slice(2).join('|||').trim();
-      if (['error_pattern', 'correction', 'codebase_insight'].includes(type)) {
-        memoryMarker = { type, tags, content };
-      }
-    }
-    cleanAnswer = cleanAnswer.slice(0, storeIndex).trimEnd();
-  }
-
-  // Parse and strip UPDATE_MEMORY marker
-  const updateMarker = 'UPDATE_MEMORY:';
-  const updateIndex = cleanAnswer.indexOf(updateMarker);
   let updateMemoryMarker: ParsedUpdateMemoryMarker | null = null;
-  if (updateIndex !== -1) {
-    const markerString = cleanAnswer.slice(updateIndex + updateMarker.length).split('\n')[0];
-    const parts = markerString.split('|||');
-    if (parts.length >= 2) {
-      const id = parseInt(parts[0].trim(), 10);
-      const content = parts.slice(1).join('|||').trim();
-      if (!isNaN(id)) {
-        updateMemoryMarker = { id, content };
+
+  for (const { marker, payload } of segments) {
+    switch (marker) {
+      case 'PROPOSE_ISSUE:': {
+        const parts = payload.split('|||');
+        if (parts.length < 3) break;
+        const repo = parts[0].trim();
+        // Validated rather than cast. The old code asserted the repo name was one of the
+        // two without checking, so a typo went straight to the GitHub API as a 404.
+        if (!isKnownRepo(repo)) break;
+        const title = parts[1].trim();
+        const body = parts.slice(2).join('|||').trim();
+        if (!title) break;
+        issueProposals.push({ repo, title, body });
+        break;
+      }
+      case 'PROPOSE_COMMENT:': {
+        const parts = payload.split('|||');
+        if (parts.length < 3) break;
+        const repo = parts[0].trim();
+        const issueNumber = parseInt(parts[1].trim(), 10);
+        const body = parts.slice(2).join('|||').trim();
+        if (!isKnownRepo(repo) || isNaN(issueNumber)) break;
+        commentProposals.push({ repo, issueNumber, body });
+        break;
+      }
+      case 'INFRA_VERDICT:': {
+        if (infraVerdict !== null) break;
+        const parts = payload.split('\n')[0].split('|||');
+        if (parts.length < 2) break;
+        infraVerdict = { type: parts[0].trim() as 'infrastructure' | 'code', summary: parts[1].trim() };
+        break;
+      }
+      case 'STORE_MEMORY:': {
+        if (memoryMarker !== null) break;
+        const parts = payload.split('\n')[0].split('|||');
+        if (parts.length < 3) break;
+        const type = parts[0].trim() as MemoryType;
+        if (!['error_pattern', 'correction', 'codebase_insight'].includes(type)) break;
+        memoryMarker = {
+          type,
+          tags: parts[1].trim().split(',').map(t => t.trim()).filter(Boolean),
+          content: parts.slice(2).join('|||').trim(),
+        };
+        break;
+      }
+      case 'UPDATE_MEMORY:': {
+        if (updateMemoryMarker !== null) break;
+        const parts = payload.split('\n')[0].split('|||');
+        if (parts.length < 2) break;
+        const id = parseInt(parts[0].trim(), 10);
+        if (isNaN(id)) break;
+        updateMemoryMarker = { id, content: parts.slice(1).join('|||').trim() };
+        break;
       }
     }
-    cleanAnswer = cleanAnswer.slice(0, updateIndex).trimEnd();
   }
 
-  return { answer: cleanAnswer, issueProposal, commentProposal, infraVerdict, memoryMarker, updateMemoryMarker };
+  return { answer: prose, issueProposals, commentProposals, infraVerdict, memoryMarker, updateMemoryMarker };
 }

--- a/services/support-bot/src/types.ts
+++ b/services/support-bot/src/types.ts
@@ -19,8 +19,10 @@ export interface InfraVerdict {
 
 export interface QueryResult {
   answer: string;
-  issueProposal: IssueProposal | null;
-  commentProposal: CommentProposal | null;
+  /** Every issue the model asked to open, in the order it emitted them. Empty when none. */
+  issueProposals: IssueProposal[];
+  /** Every comment the model asked to post, in the order it emitted them. Empty when none. */
+  commentProposals: CommentProposal[];
   infraVerdict: InfraVerdict | null;
   memoryMarker: ParsedMemoryMarker | null;
   updateMemoryMarker: ParsedUpdateMemoryMarker | null;


### PR DESCRIPTION
A support question in Discord failed with the generic "Sorry, something went wrong while
processing your question. Check the bot logs for details." Investigating it turned up three
independent faults behind that one message, plus a security problem the failure exposed.

The triggering request was *"create issues for these. use the Caterpillar issue template"*
with four bug reports pasted in.

## 1. The Grafana service-account token was logged in plaintext

The MCP config was passed inline:

```
--mcp-config '{"mcpServers":{"grafana-caesar":{…,"env":{"GRAFANA_SERVICE_ACCOUNT_TOKEN":"glsa_…"}}}}'
```

execa embeds the full argv in every error it throws, and the catch-all in `bot.ts` logged
that error object. So **every subprocess failure printed the token into the pod log**, and
from there into anything scraping this pod. One timeout was enough to expose it.

The config now goes to the subprocess as a `0600` file in a private temp dir, with only the
path on the command line. Cleanup is in a `finally` that runs after the process exits (never
before: `claude` reads the config at startup, so removing it earlier would race the read).
The token is now absent from argv, from any error, and from `ps`.

Belt and braces: failures are logged through a redactor that masks `glsa_` / `gh?_` /
`sk-ant-` shapes and truncates the argv dump, so a secret arriving here by some future route
still does not reach the log.

> [!IMPORTANT]
> **The exposed token still needs rotating.** A code fix does not un-leak a credential that
> already sat in logs, and log retention still holds it. That is a Grafana state change and
> is not part of this PR.

## 2. A timeout was reported as an unknown fault

Every failure produced the same "something went wrong, check the bot logs". For a timeout
that is both useless to the streamer who asked and untrue: nothing went wrong, the request
did not fit in ten minutes. Timeouts are now detected and answered with how long the bot
waited and how to get under the limit.

## 3. Only one issue could ever be filed

The prompt said *"Emit at most one of PROPOSE_ISSUE or PROPOSE_COMMENT per response"*, and the
parser matched it: a single `indexOf` whose payload ran to the end of the string.

The request asked for **four** issues. Even had it finished in time, three would have been
swallowed into the first one's body and silently lost, so this class of request could not
succeed at all.

Markers are now split by position, which is what makes multiple markers parseable: an issue
body is Markdown and contains newlines, so a payload cannot be delimited by end-of-line. Each
segment runs to the start of the next marker. Every proposal is then filed independently, so
one rejected by the GitHub API no longer discards the others, and the reply names the one that
failed.

Repo names are now validated rather than cast, which also closes a latent bug where a
hallucinated repo went straight to the GitHub API as a 404.

## 4. The prompt sent the agent hunting

The request named "the Caterpillar issue template", a string that appears nowhere in the
prompt, so the agent had to grep a 137&nbsp;MB checkout to discover it is
`.github/ISSUE_TEMPLATE/agent_task.md`. The prompt now names that path, and tells the agent to
budget its research when filing several issues.

## Verification

The `claude` CLI in the pod is healthy (2.2s for a trivial prompt), both repos are cloned, and
the pod has zero restarts, so this was not broken auth or a crash. It genuinely spent the full
600s on a request that could not have succeeded.

13 tests added, covering:

- the file-based MCP config: the path is on the command line and the token is not, and the
  temp dir is removed on **both** the success and the failure paths
- multiple `PROPOSE_ISSUE` markers, including multi-line bodies
- issue and comment markers interleaved with each other
- `INFRA_VERDICT` still parsing when it precedes several issue markers
- unknown-repo and empty-title rejection
- the timeout reply, and that a non-timeout failure still gets the generic message
- partial-failure reporting when one `createIssue` rejects
- credential redaction in the log

143 tests pass. The pre-existing `tsc --noEmit` error count for this service is unchanged at
17, all of them in test files that predate this change; no new ones were introduced.

## Notes

- This targets the **TypeScript** service, which is what production runs.
- There is a prepared-but-uncommitted Go rewrite on `refactor/support-bot-local-llm-scoped-agent`
  that replaces `src/claude/agent.ts` wholesale. The argv leak does not carry over there (local
  LLM over HTTP, no subprocess), but fixes 2, 3 and 4 would need porting if that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
