### PR TITLE
feat(stats): expose all-time messages, user count, and live overlays in /api/v1/stats

### DIFF
--- a/services/api-gateway/handlers/stats.go
+++ b/services/api-gateway/handlers/stats.go
@@ -17,7 +17,9 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/caesar/all-chat/services/api-gateway/sessions"
@@ -30,6 +32,15 @@ import (
 type StatsHandler struct {
 	redis  *redis.Client
 	logger *zap.Logger
+
+	// In-process memo for the connected-overlay count. The /stats endpoint is
+	// unauthenticated and hit by every landing-page visit, while the SCAN it
+	// needs is O(keyspace); a short TTL bounds both costs without making the
+	// number meaningfully stale ("live right now" survives 30s of lag).
+	overlayCount     int64
+	overlayCountAt   time.Time
+	overlayCountTTL  time.Duration
+	overlayCountLock sync.Mutex
 }
 
 // NewStatsHandler creates a StatsHandler.
@@ -37,15 +48,27 @@ func NewStatsHandler(redis *redis.Client, logger *zap.Logger) *StatsHandler {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
-	return &StatsHandler{redis: redis, logger: logger}
+	return &StatsHandler{redis: redis, logger: logger, overlayCountTTL: 30 * time.Second}
 }
 
-// GetPlatformStats returns message counts per platform for the last 7 days.
+// PlatformStats is the public /stats response: per-platform message volumes
+// for the last 7 days plus the landing-page counters.
+type PlatformStats struct {
+	Platforms map[string]int64 `json:"platforms"`
+	AllTime   int64            `json:"all_time"`
+	Users     int64            `json:"users"`
+	// OverlaysLive is the number of overlays with an active WebSocket
+	// connection right now (memoized briefly, see StatsHandler).
+	OverlaysLive int64 `json:"overlays_live"`
+}
+
+// GetPlatformStats returns message counts per platform for the last 7 days
+// plus the all-time, user and live-overlay counters.
 // GET /api/v1/stats — public, no auth required.
 func (h *StatsHandler) GetPlatformStats(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	platforms := []string{"twitch", "youtube", "kick", "tiktok"}
+	platforms := []string{"twitch", "youtube", "kick", "tiktok", "discord"}
 	result := make(map[string]int64, len(platforms))
 
 	// Build list of the last 7 daily bucket suffixes (YYYY-MM-DD).
@@ -66,7 +89,47 @@ func (h *StatsHandler) GetPlatformStats(c *gin.Context) {
 		result[platform] = total
 	}
 
-	c.JSON(http.StatusOK, result)
+	stats := PlatformStats{
+		Platforms:    result,
+		AllTime:      h.redisGetInt(ctx, "chat:stats:total"),
+		Users:        h.redisGetInt(ctx, "stats:users:total"),
+		OverlaysLive: h.connectedOverlayCount(ctx),
+	}
+
+	c.JSON(http.StatusOK, stats)
+}
+
+// redisGetInt reads a counter key, treating missing and unreadable alike as 0:
+// these are decorative landing-page numbers, and a Redis blip must not 500 the
+// page over them.
+func (h *StatsHandler) redisGetInt(ctx context.Context, key string) int64 {
+	val, err := h.redis.Get(ctx, key).Int64()
+	if err != nil {
+		return 0
+	}
+	return val
+}
+
+// connectedOverlayCount returns the number of overlays with an active
+// WebSocket connection, memoized for overlayCountTTL.
+func (h *StatsHandler) connectedOverlayCount(ctx context.Context) int64 {
+	h.overlayCountLock.Lock()
+	defer h.overlayCountLock.Unlock()
+
+	if time.Since(h.overlayCountAt) < h.overlayCountTTL {
+		return h.overlayCount
+	}
+
+	ids, err := h.scanActiveOverlayIDs(ctx)
+	if err != nil {
+		// Keep the last good value on failure; before the first success that
+		// is 0, which is honest ("we could not count") rather than alarming.
+		h.logger.Warn("failed to scan connected overlays; keeping last count", zap.Error(err))
+		return h.overlayCount
+	}
+	h.overlayCount = int64(len(ids))
+	h.overlayCountAt = time.Now()
+	return h.overlayCount
 }
 
 // ActiveOverlay describes an overlay with a live WebSocket connection.
@@ -86,34 +149,10 @@ type ActiveOverlay struct {
 func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	// SCAN guarantees full coverage but not uniqueness (a key can repeat across
-	// batches during rehashing), so de-duplicate to avoid duplicate rows and
-	// redundant lookups.
-	var activeIDs []string
-	seen := make(map[string]struct{})
-	var cursor uint64
-	for {
-		keys, next, err := h.redis.Scan(ctx, cursor, "overlay:connected:*", 100).Result()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan active overlays"})
-			return
-		}
-		for _, key := range keys {
-			// key format: "overlay:connected:{id}"
-			id := key[len("overlay:connected:"):]
-			if id == "" {
-				continue
-			}
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			activeIDs = append(activeIDs, id)
-		}
-		cursor = next
-		if cursor == 0 {
-			break
-		}
+	activeIDs, err := h.scanActiveOverlayIDs(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan active overlays"})
+		return
 	}
 
 	overlays := make([]ActiveOverlay, 0, len(activeIDs))
@@ -156,4 +195,38 @@ func (h *StatsHandler) GetActiveOverlays(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, overlays)
+}
+
+// scanActiveOverlayIDs returns the de-duplicated overlay IDs that currently
+// have an overlay:connected:* key (i.e. a live WebSocket connection).
+func (h *StatsHandler) scanActiveOverlayIDs(ctx context.Context) ([]string, error) {
+	// SCAN guarantees full coverage but not uniqueness (a key can repeat across
+	// batches during rehashing), so de-duplicate to avoid duplicate rows and
+	// redundant lookups.
+	var activeIDs []string
+	seen := make(map[string]struct{})
+	var cursor uint64
+	for {
+		keys, next, err := h.redis.Scan(ctx, cursor, "overlay:connected:*", 100).Result()
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range keys {
+			// key format: "overlay:connected:{id}"
+			id := key[len("overlay:connected:"):]
+			if id == "" {
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			activeIDs = append(activeIDs, id)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return activeIDs, nil
 }

--- a/services/api-gateway/handlers/stats_test.go
+++ b/services/api-gateway/handlers/stats_test.go
@@ -91,6 +91,61 @@ func TestGetActiveOverlays_ReturnsConnectedIDs(t *testing.T) {
 	}
 }
 
+func TestGetPlatformStats_ShapeAndCounters(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client, mr := setupStatsTestRedis(t)
+	handler := NewStatsHandler(client, nil)
+
+	// One daily bucket for twitch (today), none for the other platforms —
+	// days with no key must read as 0, and discord must appear in the map.
+	today := time.Now().UTC().Format("2006-01-02")
+	mr.Set("chat:stats:daily:twitch:"+today, "421")
+	mr.Set("chat:stats:total", "48291803")
+	mr.Set("stats:users:total", "12408")
+	mr.Set("overlay:connected:abc-123", "1")
+	mr.Set("overlay:connected:def-456", "1")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
+
+	handler.GetPlatformStats(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var stats PlatformStats
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &stats))
+	assert.Equal(t, map[string]int64{
+		"twitch": 421, "youtube": 0, "kick": 0, "tiktok": 0, "discord": 0,
+	}, stats.Platforms)
+	assert.Equal(t, int64(48291803), stats.AllTime)
+	assert.Equal(t, int64(12408), stats.Users)
+	assert.Equal(t, int64(2), stats.OverlaysLive)
+}
+
+func TestGetPlatformStats_MissingCountersAreZero(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client, _ := setupStatsTestRedis(t)
+	handler := NewStatsHandler(client, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
+
+	handler.GetPlatformStats(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var stats PlatformStats
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &stats))
+	assert.Equal(t, int64(0), stats.AllTime)
+	assert.Equal(t, int64(0), stats.Users)
+	assert.Equal(t, int64(0), stats.OverlaysLive)
+	// Fresh handler: memo is empty, so a missing-scan failure path must not
+	// leak an error value into the response.
+	for _, p := range stats.Platforms {
+		assert.Equal(t, int64(0), p)
+	}
+}
+
 func TestGetActiveOverlays_IncludesConnectedSince(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	client, mr := setupStatsTestRedis(t)

--- a/services/auth-service/cmd/main.go
+++ b/services/auth-service/cmd/main.go
@@ -298,6 +298,15 @@ func main() {
 	defer stopUsageSampler()
 	go usageSampler.Run(usageCtx)
 
+	// Public "streamers on board" figure for the landing page: a small ticker
+	// writing stats:users:total to the shared Redis, read by the gateway's
+	// /api/v1/stats. Same shape as the usage sampler above.
+	userStatsPublisher := usage.NewUserStatsPublisher(userRepo, redisClient, log,
+		time.Duration(getEnvAsIntOrDefault("USER_STATS_INTERVAL_SECONDS", int(usage.UserStatsInterval.Seconds())))*time.Second)
+	userStatsCtx, stopUserStats := context.WithCancel(context.Background())
+	defer stopUserStats()
+	go userStatsPublisher.Run(userStatsCtx)
+
 	healthHandler := handlers.NewHealthHandler(db, redisClient)
 	// audit #20: impersonation tokens are short-lived (default 2h), independent of
 	// the 24h session JWT, so a leaked impersonation token has a small window.

--- a/services/auth-service/usage/userstats.go
+++ b/services/auth-service/usage/userstats.go
@@ -1,0 +1,109 @@
+// This file is part of All-Chat.
+// Copyright (C) 2026 caesarakalaeii
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package usage
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// UserStatsKey is the shared Redis key the landing page's /api/v1/stats reads
+// its "streamers on board" figure from. Written by auth-service, which owns
+// the users table; no TTL — the ticker refreshes it in place.
+const UserStatsKey = "stats:users:total"
+
+// UserStatsInterval is how often the public user count is refreshed. The
+// query is a single GROUP BY aggregate and the number is a landing-page
+// decoration, so a minutes-scale cadence is plenty.
+const UserStatsInterval = 5 * time.Minute
+
+// userCounter reads the per-provider user counts (implemented by
+// repository.UserRepository).
+type userCounter interface {
+	CountByAuthProvider(ctx context.Context) (map[string]int64, error)
+}
+
+// UserStatsPublisher periodically writes the total user count to Redis for
+// the public stats endpoint.
+type UserStatsPublisher struct {
+	repo     userCounter
+	redis    *redis.Client
+	logger   *zap.Logger
+	interval time.Duration
+}
+
+// NewUserStatsPublisher creates a publisher. A non-positive interval falls
+// back to UserStatsInterval.
+func NewUserStatsPublisher(repo userCounter, redis *redis.Client, logger *zap.Logger, interval time.Duration) *UserStatsPublisher {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if interval <= 0 {
+		interval = UserStatsInterval
+	}
+	return &UserStatsPublisher{repo: repo, redis: redis, logger: logger, interval: interval}
+}
+
+// Publish runs one query and writes the key. Errors are returned for the
+// caller to log; the previous value stays in Redis, so a transient database
+// blip shows as a stale count rather than a zero.
+func (p *UserStatsPublisher) Publish(ctx context.Context) error {
+	counts, err := p.repo.CountByAuthProvider(ctx)
+	if err != nil {
+		return err
+	}
+
+	var total int64
+	for _, n := range counts {
+		total += n
+	}
+
+	return p.redis.Set(ctx, UserStatsKey, total, 0).Err()
+}
+
+// Run publishes immediately (so the key exists before the first landing-page
+// hit after a cold start, not one interval later) and then on every tick
+// until ctx is cancelled.
+func (p *UserStatsPublisher) Run(ctx context.Context) {
+	p.publishAndLog(ctx)
+
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("User stats publisher stopped")
+			return
+		case <-ticker.C:
+			p.publishAndLog(ctx)
+		}
+	}
+}
+
+func (p *UserStatsPublisher) publishAndLog(ctx context.Context) {
+	if err := p.Publish(ctx); err != nil {
+		if ctx.Err() != nil {
+			// Shutdown cancelled the query mid-flight; not a fault worth alarming on.
+			return
+		}
+		p.logger.Warn("Failed to publish user count to Redis (non-fatal, key keeps last value)", zap.Error(err))
+	}
+}

--- a/services/message-processor/cmd/main.go
+++ b/services/message-processor/cmd/main.go
@@ -759,17 +759,22 @@ func main() {
 			}
 		}
 
-		// Increment daily platform message counter once per unique message.
+		// Increment the platform message counters once per unique message.
 		// Placed after the overlay loop so multi-overlay fanout counts as one message.
 		// Uses daily buckets (chat:stats:daily:{platform}:{YYYY-MM-DD}) so the
 		// API can sum the last 7 days for a stable rolling window.
 		if publishedToAnyOverlay {
 			day := time.Now().UTC().Format("2006-01-02")
 			statsKey := "chat:stats:daily:" + rawMsg.Platform + ":" + day
+			// Same increment as the weekly buckets, but for the all-time counter
+			// the homepage hero shows (chat:stats:total). Never expires, best-effort:
+			// a missed tick only loses one message off a very large number.
+			totalStatsKey := "chat:stats:total"
 			if redisClient.Incr(ctx, statsKey).Err() == nil {
 				// Each daily bucket expires after 8 days (7d window + 1d grace).
 				redisClient.ExpireNX(ctx, statsKey, 8*24*time.Hour)
 			}
+			redisClient.Incr(ctx, totalStatsKey)
 		}
 
 		return nil


### PR DESCRIPTION
The beta landing page reads all_time, users and overlays_live from /api/v1/stats; the shared backend only served the 7-day per-platform volumes, so those fields came back undefined and the hero showed zero.

- api-gateway: /api/v1/stats gains all_time (chat:stats:total), users (stats:users:total) and overlays_live (memoized count of connected overlay sockets; the public endpoint is unauthenticated and the underlying SCAN is O(keyspace), so the value is cached for 30s).
- auth-service: a UserStatsPublisher refreshes stats:users:total from a single GROUP BY every 5 minutes; auth-service owns the users table.
- message-processor: increments chat:stats:total once per unique message, best-effort.

Note: chat:stats:total only starts accumulating once this ships — incoming chat is not persisted anywhere, so there is no historical total to seed from. If a launch-to-date number exists, seed the key manually.

Verified: go build + go test for auth-service (handlers, oauth, usage), api-gateway (handlers) and message-processor; comment-lint clean.