### PR TITLE
feat(auth): return OAuth flows to their originating frontend origin

### DIFF
--- a/.comment-lint.suppressions.json
+++ b/.comment-lint.suppressions.json
@@ -72,7 +72,7 @@
     "restate": 3
   },
   "services/auth-service/handlers/platform_auth_v2.go": {
-    "restate": 7
+    "restate": 6
   },
   "services/auth-service/handlers/risc_handler.go": {
     "restate": 1

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,11 @@ APP_VERSION=0.1.0
 
 # Frontend URL (used to generate OAuth redirect URIs)
 FRONTEND_URL=http://localhost:3000
+# Additional first-party frontend origins (comma-separated), e.g. a beta
+# deployment. OAuth flows started from one of these hosts use its registered
+# callback URI and redirect back to it; FRONTEND_URL stays the canonical
+# fallback. Optional; defaults to FRONTEND_URL alone.
+# FRONTEND_URLS=https://allch.at,https://beta.allch.at
 
 # Umami analytics (frontend, cookieless): configured directly in
 # frontend/src/components/Analytics.tsx (Website ID + script host are pinned

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -289,6 +289,7 @@ SOURCE_MANAGER_PORT=8088
 # Frontend
 NEXT_PUBLIC_API_URL=http://localhost:8080
 FRONTEND_URL=https://your-domain.example  # Used to auto-generate OAuth redirect URLs
+FRONTEND_URLS=  # Optional: extra first-party origins (e.g. beta), comma-separated; default is FRONTEND_URL alone
 
 # Logging
 LOG_LEVEL=info  # debug, info, warn, error

--- a/docs/plans/2026-09-08-beta-frontend.md
+++ b/docs/plans/2026-09-08-beta-frontend.md
@@ -68,9 +68,15 @@ no longer routed.
   never override it.
 - Not a blocker after all: `token-refresh-service` only refreshes tokens —
   no `redirect_uri` is involved — and needs no change.
-- Known gap, deliberately out of scope: the Discord account-link/bot-invite
-  callback (`handlers/discord.go:297`) still redirects to the canonical
-  FRONTEND_URL. A beta user linking Discord lands on allch.at/settings.
+- Discord bot-invite and account-link flows (`handlers/discord.go`,
+  `handlers/discord_identity.go`) follow the same pattern through their own
+  plumbing: `discordFlowState.Origin` records the allowlisted origin in the
+  server-side state, `flowOrigin()` re-checks the allowlist at the callback,
+  and `originProvider()` swaps `DiscordOAuth.WithRedirectURL()` so the invite
+  URL, the identity consent URL and the code exchange agree on the
+  origin-specific callback. Operator prerequisite: register
+  `https://beta.allch.at/api/v1/auth/discord/callback` as a second redirect
+  URI in the Discord developer app.
 - payment-service / share / device-link stay canonical per the "no beta
   overlay links" decision.
 
@@ -96,6 +102,10 @@ match, no wildcards).
   fallback), `stateOrigin` trust rules, `WithRedirectURL` swap, and two
   end-to-end `HandleLogin` tests (beta origin recorded in state +
   `redirect_uri`; unknown host stays canonical).
+- `discord_test.go` / `discord_identity_test.go` — beta-origin connect
+  carries the beta `redirect_uri` and records the origin in state; both
+  callback branches redirect to the flow origin; a non-allowlisted state
+  origin stays canonical.
 - `services/api-gateway/handlers/websocket_firstparty_test.go` —
   `loadFirstPartyWSOrigins` env variants.
 - `services/api-gateway/handlers/proxy_test.go` — original host forwarded,

--- a/docs/plans/2026-09-08-beta-frontend.md
+++ b/docs/plans/2026-09-08-beta-frontend.md
@@ -1,0 +1,138 @@
+# Beta frontend at beta.allch.at — required all-chat changes
+
+Date: 2026-09-08
+
+## Deployment side (done)
+
+Branch `feat/beta-frontend` in `caesar-deployment`:
+
+- `apps/workloads/all-chat/frontend-beta-deployment.yaml` — Deployment + Service
+  `frontend-beta`, image `ghcr.io/caesarakalaeii/allchat-frontend:beta`, 1
+  replica, keel `force`/`poll` (same annotations as prod frontend, so keel
+  rolls it on every new `:beta` push). Same cluster-internal
+  `NEXT_PUBLIC_API_URL`/`NEXT_PUBLIC_WS_URL` env as prod (SSR only).
+- `apps/workloads/all-chat/network-policies.yaml` — `frontend-beta` policy
+  (ingress-nginx + monitoring on 3000). Needed because of the namespace
+  default-deny and the distinct `app: frontend-beta` label.
+- `ingress/allchat-ingress.yaml` — second host rule `beta.allch.at`: `/api/`
+  and `/ws/` → `api-gateway:8080`, `/` → `frontend-beta:3000`. TLS entry with
+  secret `allchat-beta-tls` (issued by the existing `letsencrypt-prod`
+  ClusterIssuer). `cors-allow-origin` extended with `https://beta.allch.at`.
+  No `/webhooks/eventsub` on the beta host — EventSub stays on allch.at only.
+- `apps/workloads/all-chat/kustomization.yaml` — new resource listed.
+
+Prod is untouched: separate Service/labels, so the prod `frontend` Service
+selector and `frontend-pdb` (`app: frontend`) never match beta pods.
+
+## What needs no change in all-chat
+
+- **Image build**: `.github/workflows/build-and-push.yml` builds on any branch
+  with `type=ref,event=branch`. Pushing a `beta` branch that touches
+  `frontend/**` produces `ghcr.io/caesarakalaeii/allchat-frontend:beta`.
+  Operational only: maintain a `beta` branch (rebase/merge from `main` to
+  ship to beta, force-push is fine — keel follows the tag).
+- **Frontend API/WS base**: browser code already uses
+  `window.location.origin` (`frontend/src/lib/api/client.ts:36-45`,
+  `frontend/src/lib/api/websocket.ts:55-59`). Served from beta.allch.at with
+  the same-origin `/api/` + `/ws/` proxy, it just works.
+- **Cookies**: host-only cookie per `docs/pi/specs/2026-06-23-h3-cookie-auth-design.md`.
+  Set via the `beta.allch.at/api/` callback response → scoped to beta.allch.at
+  automatically. Verify no explicit `Domain=` attribute is ever set.
+- **Extension auth postMessage**: `chat/auth-success/page.tsx` targets
+  `window.location.origin` — correct per host without changes.
+
+## Required code changes — implemented (2026-09-08)
+
+### 1. OAuth flows return to the originating host
+
+All streamer OAuth (Twitch/YouTube/Kick login, add-source, moderation
+re-consent, delegated-mod consent) routes through `PlatformAuthHandlerV2`, so
+that is the only integration point; the legacy `auth_handler.go` callbacks are
+no longer routed.
+
+- `services/auth-service/oauth/state.go` — `OAuthState.Origin` records the
+  allowlisted origin the flow started from. Tampering is impossible: the
+  callback byte-compares the query state against the Redis copy, and
+  `stateOrigin()` re-checks the allowlist before use.
+- `services/auth-service/oauth/{twitch,youtube,kick}.go` — `WithRedirectURL()`
+  returns a copy with a swapped `redirect_uri`, so the authorize URL and the
+  code exchange agree with the origin-specific callback registered at the
+  provider.
+- `services/auth-service/handlers/frontend_origin.go` — allowlist from
+  `FRONTEND_URL` (canonical fallback) + `FRONTEND_URLS` (comma-separated);
+  `requestFrontendOrigin()` resolves the starting origin from
+  `X-Forwarded-Host` (the api-gateway rebuilds the request, so the original
+  `Host` never arrives); `providerForOrigin()` swaps the provider.
+- `services/api-gateway/handlers/proxy.go` — stamps `X-Forwarded-Host` with
+  the original `Host` after `copyHeaders`, so a client-supplied value can
+  never override it.
+- Not a blocker after all: `token-refresh-service` only refreshes tokens —
+  no `redirect_uri` is involved — and needs no change.
+- Known gap, deliberately out of scope: the Discord account-link/bot-invite
+  callback (`handlers/discord.go:297`) still redirects to the canonical
+  FRONTEND_URL. A beta user linking Discord lands on allch.at/settings.
+- payment-service / share / device-link stay canonical per the "no beta
+  overlay links" decision.
+
+### 2. WebSocket first-party origins
+
+`loadFirstPartyWSOrigins()` (`services/api-gateway/handlers/websocket.go`)
+now reads `FRONTEND_URL` + `FRONTEND_URLS`; beta is a first-party origin for
+the cookie-authenticated owner socket (audit #8 semantics unchanged: exact
+match, no wildcards).
+
+### Deployment wiring (caesar, branch `feat/beta-frontend`)
+
+- `allchat-config`: `FRONTEND_URLS=https://allch.at,https://beta.allch.at`;
+  `CORS_ORIGIN` and `WEBSOCKET_ALLOWED_ORIGINS` extended with
+  `https://beta.allch.at`.
+- `auth-service-deployment.yaml`: explicit `FRONTEND_URLS` configMapKeyRef
+  (auth-service uses selective key refs; api-gateway gets it via `envFrom`).
+
+### Tests
+
+- `services/auth-service/handlers/frontend_origin_test.go` — origin
+  resolution (allowlist, spoofed/multi `X-Forwarded-Host`, no-allowlist
+  fallback), `stateOrigin` trust rules, `WithRedirectURL` swap, and two
+  end-to-end `HandleLogin` tests (beta origin recorded in state +
+  `redirect_uri`; unknown host stays canonical).
+- `services/api-gateway/handlers/websocket_firstparty_test.go` —
+  `loadFirstPartyWSOrigins` env variants.
+- `services/api-gateway/handlers/proxy_test.go` — original host forwarded,
+  client header cannot override.
+- `go build ./...` + `go test ./handlers/... ./oauth/...` green for
+  auth-service and api-gateway (2026-09-08).
+
+## Decisions (2026-09-08) — implemented
+
+- **Analytics: beta and prod are separated.** `frontend/src/components/Analytics.tsx`
+  now picks the Umami website ID by `window.location.hostname`
+  (`WEBSITE_IDS`: prod ID for `allch.at`, a dedicated ID for `beta.allch.at`).
+  Open operator step: create a second website in the Umami instance and set
+  `BETA_WEBSITE_ID` — until then beta is untracked, which already guarantees
+  no beta data lands in prod stats. `lib/analytics.ts` `trackEvent` already
+  no-ops when the tracker is absent, so nothing else needs guarding.
+- **Beta is not indexed.** `frontend/src/app/robots.ts` is now host-aware
+  (dynamic via `headers()`): on `beta.allch.at` it returns
+  `Disallow: /` for every agent. The canonical/metadataBase URLs in
+  `layout.tsx`/`sitemap.ts` stay on allch.at, so what little beta does
+  expose points crawlers at prod.
+- **No beta overlay links (yet).** Server-generated links (share URLs, OBS
+  overlay URLs, payment/Patreon return URLs) keep pointing at allch.at via
+  `FRONTEND_URL` — no change. If beta-origin links are ever wanted, they
+  fall out of change 1's origin plumbing for free.
+
+## Verification after rollout
+
+1. `kubectl -n allchat get pods -l app=frontend-beta` ready; cert
+   `allchat-beta-tls` issued (`kubectl -n allchat get certificate`).
+2. `https://beta.allch.at` serves the beta build; `/api/health` proxied.
+3. Full login on beta.allch.at per provider: callback lands on
+   beta.allch.at, post-login redirect stays on beta.allch.at, cookie is set
+   host-only for beta.allch.at.
+4. Owner dashboard WebSocket connects from beta (cookie auth path).
+5. `https://beta.allch.at/robots.txt` returns `Disallow: /`;
+   `https://allch.at/robots.txt` unchanged.
+6. Beta page view sends no Umami event until `BETA_WEBSITE_ID` is set; after
+   it is set, events land in the beta website, not the prod one.
+7. Prod regression: login + WS on allch.at unchanged.

