### PR TITLE
feat(overlay): colour chat bubbles by username colour

### DIFF
--- a/docs/adr/0047-username-color-resolution-order.md
+++ b/docs/adr/0047-username-color-resolution-order.md
@@ -71,6 +71,18 @@ The middle two steps use CSS custom-property fallback syntax
 actually picks one, so an unset setting falls through to the auto colour at paint
 time with no extra plumbing.
 
+### Amendment (2026-09): bubble-colour mode resolves usernames statically
+
+When the streamer turns on "Use username colours" for bubbles (Appearance →
+Bubble colors), the bubble itself carries the chatter's colour, so repeating it
+on the name would hide the name against its own fill. `resolveUsernameColor`
+gained a `staticColor` option that skips the `user.color` short-circuit and
+returns the `var(--chat-username-color, <auto_color>)` chain unconditionally:
+every username in the feed resolves to the streamer's picker colour (or the auto
+palette) while the mode is on. Gradient usernames are unaffected — callers
+branch on `name_gradient` before reaching the resolver. Colorless chatters whose
+bubbles fall back to `auto_color` keep a legible name for the same reason.
+
 ## Consequences
 
 **Positive**

--- a/docs/overlay-themes/README.md
+++ b/docs/overlay-themes/README.md
@@ -388,10 +388,12 @@ per-row variety on the shadow and the foil border respectively, which are
 colour-independent and need none of this.
 
 Separately, the streamer can set **differently-coloured bubbles** (Appearance →
-Bubble colors): a fill per platform, and/or a palette cycled down the feed. Those
-are enforced like the table above, as `!important` rules on
-`[data-platform='<p>']` and `[data-bubble-slot='<n>']` rows, so they replace your
-bubble fill when configured and emit nothing when not. Events are never painted.
+Bubble colors): a fill per platform, a palette cycled down the feed, and/or each
+message taking its chatter's username colour (fill or 2px outline, keyed on the
+row's `data-user-bubble` attribute). Those are enforced like the table above, as
+`!important` rules on `[data-platform='<p>']`, `[data-bubble-slot='<n>']` and
+`[data-user-bubble]` rows, so they replace your bubble fill when configured and
+emit nothing when not. Events are never painted.
 
 Do not key any theme rule off `data-bubble-slot`. It is assigned from **arrival
 order**, not position, so that a row keeps its colour as the feed scrolls — a

--- a/frontend/src/app/overlay/[id]/page.tsx
+++ b/frontend/src/app/overlay/[id]/page.tsx
@@ -60,7 +60,11 @@ import {
 } from '@/lib/utils/bubbleSlot'
 import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
-import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
+import {
+  chatBubbleStyle,
+  overlayContainerStyle,
+  userBubbleStyle,
+} from '@/lib/utils/visual-inline-styles'
 import { isDisplayVisible } from '@/lib/utils/displayVisibility'
 import {
   DEFAULT_FEED_ANCHOR,
@@ -71,6 +75,7 @@ import {
   type FeedAnchor,
 } from '@/lib/utils/feedAnchor'
 import {
+  isBubbleColorFromUser,
   isMessageAnimation,
   MESSAGE_ANIMATION_CLASS,
   type MessageAnimation,
@@ -169,6 +174,12 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
   // Entry animation for new chat bubbles; null keeps the default fade + slide-up
   const [messageAnimation, setMessageAnimation] = useState<MessageAnimation | null>(null)
   const [showPlatformBadge, setShowPlatformBadge] = useState(true)
+  // Bubble colour from the username colour. The CSS rule (userBubbleRules) and
+  // the per-row values (userBubbleStyle) both key off this mode + opacity.
+  const [bubbleColorFromUser, setBubbleColorFromUser] = useState<'none' | 'background' | 'border'>(
+    'none'
+  )
+  const [bubbleUserColorOpacity, setBubbleUserColorOpacity] = useState('0.85')
   const [showPlatformIndicators, setShowPlatformIndicators] = useState(true)
   // Visibility toggles whose CSS rules are scoped to `.overlay-preview-body`
   // (preview/embed only). The live OBS overlay lacks that scope hook, so it
@@ -401,7 +412,6 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
         ? rewriteThemeFontImports(getBundledTheme(config.theme_id)?.css ?? '')
         : ''
     )
-
     if (config.visual_settings && typeof config.visual_settings === 'object') {
       const vs = config.visual_settings as Partial<VisualSettings>
       setVisualSettingsCss(visualSettingsToCss(vs))
@@ -412,6 +422,14 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
       setBubbleStyle(chatBubbleStyle(vs))
       // Unconditional: clearing the palette has to drop the slot attributes too.
       setBubblePalette(resolveBubblePalette(vs))
+      // Same for the by-username mode; also cleared unconditionally so a
+      // saved 'none'/absence restores plain bubbles on reload.
+      setBubbleColorFromUser(
+        isBubbleColorFromUser(vs.bubbleColorFromUser) ? vs.bubbleColorFromUser : 'none'
+      )
+      if (typeof vs.bubbleUserColorOpacity === 'string') {
+        setBubbleUserColorOpacity(vs.bubbleUserColorOpacity)
+      }
       for (const key of ['fontFamily', 'usernameFontFamily', 'timestampFontFamily'] as const) {
         if (typeof vs[key] === 'string') ensureGoogleFontLoaded(vs[key]!)
       }
@@ -816,6 +834,10 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                 [BUBBLE_SLOT_ATTR]: isEvent
                   ? undefined
                   : bubbleSlot(bubbleSlots, message.id, bubblePalette.length),
+                // Marks the row for the by-username bubble rule
+                // (userBubbleRules); the colour itself rides in the style
+                // below as custom properties.
+                'data-user-bubble': isEvent || bubbleColorFromUser === 'none' ? undefined : '',
               }}
               className={clsx(
                 isEvent
@@ -830,7 +852,20 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                         : 'bg-slate-900/90',
                     ]
               )}