--- a/services/api-gateway/handlers/proxy.go
+++ b/services/api-gateway/handlers/proxy.go
@@ -110,6 +110,12 @@ func (p *ProxyHandler) ForwardRequest(c *gin.Context) {
 	// Copy headers from original request (strips sensitive client headers: L17)
 	copyHeaders(backendReq.Header, c.Request.Header)
 
+	// backendReq was built fresh, so its Host is the backend's — the original
+	// host is lost. Backends that serve more than one frontend origin (the
+	// auth-service picking an OAuth redirect target) recover it from here. Set
+	// after copyHeaders so a client-supplied X-Forwarded-Host cannot win.
+	backendReq.Header.Set("X-Forwarded-Host", c.Request.Host)
+
 	// Forward request to backend
 	backendResp, err := p.client.Do(backendReq)
 	if err != nil {

--- a/services/api-gateway/handlers/proxy_test.go
+++ b/services/api-gateway/handlers/proxy_test.go
@@ -264,3 +264,47 @@ func TestProxyHandler_BackendUnavailable(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, w.Code)
 	assert.Contains(t, w.Body.String(), "backend service unavailable")
 }
+
+// The gateway rebuilds the request, so the original Host would be lost without
+// X-Forwarded-Host. The auth-service picks the OAuth redirect target from it.
+func TestProxyHandler_ForwardsOriginalHost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var gotForwardedHost string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotForwardedHost = r.Header.Get("X-Forwarded-Host")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	registry := &models.ServiceRegistry{
+		Services: map[string]*models.ServiceConfig{
+			"auth-service": {
+				Name:       "auth-service",
+				BaseURL:    backend.URL,
+				PathPrefix: "/api/v1/auth",
+			},
+		},
+	}
+
+	handler := NewProxyHandler(registry)
+	router := gin.New()
+	router.Any("/api/v1/*path", handler.ForwardRequest)
+
+	// Original host wins…
+	req := httptest.NewRequest(http.MethodGet, "http://allch.at/api/v1/auth/twitch/login", nil)
+	req.Host = "allch.at"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "allch.at", gotForwardedHost)
+
+	// …and a client-supplied X-Forwarded-Host can never override it.
+	req = httptest.NewRequest(http.MethodGet, "http://allch.at/api/v1/auth/twitch/login", nil)
+	req.Host = "allch.at"
+	req.Header.Set("X-Forwarded-Host", "evil.example.com")
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "allch.at", gotForwardedHost)
+}

--- a/services/api-gateway/handlers/websocket.go
+++ b/services/api-gateway/handlers/websocket.go
@@ -511,19 +511,33 @@ func loadAllowedOrigins() []string {
 }
 
 // loadFirstPartyWSOrigins returns the exact same-origin app origin(s) from
-// FRONTEND_URL — the only origin that may authenticate the owner socket via the
-// ambient access cookie (audit #8). Returns nil when unset (e.g. local dev),
+// FRONTEND_URL + FRONTEND_URLS — the only origins that may authenticate the
+// owner socket via the ambient access cookie (audit #8). Returns nil when unset
+// (e.g. local dev),
 // in which case originAllowedForWS falls back to the permissive WS allowlist so
 // the monitor view keeps working.
 func loadFirstPartyWSOrigins() []string {
-	v := strings.TrimSpace(os.Getenv("FRONTEND_URL"))
-	if v == "" {
-		return nil
+	// FRONTEND_URL is the canonical origin; FRONTEND_URLS (comma-separated)
+	// adds secondary origins like the beta deployment. All of them are
+	// first-party: the same backend serves them, so each one's ambient cookie
+	// is equally trusted on the owner socket.
+	values := []string{os.Getenv("FRONTEND_URL")}
+	if extra := strings.TrimSpace(os.Getenv("FRONTEND_URLS")); extra != "" {
+		values = append(values, strings.Split(extra, ",")...)
 	}
-	if u, err := url.Parse(v); err == nil && u.Scheme != "" && u.Host != "" {
-		return []string{u.Scheme + "://" + u.Host}
+	var result []string
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if u, err := url.Parse(v); err == nil && u.Scheme != "" && u.Host != "" {
+			result = append(result, u.Scheme+"://"+u.Host)
+		} else {
+			result = append(result, v)
+		}
 	}
-	return []string{v}
+	return result
 }
 
 // originAllowedForWS is the pure origin-check logic extracted from checkOrigin

--- a/services/api-gateway/handlers/websocket_firstparty_test.go
+++ b/services/api-gateway/handlers/websocket_firstparty_test.go
@@ -1,0 +1,53 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadFirstPartyWSOrigins(t *testing.T) {
+	t.Run("FRONTEND_URL alone", func(t *testing.T) {
+		t.Setenv("FRONTEND_URL", "https://allch.at")
+		t.Setenv("FRONTEND_URLS", "")
+		assert.Equal(t, []string{"https://allch.at"}, loadFirstPartyWSOrigins())
+	})
+
+	t.Run("FRONTEND_URLS adds the beta origin", func(t *testing.T) {
+		t.Setenv("FRONTEND_URL", "https://allch.at")
+		t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+		assert.Equal(t,
+			[]string{"https://allch.at", "https://beta.allch.at"},
+			loadFirstPartyWSOrigins())
+	})
+
+	t.Run("trailing slashes and spacing are normalised", func(t *testing.T) {
+		t.Setenv("FRONTEND_URL", "https://allch.at/")
+		t.Setenv("FRONTEND_URLS", " https://beta.allch.at/ , https://staging.allch.at")
+		assert.Equal(t,
+			[]string{"https://allch.at", "https://beta.allch.at", "https://staging.allch.at"},
+			loadFirstPartyWSOrigins())
+	})
+
+	t.Run("unset FRONTEND_URL yields no first-party origins", func(t *testing.T) {
+		t.Setenv("FRONTEND_URL", "")
+		t.Setenv("FRONTEND_URLS", "")
+		assert.Nil(t, loadFirstPartyWSOrigins())
+	})
+}

--- a/services/auth-service/README.md
+++ b/services/auth-service/README.md
@@ -82,6 +82,11 @@ FRONTEND_URL=http://localhost:3000
 PORT=8081
 LOG_LEVEL=info  # debug, info, warn, error
 
+# Extra first-party frontend origins (e.g. the beta deployment), comma-separated.
+# OAuth flows started from one of these hosts use its registered callback URI
+# and redirect back to it; FRONTEND_URL stays the canonical fallback.
+# FRONTEND_URLS=https://allch.at,https://beta.allch.at
+
 # OpenTelemetry tracing
 OTEL_ENABLED=false
 OTEL_EXPORTER_OTLP_ENDPOINT=localhost:4317

--- a/services/auth-service/handlers/discord.go
+++ b/services/auth-service/handlers/discord.go
@@ -167,10 +167,39 @@ func (m *memStateStore) Del(_ context.Context, state string) error {
 	return nil
 }
 
-// HandleConnect generates a CSRF state token, stores it in Redis (state -> userID), and
+// flowOrigin returns the allowlisted frontend origin a Discord flow started from. States
+// written before the field existed — and legacy bare-user-id states still in flight across
+// a deploy — resolve to the handler's canonical frontend. The Discord counterpart of
+// stateOrigin for the V2 flows.
+func (h *DiscordHandler) flowOrigin(flow discordFlowState) string {
+	if origin := allowlistedOrigin(flow.Origin); origin != "" {
+		return origin
+	}
+	return strings.TrimSuffix(h.frontendURL, "/")
+}
+
+// originProvider returns the provider a flow bound to origin builds its authorize URL
+// and exchanges its code with: the shared instance for the canonical origin, else a copy
+// whose redirect_uri points at that origin's registered callback — the same swap
+// providerForOrigin applies to the V2 flows. Discord keeps its own because the handler's
+// provider interface (invite, guild and identity methods) is not oauth.OAuthProvider.
+// A non-concrete provider (tests) is returned unchanged.
+func (h *DiscordHandler) originProvider(origin string) DiscordOAuthProvider {
+	if origin == strings.TrimSuffix(h.frontendURL, "/") {
+		return h.oauth
+	}
+	if p, ok := h.oauth.(*oauth.DiscordOAuth); ok {
+		return p.WithRedirectURL(originCallbackURL(origin, oauth.PlatformDiscord))
+	}
+	return h.oauth
+}
+
+// HandleConnect generates a CSRF state token, stores it in Redis (state -> flow), and
 // returns the Discord bot invite URL for the authenticated user. When ?moderation=true,
 // it returns the elevated moderation re-invite URL (ADR-0017): re-authorizing on an
 // existing guild upgrades the bot's permissions in place so the streamer can moderate.
+// The invite URL and the stored state both carry the originating frontend's origin, so
+// a beta.allch.at user is sent back to beta (see originProvider and flowOrigin).
 // Route: GET /discord/connect (JWT required)
 func (h *DiscordHandler) HandleConnect(c *gin.Context) {
 	userIDRaw, exists := c.Get("user_id")
@@ -180,6 +209,8 @@ func (h *DiscordHandler) HandleConnect(c *gin.Context) {
 	}
 	userID := fmt.Sprintf("%v", userIDRaw)
 
+	origin := requestFrontendOrigin(c)
+
 	state, err := generateRandomString(32)
 	if err != nil {
 		h.log.Error("discord: failed to generate state", zap.Error(err))
@@ -187,15 +218,22 @@ func (h *DiscordHandler) HandleConnect(c *gin.Context) {
 		return
 	}
 
-	if err := h.stateStore.Set(c.Request.Context(), state, userID, 10*time.Minute); err != nil {
+	stored, err := encodeDiscordFlowState(discordFlowState{UserID: userID, Origin: origin})
+	if err != nil {
+		h.log.Error("discord: failed to encode state", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+		return
+	}
+	if err := h.stateStore.Set(c.Request.Context(), state, stored, 10*time.Minute); err != nil {
 		h.log.Error("discord: failed to store OAuth state", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		return
 	}
 
-	inviteURL := h.oauth.GetAuthURL(state)
+	provider := h.originProvider(origin)
+	inviteURL := provider.GetAuthURL(state)
 	if c.Query("moderation") == "true" {
-		inviteURL = h.oauth.GetModerationAuthURL(state)
+		inviteURL = provider.GetModerationAuthURL(state)
 	}
 	c.JSON(http.StatusOK, gin.H{"bot_invite_url": inviteURL})
 }
@@ -240,6 +278,7 @@ func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 		return
 	}
 	userID := flow.UserID
+	origin := h.flowOrigin(flow)
 
 	// Only the bot invite carries a guild; the account link never does.
 	if guildID == "" {
@@ -248,7 +287,7 @@ func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 	}
 
 	// Exchange code for token (stored for audit only — not used for subsequent calls)
-	_, err = h.oauth.ExchangeCode(ctx, code)
+	_, err = h.originProvider(origin).ExchangeCode(ctx, code)
 	if err != nil {
 		h.log.Error("discord: code exchange failed", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to exchange authorization code"})
@@ -294,7 +333,7 @@ func (h *DiscordHandler) HandleCallback(c *gin.Context) {
 		zap.String("guild_name", guildName),
 	)
 
-	redirectURL := strings.TrimSuffix(h.frontendURL, "/") + "/settings?discord=connected"
+	redirectURL := origin + "/settings?discord=connected"
 	c.Redirect(http.StatusFound, redirectURL)
 }
 

--- a/services/auth-service/handlers/discord_identity.go
+++ b/services/auth-service/handlers/discord_identity.go
@@ -54,6 +54,9 @@ type discordFlowState struct {
 	// Return is an allowlisted key naming where to send the browser afterwards — a key, never a
 	// URL, so this can never become an open redirect.
 	Return string `json:"return,omitempty"`
+	// Origin is the allowlisted frontend origin the flow started from, redirecting the
+	// callback back to the host the user began on (beta.allch.at as well as allch.at).
+	Origin string `json:"origin,omitempty"`
 }
 
 // discordReturnPaths is the closed allowlist of post-link destinations. A streamer links from
@@ -104,6 +107,8 @@ func (h *DiscordHandler) HandleIdentityConnect(c *gin.Context) {
 	}
 	userID := fmt.Sprintf("%v", userIDRaw)
 
+	origin := requestFrontendOrigin(c)
+
 	returnKey := c.Query("return")
 	if _, ok := discordReturnPaths[returnKey]; !ok {
 		returnKey = defaultDiscordReturn
@@ -119,6 +124,7 @@ func (h *DiscordHandler) HandleIdentityConnect(c *gin.Context) {
 		Kind:   discordFlowIdentity,
 		UserID: userID,
 		Return: returnKey,
+		Origin: origin,
 	})
 	if err != nil {
 		h.log.Error("discord identity: failed to encode state", zap.Error(err))
@@ -131,7 +137,7 @@ func (h *DiscordHandler) HandleIdentityConnect(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"auth_url": h.oauth.GetIdentityAuthURL(state)})
+	c.JSON(http.StatusOK, gin.H{"auth_url": h.originProvider(origin).GetIdentityAuthURL(state)})
 }
 
 // completeIdentityLink finishes the account link. Called from the shared callback once the stored
@@ -146,17 +152,20 @@ func (h *DiscordHandler) completeIdentityLink(c *gin.Context, flow discordFlowSt
 		return
 	}
 
-	token, err := h.oauth.ExchangeCode(ctx, code)
+	origin := h.flowOrigin(flow)
+	provider := h.originProvider(origin)
+
+	token, err := provider.ExchangeCode(ctx, code)
 	if err != nil {
 		h.log.Error("discord identity: code exchange failed", zap.Error(err))
-		h.redirectIdentity(c, flow.Return, "error=exchange_failed")
+		h.redirectIdentity(c, origin, flow.Return, "error=exchange_failed")
 		return
 	}
 
 	identity, err := h.oauth.GetIdentity(ctx, token.AccessToken)
 	if err != nil {
 		h.log.Error("discord identity: identity read failed", zap.Error(err))
-		h.redirectIdentity(c, flow.Return, "error=identity_unavailable")
+		h.redirectIdentity(c, origin, flow.Return, "error=identity_unavailable")
 		return
 	}
 
@@ -167,11 +176,11 @@ func (h *DiscordHandler) completeIdentityLink(c *gin.Context, flow discordFlowSt
 		// user round the consent loop forever.
 		h.log.Warn("discord identity: account already linked to another user",
 			zap.String("user_id", flow.UserID))
-		h.redirectIdentity(c, flow.Return, "error=already_linked")
+		h.redirectIdentity(c, origin, flow.Return, "error=already_linked")
 		return
 	case err != nil:
 		h.log.Error("discord identity: failed to store link", zap.String("user_id", flow.UserID), zap.Error(err))
-		h.redirectIdentity(c, flow.Return, "error=save_failed")
+		h.redirectIdentity(c, origin, flow.Return, "error=save_failed")
 		return
 	}
 
@@ -179,16 +188,17 @@ func (h *DiscordHandler) completeIdentityLink(c *gin.Context, flow discordFlowSt
 	// on Discord — every write is the bot — so retaining the token would be a credential held for
 	// no purpose.
 	h.log.Info("discord identity: linked", zap.String("user_id", flow.UserID))
-	h.redirectIdentity(c, flow.Return, "discord_account=linked")
+	h.redirectIdentity(c, origin, flow.Return, "discord_account=linked")
 }
 
-// redirectIdentity sends the browser back to the allowlisted return path with a result marker.
-func (h *DiscordHandler) redirectIdentity(c *gin.Context, returnKey, query string) {
+// redirectIdentity sends the browser back to the allowlisted return path on the origin
+// the flow started from, with a result marker.
+func (h *DiscordHandler) redirectIdentity(c *gin.Context, origin, returnKey, query string) {
 	path, ok := discordReturnPaths[returnKey]
 	if !ok {
 		path = discordReturnPaths[defaultDiscordReturn]
 	}
-	c.Redirect(http.StatusFound, strings.TrimSuffix(h.frontendURL, "/")+path+"?"+query)
+	c.Redirect(http.StatusFound, origin+path+"?"+query)
 }
 
 // HandleGetIdentity reports whether the caller has linked a Discord account.

--- a/services/auth-service/handlers/discord_identity_test.go
+++ b/services/auth-service/handlers/discord_identity_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -315,4 +316,114 @@ func TestHandleDeleteIdentity_RequiresAuth(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 	assert.False(t, r.deleteIdentityCalled)
+}
+
+// --- Frontend-origin behaviour (beta.allch.at) ---
+
+// authedFromHost is authed plus the api-gateway's X-Forwarded-Host stamp — the only way
+// the originating frontend host reaches the auth-service behind the proxy.
+func authedFromHost(h *DiscordHandler, method, target, forwardedHost, userID string, fn func(*DiscordHandler, *gin.Context)) *httptest.ResponseRecorder {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, target, nil)
+	c.Request.Header.Set("X-Forwarded-Host", forwardedHost)
+	c.Set("user_id", userID)
+	fn(h, c)
+	return w
+}
+
+// TestHandleIdentityConnect_BetaOriginSwapsRedirectURI: the consent URL must carry the
+// beta callback URI and the state must remember the beta origin for the shared callback.
+func TestHandleIdentityConnect_BetaOriginSwapsRedirectURI(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	provider := oauth.NewDiscordOAuth("id", "secret", "https://allch.at/api/v1/auth/discord/callback")
+	h := newTestDiscordHandlerNoRedis(provider, &mockDiscordRepo{}, "https://allch.at")
+	store := h.stateStore.(*memStateStore)
+
+	w := authedFromHost(h, http.MethodGet, "/discord/identity/connect?return=moderate",
+		"beta.allch.at", "user-1", (*DiscordHandler).HandleIdentityConnect)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	authURL, err := url.Parse(body["auth_url"])
+	require.NoError(t, err)
+	assert.Equal(t, "https://beta.allch.at/api/v1/auth/discord/callback",
+		authURL.Query().Get("redirect_uri"))
+
+	require.Len(t, store.states, 1, "exactly one state is issued")
+	for _, stored := range store.states {
+		flow := parseDiscordFlowState(stored)
+		assert.Equal(t, "https://beta.allch.at", flow.Origin)
+	}
+}
+
+// TestCallback_BotInviteRedirectsToFlowOrigin: the invite callback must land the browser
+// back on the frontend the state was issued for, not the canonical one.
+func TestCallback_BotInviteRedirectsToFlowOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	r := &mockDiscordRepo{}
+	h := identityHandler(&mockDiscordOAuth{exchangeToken: &oauth2.Token{AccessToken: "tok"}}, r)
+
+	stored, err := encodeDiscordFlowState(discordFlowState{UserID: "user-1", Origin: "https://beta.allch.at"})
+	require.NoError(t, err)
+	w := callback(t, h, stored, "&code=abc&guild_id=g-1")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://beta.allch.at/settings?discord=connected", w.Header().Get("Location"))
+	assert.True(t, r.upsertCalled, "the invite branch must still record the guild")
+}
+
+// TestCallback_IdentityFlowRedirectsToFlowOrigin: the account link lands the browser back
+// on its own return path, on the origin it started from.
+func TestCallback_IdentityFlowRedirectsToFlowOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	o := &mockDiscordOAuth{
+		exchangeToken: &oauth2.Token{AccessToken: "user-token"},
+		identity:      &oauth.DiscordIdentity{ID: "42424242", Username: "volunteer"},
+	}
+	h := identityHandler(o, &mockDiscordRepo{})
+
+	stored, err := encodeDiscordFlowState(discordFlowState{
+		Kind:   discordFlowIdentity,
+		UserID: "user-1",
+		Return: "moderate",
+		Origin: "https://beta.allch.at",
+	})
+	require.NoError(t, err)
+	w := callback(t, h, stored, "&code=abc")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://beta.allch.at/moderate?discord_account=linked", w.Header().Get("Location"))
+}
+
+// TestCallback_UnknownStateOriginStaysCanonical: a state origin that is not on the
+// allowlist must never become a redirect target, even though the state is server-written.
+func TestCallback_UnknownStateOriginStaysCanonical(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	o := &mockDiscordOAuth{
+		exchangeToken: &oauth2.Token{AccessToken: "user-token"},
+		identity:      &oauth.DiscordIdentity{ID: "42", Username: "v"},
+	}
+	h := identityHandler(o, &mockDiscordRepo{})
+
+	stored, err := encodeDiscordFlowState(discordFlowState{
+		Kind:   discordFlowIdentity,
+		UserID: "user-1",
+		Origin: "https://evil.example.com",
+	})
+	require.NoError(t, err)
+	w := callback(t, h, stored, "&code=abc")
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, "https://allch.at/settings?discord_account=linked", w.Header().Get("Location"))
 }

--- a/services/auth-service/handlers/discord_test.go
+++ b/services/auth-service/handlers/discord_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -478,6 +479,58 @@ func TestHandleDiscordCallback_StoresGuild(t *testing.T) {
 	location := w.Header().Get("Location")
 	if !containsString(location, "discord=connected") {
 		t.Errorf("redirect Location %q must contain 'discord=connected'", location)
+	}
+}
+
+// TestHandleDiscordConnect_BetaOriginSwapsRedirectURI: an invite started from the beta
+// frontend must carry the beta callback URI in the invite URL and record the beta origin
+// in the stored state, so the shared callback sends the streamer back to beta.
+func TestHandleDiscordConnect_BetaOriginSwapsRedirectURI(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+	gin.SetMode(gin.TestMode)
+
+	provider := oauth.NewDiscordOAuth("id", "secret", "https://allch.at/api/v1/auth/discord/callback")
+	handler := newTestDiscordHandlerNoRedis(provider, &mockDiscordRepo{}, "https://allch.at")
+
+	router := gin.New()
+	router.GET("/discord/connect", func(c *gin.Context) {
+		c.Set("user_id", "user-123")
+		handler.HandleConnect(c)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/discord/connect", nil)
+	req.Header.Set("X-Forwarded-Host", "beta.allch.at")
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	inviteURL, err := url.Parse(resp["bot_invite_url"])
+	if err != nil {
+		t.Fatalf("bot_invite_url is not a URL: %v", err)
+	}
+	if got := inviteURL.Query().Get("redirect_uri"); got != "https://beta.allch.at/api/v1/auth/discord/callback" {
+		t.Errorf("invite redirect_uri %q does not point at the beta callback", got)
+	}
+
+	store := handler.stateStore.(*memStateStore)
+	if len(store.states) != 1 {
+		t.Fatalf("expected exactly one stored state, got %d", len(store.states))
+	}
+	for _, stored := range store.states {
+		flow := parseDiscordFlowState(stored)
+		if flow.Origin != "https://beta.allch.at" {
+			t.Errorf("state origin %q does not record the beta frontend", flow.Origin)
+		}
+		if flow.Kind != "" {
+			t.Errorf("a connect state must be a bot invite, got kind %q", flow.Kind)
+		}
 	}
 }
 

--- a/services/auth-service/handlers/frontend_origin.go
+++ b/services/auth-service/handlers/frontend_origin.go
@@ -88,12 +88,30 @@ func stateOrigin(state *oauth.OAuthState) string {
 	if state == nil {
 		return canonicalFrontendURL()
 	}
-	if origin := normalizeOrigin(state.Origin); origin != "" {
+	if origin := allowlistedOrigin(state.Origin); origin != "" {
+		return origin
+	}
+	return canonicalFrontendURL()
+}
+
+// allowlistedOrigin returns raw as a normalized origin when it is currently
+// allowlisted, "" otherwise. The shared re-check behind stateOrigin and the
+// Discord flow-origin lookup: a stored origin is server-written, but the
+// allowlist may have shrunk between authorize and callback.
+func allowlistedOrigin(raw string) string {
+	if origin := normalizeOrigin(raw); origin != "" {
 		if _, ok := allowedFrontendOrigins()[origin]; ok {
 			return origin
 		}
 	}
-	return canonicalFrontendURL()
+	return ""
+}
+
+// originCallbackURL is the auth callback URI registered at the platform for
+// origin: every allowlisted frontend origin has its own callback registration
+// there, at the same path on its own host.
+func originCallbackURL(origin string, platform oauth.Platform) string {
+	return fmt.Sprintf("%s/api/v1/auth/%s/callback", origin, platform)
 }
 
 // providerForOrigin returns a provider whose redirect_uri points at origin's
@@ -105,7 +123,7 @@ func providerForOrigin(provider oauth.OAuthProvider, platform oauth.Platform, or
 	if origin == canonicalFrontendURL() {
 		return provider
 	}
-	redirectURL := fmt.Sprintf("%s/api/v1/auth/%s/callback", origin, platform)
+	redirectURL := originCallbackURL(origin, platform)
 	switch p := provider.(type) {
 	case *oauth.TwitchOAuth:
 		return p.WithRedirectURL(redirectURL)

--- a/services/auth-service/handlers/frontend_origin.go
+++ b/services/auth-service/handlers/frontend_origin.go
@@ -1,0 +1,119 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/gin-gonic/gin"
+)
+
+// canonicalFrontendURL returns FRONTEND_URL, the default origin every OAuth
+// flow returns to when the request carries no allowlisted origin of its own.
+func canonicalFrontendURL() string {
+	return strings.TrimSuffix(getEnvOrDefault("FRONTEND_URL", "http://localhost:3000"), "/")
+}
+
+// allowedFrontendOrigins is the set of origins an OAuth flow may redirect back
+// to: the canonical FRONTEND_URL plus every entry in FRONTEND_URLS (comma-
+// separated). Normalised to scheme://host so a trailing slash in either env
+// var cannot split the set.
+func allowedFrontendOrigins() map[string]struct{} {
+	allowed := map[string]struct{}{canonicalFrontendURL(): {}}
+	for _, raw := range strings.Split(getEnvOrDefault("FRONTEND_URLS", ""), ",") {
+		origin := normalizeOrigin(raw)
+		if origin != "" {
+			allowed[origin] = struct{}{}
+		}
+	}
+	return allowed
+}
+
+// normalizeOrigin reduces an origin to scheme://host, dropping path, trailing
+// slash and casing differences in the host. Returns "" for anything that does
+// not parse to an absolute http(s) URL.
+func normalizeOrigin(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + strings.ToLower(u.Host)
+}
+
+// requestFrontendOrigin resolves which frontend origin started this OAuth
+// flow. The browser's Host never reaches the auth-service: the api-gateway
+// builds a fresh backend request and stamps the original host on
+// X-Forwarded-Host (see api-gateway proxy.go). A host that is not on the
+// allowlist falls back to the canonical FRONTEND_URL, so the value returned
+// here is always safe to redirect to.
+func requestFrontendOrigin(c *gin.Context) string {
+	host := c.Request.Host
+	if forwarded := c.GetHeader("X-Forwarded-Host"); forwarded != "" {
+		// First entry wins; the gateway sets exactly one, anything beyond it
+		// came from the client and is untrusted.
+		host, _, _ = strings.Cut(forwarded, ",")
+		host = strings.TrimSpace(host)
+	}
+	if origin := normalizeOrigin("https://" + host); origin != "" {
+		if _, ok := allowedFrontendOrigins()[origin]; ok {
+			return origin
+		}
+	}
+	return canonicalFrontendURL()
+}
+
+// stateOrigin returns the origin recorded in a verified OAuth state, falling
+// back to the canonical frontend for states written before Origin existed.
+// The state is already trusted at this point (the callback byte-compares it
+// against the Redis copy); the allowlist re-check guards against an allowlist
+// that shrank between login and callback.
+func stateOrigin(state *oauth.OAuthState) string {
+	if state == nil {
+		return canonicalFrontendURL()
+	}
+	if origin := normalizeOrigin(state.Origin); origin != "" {
+		if _, ok := allowedFrontendOrigins()[origin]; ok {
+			return origin
+		}
+	}
+	return canonicalFrontendURL()
+}
+
+// providerForOrigin returns a provider whose redirect_uri points at origin's
+// auth callback, so the authorize URL and the code exchange agree with the
+// callback URI registered at the platform for that origin. The canonical
+// origin returns the provider unchanged — one instance, no copies, for the
+// overwhelmingly common case.
+func providerForOrigin(provider oauth.OAuthProvider, platform oauth.Platform, origin string) oauth.OAuthProvider {
+	if origin == canonicalFrontendURL() {
+		return provider
+	}
+	redirectURL := fmt.Sprintf("%s/api/v1/auth/%s/callback", origin, platform)
+	switch p := provider.(type) {
+	case *oauth.TwitchOAuth:
+		return p.WithRedirectURL(redirectURL)
+	case *oauth.YouTubeOAuth:
+		return p.WithRedirectURL(redirectURL)
+	case *oauth.KickOAuth:
+		return p.WithRedirectURL(redirectURL)
+	default:
+		return provider
+	}
+}

--- a/services/auth-service/handlers/frontend_origin_test.go
+++ b/services/auth-service/handlers/frontend_origin_test.go
@@ -1,0 +1,209 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/caesar/all-chat/services/auth-service/oauth"
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func originTestContext(host, forwardedHost string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "https://"+host+"/twitch/login", nil)
+	if forwardedHost != "" {
+		req.Header.Set("X-Forwarded-Host", forwardedHost)
+	}
+	c.Request = req
+	return c
+}
+
+func TestRequestFrontendOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	tests := []struct {
+		name          string
+		host          string
+		forwardedHost string
+		want          string
+	}{
+		{"allowlisted beta host via gateway header", "auth-service:8081", "beta.allch.at", "https://beta.allch.at"},
+		{"allowlisted prod host via gateway header", "auth-service:8081", "allch.at", "https://allch.at"},
+		{"unknown forwarded host falls back to canonical", "auth-service:8081", "evil.example.com", "https://allch.at"},
+		{"first forwarded entry wins", "auth-service:8081", "beta.allch.at, evil.example.com", "https://beta.allch.at"},
+		{"no gateway header uses request host", "allch.at", "", "https://allch.at"},
+		{"trailing slash in FRONTEND_URLS still matches", "auth-service:8081", "beta.allch.at", "https://beta.allch.at"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requestFrontendOrigin(originTestContext(tt.host, tt.forwardedHost)))
+		})
+	}
+}
+
+func TestRequestFrontendOrigin_NoAllowlistConfigured(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "")
+
+	// Without FRONTEND_URLS the beta host is not first-party and the flow must
+	// return to the canonical origin, never to the unverified request host.
+	c := originTestContext("auth-service:8081", "beta.allch.at")
+	assert.Equal(t, "https://allch.at", requestFrontendOrigin(c))
+}
+
+func TestStateOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	t.Run("nil state falls back to canonical", func(t *testing.T) {
+		assert.Equal(t, "https://allch.at", stateOrigin(nil))
+	})
+	t.Run("empty origin is canonical (states predating the field)", func(t *testing.T) {
+		assert.Equal(t, "https://allch.at", stateOrigin(&oauth.OAuthState{}))
+	})
+	t.Run("allowlisted origin survives", func(t *testing.T) {
+		s := &oauth.OAuthState{Origin: "https://beta.allch.at"}
+		assert.Equal(t, "https://beta.allch.at", stateOrigin(s))
+	})
+	t.Run("non-allowlisted origin is rejected", func(t *testing.T) {
+		s := &oauth.OAuthState{Origin: "https://evil.example.com"}
+		assert.Equal(t, "https://allch.at", stateOrigin(s))
+	})
+}
+
+func TestProviderForOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	canonical := "https://allch.at/api/v1/auth/twitch/callback"
+	twitch := oauth.NewTwitchOAuth("id", "secret", canonical)
+
+	t.Run("canonical origin returns the provider unchanged", func(t *testing.T) {
+		assert.Same(t, twitch, providerForOrigin(twitch, oauth.PlatformTwitch, "https://allch.at"))
+	})
+	t.Run("beta origin swaps the redirect URI", func(t *testing.T) {
+		p := providerForOrigin(twitch, oauth.PlatformTwitch, "https://beta.allch.at")
+		authURL, err := url.Parse(p.GetAuthURL("state"))
+		require.NoError(t, err)
+		assert.Equal(t,
+			"https://beta.allch.at/api/v1/auth/twitch/callback",
+			authURL.Query().Get("redirect_uri"))
+		// The original provider is untouched.
+		origURL, _ := url.Parse(twitch.GetAuthURL("state"))
+		assert.Equal(t, canonical, origURL.Query().Get("redirect_uri"))
+	})
+}
+
+// A login started on the beta host must carry that origin into the provider's
+// redirect_uri and into the server-side state the callback later reads.
+func TestHandleLogin_RecordsAllowlistedOrigin(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	mr := miniredis.RunT(t)
+	h := &PlatformAuthHandlerV2{
+		providers: map[oauth.Platform]oauth.OAuthProvider{
+			oauth.PlatformTwitch: oauth.NewTwitchOAuth("id", "secret", "https://allch.at/api/v1/auth/twitch/callback"),
+		},
+		redis:       redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		logger:      zap.NewNop(),
+		frontendURL: "https://allch.at",
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/twitch/login", h.HandleLogin(oauth.PlatformTwitch))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "https://auth-service:8081/twitch/login", nil)
+	req.Header.Set("X-Forwarded-Host", "beta.allch.at")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	authURL, err := url.Parse(body["auth_url"])
+	require.NoError(t, err)
+	assert.Equal(t,
+		"https://beta.allch.at/api/v1/auth/twitch/callback",
+		authURL.Query().Get("redirect_uri"))
+
+	// Twitch login also stashes the PKCE verifier; the state is the other key.
+	var stateKeys []string
+	for _, k := range mr.Keys() {
+		if strings.HasPrefix(k, "oauth_state:") {
+			stateKeys = append(stateKeys, k)
+		}
+	}
+	require.Len(t, stateKeys, 1, "expected exactly the stored oauth state")
+	stored, err := mr.Get(stateKeys[0])
+	require.NoError(t, err)
+	var state oauth.OAuthState
+	require.NoError(t, json.Unmarshal([]byte(stored), &state))
+	assert.Equal(t, "https://beta.allch.at", state.Origin)
+}
+
+// Without the allowlist header the same handler must keep redirecting to the
+// canonical callback exactly as before the origin plumbing existed.
+func TestHandleLogin_UnknownHostStaysCanonical(t *testing.T) {
+	t.Setenv("FRONTEND_URL", "https://allch.at")
+	t.Setenv("FRONTEND_URLS", "https://beta.allch.at")
+
+	mr := miniredis.RunT(t)
+	h := &PlatformAuthHandlerV2{
+		providers: map[oauth.Platform]oauth.OAuthProvider{
+			oauth.PlatformTwitch: oauth.NewTwitchOAuth("id", "secret", "https://allch.at/api/v1/auth/twitch/callback"),
+		},
+		redis:       redis.NewClient(&redis.Options{Addr: mr.Addr()}),
+		logger:      zap.NewNop(),
+		frontendURL: "https://allch.at",
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/twitch/login", h.HandleLogin(oauth.PlatformTwitch))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "https://auth-service:8081/twitch/login", nil)
+	req.Header.Set("X-Forwarded-Host", "evil.example.com")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	authURL, err := url.Parse(body["auth_url"])
+	require.NoError(t, err)
+	assert.Equal(t,
+		"https://allch.at/api/v1/auth/twitch/callback",
+		authURL.Query().Get("redirect_uri"))
+}

--- a/services/auth-service/handlers/mod_consent.go
+++ b/services/auth-service/handlers/mod_consent.go
@@ -61,6 +61,10 @@ func (h *PlatformAuthHandlerV2) HandleModConsent(platform oauth.Platform) gin.Ha
 			return
 		}
 
+		// Origin handling: see HandleLogin.
+		origin := requestFrontendOrigin(c)
+		provider = providerForOrigin(provider, platform, origin)
+
 		userID, exists := c.Get("user_id")
 		if !exists {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized - please log in first"})
@@ -117,6 +121,7 @@ func (h *PlatformAuthHandlerV2) HandleModConsent(platform oauth.Platform) gin.Ha
 		}
 
 		oauthState := oauth.NewModConsentState(csrfToken, userIDStr)
+		oauthState.Origin = origin
 		if err := oauthState.Validate(); err != nil {
 			h.logger.Error("Invalid mod-consent OAuth state", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -214,7 +219,7 @@ func (h *PlatformAuthHandlerV2) completeModConsent(
 	// moderator and an empty user id must never reach the store.
 	if state.UserID == "" {
 		h.logger.Error("mod-consent callback without a user id", zap.String("platform", string(platform)))
-		h.redirectModConsent(c, platform, state.CSRFToken, "", "invalid_state")
+		h.redirectModConsent(c, platform, state.CSRFToken, stateOrigin(state), "", "invalid_state")
 		return
 	}
 
@@ -232,7 +237,7 @@ func (h *PlatformAuthHandlerV2) completeModConsent(
 			zap.String("platform", string(platform)),
 			zap.String("user_id", state.UserID),
 			zap.Error(err))
-		h.redirectModConsent(c, platform, state.CSRFToken, "", "credential_store_failed")
+		h.redirectModConsent(c, platform, state.CSRFToken, stateOrigin(state), "", "credential_store_failed")
 		return
 	}
 
@@ -242,7 +247,7 @@ func (h *PlatformAuthHandlerV2) completeModConsent(
 		zap.String("platform_user_id", platformUser.GetID()),
 		zap.Strings("granted_scopes", granted))
 
-	h.redirectModConsent(c, platform, state.CSRFToken, string(platform), "")
+	h.redirectModConsent(c, platform, state.CSRFToken, stateOrigin(state), string(platform), "")
 }
 
 // redirectModConsent returns the moderator to the moderation area.
@@ -251,8 +256,8 @@ func (h *PlatformAuthHandlerV2) completeModConsent(
 // moderator was already signed in when they started, and this flow deliberately does not
 // re-issue a session — it grants a capability to an existing account rather than establishing
 // one.
-func (h *PlatformAuthHandlerV2) redirectModConsent(c *gin.Context, platform oauth.Platform, csrfToken, connected, errCode string) {
-	target := fmt.Sprintf("%s/moderate", h.frontendURL)
+func (h *PlatformAuthHandlerV2) redirectModConsent(c *gin.Context, platform oauth.Platform, csrfToken, origin, connected, errCode string) {
+	target := fmt.Sprintf("%s/moderate", origin)
 	switch {
 	case errCode != "":
 		target = fmt.Sprintf("%s?error=%s&platform=%s", target, errCode, platform)

--- a/services/auth-service/handlers/platform_auth_v2.go
+++ b/services/auth-service/handlers/platform_auth_v2.go
@@ -109,8 +109,13 @@ func (h *PlatformAuthHandlerV2) HandleLogin(platform oauth.Platform) gin.Handler
 			return
 		}
 
-		// Create login state
+		// Create login state. The allowlisted origin the flow started from decides
+		// which registered callback URI the provider sees and which frontend the
+		// user returns to (beta.allch.at vs allch.at).
+		origin := requestFrontendOrigin(c)
+		provider = providerForOrigin(provider, platform, origin)
 		oauthState := oauth.NewLoginState(csrfToken)
+		oauthState.Origin = origin
 		if err := oauthState.Validate(); err != nil {
 			h.logger.Error("Invalid OAuth state", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -293,8 +298,12 @@ func (h *PlatformAuthHandlerV2) HandleAddSource(platform oauth.Platform) gin.Han
 			return
 		}
 
-		// Create add-source state with current user_id for account linking
+		// Create add-source state with current user_id for account linking.
+		// Origin handling: see HandleLogin.
+		origin := requestFrontendOrigin(c)
+		provider = providerForOrigin(provider, platform, origin)
 		oauthState := oauth.NewAddSourceState(csrfToken, overlayID, userIDStr)
+		oauthState.Origin = origin
 		if err := oauthState.Validate(); err != nil {
 			h.logger.Error("Invalid OAuth state", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -420,7 +429,10 @@ func (h *PlatformAuthHandlerV2) HandleEnableModeration(platform oauth.Platform) 
 			return
 		}
 
+		origin := requestFrontendOrigin(c)
+		provider = providerForOrigin(provider, platform, origin)
 		oauthState := oauth.NewModerationState(csrfToken, overlayID, userIDStr)
+		oauthState.Origin = origin
 		if err := oauthState.Validate(); err != nil {
 			h.logger.Error("Invalid OAuth state", zap.Error(err))
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -659,6 +671,11 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 
 		// State was already deleted atomically by GetDel (audit L5).
 
+		// The origin is trusted: the query state byte-matched the server-stored
+		// copy, and stateOrigin re-checks the allowlist before use.
+		origin := stateOrigin(oauthState)
+		provider = providerForOrigin(provider, platform, origin)
+
 		// Exchange code for token (handle PKCE for Kick)
 		token, err := h.exchangeCodeForToken(c.Request.Context(), provider, platform, code, oauthState.CSRFToken)
 		if err != nil {
@@ -696,7 +713,7 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 				zap.String("platform", string(platform)),
 				zap.String("platform_id", platformUser.GetID()),
 			)
-			h.redirectWithTombstone(c, platform, oauthState.CSRFToken, fmt.Sprintf("%s/auth/banned", h.frontendURL))
+			h.redirectWithTombstone(c, platform, oauthState.CSRFToken, fmt.Sprintf("%s/auth/banned", origin))
 			return
 		}
 
@@ -807,7 +824,7 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 						zap.String("existing_username", dupErr.ExistingUsername),
 					)
 					redirectURL := fmt.Sprintf("%s/auth/callback?error=duplicate_account&existing_username=%s&platform=%s",
-						h.frontendURL,
+						origin,
 						dupErr.ExistingUsername,
 						dupErr.Platform,
 					)
@@ -843,9 +860,9 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 				)
 				// Redirect with error. Moderation re-consent returns to the overlay
 				// monitor it was launched from, not the overlay settings page.
-				errRedirect := fmt.Sprintf("%s/overlays/%s?error=failed_to_add_source", h.frontendURL, oauthState.OverlayID)
+				errRedirect := fmt.Sprintf("%s/overlays/%s?error=failed_to_add_source", origin, oauthState.OverlayID)
 				if oauthState.IsModeration() {
-					errRedirect = fmt.Sprintf("%s/overlay/%s/view?error=moderation_setup_failed", h.frontendURL, oauthState.OverlayID)
+					errRedirect = fmt.Sprintf("%s/overlay/%s/view?error=moderation_setup_failed", origin, oauthState.OverlayID)
 				}
 				h.redirectWithTombstone(c, platform, oauthState.CSRFToken, errRedirect)
 				return
@@ -884,7 +901,7 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate redirect"})
 				return
 			}
-			redirectURL := fmt.Sprintf("%s/auth/callback?code=%s", h.frontendURL, code)
+			redirectURL := fmt.Sprintf("%s/auth/callback?code=%s", origin, code)
 
 			h.logger.Info("Source added successfully via OAuth",
 				zap.String("platform", string(platform)),
@@ -912,7 +929,7 @@ func (h *PlatformAuthHandlerV2) HandleCallback(platform oauth.Platform) gin.Hand
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate redirect"})
 				return
 			}
-			redirectURL := fmt.Sprintf("%s/auth/callback?code=%s", h.frontendURL, code)
+			redirectURL := fmt.Sprintf("%s/auth/callback?code=%s", origin, code)
 
 			h.logger.Info("User authenticated successfully",
 				zap.String("platform", string(platform)),
@@ -1468,10 +1485,11 @@ func (h *PlatformAuthHandlerV2) addSourceToOverlay(
 // failure, returning the user to the page the flow was launched from: the overlay
 // monitor for a moderation re-consent (ADR-0017), otherwise overlay settings.
 func (h *PlatformAuthHandlerV2) youtubeAddSourceErrorURL(state *oauth.OAuthState, errCode string) string {
+	origin := stateOrigin(state)
 	if state.IsModeration() {
-		return fmt.Sprintf("%s/overlay/%s/view?error=%s", h.frontendURL, state.OverlayID, errCode)
+		return fmt.Sprintf("%s/overlay/%s/view?error=%s", origin, state.OverlayID, errCode)
 	}
-	return fmt.Sprintf("%s/overlays/%s?error=%s", h.frontendURL, state.OverlayID, errCode)
+	return fmt.Sprintf("%s/overlays/%s?error=%s", origin, state.OverlayID, errCode)
 }
 
 // redirectWithTombstone performs an OAuth redirect and stores an idempotency tombstone in Redis.

--- a/services/auth-service/oauth/discord.go
+++ b/services/auth-service/oauth/discord.go
@@ -97,6 +97,23 @@ func (d *DiscordOAuth) WithBotToken(botToken string) *DiscordOAuth {
 	return d
 }
 
+// WithRedirectURL returns a provider that redirects to redirectURL instead. Used to
+// point the invite and identity flows at a second frontend origin (beta.allch.at)
+// whose callback URI is registered separately with the Discord app; both authorize
+// URLs and the code exchange must agree on it. Built field-wise rather than by struct
+// copy: the botID cache's mutex must not be copied (go vet copylocks), and the
+// swapped copy simply resolves its own botID if it ever needs one.
+func (d *DiscordOAuth) WithRedirectURL(redirectURL string) *DiscordOAuth {
+	return &DiscordOAuth{
+		clientID:     d.clientID,
+		clientSecret: d.clientSecret,
+		redirectURL:  redirectURL,
+		botToken:     d.botToken,
+		client:       d.client,
+		apiBase:      d.apiBase,
+	}
+}
+
 // GetAuthURL returns the base Discord bot invite URL. This shows a guild picker (not a
 // user login page) because scope=bot signals Discord to use the bot authorization flow.
 // The base permissions are VIEW_CHANNEL | SEND_MESSAGES | READ_MESSAGE_HISTORY (68608).

--- a/services/auth-service/oauth/kick.go
+++ b/services/auth-service/oauth/kick.go
@@ -62,6 +62,16 @@ func NewKickOAuth(clientID, clientSecret, redirectURL string) *KickOAuth {
 	}
 }
 
+// WithRedirectURL returns a copy that redirects to redirectURL instead. Used to
+// point one deployment's OAuth flow at a second frontend origin (beta.allch.at)
+// whose callback URI is registered separately with the provider. The tokenURL
+// test seam carries over.
+func (k *KickOAuth) WithRedirectURL(redirectURL string) *KickOAuth {
+	copy := *k
+	copy.redirectURL = redirectURL
+	return &copy
+}
+
 // GetAuthURL generates the OAuth authorization URL with PKCE
 // Kick requires OAuth 2.1 with PKCE (Proof Key for Code Exchange)
 // Scopes: chat:read, chat:write, channel:read, user:read, etc.

--- a/services/auth-service/oauth/state.go
+++ b/services/auth-service/oauth/state.go
@@ -48,11 +48,18 @@ const PurposeModeration = "moderation"
 
 // OAuthState represents the state parameter for OAuth flow
 type OAuthState struct {
-	CSRFToken string      `json:"csrf_token"` // Random string for CSRF protection
+	CSRFToken string      `json:"csrf_token"`           // Random string for CSRF protection
 	OverlayID string      `json:"overlay_id,omitempty"` // Target overlay for source addition
-	UserID    string      `json:"user_id,omitempty"` // Current user ID for account linking
-	Action    OAuthAction `json:"action"` // Action to take after callback
-	Purpose   string      `json:"purpose,omitempty"` // Sub-flow marker (e.g. moderation re-consent)
+	UserID    string      `json:"user_id,omitempty"`    // Current user ID for account linking
+	Action    OAuthAction `json:"action"`               // Action to take after callback
+	Purpose   string      `json:"purpose,omitempty"`    // Sub-flow marker (e.g. moderation re-consent)
+	// Origin is the allowlisted frontend origin (e.g. https://beta.allch.at) the
+	// flow was started from. It selects the provider redirect_uri at authorize
+	// and exchange time and the frontend the callback redirects back to. Set
+	// server-side only; the callback byte-compares the query state against the
+	// Redis copy, so a tampered origin never survives validation. Empty means
+	// the canonical FRONTEND_URL (states written before this field existed).
+	Origin string `json:"origin,omitempty"`
 }
 
 // NewLoginState creates a new state for login flow

--- a/services/auth-service/oauth/twitch.go
+++ b/services/auth-service/oauth/twitch.go
@@ -70,6 +70,15 @@ func NewTwitchOAuth(clientID, clientSecret, redirectURL string) *TwitchOAuth {
 	}
 }
 
+// WithRedirectURL returns a copy that redirects to redirectURL instead. Used to
+// point one deployment's OAuth flow at a second frontend origin (beta.allch.at)
+// whose callback URI is registered separately with the provider.
+func (t *TwitchOAuth) WithRedirectURL(redirectURL string) *TwitchOAuth {
+	config := *t.config
+	config.RedirectURL = redirectURL
+	return &TwitchOAuth{config: &config, client: t.client}
+}
+
 // GetAuthURL generates the OAuth authorization URL
 func (t *TwitchOAuth) GetAuthURL(state string) string {
 	return t.config.AuthCodeURL(state)

--- a/services/auth-service/oauth/youtube.go
+++ b/services/auth-service/oauth/youtube.go
@@ -76,6 +76,15 @@ func NewYouTubeOAuth(clientID, clientSecret, redirectURL string) *YouTubeOAuth {
 	}
 }
 
+// WithRedirectURL returns a copy that redirects to redirectURL instead. Used to
+// point one deployment's OAuth flow at a second frontend origin (beta.allch.at)
+// whose callback URI is registered separately with the provider.
+func (y *YouTubeOAuth) WithRedirectURL(redirectURL string) *YouTubeOAuth {
+	config := *y.config
+	config.RedirectURL = redirectURL
+	return &YouTubeOAuth{config: &config, client: y.client}
+}
+
 // GetAuthURL generates the OAuth authorization URL
 // Uses "select_account" prompt to support incremental authorization.
 // This allows users to choose their account without forcing re-consent on every login,


### PR DESCRIPTION
The backend serves both frontends (allch.at, beta.allch.at) and redirects every OAuth flow back to the host it started from.

- Twitch/YouTube/Kick (login, add-source, moderation re-consent, delegated-mod consent) record the allowlisted origin in the server-verified OAuth state, build the provider redirect_uri for that origin, and redirect back to it after the callback.
- The Discord bot invite and account link follow the same pattern through their own flow state: origin recorded server-side, allowlist re-checked at the callback, origin-specific redirect_uri for authorize URL and code exchange.
- Allowlist from FRONTEND_URL (canonical fallback) plus comma-separated FRONTEND_URLS. Unknown hosts stay canonical, so prod behaviour is unchanged.
- api-gateway stamps X-Forwarded-Host from the original request host (client-supplied values cannot override it) and accepts every FRONTEND_URLS entry as a first-party WebSocket origin.

Operator prerequisite for beta: register https://beta.allch.at/api/v1/auth/discord/callback as a second redirect URI in the Discord developer app (the Twitch/YouTube/Kick beta callbacks are already registered).

Verified: go build + go test for auth-service (handlers, oauth) and api-gateway, including new beta-origin tests for both Discord branches and a non-allowlisted-origin fallback test.