-              style={isEvent ? undefined : bubbleStyle}
+              style={
+                isEvent
+                  ? undefined
+                  : {
+                      ...bubbleStyle,
+                      ...(bubbleColorFromUser !== 'none'
+                        ? userBubbleStyle(
+                            message.user,
+                            { bubbleUserColorOpacity },
+                            bubbleColorFromUser
+                          )
+                        : {}),
+                    }
+              }
             >
               <div className="flex items-start gap-3">
                 {/* Avatar */}
@@ -932,7 +967,9 @@ export default function OBSOverlayPage({ params }: { params: Promise<{ id: strin
                         <span
                           className="chat-username text-sm font-semibold"
                           style={{
-                            color: resolveUsernameColor(message.user),
+                            color: resolveUsernameColor(message.user, {
+                              staticColor: bubbleColorFromUser !== 'none',
+                            }),
                           }}
                         >
                           {message.user?.display_name || message.user?.username}

--- a/frontend/src/app/overlays/[id]/page.tsx
+++ b/frontend/src/app/overlays/[id]/page.tsx
@@ -2061,6 +2061,8 @@ export default function OverlayEditorPage({ params }: { params: Promise<{ id: st
           // The palette's CSS rules key on a per-row attribute the preview has
           // to render itself, so it needs the list, not just the CSS.
           bubblePalette: settings.bubblePalette,
+          bubbleColorFromUser: settings.bubbleColorFromUser,
+          bubbleUserColorOpacity: settings.bubbleUserColorOpacity,
         },
       },
       '*'

--- a/frontend/src/app/overlays/[id]/preview/embed/page.tsx
+++ b/frontend/src/app/overlays/[id]/preview/embed/page.tsx
@@ -54,13 +54,18 @@ import {
   type BubbleSlotState,
 } from '@/lib/utils/bubbleSlot'
 import {
+  isBubbleColorFromUser,
   isMessageAnimation,
   MESSAGE_ANIMATION_CLASS,
   type MessageAnimation,
 } from '@/lib/types/visual-settings'
 import { getBundledTheme } from '@/lib/theme-marketplace/bundled-themes'
 import { rewriteThemeFontImports } from '@/lib/theme-marketplace/font-proxy'
-import { chatBubbleStyle, overlayContainerStyle } from '@/lib/utils/visual-inline-styles'
+import {
+  chatBubbleStyle,
+  overlayContainerStyle,
+  userBubbleStyle,
+} from '@/lib/utils/visual-inline-styles'
 import { AllChatBadge } from '@/components/AllChatBadge'
 import { UserAvatar } from '@/components/UserAvatar'
 import { PremiumBadge } from '@/components/PremiumBadge'
@@ -211,6 +216,13 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
   // enough — the per-row slot attribute has to be written in React).
   const [bubblePalette, setBubblePalette] = useState<string[]>([])
   const [bubbleSlots, setBubbleSlots] = useState<BubbleSlotState>(EMPTY_BUBBLE_SLOTS)
+  // Bubble colour from the username colour, mirroring the live overlay. Arrives
+  // on load from visual_settings and live via VISUAL_SETTINGS_UPDATE (the CSS
+  // rule needs the per-row attribute + custom properties React must write).
+  const [bubbleColorFromUser, setBubbleColorFromUser] = useState<'none' | 'background' | 'border'>(
+    'none'
+  )
+  const [bubbleUserColorOpacity, setBubbleUserColorOpacity] = useState('0.85')
   const [platformBadgePosition, setPlatformBadgePosition] = useState<'before' | 'after'>('before')
   const [platformBadgeStyle, setPlatformBadgeStyle] = useState<'text' | 'icon'>('text')
   const [showPlatformBadge, setShowPlatformBadge] = useState(true)
@@ -338,6 +350,14 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         setMessageAnimation(isMessageAnimation(s.messageAnimation) ? s.messageAnimation : null)
         // Same reason: emptying the palette has to drop the slot attributes too
         setBubblePalette(resolveBubblePalette({ bubblePalette: s.bubblePalette }))
+        // Unconditional too: switching the mode off must drop the per-row
+        // attribute and custom properties, not just the CSS rule.
+        setBubbleColorFromUser(
+          isBubbleColorFromUser(s.bubbleColorFromUser) ? s.bubbleColorFromUser : 'none'
+        )
+        if (typeof s.bubbleUserColorOpacity === 'string') {
+          setBubbleUserColorOpacity(s.bubbleUserColorOpacity)
+        }
         return
       }
       // Live custom/theme CSS from the editor (theme apply, or typing in the
@@ -472,6 +492,10 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
         setContainerStyle(overlayContainerStyle(vs))
         setBubbleStyle(chatBubbleStyle(vs))
         setBubblePalette(resolveBubblePalette(vs))
+        setBubbleColorFromUser(isBubbleColorFromUser(vs.bubbleColorFromUser) ? vs.bubbleColorFromUser : 'none')
+        if (typeof vs.bubbleUserColorOpacity === 'string') {
+          setBubbleUserColorOpacity(vs.bubbleUserColorOpacity)
+        }
         // Apply non-CSS visual settings
         if (vs.showPlatformBadge !== undefined) {
           setShowPlatformBadge(vs.showPlatformBadge !== 'none')
@@ -778,6 +802,9 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                       [BUBBLE_SLOT_ATTR]: isEvent
                         ? undefined
                         : bubbleSlot(bubbleSlots, message.id, bubblePalette.length),
+                      // Marks the row for the by-username bubble rule; the
+                      // colour rides in the style below.
+                      'data-user-bubble': isEvent || bubbleColorFromUser === 'none' ? undefined : '',
                     }}
                     className={
                       isEvent
@@ -791,7 +818,20 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                               : feedLayout.defaultEntryAnimationClass
                           )
                     }
-                    style={isEvent ? undefined : bubbleStyle}
+                    style={
+                      isEvent
+                        ? undefined
+                        : {
+                            ...bubbleStyle,
+                            ...(bubbleColorFromUser !== 'none'
+                              ? userBubbleStyle(
+                                  message.user,
+                                  { bubbleUserColorOpacity },
+                                  bubbleColorFromUser
+                                )
+                              : {}),
+                          }
+                    }
                   >
                     <div className="flex items-start gap-3">
                       {/* Avatar */}
@@ -903,7 +943,11 @@ export default function OverlayEmbedPage({ params }: { params: Promise<{ id: str
                           ) : (
                             <span
                               className="chat-username text-sm font-semibold"
-                              style={{ color: resolveUsernameColor(message.user) }}
+                              style={{
+                                color: resolveUsernameColor(message.user, {
+                                  staticColor: bubbleColorFromUser !== 'none',
+                                }),
+                              }}
                             >
                               {message.user.display_name}
                             </span>

--- a/frontend/src/components/appearance/BubbleColorsGroup.tsx
+++ b/frontend/src/components/appearance/BubbleColorsGroup.tsx
@@ -19,21 +19,25 @@
  */
 
 /**
- * Differently-coloured chat bubbles, on two independent axes:
+ * Differently-coloured chat bubbles, on three independent axes:
  *
+ * - By username — each row takes its chatter's username colour, as a fill or
+ *   an outline. The name itself goes static (the streamer's picker / auto
+ *   palette) so it stays readable against its own colour.
  * - Per platform — Twitch rows one fill, YouTube another. Useful for
  *   multistreamers who want to tell sources apart at a glance.
  * - Palette — 2 to MAX_BUBBLE_PALETTE fills cycled down the feed, for rhythm.
  *
- * A platform fill wins over the palette on that platform's rows; the emitted CSS
- * encodes that by source order (see bubbleFillRules).
+ * The username axis wins over a platform fill or the palette on every row
+ * (see userBubbleRules in visual-settings-to-css); the remaining two keep
+ * their source-order precedence.
  *
  * Free to use. `locked` comes from the server-resolved `bubble_colors_locked`
  * flag on the overlay config rather than from `user.is_premium`, so flipping the
  * `bubble_colors` gate to premium in the admin UI locks these controls with no
  * deploy — and until someone does, nothing here mentions Premium.
  */
-
+import clsx from 'clsx'
 import React from 'react'
 import { Button } from '@/components/ui/button'
 import { Plus, RotateCcw, X } from 'lucide-react'
@@ -44,6 +48,8 @@ import { emphasise } from '@/lib/i18n/emphasise'
 import type { VisualSettings } from '@/lib/types/visual-settings'
 import { MAX_BUBBLE_PALETTE } from '@/lib/utils/visual-settings-to-css'
 import { ColorPickerControl } from './ColorPickerControl'
+import { SliderControl } from './SliderControl'
+import { ToggleSwitch } from './ToggleSwitch'
 
 /** Starting colour for a newly added palette entry — a neutral dark bubble. */
 const NEW_SWATCH = '#1e293b'
@@ -103,6 +109,68 @@ export function BubbleColorsGroup({
       )}
 
       <fieldset disabled={locked} className="space-y-5 disabled:opacity-50">
+        <div data-setting-anchor="bubbleColorFromUser" className="space-y-3">
+          <div>
+            <h3 className="text-sm font-medium text-text">
+              {t('overlayEditor.bubbleColors.userColorHeading')}
+            </h3>
+            <p className="text-xs text-text-dim">
+              {t('overlayEditor.bubbleColors.userColorBody')}
+            </p>
+          </div>
+          <ToggleSwitch
+            label={t('overlayEditor.bubbleColors.userColorToggle')}
+            checked={visualSettings.bubbleColorFromUser === 'background' ||
+              visualSettings.bubbleColorFromUser === 'border'}
+            onChange={(checked) =>
+              onChange({ bubbleColorFromUser: checked ? 'background' : undefined })
+            }
+          />
+          <div
+            className={clsx(
+              'mt-2 space-y-2 pl-2',
+              visualSettings.bubbleColorFromUser === 'background' ||
+                visualSettings.bubbleColorFromUser === 'border'
+                ? ''
+                : 'pointer-events-none opacity-40'
+            )}
+          >
+            <div className="flex gap-4">
+              {(['background', 'border'] as const).map((mode) => (
+                <label
+                  key={mode}
+                  className="flex cursor-pointer items-center gap-1.5 text-xs text-text-sub"
+                >
+                  <input
+                    type="radio"
+                    name="bubbleColorFromUserMode"
+                    value={mode}
+                    checked={visualSettings.bubbleColorFromUser === mode}
+                    onChange={() => onChange({ bubbleColorFromUser: mode })}
+                    className="accent-twitch"
+                  />
+                  {t(
+                    mode === 'background'
+                      ? 'overlayEditor.bubbleColors.userColorModeBackground'
+                      : 'overlayEditor.bubbleColors.userColorModeBorder'
+                  )}
+                </label>
+              ))}
+            </div>
+            <SliderControl
+              label={t('overlayEditor.bubbleColors.userColorOpacity')}
+              value={parseFloat(visualSettings.bubbleUserColorOpacity ?? '0.85')}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(v) => onChange({ bubbleUserColorOpacity: `${v}` })}
+            />
+            <p className="text-xs text-text-dim">
+              {t('overlayEditor.bubbleColors.userColorOpacityNote')}
+            </p>
+          </div>
+        </div>
+
         <div className="space-y-3">
           <div>
             <h3 className="text-sm font-medium text-text">

--- a/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
+++ b/frontend/src/components/appearance/__tests__/BubbleColorsGroup.test.tsx
@@ -107,4 +107,56 @@ describe('BubbleColorsGroup', () => {
     expect(screen.getByLabelText(/remove colour 1/i)).toHaveProperty('disabled', true)
     expect(screen.getByText(/add colour/i)).toHaveProperty('disabled', true)
   })
+
+  describe('by-username bubbles', () => {
+    it('is off by default and the mode controls are dimmed', () => {
+      renderGroup({})
+
+      const toggle = screen.getByRole('switch', { name: 'Use username colours' })
+      expect(toggle.getAttribute('aria-checked')).toBe('false')
+      // Radios are in the tree but unchecked while the toggle is off.
+      expect(screen.getByLabelText('Fill')).toHaveProperty('checked', false)
+      expect(screen.getByLabelText('Outline')).toHaveProperty('checked', false)
+    })
+
+    it('turning the toggle on selects fill mode', () => {
+      const { onChange } = renderGroup({})
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Use username colours' }))
+
+      expect(onChange).toHaveBeenCalledWith({ bubbleColorFromUser: 'background' })
+    })
+
+    it('turning the toggle off unsets the setting', () => {
+      const { onChange } = renderGroup({ bubbleColorFromUser: 'border' })
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Use username colours' }))
+
+      expect(onChange).toHaveBeenCalledWith({ bubbleColorFromUser: undefined })
+    })
+
+
+    it('picking Outline patches the mode without touching the opacity', () => {
+      const { onChange } = renderGroup({
+        bubbleColorFromUser: 'background',
+        bubbleUserColorOpacity: '0.5',
+      })
+
+      fireEvent.click(screen.getByLabelText('Outline'))
+
+      expect(onChange).toHaveBeenCalledWith({ bubbleColorFromUser: 'border' })
+    })
+
+    it('moving the opacity slider patches the setting as a string', () => {
+      const { onChange } = renderGroup({
+        bubbleColorFromUser: 'background',
+        bubbleUserColorOpacity: '0.85',
+      })
+
+      // SliderControl fires change with the numeric value.
+      fireEvent.change(screen.getByLabelText(/fill opacity/i), { target: { value: '0.5' } })
+
+      expect(onChange).toHaveBeenCalledWith({ bubbleUserColorOpacity: '0.5' })
+    })
+  })
 })

--- a/frontend/src/components/editor/sectionRegistry.ts
+++ b/frontend/src/components/editor/sectionRegistry.ts
@@ -223,7 +223,11 @@ export const EDITOR_SECTIONS: EditorSection[] = [
     description: 'A different bubble fill per platform, or a palette cycled down the feed.',
     keywords: 'premium multicolour multicolor alternating rotate cycle rainbow per platform',
     entries: [
-      { label: 'Twitch bubble', keywords: 'platform fill purple' },
+      {
+        label: 'Color bubbles by username',
+        keywords: 'user username viewer chatter color fill border outline',
+        anchorId: 'bubbleColorFromUser',
+      },
       { label: 'YouTube bubble', keywords: 'platform fill red' },
       { label: 'Kick bubble', keywords: 'platform fill green' },
       { label: 'TikTok bubble', keywords: 'platform fill cyan' },

--- a/frontend/src/lib/i18n/__tests__/overlayEditor.test.ts
+++ b/frontend/src/lib/i18n/__tests__/overlayEditor.test.ts
@@ -312,6 +312,20 @@ describe('bubble colours group copy', () => {
     )
   })
 
+  it('keeps the by-username section copy', () => {
+    expect(t('overlayEditor.bubbleColors.userColorHeading')).toBe('Colour bubbles by username')
+    expect(t('overlayEditor.bubbleColors.userColorBody')).toBe(
+      'Each message takes its chatter’s username colour on the bubble. Colourless chatters get an auto-assigned colour.'
+    )
+    expect(t('overlayEditor.bubbleColors.userColorToggle')).toBe('Use username colours')
+    expect(t('overlayEditor.bubbleColors.userColorModeBackground')).toBe('Fill')
+    expect(t('overlayEditor.bubbleColors.userColorModeBorder')).toBe('Outline')
+    expect(t('overlayEditor.bubbleColors.userColorOpacity')).toBe('Fill opacity')
+    expect(t('overlayEditor.bubbleColors.userColorOpacityNote')).toBe(
+      'Applies to flat colours; gradient names fill the bubble opaque. Outline always uses its own 2px width.'
+    )
+   })
+
   it('keeps the palette section copy', () => {
     expect(t('overlayEditor.bubbleColors.paletteHeading')).toBe('Palette')
     expect(t('overlayEditor.bubbleColors.paletteBody')).toBe(

--- a/frontend/src/lib/i18n/messages/en/overlayEditor.ts
+++ b/frontend/src/lib/i18n/messages/en/overlayEditor.ts
@@ -156,6 +156,15 @@ export const overlayEditor = {
     charsUnit: ' chars',
   },
   bubbleColors: {
+    userColorHeading: 'Colour bubbles by username',
+    userColorBody:
+      'Each message takes its chatter’s username colour on the bubble. Colourless chatters get an auto-assigned colour.',
+    userColorToggle: 'Use username colours',
+    userColorModeBackground: 'Fill',
+    userColorModeBorder: 'Outline',
+    userColorOpacity: 'Fill opacity',
+    userColorOpacityNote:
+      'Applies to flat colours; gradient names fill the bubble opaque. Outline always uses its own 2px width.',
     lockedNotice:
       'Different bubble colours per platform, or a palette cycled down the feed, are a {emphasis} feature.',
     lockedNoticeEmphasis: 'Premium',

--- a/frontend/src/lib/types/visual-settings.ts
+++ b/frontend/src/lib/types/visual-settings.ts
@@ -40,6 +40,11 @@ export function isMessageAnimation(value: unknown): value is MessageAnimation {
   return typeof value === 'string' && (MESSAGE_ANIMATIONS as readonly string[]).includes(value)
 }
 
+/** The two modes that actually colour a bubble (absent/'none' = off). */
+export function isBubbleColorFromUser(value: unknown): value is 'background' | 'border' {
+  return value === 'background' || value === 'border'
+}
+
 /**
  * Static value → class map (no runtime string building; className strings must
  * be statically greppable, see DESIGN_SYSTEM.md). Classes live in globals.css.
@@ -147,12 +152,22 @@ export interface VisualSettings {
   // applied as a .msg-anim-* class on the chat bubble)
   messageAnimation?: MessageAnimation
 
+  // Bubble colour from the username colour — non-CSS settings read into
+  // React state on both overlay surfaces. The CSS half lives in
+  // userBubbleRules (visual-settings-to-css): an !important rule in the
+  // visual-customizer layer keyed on the per-row [data-user-bubble]
+  // attribute, beating palette/platform fills on specificity. Not in
+  // PROPERTY_MAP, so no --chat-* variable is emitted.
+  bubbleColorFromUser?: 'none' | 'background' | 'border'
+  bubbleUserColorOpacity?: string // decimal '0'–'1'; gradients ignore it
+
   // Pronoun display — all three are read into React state and applied
   // by conditional render / inline style. None is in PROPERTY_MAP, so no
   // `--chat-show-pronouns` variable is ever emitted; do not write CSS against one.
   showPronouns?: 'inline' | 'none'
   pronounPosition?: 'before' | 'after'
   pronounColor?: string
+
 
   // Sizing
   avatarSize?: string // --chat-avatar-size

--- a/frontend/src/lib/utils/__tests__/customizer-coverage.test.ts
+++ b/frontend/src/lib/utils/__tests__/customizer-coverage.test.ts
@@ -209,6 +209,8 @@ describe('visual customizer property coverage', () => {
       'kickBubbleBg',
       'tiktokBubbleBg',
       'discordBubbleBg',
+      'bubbleColorFromUser',
+      'bubbleUserColorOpacity',
     ] as const) {
       expect(mapped.has(field), `${field} must not be in PROPERTY_MAP`).toBe(false)
     }

--- a/frontend/src/lib/utils/__tests__/usernameColor.test.ts
+++ b/frontend/src/lib/utils/__tests__/usernameColor.test.ts
@@ -60,4 +60,19 @@ describe('resolveUsernameColor', () => {
   it('tolerates an undefined user', () => {
     expect(resolveUsernameColor(undefined)).toBe('var(--chat-username-color, #FFFFFF)')
   })
+
+  it('goes static when the bubble takes the username colour (swap mode)', () => {
+    // The bubble already carries the chatter's colour, so the name must not
+    // repeat it: staticColor skips the viewer-colour short-circuit and returns
+    // the var chain unconditionally — streamer's picker, else auto, else white.
+    expect(
+      resolveUsernameColor({ color: '#DAA520', auto_color: '#5B8DEF' }, { staticColor: true })
+    ).toBe('var(--chat-username-color, #5B8DEF)')
+    expect(resolveUsernameColor({ color: '#DAA520' }, { staticColor: true })).toBe(
+      'var(--chat-username-color, #FFFFFF)'
+    )
+    expect(resolveUsernameColor(undefined, { staticColor: true })).toBe(
+      'var(--chat-username-color, #FFFFFF)'
+    )
+  })
 })

--- a/frontend/src/lib/utils/__tests__/visual-inline-styles.test.ts
+++ b/frontend/src/lib/utils/__tests__/visual-inline-styles.test.ts
@@ -17,7 +17,22 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { chatBubbleStyle, hexToRgba, overlayContainerStyle } from '../visual-inline-styles'
+import {
+  chatBubbleStyle,
+  hexToRgba,
+  overlayContainerStyle,
+  userBubbleStyle,
+} from '../visual-inline-styles'
+import type { UserInfo } from '@/lib/types/message'
+
+/** Only the colour fields matter here; the rest of UserInfo is payload. */
+const user = (fields: Partial<UserInfo> = {}): UserInfo => ({
+  id: 'u1',
+  username: 'someone',
+  display_name: 'someone',
+  badges: [],
+  ...fields,
+})
 
 describe('hexToRgba', () => {
   it('combines a 6-digit hex with a 0–1 opacity', () => {
@@ -89,5 +104,68 @@ describe('chatBubbleStyle', () => {
     expect(chatBubbleStyle({ bubbleShadow: '0 0 8px red' })).toEqual({
       boxShadow: '0 0 8px red',
     })
+  })
+})
+
+describe('userBubbleStyle', () => {
+  it('background mode resolves a flat colour through the opacity setting', () => {
+    expect(
+      userBubbleStyle(user({ color: '#DAA520' }), { bubbleUserColorOpacity: '0.85' }, 'background')
+    ).toEqual({ '--row-user-bg': 'rgba(218, 165, 32, 0.85)' })
+  })
+
+  it('background mode falls back to the auto colour when no manual colour', () => {
+    expect(userBubbleStyle(user({ auto_color: '#5B8DEF' }), {}, 'background')).toEqual({
+      '--row-user-bg': 'rgba(91, 141, 239, 1)',
+    })
+  })
+
+  it('background mode applies a gradient opaque, ignoring the opacity', () => {
+    expect(
+      userBubbleStyle(
+        user({ name_gradient: { type: 'linear', colors: ['#ff0000', '#0000ff'], angle: 90 } }),
+        { bubbleUserColorOpacity: '0.2' },
+        'background'
+      )
+    ).toEqual({ '--row-user-bg-image': 'linear-gradient(90deg, #ff0000, #0000ff)' })
+  })
+
+  it('background mode returns empty for a colourless chatter or a rejected gradient', () => {
+    expect(userBubbleStyle(user(), {}, 'background')).toEqual({})
+    expect(userBubbleStyle(undefined, {}, 'background')).toEqual({})
+    // Invalid stops are rejected by buildGradientCSS; no partial fill leaks.
+    expect(
+      userBubbleStyle(
+        user({ name_gradient: { type: 'linear', colors: ['red('], angle: 90 } }),
+        {},
+        'background'
+      )
+    ).toEqual({})
+  })
+
+  it('border mode emits colour plus its own 2px width', () => {
+    expect(userBubbleStyle(user({ color: '#DAA520' }), {}, 'border')).toEqual({
+      '--row-user-border-color': '#DAA520',
+      '--row-user-border-width': '2px',
+    })
+    expect(userBubbleStyle(user({ auto_color: '#5B8DEF' }), {}, 'border')).toEqual({
+      '--row-user-border-color': '#5B8DEF',
+      '--row-user-border-width': '2px',
+    })
+  })
+
+  it('border mode uses the gradient’s first stop for a gradient name', () => {
+    expect(
+      userBubbleStyle(
+        user({ name_gradient: { type: 'linear', colors: ['#ff0000', '#0000ff'], angle: 90 } }),
+        {},
+        'border'
+      )
+    ).toEqual({ '--row-user-border-color': '#ff0000', '--row-user-border-width': '2px' })
+  })
+
+  it('border mode returns empty for a colourless chatter', () => {
+    expect(userBubbleStyle(user(), {}, 'border')).toEqual({})
+    expect(userBubbleStyle(undefined, {}, 'border')).toEqual({})
   })
 })

--- a/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
+++ b/frontend/src/lib/utils/__tests__/visual-settings-to-css.test.ts
@@ -117,6 +117,10 @@ describe('visualSettingsToCss', () => {
       showPronouns: 'inline',
       pronounPosition: 'after',
       pronounColor: '#7B68EE',
+      // By-username bubble colouring (not CSS-driven per se — one generated
+      // rule keyed on [data-user-bubble], no --chat-* vars)
+      bubbleColorFromUser: 'background',
+      bubbleUserColorOpacity: '0.85',
     }
 
     const result = visualSettingsToCss(full)
@@ -136,7 +140,26 @@ describe('visualSettingsToCss', () => {
     expect(result).not.toContain('fly-left')
     // All 52 CSS properties present (excludes non-CSS fields)
     expect((result.match(/--chat-|--platform-/g) ?? []).length).toBe(52)
+    // The by-username mode emits its [data-user-bubble] rule, not variables
+    expect(result).toContain('div[data-user-bubble]:not(.event-message):not(.scroll-anchor)')
+    expect(result).toContain(
+      'background-color: var(--row-user-bg, var(--row-user-bg-image, transparent)) !important;'
+    )
+    expect(result).toContain('border-color: var(--row-user-border-color, transparent) !important;')
+    expect(result).toContain('border-width: var(--row-user-border-width, 0px) !important;')
   })
+
+  it('emits the user-bubble rule unchanged for border mode and nothing when off', () => {
+    const borderCss = visualSettingsToCss({ bubbleColorFromUser: 'border' })
+    expect(borderCss).toContain('div[data-user-bubble]:not(.event-message):not(.scroll-anchor)')
+    // Both feed scopes are covered by one rule
+    expect(borderCss).toContain('.overlay-preview-body > div[data-user-bubble]')
+    expect(borderCss).toContain('.overlay-live-body > div[data-user-bubble]')
+
+    // Off ('none') and absent emit no rule at all
+    expect(visualSettingsToCss({ bubbleColorFromUser: 'none' })).toBe('')
+    expect(visualSettingsToCss({ bubbleUserColorOpacity: '0.5' })).toBe('')
+   })
 
   it('wraps output in correct cascade layer syntax', () => {
     const result = visualSettingsToCss({ fontFamily: 'Roboto' })

--- a/frontend/src/lib/utils/usernameColor.ts
+++ b/frontend/src/lib/utils/usernameColor.ts
@@ -51,8 +51,15 @@ export interface UsernameColorUser {
  * Note the ordering constraint this encodes: the auto color must NOT be folded
  * into `color` upstream, or the streamer's setting could never apply.
  */
-export function resolveUsernameColor(user: UsernameColorUser | undefined): string {
-  if (user?.color) {
+export function resolveUsernameColor(
+  user: UsernameColorUser | undefined,
+  opts?: { staticColor?: boolean }
+): string {
+  // staticColor: the bubble is already carrying the username colour, so the
+  // name itself goes static (the streamer's picker / auto palette) to keep the
+  // row readable. Skips the `color` short-circuit; gradient usernames are
+  // unaffected — callers branch on name_gradient before reaching here.
+  if (user?.color && !opts?.staticColor) {
     return user.color
   }
   return `var(--chat-username-color, ${user?.auto_color || '#FFFFFF'})`

--- a/frontend/src/lib/utils/visual-inline-styles.ts
+++ b/frontend/src/lib/utils/visual-inline-styles.ts
@@ -17,7 +17,9 @@
  */
 
 import type { CSSProperties } from 'react'
+import type { UserInfo } from '@/lib/types/message'
 import type { VisualSettings } from '@/lib/types/visual-settings'
+import { buildGradientCSS } from '@/lib/utils/gradient'
 import { normalizeHex } from '@/lib/utils/hex-alpha'
 
 /**
@@ -79,4 +81,42 @@ export function chatBubbleStyle(vs: Partial<VisualSettings>): CSSProperties {
   if (bg) style.backgroundColor = bg
   if (vs.bubbleShadow) style.boxShadow = vs.bubbleShadow
   return style
+}
+
+/**
+ * Per-row custom properties carrying a chatter's username colour onto their
+ * bubble. The receiver is the [data-user-bubble] rule userBubbleRules emits in
+ * the visual-customizer layer (see visual-settings-to-css): these inline values
+ * lose nothing to competing !important rules because inline custom properties
+ * are only declarations — the generated rule's !important consumption wins the
+ * cascade the moment the row carries the attribute.
+ *
+ * Gradients are applied opaque: buildGradientCSS cannot fade a whole gradient,
+ * so bubbleUserColorOpacity is honoured for flat colours only.
+ */
+export function userBubbleStyle(
+  user: UserInfo | undefined,
+  vs: Partial<VisualSettings>,
+  mode: 'background' | 'border'
+): CSSProperties {
+  const gradient =
+    user?.name_gradient && buildGradientCSS(user.name_gradient) !== ''
+      ? user.name_gradient
+      : undefined
+  if (mode === 'background') {
+    if (gradient) return { '--row-user-bg-image': buildGradientCSS(gradient) } as CSSProperties
+    const fill = hexToRgba(user?.color || user?.auto_color, vs.bubbleUserColorOpacity)
+    if (fill) return { '--row-user-bg': fill } as CSSProperties
+    return {}
+  }
+  // Border mode. A gradient border has no faithful outline equivalent, so the
+  // first stop stands in for the gradient; it is the colour the viewer most
+  // associates with the name. Width is deliberately this mode's own 2px, not
+  // bubbleBorderWidth — a border nobody sized would never appear.
+  const borderColor = gradient ? gradient.colors[0] : user?.color || user?.auto_color
+  if (!borderColor || !normalizeHex(borderColor)) return {}
+  return {
+    '--row-user-border-color': borderColor,
+    '--row-user-border-width': '2px',
+  } as CSSProperties
 }

--- a/frontend/src/lib/utils/visual-settings-to-css.ts
+++ b/frontend/src/lib/utils/visual-settings-to-css.ts
@@ -283,6 +283,40 @@ function bubbleFillRules(settings: Partial<VisualSettings>): string[] {
 }
 
 /**
+ * Bubble colour from the username colour. The overlay surfaces write each
+ * row's colour as inline custom properties (userBubbleStyle in
+ * visual-inline-styles) and mark the row with `data-user-bubble`; this rule is
+ * the !important consumer that turns them into a visible fill or border.
+ *
+ * Beats everything else by specificity, not order: three attribute/class
+ * selectors plus the scope class (0,4,0... counting `:not()` arguments —
+ * [data-user-bubble] plus two :not()s) outrank palette and platform fills
+ * (one attribute plus one :not()), so it is emitted after them but wins
+ * regardless. The `:not(.scroll-anchor)` is documentary — the sentinel never
+ * carries the attribute — matching the events.css row rule's shape so the
+ * two selectors stay diffable side by side.
+ *
+ * Both custom properties always consume: in background mode the border pair
+ * falls back to transparent/0px, in border mode the fill pair to transparent,
+ * so a row's unused half is inert without a second rule.
+ */
+function userBubbleRules(settings: Partial<VisualSettings>): string[] {
+  const mode = settings.bubbleColorFromUser
+  if (mode !== 'background' && mode !== 'border') return []
+  return [
+    [
+      FEED_SCOPES.map(
+        (scope) => `  ${scope} > div[data-user-bubble]:not(.event-message):not(.scroll-anchor)`
+      ).join(',\n') + ' {',
+      '    background-color: var(--row-user-bg, var(--row-user-bg-image, transparent)) !important;',
+      '    border-color: var(--row-user-border-color, transparent) !important;',
+      '    border-width: var(--row-user-border-width, 0px) !important;',
+      '  }',
+    ].join('\n'),
+  ]
+}
+
+/**
  * The value to emit for a field, which is not always the value that was
  * stored. `textShadow` carries the outline's thickness inside the declaration
  * (see text-outline.ts), so the declaration is re-derived from that thickness
@@ -347,7 +381,7 @@ export function visualSettingsToCss(settings: Partial<VisualSettings>): string {
   if (declarations.length > 0) {
     blocks.push(['  :root {', ...declarations, '  }'].join('\n'))
   }
-  blocks.push(...overrideRules(settings), ...bubbleFillRules(settings))
+  blocks.push(...overrideRules(settings), ...bubbleFillRules(settings), ...userBubbleRules(settings))
 
   if (blocks.length === 0) {
     return ''

--- a/frontend/src/styles/EVENTS_CSS_API.md
+++ b/frontend/src/styles/EVENTS_CSS_API.md
@@ -147,7 +147,8 @@ worth knowing:
   `--event-*` tokens or overriding event rules works without ceremony.
 - Unlayered theme CSS **cannot** beat an `!important` rule inside
   `@layer visual-customizer`. That is why event rows are excluded from the
-  bubble-forcing block there: an inescapable rule is the wrong tool for
+  bubble-forcing rules there (the shape block, and the username-colour bubble
+  block keyed on `data-user-bubble`): an inescapable rule is the wrong tool for
   something themes are supposed to restyle.
 - Putting a rule in `@layer user-overrides` raises its priority for normal
   declarations and _lowers_ it for `!important` ones. Pick one or the other, not


### PR DESCRIPTION
## What

Adds an Appearance -> Bubble colors option that fills or outlines each chat bubble with its chatter's username colour. Chatters without a colour fall back to their auto palette colour. While the mode is on, usernames render in the static username colour so they stay legible against their own bubble fill.

- Generated rule lives in `@layer visual-customizer` with `!important`, keyed on the row's `data-user-bubble` attribute; events are excluded via `:not(.event-message)`
- Both modes (background fill, border outline) emit inline custom properties per row (`--row-user-bg`, `--row-user-border-color`, `--row-user-border-width`)
- `resolveUsernameColor` gains a `staticColor` option that skips the `user.color` short-circuit while the mode is on
- Settings ride in `visual_settings` (`bubbleColorFromUser`, `bubbleUserColorOpacity`); no DB migration, gate open (`bubble_colors`)
- Docs: ADR-0047 amendment, overlay-themes README enforced-rules paragraph, EVENTS_CSS_API cascade note

## Verification

- `tsc --noEmit` clean; full vitest suite green (1922 passed)
- Browser-verified in dev stack: editor toggle renders Fill/Outline radios; preview iframe rows gain per-user bubble colours in both modes; computed styles beat `bg-slate-900/90`
- Persistence: Save -> PUT config 200, `bubbleColorFromUser: "background"` in `overlay_configs.visual_settings`, survives editor reload
- Live overlay: 36 rows with `data-user-bubble`, per-user colours, static usernames